### PR TITLE
Pull request to fix JBRULES-2976

### DIFF
--- a/drools-core/src/main/java/org/drools/marshalling/impl/DefaultMarshaller.java
+++ b/drools-core/src/main/java/org/drools/marshalling/impl/DefaultMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 JBoss Inc
+ * Copyright 2010, 2011 JBoss Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ public class DefaultMarshaller
                                                                      (InternalRuleBase) ((InternalKnowledgeBase) kbase).getRuleBase(),
                                                                      (InternalWorkingMemory) ((StatefulKnowledgeSessionImpl) session).session,
                                                                      RuleBaseNodes.getNodeMap( (InternalRuleBase) ((InternalKnowledgeBase) kbase).getRuleBase() ),
-                                                                     ((StatefulKnowledgeSessionImpl)session).session.getObjectMarshallingStrategyStore(),
+                                                                     this.strategyStore,
                                                                      this.marshallingConfig.isMarshallProcessInstances(),
                                                                      this.marshallingConfig.isMarshallWorkItems(), session.getEnvironment());
         OutputMarshaller.writeSession( context );


### PR DESCRIPTION
Hello; I'm new to git and github, so I apologize if I am inadvertently ignoring etiquette or making some other mistake.

[JBRULES-2976](https://issues.jboss.org/browse/JBRULES-2976) is a bug where the `DefaultMarshaller`--the default implementation of the `Marshaller` interface--does not use the `ObjectMarshallingStrategy` that is supplied at construction.  It _stores_ it, but never does anything with it.  Instead, the strategy reachable from the supplied `StatefulKnowledgeSession` is used instead.

The patch/pull request here makes sure that the strategy is used appropriately.

All tests continue to pass in the drools-core module.

Please do let me know if this is an appropriate pull request, or what else I should do to get this fix in.

Thanks for all the work done on the Drools project.

Best,
Laird
