### PR TITLE
Jbpm 3106

### DIFF
--- a/drools-persistence-jpa/pom.xml
+++ b/drools-persistence-jpa/pom.xml
@@ -64,28 +64,18 @@
       <groupId>org.drools</groupId>
       <artifactId>knowledge-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
@@ -96,7 +86,6 @@
       <artifactId>jaxb-xjc</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.osgi.core</artifactId>
@@ -113,17 +102,14 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-annotations</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-commons-annotations</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
@@ -135,22 +121,18 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>persistence-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
     </dependency>
-
     <dependency>
       <groupId>javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>
-
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>jta</artifactId>
@@ -185,6 +167,13 @@
         <artifactId>com.springsource.javax.resource</artifactId>
         <version>1.5.0</version>
     </dependency-->
+    
+    <!--  Test -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/TransactionManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/TransactionManager.java
@@ -1,4 +1,19 @@
-package org.drools.persistence;
+/*
+ * Copyright 2011 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.drools.persistence;
 
 
 public interface TransactionManager {
@@ -19,11 +34,11 @@ public interface TransactionManager {
 
     int getStatus();
 
-    void begin();
+    boolean begin();
 
-    void commit();
+    void commit(boolean transactionOwner);
 
-    void rollback();
+    void rollback(boolean transactionOwner);
 
     void registerTransactionSynchronization(TransactionSynchronization ts);
 

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
@@ -1,4 +1,19 @@
-package org.drools.persistence.jpa;
+/*
+ * Copyright 2011 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.drools.persistence.jpa;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/KnowledgeStoreServiceImpl.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/KnowledgeStoreServiceImpl.java
@@ -1,4 +1,19 @@
-package org.drools.persistence.jpa;
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.drools.persistence.jpa;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -51,7 +66,7 @@ public class KnowledgeStoreServiceImpl
             throw new IllegalArgumentException( "Environment cannot be null" );
         }
 
-        return new CommandBasedStatefulKnowledgeSession( (CommandService) buildCommanService( kbase,
+        return new CommandBasedStatefulKnowledgeSession( (CommandService) buildCommandService( kbase,
                                                                              mergeConfig( configuration ),
                                                                              environment ) );
     }
@@ -68,13 +83,13 @@ public class KnowledgeStoreServiceImpl
             throw new IllegalArgumentException( "Environment cannot be null" );
         }
 
-        return new CommandBasedStatefulKnowledgeSession( (CommandService) buildCommanService( id,
+        return new CommandBasedStatefulKnowledgeSession( (CommandService) buildCommandService( id,
                                                                                               kbase,
                                                                                               mergeConfig( configuration ),
                                                                                               environment ) );
     }
 
-    private CommandExecutor buildCommanService(Integer sessionId,
+    private CommandExecutor buildCommandService(Integer sessionId,
                                               KnowledgeBase kbase,
                                               KnowledgeSessionConfiguration conf,
                                               Environment env) {
@@ -104,7 +119,7 @@ public class KnowledgeStoreServiceImpl
         }
     }
 
-    private CommandExecutor buildCommanService(KnowledgeBase kbase,
+    private CommandExecutor buildCommandService(KnowledgeBase kbase,
                                               KnowledgeSessionConfiguration conf,
                                               Environment env) {
 

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/map/ManualTransactionManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/map/ManualTransactionManager.java
@@ -1,14 +1,32 @@
+/*
+ * Copyright 2011 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.persistence.map;
 
 import org.drools.persistence.TransactionManager;
 import org.drools.persistence.TransactionSynchronization;
 import org.drools.persistence.info.SessionInfo;
 import org.drools.persistence.info.WorkItemInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ManualTransactionManager
     implements
     TransactionManager {
     
+    private Logger logger = LoggerFactory.getLogger( getClass() );
     private NonTransactionalPersistentSession session;
     private KnowledgeSessionStorage storage;
     private TransactionSynchronization transactionSynchronization;
@@ -23,10 +41,15 @@ public class ManualTransactionManager
         return 0;
     }
 
-    public void begin() {
+    public boolean begin() {
+        // There are no transactions since everything 
+        //  is in memory and instantaneous
+        return true;
     }
 
-    public void commit() {
+    public void commit(boolean transactionOwner) {
+        // Do not check if the caller is the transactionOwner 
+        //  because there's no need to "wait" for a commit
         try{
             for(SessionInfo sessionInfo : session.getStoredKnowledgeSessions()){
                 sessionInfo.update();
@@ -40,16 +63,16 @@ public class ManualTransactionManager
             try{
                 transactionSynchronization.afterCompletion(TransactionManager.STATUS_COMMITTED);
             } catch (RuntimeException re){
-                //FIXME log error
+                logger.warn("Unable to synchronize transaction after commit, see cause.", re);
             }
         } catch (RuntimeException re) {
             transactionSynchronization.afterCompletion(TransactionManager.STATUS_ROLLEDBACK);
         }
-        //we shouldn't clear session here b/c doing so we lose the track of this objects on successive
-        //interactions
+        // We shouldn't clear session here because by doing so 
+        //  we lose track of this objects on successive interactions
     }
 
-    public void rollback() {
+    public void rollback(boolean transactionOwner) {
     }
 
     public void registerTransactionSynchronization(TransactionSynchronization ts) {

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.jta;
+
+import static junit.framework.Assert.assertTrue;
+import static org.drools.persistence.util.PersistenceUtil.*;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.FlushModeType;
+import javax.persistence.Persistence;
+import javax.transaction.UserTransaction;
+
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.base.MapGlobalResolver;
+import org.drools.builder.KnowledgeBuilder;
+import org.drools.builder.KnowledgeBuilderFactory;
+import org.drools.builder.ResourceType;
+import org.drools.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.impl.EnvironmentFactory;
+import org.drools.io.ResourceFactory;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.TransactionManager;
+import org.drools.persistence.jpa.JPAKnowledgeService;
+import org.drools.persistence.jpa.JpaPersistenceContextManager;
+import org.drools.runtime.Environment;
+import org.drools.runtime.EnvironmentName;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.codemodel.JPackage;
+
+import bitronix.tm.TransactionManagerServices;
+import bitronix.tm.internal.BitronixRollbackException;
+import bitronix.tm.resource.jdbc.PoolingDataSource;
+
+public class JtaTransactionManagerTest {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    // Datasource (setup & clean up)
+    private PoolingDataSource ds1;
+    private EntityManagerFactory emf;
+
+    private static String simpleRule = "package org.drools.test\n"
+            + "global java.util.List list\n" 
+            + "rule rule1\n" 
+            + "when\n"
+            + "  Integer(intValue > 0)\n" 
+            + "then\n" 
+            + "  list.add( 1 );\n"
+            + "end\n" 
+            + "\n";
+
+    @Before
+    public void setup() {
+        // Initialize datasource and global settings
+        ds1 = setupPoolingDataSource();
+        ds1.init();
+
+        emf = Persistence.createEntityManagerFactory(DROOLS_PERSISTENCE_UNIT_NAME);
+    }
+
+    private Environment initializeEnvironment(EntityManagerFactory emf) {
+        Environment env = KnowledgeBaseFactory.newEnvironment();
+        env.set(EnvironmentName.ENTITY_MANAGER_FACTORY, emf);
+        env.set(EnvironmentName.GLOBALS, new MapGlobalResolver());
+        env.set(EnvironmentName.TRANSACTION_MANAGER,
+                TransactionManagerServices.getTransactionManager());
+        
+        return env;
+    }
+   
+    private KnowledgeBase initializeKnowledgeBase(String rule) { 
+        // Initialize knowledge base/session/etc..
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(rule.getBytes()), ResourceType.DRL);
+
+        if (kbuilder.hasErrors()) {
+            fail(kbuilder.getErrors().toString());
+        }
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+       
+        return kbase;
+    }
+   
+    public static final String DEFAULT_USER_TRANSACTION_NAME = "java:comp/UserTransaction";
+
+    protected UserTransaction findUserTransaction() {
+        try {
+            InitialContext context = new InitialContext();
+            return (UserTransaction) context.lookup( DEFAULT_USER_TRANSACTION_NAME );
+        } catch ( NamingException ex ) {
+            logger.debug( "No UserTransaction found at JNDI location [{}]",
+                          DEFAULT_USER_TRANSACTION_NAME,
+                          ex );
+            return null;
+        }
+    }
+    
+    @After
+    public void cleanUp() {
+        emf.close();
+        ds1.close();
+    }
+
+    private String getTestName() { 
+        String testName = null;
+        StackTraceElement [] ste = Thread.currentThread().getStackTrace();
+        String methodName =  ste[2].getMethodName();
+        return methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
+    }
+    @Test
+    public void showingTransactionTestObjectsNeedTransactions()  throws Exception {
+        String testName = getTestName();
+        
+        // Create linked transactionTestObjects but only persist the main one.
+        TransactionTestObject badMainObject = new TransactionTestObject();
+        badMainObject.setName("bad" + testName);
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("sub" + testName);
+        badMainObject.setSubObject(subObject);
+       
+        // Initialized persistence/tx's and persist to db
+        EntityManager em = emf.createEntityManager();
+        em.setFlushMode(FlushModeType.COMMIT);
+        UserTransaction tx = findUserTransaction();
+        tx.begin();
+        em.joinTransaction();
+        em.persist(badMainObject);
+        
+        boolean rollBackExceptionthrown = false;
+        try { 
+            tx.commit();
+        }
+        catch( Exception e ) { 
+            if( e instanceof BitronixRollbackException ) { 
+                rollBackExceptionthrown = true;
+            }
+        }           
+        assertTrue( "A rollback exception should have been thrown because of foreign key violations.", rollBackExceptionthrown );
+       
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("main" + testName);
+        mainObject.setSubObject(subObject);
+        
+        // Now persist both.. 
+        tx.begin();
+        em.joinTransaction();
+        em.persist(mainObject);
+        em.persist(subObject);
+        
+        try { 
+            tx.commit();
+        }
+        catch( Exception e ) { 
+            e.printStackTrace();
+            fail( "No exception should have been thrown: " + e.getMessage() );
+        }           
+    }
+
+    @Test
+    public void basicTransactionManagerTest() {
+        String testName = getTestName();
+        
+        // Setup the JtaTransactionmanager
+        Environment env = initializeEnvironment(emf);
+        Object tm = env.get( EnvironmentName.TRANSACTION_MANAGER );
+        TransactionManager txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+                env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+                tm ); 
+           
+        // Create linked transactionTestObjects 
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("main" + testName);
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("sub" + testName);
+        mainObject.setSubObject(subObject);
+      
+        // Commit the mainObject after "commiting" the subObject
+        EntityManager em = emf.createEntityManager();
+        try { 
+            // Begin the real trasnaction
+            boolean txOwner = txm.begin();
+      
+            // Do the "sub" transaction 
+            // - the txm doesn't really commit, 
+            //   because we keep track of who's the tx owner.
+            boolean notTxOwner = txm.begin();
+            em.persist(mainObject);
+            txm.commit(notTxOwner);
+       
+            // Finish the transaction off
+            em.persist(subObject);
+            txm.commit(txOwner);
+        }
+        catch( Throwable t ) { 
+            fail( "No exception should have been thrown: " + t.getMessage() );
+        }
+    }
+   
+    @Test
+    public void basicTransactionRollbackTest() {
+        Environment env = initializeEnvironment(emf);
+        Object tm = env.get( EnvironmentName.TRANSACTION_MANAGER );
+        TransactionManager txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+                env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+                tm ); 
+           
+        // Create linked transactionTestObjects 
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("main");
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("sub");
+        mainObject.setSubObject(subObject);
+       
+        EntityManager em = emf.createEntityManager();
+        try { 
+            boolean txOwner = txm.begin();
+            
+            boolean notTxOwner = txm.begin();
+            em.persist(mainObject);
+            txm.rollback(notTxOwner);
+        
+            em.persist(subObject);
+            txm.rollback(txOwner);
+        }
+        catch( Exception e ) { 
+            fail("There should not be an exception thrown here: " + e.getMessage());
+        }
+        
+    }
+
+    public static String COMMAND_ENTITY_MANAGER = "drools.persistence.test.command.EntityManager";
+    public static String COMMAND_ENTITY_MANAGER_FACTORY = "drools.persistence.test.EntityManagerFactory";
+    
+    @Test
+    public void testSingleSessionCommandServiceAndJtaTransactionManagerTogether() { 
+            
+        // Initialize drools environment stuff
+        Environment env = initializeEnvironment(emf);
+        KnowledgeBase kbase = initializeKnowledgeBase(simpleRule);
+        StatefulKnowledgeSession commandKSession = JPAKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        SingleSessionCommandService commandService = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) commandKSession).getCommandService();
+        JpaPersistenceContextManager jpm = (JpaPersistenceContextManager) getValueOfField("jpm", commandService);
+
+        jpm.getApplicationScopedPersistenceContext();
+        EntityManager em = (EntityManager) getValueOfField("appScopedEntityManager", jpm);
+        
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("mainCommand");
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("subCommand");
+        mainObject.setSubObject(subObject);
+       
+        HashMap<String, Object> emEnv = new HashMap<String, Object>();
+        emEnv.put(COMMAND_ENTITY_MANAGER_FACTORY, emf);
+        emEnv.put(COMMAND_ENTITY_MANAGER, em);
+        
+        TransactionTestCommand txTestCmd = new TransactionTestCommand(mainObject, subObject, emEnv);
+       
+        
+        commandKSession.execute(txTestCmd);
+        
+    }
+
+}

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.jta;
+
+import static org.drools.persistence.jta.JtaTransactionManagerTest.*;
+import java.util.HashMap;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.base.MapGlobalResolver;
+import org.drools.command.Context;
+import org.drools.command.impl.GenericCommand;
+import org.drools.command.impl.KnowledgeCommandContext;
+import org.drools.persistence.jpa.JPAKnowledgeService;
+import org.drools.runtime.Environment;
+import org.drools.runtime.EnvironmentName;
+import org.drools.runtime.StatefulKnowledgeSession;
+
+import bitronix.tm.TransactionManagerServices;
+
+
+/**
+ * Please make sure you understand foreign keys 
+ * and how they work with regards to JPA before continuing further: 
+ * - http://download.oracle.com/javaee/5/tutorial/doc/bnbqa.html#bnbqj
+ * - http://en.wikipedia.org/wiki/Foreign_key
+ * 
+ *
+ */
+public class TransactionTestCommand implements GenericCommand<Void> {
+
+    private static final long serialVersionUID = -7640078670024414748L;
+    
+    private Object mainObject;
+    private Object subObject;
+    private EntityManager em;
+    private EntityManagerFactory emf;
+    
+    public TransactionTestCommand(Object mainObject, Object subObject, HashMap<String, Object> env) { 
+      this.mainObject = mainObject;
+      this.subObject = subObject; 
+      setPersistenceFields(env);
+    }
+    
+    public TransactionTestCommand(Object mainObject, HashMap<String, Object> env) { 
+      this.mainObject = mainObject;
+      this.subObject = null;
+      setPersistenceFields(env);
+    }
+
+    private void setPersistenceFields(HashMap<String, Object> env) { 
+        this.em = (EntityManager) env.get(COMMAND_ENTITY_MANAGER);
+        this.emf = (EntityManagerFactory) env.get(COMMAND_ENTITY_MANAGER_FACTORY);
+    }
+    
+    private HashMap<String, Object> getPersistenceEnvironment() { 
+        HashMap<String, Object> env = new HashMap<String, Object>();
+        env.put(COMMAND_ENTITY_MANAGER, this.em);
+        env.put(COMMAND_ENTITY_MANAGER_FACTORY, this.emf);
+        return env;
+    }
+    
+    public Void execute(Context context) {
+        em.joinTransaction();
+        em.persist(mainObject);
+
+        if( subObject != null ) { 
+            StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
+  
+            // THe following 3 lines are the important ones! (See below for an explanation)
+            KnowledgeBase cleanKBase = KnowledgeBaseFactory.newKnowledgeBase();
+            cleanKBase.addKnowledgePackages(ksession.getKnowledgeBase().getKnowledgePackages());
+            StatefulKnowledgeSession commandKSession = JPAKnowledgeService.newStatefulKnowledgeSession( cleanKBase, null, initializeEnvironment() );
+
+            /**
+             *  Here's what's going on: 
+             *  If the SingleSessionCommandService (SSCS) & JtaTransactionManager (JTM) were _not_ aware of transactions, 
+             *  -> then inserting the mainObject _before_ having inserted the subObject
+             *     would cause the operation/persist to fail and the transaction to fail. 
+             *     - This is because the mainObject contains a foreign key referring to the subObject.
+             *     
+             *  However, the SSCS & JTM check whether or not they're owners of the transaction
+             *  when starting and when committing the transaction they use. 
+             *  -> So that when we insert the mainObject here (via a _new_ CommandBasedStatefulKnowledgeSession), 
+             *     it does _not_ mess with the transaction state and the operation succeeds.  
+             */ 
+            TransactionTestCommand transactionTestSubCommand 
+                = new TransactionTestCommand(this.subObject, getPersistenceEnvironment()); commandKSession.execute(transactionTestSubCommand);
+        }
+
+        return null;
+    }
+ 
+    private Environment initializeEnvironment() {
+        Environment env = KnowledgeBaseFactory.newEnvironment();
+        env.set(EnvironmentName.ENTITY_MANAGER_FACTORY, emf);
+        env.set(EnvironmentName.GLOBALS, new MapGlobalResolver());
+        env.set(EnvironmentName.TRANSACTION_MANAGER,
+                TransactionManagerServices.getTransactionManager());
+        
+        return env;
+    }
+    
+}

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestObject.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/TransactionTestObject.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.jta;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Version;
+
+/**
+ * This class is used to test transactions. 
+ * It specifically has a 
+ * 
+ *
+ */
+@Entity
+@SequenceGenerator(name="txTestIdSeq", sequenceName="TXTESTOBJ_ID_SEQ")
+public class TransactionTestObject implements Serializable {
+
+    private static final long serialVersionUID = 8991032325499307158L;
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.AUTO, generator="txTestIdSeq")
+    @Column(name="ID")
+    private Long id;
+    
+    private String name;
+
+	@OneToOne
+	private TransactionTestObject subObject;
+	
+    public TransactionTestObject(){}
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setSubObject(TransactionTestObject subObject) {
+        if( subObject == this ) { 
+            // no-op
+            return;
+        }
+        this.subObject = subObject;
+    }
+
+    public TransactionTestObject getSubObject() {
+        return subObject;
+    }
+    
+}

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/JpaBasedPersistenceTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/JpaBasedPersistenceTest.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.persistence.map.impl;
 
 import static org.drools.persistence.util.PersistenceUtil.*;
-import javax.persistence.EntityManager;
+
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
@@ -9,28 +24,42 @@ import org.drools.KnowledgeBase;
 import org.drools.KnowledgeBaseFactory;
 import org.drools.base.MapGlobalResolver;
 import org.drools.persistence.jpa.JPAKnowledgeService;
+import org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy;
+import org.drools.persistence.jta.JtaTransactionManager;
 import org.drools.runtime.Environment;
 import org.drools.runtime.EnvironmentName;
 import org.drools.runtime.StatefulKnowledgeSession;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bitronix.tm.TransactionManagerServices;
 import bitronix.tm.resource.jdbc.PoolingDataSource;
 
 public class JpaBasedPersistenceTest extends MapPersistenceTest {
 
+    private static Logger logger = LoggerFactory.getLogger(JPAPlaceholderResolverStrategy.class);
+    
     private  PoolingDataSource ds1;
     private EntityManagerFactory emf;
+    private JtaTransactionManager txm;
+    private boolean useTransactions = false;
     
     @Before
     public void setUp() throws Exception {
         ds1 = setupPoolingDataSource();
         
         ds1.init();
-        emf = Persistence.createEntityManagerFactory( PERSISTENCE_UNIT_NAME );
+        emf = Persistence.createEntityManagerFactory( DROOLS_PERSISTENCE_UNIT_NAME );
+        if( useTransactions() ) { 
+            useTransactions = true;
+            Environment env = createEnvironment();
+            Object tm = env.get( EnvironmentName.TRANSACTION_MANAGER );
+            this.txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+                env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+                tm ); 
+        }
     }
     
     @After
@@ -54,8 +83,16 @@ public class JpaBasedPersistenceTest extends MapPersistenceTest {
 
     @Override
     protected long getSavedSessionsCount() {
-        System.out.println("quering");
-        return emf.createEntityManager().createQuery( "FROM SessionInfo" ).getResultList().size();
+        logger.info("quering number of saved sessions.");
+        boolean transactionOwner = false;
+        if( useTransactions ) { 
+            transactionOwner = txm.begin();
+        }
+        long savedSessionsCount =  emf.createEntityManager().createQuery( "FROM SessionInfo" ).getResultList().size();
+        if( useTransactions ) { 
+            txm.commit(transactionOwner);
+        }
+        return savedSessionsCount;
     }
 
     private Environment createEnvironment(){

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapPersistenceTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/map/impl/MapPersistenceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.persistence.map.impl;
 
 import org.drools.KnowledgeBase;
@@ -8,13 +23,18 @@ import org.drools.builder.KnowledgeBuilderErrors;
 import org.drools.builder.KnowledgeBuilderFactory;
 import org.drools.builder.ResourceType;
 import org.drools.io.impl.ByteArrayResource;
+import org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy;
 import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.rule.FactHandle;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class MapPersistenceTest {
 
+    private static Logger logger = LoggerFactory.getLogger(JPAPlaceholderResolverStrategy.class);
+    
     @Test
     public void createPersistentSession() {
         KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
@@ -46,7 +66,7 @@ public abstract class MapPersistenceTest {
         KnowledgeBuilderErrors errors = kbuilder.getErrors();
         if ( errors != null && errors.size() > 0 ) {
             for ( KnowledgeBuilderError error : errors ) {
-                System.out.println( "Error: " + error.getMessage() );
+                logger.warn( "Error: " + error.getMessage() );
             }
             Assert.fail( "KnowledgeBase did not build" );
         }

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2011 Red Hat Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.session;
+
+import static org.drools.persistence.util.PersistenceUtil.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Random;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.base.MapGlobalResolver;
+import org.drools.builder.KnowledgeBuilder;
+import org.drools.builder.KnowledgeBuilderFactory;
+import org.drools.builder.ResourceType;
+import org.drools.common.DefaultFactHandle;
+import org.drools.definition.KnowledgePackage;
+import org.drools.io.ResourceFactory;
+import org.drools.persistence.PersistenceContextManager;
+import org.drools.persistence.info.SessionInfo;
+import org.drools.persistence.jpa.JPAKnowledgeService;
+import org.drools.persistence.jpa.JpaPersistenceContextManager;
+import org.drools.runtime.Environment;
+import org.drools.runtime.EnvironmentName;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.drools.runtime.rule.FactHandle;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import bitronix.tm.TransactionManagerServices;
+import bitronix.tm.resource.jdbc.PoolingDataSource;
+
+public class ReloadSessionTest {
+
+    // Datasource (setup & clean up)
+    private PoolingDataSource ds1;
+    private EntityManagerFactory emf;
+
+    private static String simpleRule = "package org.drools.test\n"
+            + "global java.util.List list\n" 
+            + "rule rule1\n" 
+            + "when\n"
+            + "  Integer(intValue > 0)\n" 
+            + "then\n" 
+            + "  list.add( 1 );\n"
+            + "end\n" 
+            + "\n";
+
+    @Before
+    public void setup() {
+        // Initialize datasource and global settings
+        ds1 = setupPoolingDataSource();
+        ds1.init();
+        
+        emf = Persistence.createEntityManagerFactory(DROOLS_PERSISTENCE_UNIT_NAME);
+    }
+
+    @After
+    public void cleanUp() {
+        emf.close();
+        ds1.close();
+    }
+
+    private KnowledgeBase initializeKnowledgeBase(String rule) { 
+        // Initialize knowledge base/session/etc..
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(rule.getBytes()), ResourceType.DRL);
+
+        if (kbuilder.hasErrors()) {
+            fail(kbuilder.getErrors().toString());
+        }
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+       
+        return kbase;
+    }
+    
+    private Environment initializeEnvironment(EntityManagerFactory emf) {
+        Environment env = KnowledgeBaseFactory.newEnvironment();
+        env.set(EnvironmentName.ENTITY_MANAGER_FACTORY, emf);
+        env.set(EnvironmentName.GLOBALS, new MapGlobalResolver());
+        env.set(EnvironmentName.TRANSACTION_MANAGER,
+                TransactionManagerServices.getTransactionManager());
+        
+        return env;
+    }
+
+    @Test 
+    public void reloadKnowledgeSessionTest() { 
+        
+        // Initialize drools environment stuff
+        Environment env = initializeEnvironment(emf);
+        KnowledgeBase kbase = initializeKnowledgeBase(simpleRule);
+        StatefulKnowledgeSession commandKSession = JPAKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        assertTrue("There should be NO facts present in a new (empty) knowledge session.", commandKSession.getFactHandles().isEmpty());
+        
+        // Persist a facthandle to the database
+        Integer integerFact = (new Random()).nextInt(Integer.MAX_VALUE-1) + 1;
+        commandKSession.insert( integerFact );
+       
+        // At this point in the code, the fact has been persisted to the database
+        //  (within a transaction via the SingleSessionCommandService) 
+        Collection<FactHandle> factHandles =  commandKSession.getFactHandles();
+        assertTrue("At least one fact should have been inserted by the ksession.insert() method above.", !factHandles.isEmpty());
+        FactHandle origFactHandle = factHandles.iterator().next();
+        assertTrue("The stored fact should contain the same number as the value inserted (but does not).", 
+                Integer.parseInt(((DefaultFactHandle) origFactHandle).getObject().toString()) == integerFact.intValue() );
+        
+        // Save the sessionInfo id in order to retrieve it later
+        int sessionInfoId = commandKSession.getId();
+        
+        // Clean up the session, environment, etc.
+        PersistenceContextManager pcm = (PersistenceContextManager) commandKSession.getEnvironment().get(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER);
+        commandKSession.dispose();
+        pcm.dispose();
+        emf.close();
+     
+        // Reload session from the database
+        emf = Persistence.createEntityManagerFactory(DROOLS_PERSISTENCE_UNIT_NAME);
+        env = initializeEnvironment(emf);
+       
+        // Re-initialize the knowledge session _and knowledge base_: 
+        //  - a KnowledgeBase instantiation (can) contain a hierarchy of references 
+        //    that eventually references an object store 
+        //    This means it _must_ be reinitialized when reloading the persistence context.
+        KnowledgeBase newkbase = initializeKnowledgeBase(simpleRule);
+        StatefulKnowledgeSession newCommandKSession 
+            = JPAKnowledgeService.loadStatefulKnowledgeSession(sessionInfoId, newkbase, null, env);
+       
+        // Test that the session has been successfully reinitialized
+        factHandles =  newCommandKSession.getFactHandles();
+        assertTrue("At least one fact should have been persisted by the ksession.insert above.", 
+                !factHandles.isEmpty() && factHandles.size() == 1);
+        FactHandle retrievedFactHandle = factHandles.iterator().next();
+        assertTrue("If the retrieved and original FactHandle object are the same, then the knowledge session has NOT been reloaded!", 
+                origFactHandle != retrievedFactHandle);
+        assertTrue("The retrieved fact should contain the same info as the original (but does not).", 
+                Integer.parseInt(((DefaultFactHandle) retrievedFactHandle).getObject().toString()) == integerFact.intValue() );
+        
+        // Test to see if the (retrieved) facts can be processed
+        ArrayList<Object>list = new ArrayList<Object>();
+        newCommandKSession.setGlobal( "list", list );
+        newCommandKSession.fireAllRules();
+        assertEquals( 1, list.size() );
+    }
+
+}

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/util/PersistenceUtil.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/util/PersistenceUtil.java
@@ -1,36 +1,92 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.persistence.util;
+
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import org.drools.persistence.jta.JtaTransactionManager;
+import org.drools.runtime.Environment;
+import org.drools.runtime.EnvironmentName;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Server;
 import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bitronix.tm.resource.jdbc.PoolingDataSource;
 
 public class PersistenceUtil {
 
-    public static final String PERSISTENCE_UNIT_NAME = "org.drools.persistence.jpa";
+    private static Logger logger = LoggerFactory.getLogger( PersistenceUtil.class );
+
+    public static final String DROOLS_PERSISTENCE_UNIT_NAME = "org.drools.persistence.jpa";
+    public static final String JBPM_PERSISTENCE_UNIT_NAME = "org.jbpm.persistence.jpa";
         
     protected static final String DATASOURCE_PROPERTIES = "/datasource.properties";
     private static TestH2Server h2Server = new TestH2Server();
+    
+    private static Properties defaultProperties = null;
+   
+    private static Properties getDefaultProperties() { 
+        if( defaultProperties == null ) { 
+            String [] keyArr = { "serverName", "portNumber", "databaseName", "url", 
+                    "user", "password", "driverClassName", "className", 
+                    "maxPoolSize", "allowLocalTransactions" };
+            String [] defaultPropArr= { "", "", "", "jdbc:h2:tcp://localhost/JPADroolsFlow", 
+                    "sa", "", "org.h2.Driver", "bitronix.tm.resource.jdbc.lrc.LrcXADataSource", 
+                    "16", "true" };
+            Assert.assertTrue("Unequal number of keys for default properties", keyArr.length == defaultPropArr.length);
+            defaultProperties = new Properties();
+            for( int i = 0; i < keyArr.length; ++i ) { 
+                defaultProperties.put(keyArr[i], defaultPropArr[i]);
+            }
+        }
+        
+        return defaultProperties;
+    }
 
-    private static Properties getDatasourceProperties() {
-        String propertiesNotFound = "Unable to load datasource properties ["+ DATASOURCE_PROPERTIES + "]";
+    public static Properties getDatasourceProperties() {
+        boolean propertiesNotFound = false;
 
         InputStream propsInputStream = PersistenceUtil.class.getResourceAsStream(DATASOURCE_PROPERTIES);
-        Assert.assertNotNull(propertiesNotFound, propsInputStream);
         Properties props = new Properties();
-        try {
-            props.load(propsInputStream);
-        } catch (IOException ioe) {
-            Assert.fail(propertiesNotFound + ": " + ioe.getMessage());
-            ioe.printStackTrace();
+        if( propsInputStream != null ) { 
+            try {
+                props.load(propsInputStream);
+            } catch (IOException ioe) {
+                propertiesNotFound = true;
+                logger.warn("Unable to find properties, using default H2 properties: " + ioe.getMessage());
+                ioe.printStackTrace();
+            }
+        }
+        else { 
+            propertiesNotFound = true;
         }
 
+        String password = props.getProperty("password");
+        if( "${maven.jdbc.password}".equals(password) || propertiesNotFound )  { 
+           props = getDefaultProperties();
+        }
+            
         return props;
     }
 
@@ -103,6 +159,18 @@ public class PersistenceUtil {
 
         return pds;
     }
+    
+    public static boolean useTransactions() { 
+        boolean useTransactions = false;
+        String databaseDriverClassName =  getDatasourceProperties().getProperty("driverClassName");
+        
+        // Postgresql has a "Large Object" api which REQUIRES the use of transactions, since 
+        //  @Lob/byte array is actually stored in multiple tables. 
+        if( databaseDriverClassName.startsWith("org.postgresql") ) { 
+            useTransactions = true;
+        }
+        return useTransactions;
+    }
 
     private static class TestH2Server {
         private Server realH2Server;
@@ -129,4 +197,30 @@ public class PersistenceUtil {
         }
 
     }
+    
+    public static Object getValueOfField(String fieldname, Object source) {
+        String sourceClassName = source.getClass().getSimpleName();
+    
+        Field field = null;
+        try {
+            field = source.getClass().getDeclaredField(fieldname);
+            field.setAccessible(true);
+        } catch (SecurityException e) {
+            fail("Unable to retrieve " + fieldname + " field from " + sourceClassName + ": " + e.getCause());
+        } catch (NoSuchFieldException e) {
+            fail("Unable to retrieve " + fieldname + " field from " + sourceClassName + ": " + e.getCause());
+        }
+    
+        assertNotNull("." + fieldname + " field is null!?!", field);
+        Object fieldValue = null;
+        try {
+            fieldValue = field.get(source);
+        } catch (IllegalArgumentException e) {
+            fail("Unable to retrieve value of " + fieldname + " from " + sourceClassName + ": " + e.getCause());
+        } catch (IllegalAccessException e) {
+            fail("Unable to retrieve value of " + fieldname + " from " + sourceClassName + ": " + e.getCause());
+        }
+        return fieldValue;
+    }
+
 }

--- a/drools-persistence-jpa/src/test/resources/META-INF/persistence.xml
+++ b/drools-persistence-jpa/src/test/resources/META-INF/persistence.xml
@@ -11,6 +11,7 @@
       <jta-data-source>jdbc/testDS1</jta-data-source>        
       <class>org.drools.persistence.info.SessionInfo</class>
       <class>org.drools.persistence.info.WorkItemInfo</class>
+      <class>org.drools.persistence.jta.TransactionTestObject</class>
       <properties>
         <property name="hibernate.max_fetch_depth" value="3"/>
         <property name="hibernate.hbm2ddl.auto" value="update" />

--- a/drools-persistence-jpa/src/test/resources/log4j.xml
+++ b/drools-persistence-jpa/src/test/resources/log4j.xml
@@ -12,9 +12,19 @@
 		<level value="INFO"/>
 	</logger>
 	
-	<!-- logger name="org.hibernate">
-		<level value="INFO"/>
-	</logger -->
+    <logger name="org.hibernate.cfg.annotations">
+        <level value="WARN"/>
+    </logger>
+    <logger name="org.hibernate.cfg.AnnotationBinder">
+        <level value="WARN"/>
+    </logger>
+    <logger name="org.hibernate.cfg.SettingsFactory">
+        <level value="WARN"/>
+    </logger>
+    <logger name="org.hibernate.tool.hbm2ddl">
+        <level value="WARN"/>
+    </logger>
+
 	<root>
 		<priority value="INFO"/>
 		<appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
This majority of this pull-request is code to fix jbpm-3106 and how the (JTA) transactions are handled by the SingleSessionCommand Service. 

The rest is additional tests and typo fixes. 

It looks like, once upon a time, someone started implementing support/logic for a local transactions (e.g. non-JTA transactions, via the entity manager, etc.) However, this logic was active when JTA transactions were being used, causing the following to sometimes happen: 
1. begin transaction (layer A)
2. begin another transaction (layer B)
3. commit transaction!! (layer B)
4. commit transaction!! -- bang (layer B). 

This happened because the logic to keep track of how started or owns the transaction, was in the transactionManager itself -- but once you start the transaction, you can't tell if you started it or someone else did. The fix is to migrate the logic to the SingleSessionCommandService. 

The change on the TransactionManager interface will break jbpm-persistence-jpa (because it also depends on that interface). I will keep track of when the pull-request is applied and make sure to fix jbpm when that happens. 

Also, the primary cause of jbpm-3106 is that SingleSessionCommandService.initKSession() was being called outside of a transaction, which is a problem when drools/jbpm runs on PostgreSQL. A @Lob in postgresql is stored via the "Large Object" mechanism (http://jdbc.postgresql.org/documentation/84/binary-data.html) which stores the actual field in another table -- thus requiring a transaction because two tables will be involved. Because initKSession() modifies the SessionInfo object (which has a @Lob) field, the initKSession() method needs to be called within a transaction. 

The pull-request also contains the following: 
- fix for PersistenceUtil so that developers not using maven plugins still get the default values
- cleaned out commented-out tests that were moved to jbpm-persistence-jpa a while ago. 
- added Copyright headers. 
- one or two typo's fix (buildComman_d_Service)
- Added a test illustrating how to reload a ksession via JPA
