### PR TITLE
JBRULES-3205: Add 'name' and 'description' attributes to <Resource> element

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/BaseResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/BaseResource.java
@@ -28,6 +28,9 @@ public abstract class BaseResource
     private ResourceType         resourceType;
     private ResourceConfiguration configuration;
 
+    private String name;
+    private String description;
+    
     public ResourceConfiguration getConfiguration() {
         return configuration;
     }
@@ -42,6 +45,22 @@ public abstract class BaseResource
 
     public ResourceType getResourceType() {
         return this.resourceType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
 }

--- a/drools-core/src/main/java/org/drools/io/internal/InternalResource.java
+++ b/drools-core/src/main/java/org/drools/io/internal/InternalResource.java
@@ -45,4 +45,7 @@ public interface InternalResource extends Resource {
     
     long getLastRead();
 
+    void setDescription(String description); 
+
+    void setName(String name);
 }

--- a/drools-core/src/main/java/org/drools/xml/changeset/ResourceHandler.java
+++ b/drools-core/src/main/java/org/drools/xml/changeset/ResourceHandler.java
@@ -63,6 +63,9 @@ public class ResourceHandler extends BaseAbstractHandler
         String basicAuthentication = attrs.getValue( "basicAuthentication" );
         String username = attrs.getValue( "username" );
         String password = attrs.getValue( "password" );
+        
+        String name = attrs.getValue( "name" );
+        String description = attrs.getValue( "description" );
 
         
         emptyAttributeCheck( localName,
@@ -86,6 +89,9 @@ public class ResourceHandler extends BaseAbstractHandler
         }
         
         resource.setResourceType( ResourceType.getResourceType( type ) );
+        
+        resource.setName(name);
+        resource.setDescription(description);
         
         return resource;
     }

--- a/drools-core/src/test/java/org/drools/xml/XmlChangeSetReaderTest.java
+++ b/drools-core/src/test/java/org/drools/xml/XmlChangeSetReaderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2011 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.xml;
+
+import java.util.Collection;
+import org.drools.ChangeSet;
+import org.drools.io.Resource;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class XmlChangeSetReaderTest {
+    
+    @Test
+    public void testResourceAttributes() throws Exception{
+        SemanticModules semanticModules = new SemanticModules();
+        semanticModules.addSemanticModule( new ChangeSetSemanticModule() );
+        
+        XmlChangeSetReader changeSetReader = new XmlChangeSetReader(semanticModules);
+
+        changeSetReader.setClassLoader(XmlChangeSetReaderTest.class.getClassLoader(),
+                                   null );
+        
+        ChangeSet changeSet = changeSetReader.read(XmlChangeSetReaderTest.class.getClassLoader().getResourceAsStream("org/drools/xml/test-change-set.xml"));
+        
+        Assert.assertNotNull(changeSet);
+        
+        Collection<Resource> resourcesAdded = changeSet.getResourcesAdded();
+        
+        Assert.assertNotNull(resourcesAdded);
+        
+        Assert.assertEquals(4, resourcesAdded.size());
+        
+        Resource resource1 = null;
+        Resource resource2 = null;
+        Resource resource3 = null;
+        Resource secureResource = null;
+        
+        for (Resource resource : resourcesAdded) {
+            if (resource.getName() != null && resource.getName().equals("resource1")){
+                resource1 = resource;
+            } else if (resource.getName() != null && resource.getName().equals("secureResource")){
+                secureResource = resource;
+            } else if (resource.getName() == null && resource.getDescription() == null){
+                resource3 = resource;
+            } else if (resource.getName() == null){
+                resource2 = resource;
+            }
+        }
+        
+        Assert.assertNotNull(resource1);
+        Assert.assertNotNull(resource2);
+        Assert.assertNotNull(resource3);
+        Assert.assertNotNull(secureResource);
+        
+        Assert.assertNull(resource1.getDescription());
+        
+        Assert.assertEquals("another description", resource2.getDescription());
+        
+        Assert.assertEquals("some useful description", secureResource.getDescription());
+        
+    }
+}

--- a/drools-core/src/test/resources/org/drools/xml/test-change-set.xml
+++ b/drools-core/src/test/resources/org/drools/xml/test-change-set.xml
@@ -1,0 +1,13 @@
+<change-set xmlns='http://drools.org/drools-5.0/change-set'
+            xmlns:xs='http://www.w3.org/2001/XMLSchema-instance'
+            xs:schemaLocation='http://drools.org/drools-5.0/change-set http://anonsvn.jboss.org/repos/labs/labs/jbossrules/trunk/drools-api/src/main/resources/change-set-1.0.0.xsd' >
+            
+    <add>
+      <resource name="resource1"  source='classpath:data/IntegrationExampleTest.xls' type="DTABLE">
+          <decisiontable-conf input-type="XLS" worksheet-name="Tables_2" />
+      </resource>
+      <resource name="secureResource" description="some useful description" basic-authentication="enabled" username="someUser" password="somePassword" type="DRL" source="http://someHost:1234/someDRLResource.drl"/>
+      <resource description="another description" type="DRL" source="http://someHost:1234/someOtherDRLResource.drl"/>
+      <resource type="DRL" source="http://someHost:1234/someOtherDRLResource2.drl"/>
+    </add>
+</change-set>


### PR DESCRIPTION
JBRULES-3205: Add 'name' and 'description' attributes to <Resource> element in change-sets
    - Added getters for name and description to InternalResource
    - getters implemented in BaseResourc
    - ResourceHandler takes in account these 2 attributes when creating the Resource
    - Test for ResourceHandler created
