### PR TITLE
Oracle fixes

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/info/SessionInfo.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/info/SessionInfo.java
@@ -10,15 +10,18 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 
 import org.drools.persistence.SessionMarshallingHelper;
 
 @Entity
+@SequenceGenerator(name="sessionInfoIdSeq", sequenceName="SESSIONINFO_ID_SEQ")
 public class SessionInfo {
+    
     private @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator="sessionInfoIdSeq")
     Integer                        id;
 
     @Version

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/info/WorkItemInfo.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/info/WorkItemInfo.java
@@ -12,6 +12,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.PreUpdate;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 
@@ -23,10 +24,11 @@ import org.drools.process.instance.WorkItem;
 import org.drools.runtime.Environment;
 
 @Entity
+@SequenceGenerator(name="workItemInfoIdSeq", sequenceName="WORKITEMINFO_ID_SEQ")
 public class WorkItemInfo  {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator="workItemInfoIdSeq")
     private Long   workItemId;
 
     @Version

--- a/drools-persistence-jpa/src/test/resources/log4j.xml
+++ b/drools-persistence-jpa/src/test/resources/log4j.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out"/>
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%-4r %d{dd/MM HH:mm:ss,SSS}[%t] %-5p %c{3}.%M %x - %m%n"/>
+		</layout>
+	</appender>
+
+	<logger name="org.drools">
+		<level value="INFO"/>
+	</logger>
+	
+	<!-- logger name="org.hibernate">
+		<level value="INFO"/>
+	</logger -->
+	<root>
+		<priority value="INFO"/>
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</log4j:configuration>


### PR DESCRIPTION
Unit tests that run on Oracle fail when trying to lookup the next sequence value for a generated value -- when trying to use the default hibernate_sequence. 

This pull request adds/implements the JPA @SequenceGenerator annotation to the 2 classes in drools-persistence-jpa so that sequences are explicitly created in the database. This ensures that drools-persistence-jpa will work on Oracle databases while keeping compatibility with other databases. 

See https://hudson.qa.jboss.com/hudson/view/Drools%20jBPM/job/drools-persistence-db-matrix/database=oracle11gR1/lastCompletedBuild/testReport/ for more information on how the tests fail. 
