### PR TITLE
Without that addition drools doesn't run with java7

### DIFF
--- a/drools-compiler/src/main/java/org/drools/rule/builder/dialect/java/JavaDialectConfiguration.java
+++ b/drools-compiler/src/main/java/org/drools/rule/builder/dialect/java/JavaDialectConfiguration.java
@@ -37,7 +37,7 @@ public class JavaDialectConfiguration
     public static final int             ECLIPSE         = 0;
     public static final int             JANINO          = 1;
 
-    public static final String[]        LANGUAGE_LEVELS = new String[]{"1.5", "1.6"};
+    public static final String[]        LANGUAGE_LEVELS = new String[]{"1.5", "1.6", "1.7"};
 
     private String                      languageLevel;
 


### PR DESCRIPTION
I consider this a bug since further down that file java7 is considered
