### PR TITLE
Jbpm 3300 (DO NOT PULL)

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -77,7 +77,14 @@
       <artifactId>activation</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/drools-core/src/main/java/org/drools/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/impl/KnowledgeBaseImpl.java
@@ -184,7 +184,9 @@ public class KnowledgeBaseImpl
         if (sss != null) {
             for (StatefulSession ss : sss) {
                 if (ss instanceof ReteooStatefulSession) {
-                    c.add(new StatefulKnowledgeSessionImpl((ReteooStatefulSession)ss, this));
+                    StatefulKnowledgeSession session = (StatefulKnowledgeSession) ((ReteooStatefulSession) ss).getKnowledgeRuntime();
+                    ((StatefulKnowledgeSessionImpl) session).kbase = this;
+                    c.add(session);
                 }
             }
         }

--- a/drools-core/src/main/java/org/drools/marshalling/impl/InputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/marshalling/impl/InputMarshaller.java
@@ -210,6 +210,7 @@ public class InputMarshaller {
             clock.advanceTime( time,
                                TimeUnit.MILLISECONDS );
         }
+        SerializablePlaceholderResolverStrategy.cleanupCache();
 
         // RuleFlowGroups need to reference the session
         for (RuleFlowGroup group : agenda.getRuleFlowGroupsMap().values()) {

--- a/drools-core/src/main/java/org/drools/marshalling/impl/ObjectMarshallingStrategyStore.java
+++ b/drools-core/src/main/java/org/drools/marshalling/impl/ObjectMarshallingStrategyStore.java
@@ -16,6 +16,8 @@
 
 package org.drools.marshalling.impl;
 
+import java.util.HashSet;
+
 import org.drools.core.util.StringUtils;
 import org.drools.marshalling.ObjectMarshallingStrategy;
 
@@ -24,6 +26,13 @@ public class ObjectMarshallingStrategyStore {
     
     public ObjectMarshallingStrategyStore(ObjectMarshallingStrategy[] strategiesList) {
         this.strategiesList = strategiesList;
+        HashSet<Class<?>> strategySet = new HashSet<Class<?>>();
+        for( int i = 0; i < strategiesList.length; ++i ) { 
+            if( ! strategySet.add(strategiesList[i].getClass()) ) { 
+               throw new RuntimeException("Two strategy instances of type " + strategiesList[i].getClass().getSimpleName() 
+                       + " are being used. Please only use one instance of each type of strategy." );
+            }
+        }
     }
    
     // Old marshalling algorithm methods

--- a/drools-core/src/main/java/org/drools/marshalling/impl/SerializablePlaceholderResolverStrategy.java
+++ b/drools-core/src/main/java/org/drools/marshalling/impl/SerializablePlaceholderResolverStrategy.java
@@ -19,42 +19,338 @@ package org.drools.marshalling.impl;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.drools.marshalling.ObjectMarshallingStrategy;
 import org.drools.marshalling.ObjectMarshallingStrategyAcceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Joe Walnes included as author because of the use of idea's and code found here: 
+ * - http://svn.codehaus.org/xstream/trunk/xstream/src/java/com/thoughtworks/xstream/core/util/ObjectIdDictionary.java 
+ * 
+ * @author Joe Walnes
+ * @author Drools/jBPM
+ */
 public class SerializablePlaceholderResolverStrategy
     implements
     ObjectMarshallingStrategy {
 
-    private int index;
     
     private ObjectMarshallingStrategyAcceptor acceptor;
+
+    private Logger logger = LoggerFactory.getLogger(SerializablePlaceholderResolverStrategy.class);
+    
+    // We use the concurrentHashMap as a "ConcurrentHashSet". 
+    protected static HashMap<Object, Object> objectCache = new HashMap<Object, Object>();
+    protected static HashSet<String> writtenObjectHashCodeSet = new HashSet<String>();
+    // The Integer and Long constant pools mostly only cover [-127,128] -- so we use the String Constant Pool
+    protected static HashMap<String, Integer> objectIdHashCodeMap = new HashMap<String, Integer>();
+    
+    // Not final so that we can do test things
+    // The lock is static because the locked _objects_ (above) are also static!
+    protected static ReadWriteLock cacheLock = new ReentrantReadWriteLock(true);
     
     public SerializablePlaceholderResolverStrategy(ObjectMarshallingStrategyAcceptor acceptor) {
         this.acceptor = acceptor;
     }
     
-    public int getIndex() {
-        return this.index;
+    /**
+     * There are two situations that we must take into account here.</p>
+     * We are reading a data stream that was written:<ol>
+     * <li>before this JVM started
+     * <ul><li>which means that the retrieved object id references an identity hashcode that doesn't map to this JVM</li></ul></li>
+     * <li><i>by this</i> JVM and thus references an identity hashcode of an object in <i>this</i> JVM
+     *     </br>&nbsp;</li>
+     * </ol>
+     * 
+     * </p>
+     * The following applies to the description of the algorithm below: <ul>
+     * <li>The algorithm is optimized to try read locks first before resorting to write locks</li>
+     * <li>"Mapping" refers to a mapping in the objectIdHashCode map between an object id -> (object system identiy) hash code</li>
+     * </ul>
+     * 
+     * </p>
+     * 
+     * <b>Algorithm</b>
+     * </p>
+     * Check first with a read lock:</p>
+     * <ol>
+     * <li>If there is a mapping (object Id -> hashCode), retrieve the wrapped object from the cache
+     * <ol><li>If the wrapped object is not null, return the object wrapped</li>
+     *     <li>Otherwise, retry this with a write lock (checkWithWriteLock = true)</li></ol></li>
+     * <li>If there is no mapping, but 1. the written object hashcode set contains the object id and
+     *     2. the object cache contains a wrapped object for the objectId 
+     * <ol><li>then use the wrapped object
+     *     </p>[<i>this</i> JVM has written the object]</li></ol>
+     * </li>
+     * </ol>
+     * If neither of the above clauses succeeded, release the read lock and acquire a write lock:</p>
+     * <ol>
+     * <li>If there is a mapping (object Id -> hashCode),  retrieve the wrapped object from the cache
+     * <ol><li>If the wrapped object is not null, return the object wrapped</li>
+     *     <li>Otherwise, insert the read fact object into the cache and return the read fact object</li></ol></li>
+     * <li>If there is no mapping
+     * <ol><li>add the mapping and retrieve the (expectedly null) wrapped object to the cache</li>
+     *     <li>If the object does not exist in the cache as expected, add the object to the cache</li>
+     *     <li>If the object already (somehow?) exists in the cache, warn and use the read object</li></ol></li>
+     * </ol>
+     */
+    public Object read(ObjectInputStream os) throws IOException, ClassNotFoundException {
+        Object firstObject = os.readObject();
+        if( firstObject instanceof ObjectId ) { 
+            // read the next, and real object
+            Object factObject = os.readObject();
+            ObjectId objectId = (ObjectId) firstObject;
+
+            // Operations that can be done outside of the lock
+            ObjectWrapper emptyWrappedObject = new ObjectWrapper();
+            String objectIdString = String.valueOf(objectId.id).intern();
+            boolean checkWithWriteLock = true;
+            
+            // Try checking the cache with a read lock first..
+            cacheLock.readLock().lock();
+            Integer mappedHashCode = objectIdHashCodeMap.get(objectIdString);
+            if( mappedHashCode != null ) { 
+            // read lock: Mapping found for the object, retrieve object from cache
+                checkWithWriteLock = false;
+                emptyWrappedObject.setHashCode(mappedHashCode);
+                WeakObjectWrapper mappedWrappedObject = (WeakObjectWrapper) objectCache.get(emptyWrappedObject);
+                cacheLock.readLock().unlock();
+                if( mappedWrappedObject != null ) { 
+                    // Double check that garbage collection hasn't done something weird
+                    factObject = (mappedWrappedObject.get() != null ? mappedWrappedObject.get() : factObject );
+                }
+                else { 
+                    logger.error("IMPOSSIBLE situation occurred: object not present in cache " +
+                            "for object Id [{}] -> hashcode [{}] mapping of class " + factObject.getClass().getName(),
+                            objectIdString, mappedHashCode );
+                    checkWithWriteLock = true;
+                    // use the factObject read from the stream
+                }
+            }
+            else { 
+            // read lock: no mapping found
+                boolean objectWrittenByThisJVM = writtenObjectHashCodeSet.contains(objectIdString); 
+                emptyWrappedObject.setHashCode(objectId.id); 
+                WeakObjectWrapper objectIdWrappedObject = (WeakObjectWrapper) objectCache.get(emptyWrappedObject);
+                cacheLock.readLock().unlock();
+                if( objectWrittenByThisJVM && objectIdWrappedObject != null ) { 
+                // read lock: the object was written by this JVM and exists in the cache 
+                    factObject = (objectIdWrappedObject.get() != null ? objectIdWrappedObject.get() : factObject );
+                    checkWithWriteLock = false;
+                }
+            }
+            
+            if( checkWithWriteLock ) { 
+            // recheck with write lock and if still not there, proceed
+                cacheLock.writeLock().lock(); 
+                mappedHashCode = objectIdHashCodeMap.get(objectIdString);
+                if( mappedHashCode != null ) { 
+                // write lock: Between read.unlock() and write.lock(), another thread read the same object    
+                    emptyWrappedObject.setHashCode(mappedHashCode);
+                    WeakObjectWrapper mappedWrappedObject = (WeakObjectWrapper) objectCache.get(emptyWrappedObject);
+                    if( mappedWrappedObject != null ) { 
+                        cacheLock.writeLock().unlock();
+                        // Double check that garbage collection hasn't done something weird
+                        factObject = (mappedWrappedObject.get() != null ? mappedWrappedObject.get() : factObject );
+                    }
+                    else { 
+                        WeakObjectWrapper wrappedObject = new WeakObjectWrapper(factObject);
+                        objectCache.put(wrappedObject, wrappedObject);
+                        cacheLock.writeLock().unlock();
+                        logger.error("IMPOSSIBLE situation occurred: object not present in cache " +
+                                "for object Id [{}] -> hashcode [{}] mapping of class " + factObject.getClass().getName(),
+                                objectIdString, mappedHashCode );
+                        // use the factObject read from the stream
+                    }
+                }
+                else { 
+                // write lock: no mapping present for object -> The object was written by a _different_ JVM 
+                    // --> this thread is the first to insert the mapping
+                    WeakObjectWrapper wrappedObject = new WeakObjectWrapper(factObject);
+                    objectIdHashCodeMap.put(objectIdString, wrappedObject.hashCode());
+                    WeakObjectWrapper cachedWrappedObject = (WeakObjectWrapper) objectCache.put(wrappedObject, wrappedObject);
+                    cacheLock.writeLock().unlock();
+                    if( cachedWrappedObject != null ) { 
+                        /** 
+                         * If the above is true, then the object inserted DID overwrite mapping, which is weird: 
+                         * -> If this happens, it means that _another_ thread inserted an object into the cache
+                         *    with the _SAME_ (system identity) hashcode as the object that we have _just_ created!
+                         *    This is the "hashcode not unique" situation.
+                         *    
+                         * In this case, we do NOT use the cache object, but use the object read.
+                         * We can trust the content (but not integrity) of the object read,
+                         * but we can _not_ trust the content or integrity of the cached object.
+                         * 
+                         * Lastly, the cache has been updated with the new object, 
+                         * so this should not occur again for this hashcode
+                         */
+                        logger.error("IMPOSSIBLE situation occurred: object present in cache WITHOUT mapping " +
+                                     "for object Id [{}] -> hashcode [{}] mapping of class " + factObject.getClass().getName(),
+                                     objectIdString, mappedHashCode );
+                        // use the factObject read from the stream
+                    } // if objectCache.put (no mapping) returns an object
+                } // else check mapping with write lock had no results
+            } // else check mapping with readlock had no results
+
+            return factObject;
+        }
+        else { 
+            // backwards compatibility (if this replaces the serializable placeholder resolver)
+            return firstObject;
+        }
     }
 
-    public void setIndex(int index) {
-        this.index = index;
-    }
-
-    public Object read(ObjectInputStream os) throws IOException,
-                                                       ClassNotFoundException {
-        return  os.readObject();
-    }
-
-    public void write(ObjectOutputStream os,
-                      Object object) throws IOException {
-        os.writeObject( object );
+    /**
+     * This method does 2 things: <ul>
+     * <li>It serializes the object and inserts it into the stream (via .writeObject(...)).</li>
+     * <li>It inserts the object into the cache maintained by this strategy</li>
+     * </ul>
+     * 
+     * @param os The stream with which to write the object and associated information.
+     * @param object The (fact or parameter) object to serialize
+     */
+    public void write(ObjectOutputStream os, Object object) throws IOException {
+        WeakObjectWrapper wrappedObject = new WeakObjectWrapper(object);
+        cacheLock.writeLock().lock();
+        // If the hashcode has already been added, then one of two things has happened: 
+        // 1. another thread has inserted the same object (wrapped) into the cache
+        // 2. a (system identity) hashcode clash has occurred: the chances of this are _VERY_ small and we can't do anything about it.
+        if( ! objectIdHashCodeMap.containsKey(String.valueOf(wrappedObject.hashCode()).intern()) ) { 
+            // not a read object
+            if(  writtenObjectHashCodeSet.add(String.valueOf(wrappedObject.hashCode).intern()) ) { 
+                objectCache.put(wrappedObject, wrappedObject);
+            }
+        }
+        cacheLock.writeLock().unlock();
+       
+        os.writeObject(new ObjectId(wrappedObject.hashCode()));
+        os.writeObject(object);
     }
 
     public boolean accept(Object object) {
         return acceptor.accept( object );
     }
 
+    /**
+     * This method ensures that (weak) references to garbage collected objects are removed 
+     *  once the objects have been garbage collected
+     */
+    public static void cleanupCache() {
+        HashMap<Integer, String> hashCodeObjectIdMap = new HashMap<Integer, String>();
+        WeakObjectWrapper wrappedObject;
+        cacheLock.writeLock().lock();
+        for( String id : objectIdHashCodeMap.keySet() ) { 
+            hashCodeObjectIdMap.put(objectIdHashCodeMap.get(id), id);
+        }
+        while ((wrappedObject = (WeakObjectWrapper) queue.poll()) != null) {
+            writtenObjectHashCodeSet.remove(wrappedObject.hashCode());
+            objectIdHashCodeMap.remove( hashCodeObjectIdMap.get(wrappedObject.hashCode()) );
+            objectCache.remove(wrappedObject);
+        }
+        cacheLock.writeLock().unlock();
+    }
+
+    /**
+     * Helper classes: serialization
+     */
+    @SuppressWarnings("serial")
+    protected static class ObjectId implements Serializable { 
+        protected int id;
+        
+        protected ObjectId(int idValue) { 
+            this.id = idValue;
+        }
+    }
+
+    
+    /**
+     * Helper classes: caching
+     */
+    @SuppressWarnings("rawtypes")
+    private static final ReferenceQueue queue = new ReferenceQueue();
+    
+    protected static interface Wrapper {
+        int hashCode();
+        boolean equals(Object obj);
+        String toString();
+        Object get();
+    }
+
+   
+    @SuppressWarnings("rawtypes")
+    protected static class WeakObjectWrapper extends WeakReference implements Wrapper {
+
+        private final int hashCode;
+
+        @SuppressWarnings("unchecked")
+        public WeakObjectWrapper(Object obj) {
+            super(obj, queue);
+            hashCode = System.identityHashCode(obj);
+        }
+
+        public int hashCode() {
+            return hashCode;
+        }
+
+        public boolean equals(Object other) {
+            return this.hashCode == ((Wrapper)other).hashCode();
+        }
+
+        public String toString() {
+            Object obj = get();
+            return obj == null ? "(null)" : obj.toString();
+        }
+
+        public Object get() {
+            return super.get();
+        }
+    }
+    
+    protected static class ObjectWrapper implements Wrapper {
+
+        private final Object obj;
+        private int hashCode;
+
+        public ObjectWrapper() { 
+            obj = null;
+            hashCode = -1;
+        }
+        
+        @SuppressWarnings({ "unused" })
+        public ObjectWrapper(Object obj) {
+            hashCode = System.identityHashCode(obj);
+            this.obj = obj;
+        }
+
+        public void setHashCode(int hashCode) {
+            this.hashCode = hashCode;
+        }
+
+        public int hashCode() {
+            return hashCode;
+        }
+
+        public boolean equals(Object other) {
+            return this.hashCode == ((Wrapper)other).hashCode();
+        }
+
+        public String toString() {
+            Object obj = get();
+            return obj == null ? "(null)" : obj.toString();
+        }
+
+        public Object get() {
+            return obj;
+        }
+    }
+    
 }

--- a/drools-core/src/test/java/org/drools/marshalling/impl/SerializablePlaceholderResolverStrategyTest.java
+++ b/drools-core/src/test/java/org/drools/marshalling/impl/SerializablePlaceholderResolverStrategyTest.java
@@ -1,0 +1,470 @@
+package org.drools.marshalling.impl;
+
+import static junit.framework.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.drools.marshalling.ObjectMarshallingStrategy;
+import org.drools.marshalling.impl.SerializablePlaceholderResolverStrategy.ObjectWrapper;
+import org.drools.marshalling.impl.SerializablePlaceholderResolverStrategy.WeakObjectWrapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SerializablePlaceholderResolverStrategyTest { 
+
+    private SerializablePlaceholderResolverStrategy strategy;
+        
+    @Before
+    public void before() { 
+        strategy = new SerializablePlaceholderResolverStrategy(ClassObjectMarshallingStrategyAcceptor.DEFAULT);
+        SerializablePlaceholderResolverStrategy.objectCache = new HashMap<Object, Object>();
+        SerializablePlaceholderResolverStrategy.objectIdHashCodeMap = new HashMap<String, Integer>();
+    }
+   
+    @After
+    public void after() { 
+        verifyThatCacheLocksAreCleared();
+        SerializablePlaceholderResolverStrategy.cacheLock = new ReentrantReadWriteLock();
+        strategy = null;
+    }
+    
+    @Test
+    public void testRetrieveWithEmptyWrappedObject() { 
+        Object factObject = new Object();
+        WeakObjectWrapper wrappedObject = new WeakObjectWrapper(factObject);
+        ObjectWrapper emptyWrappedObject = new ObjectWrapper();        
+        emptyWrappedObject.setHashCode(wrappedObject.hashCode());
+       
+        HashMap<Object, Object> cache = new HashMap<Object, Object>();
+        
+        cache.put(wrappedObject, wrappedObject);
+        WeakObjectWrapper retrievedWrappedObject = (WeakObjectWrapper) cache.get(emptyWrappedObject);
+        Object retrievedFactObject = retrievedWrappedObject.get();
+        
+        assertTrue(retrievedFactObject == factObject);
+    }
+    
+    @Test
+    public void testReadWriteSameJVM() throws Exception {
+        Object [] fieldVals = { "Spiderman", 23, true };
+        SuperHero obj = new SuperHero(fieldVals);
+      
+        // write
+        byte [] data = serializeObjectWithStrategy(strategy, obj);
+       
+        // read
+        SuperHero objCopy = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+        assertTrue(objCopy == obj);
+        verifyFieldValuesOfObject(fieldVals, objCopy);
+        
+        // write
+        byte [] copyData = serializeObjectWithStrategy(strategy, objCopy);
+        assertThatByteArraysAreEqual(data, copyData);
+       
+        // read again
+        objCopy = (SuperHero) deserializeObjectWithStrategy(strategy, copyData);
+        assertTrue(objCopy == obj);
+        verifyFieldValuesOfObject(fieldVals, objCopy);
+    }
+
+    @Test
+    public void testReadTwiceInSameJVM() throws Exception { 
+        Object [] fieldVals = { "Superman", 24, true };
+        SuperHero obj = new SuperHero(fieldVals);
+      
+        // setup
+        byte [] data = serializeObjectWithoutStrategy(obj);
+       
+        // read
+        SuperHero objCopyA = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+        assertTrue(objCopyA != obj); // new object created
+        verifyFieldValuesOfObject(fieldVals, objCopyA);
+       
+        // read again
+        SuperHero objCopyB = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+        assertTrue(objCopyB == objCopyA); // same object used
+        verifyFieldValuesOfObject(fieldVals, objCopyB);
+    }
+    
+    @Test
+    public void testReadChangeAndReadAgain() throws Exception { 
+        Object [] fieldVals = { "Superman", 24, true };
+        SuperHero obj = new SuperHero(fieldVals);
+      
+        // setup
+        byte [] data = serializeObjectWithoutStrategy(obj);
+       
+        // read
+        SuperHero objCopyA = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+        assertTrue(objCopyA != obj); // new object created
+        verifyFieldValuesOfObject(fieldVals, objCopyA);
+   
+        // Change
+        objCopyA.name = "Bizarro";
+        objCopyA.age = 42;
+        objCopyA.good = false;
+        fieldVals = getFieldValues(objCopyA);
+        
+        // read again
+        SuperHero objCopyB = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+        assertTrue(objCopyB == objCopyA); // same object used
+        verifyFieldValuesOfObject(fieldVals, objCopyB);
+    }
+
+    @Test
+    public void testReadChangeWriteAndReadAgain() throws Exception { 
+        Object [] fieldVals = { "Superman", 24, true };
+        SuperHero obj = new SuperHero(fieldVals);
+      
+        // setup
+        byte [] data = serializeObjectWithoutStrategy(obj);
+       
+        // read
+        SuperHero objCopyA = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+        assertTrue(objCopyA != obj); // new object created
+        verifyFieldValuesOfObject(fieldVals, objCopyA);
+   
+        // change
+        objCopyA.name = "Bizarro";
+        objCopyA.age = 42;
+        objCopyA.good = false;
+        fieldVals = getFieldValues(objCopyA);
+      
+        // write
+        byte [] newData = serializeObjectWithStrategy(strategy, objCopyA);
+        
+        // read again
+        SuperHero objCopyB = (SuperHero) deserializeObjectWithStrategy(strategy, newData);
+        assertTrue(objCopyB == objCopyA); // same object used
+        verifyFieldValuesOfObject(fieldVals, objCopyB);
+    }
+    
+    
+    @Test
+    public void testAnotherThreadReadsBetweenReadAndWriteLockAfterRead() throws Exception { 
+        // data setup
+        Object [] fieldVals = { "Black Mask", 27, false };
+        SuperHero obj = new SuperHero(fieldVals);
+        byte [] data = serializeObjectWithoutStrategy(obj);
+        
+        SerializablePlaceholderResolverStrategy.cacheLock = (ReadWriteLock) WaitingReadWriteLockProxy.newInstance(new ReentrantReadWriteLock());
+       
+        WrappedObject wrappedObject = new WrappedObject();
+        ReadAndWaitTestCase readAndWaitTestCase = new ReadAndWaitTestCase(data, obj, wrappedObject, fieldVals);
+        NormalReadTestCase normalTestCase = new NormalReadTestCase(data, obj, wrappedObject, fieldVals);
+       
+        Thread readAndWaitThread = new Thread(readAndWaitTestCase);
+        Thread normalThread = new Thread(normalTestCase);
+       
+        readAndWaitThread.start();
+        // readAndWait is now waiting on the semaphore
+        
+        normalThread.start();
+        // normal has now inserted the object into the shared WrappedObject
+       
+        int w = 0; // wait max 1 second
+        while( normalThread.isAlive() && ++w < 100 ) { 
+            Thread.sleep(10);
+        }
+        if( w == 100 ) { 
+            assertTrue("NormalTest thread still alive!", ! normalThread.isAlive());
+        }
+
+        synchronized(WaitingReadWriteLockProxy.semaphore) { 
+            WaitingReadWriteLockProxy.semaphore.notifyAll();
+        }
+        // readAndWait finishes it's work (and verifies results)
+       
+        w = 0; // wait max 1 second
+        while( readAndWaitThread.isAlive() && ++w < 100 ) { 
+            Thread.sleep(10);
+        }
+        if( w == 100 ) { 
+            assertTrue("ReadAndWait thread still alive!", ! readAndWaitThread.isAlive());
+        }
+        
+        assertTrue("Read and Wait test case failed: " + readAndWaitTestCase.failMessage, 
+                readAndWaitTestCase.testFailed != true);
+        assertTrue("Normal test case failed: " + normalTestCase.failMessage, normalTestCase.testFailed != true);
+    }
+
+    @Test
+    public void testAnotherThreadReadsBetweenReadAndWriteLockAfterWrite() throws Exception { 
+        // data setup
+        Object [] fieldVals = { "Doctor Octopus", 34, false };
+        SuperHero obj = new SuperHero(fieldVals);
+        byte [] data = serializeObjectWithStrategy(strategy, obj);
+        
+        SerializablePlaceholderResolverStrategy.cacheLock = (ReadWriteLock) WaitingReadWriteLockProxy.newInstance(new ReentrantReadWriteLock());
+        
+        WrappedObject wrappedObject = new WrappedObject();
+        // original Object == read object
+        ReadAndWaitTestCase readAndWaitTestCase = new ReadAndWaitTestCase(data, null, wrappedObject, fieldVals);
+        // original object == read object
+        NormalReadTestCase normalTestCase = new NormalReadTestCase(data, null, wrappedObject, fieldVals);
+       
+        Thread readAndWaitThread = new Thread(readAndWaitTestCase);
+        Thread normalThread = new Thread(normalTestCase);
+      
+        readAndWaitThread.start();
+        // readAndWait has found object and is now waiting on the semaphore
+        normalThread.start();
+        // normal has also found object
+       
+        int w = 0; // wait max 1 second
+        while( normalThread.isAlive() && ++w < 100 ) { 
+            Thread.sleep(10);
+        }
+        if( w == 100 ) { 
+            assertTrue("NormalTest thread still alive!", ! normalThread.isAlive());
+        }
+        
+        synchronized(WaitingReadWriteLockProxy.semaphore) { 
+            WaitingReadWriteLockProxy.semaphore.notifyAll();
+        }
+        // readAndWait finishes it's work (and verifies results)
+       
+        w = 0; // wait max 1 second
+        while( readAndWaitThread.isAlive() && ++w < 100 ) { 
+            Thread.sleep(10);
+        }
+        if( w == 100 ) { 
+            assertTrue("ReadAndWait thread still alive!", ! readAndWaitThread.isAlive());
+        }
+        
+        assertTrue("Read and Wait test case failed: " + readAndWaitTestCase.failMessage, 
+                readAndWaitTestCase.testFailed != true);
+        assertTrue("Normal test case failed: " + normalTestCase.failMessage, normalTestCase.testFailed != true);
+    }
+
+    /**
+     * =============
+     * Serialize and deserialize: helper methods
+     * =============
+     */
+    
+    protected static byte [] serializeObjectWithStrategy(ObjectMarshallingStrategy strategy, Object object) throws Exception { 
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        
+        strategy.write(oos, object);
+        
+        oos.close();
+        byte [] result = baos.toByteArray();
+        baos.close();
+        return result;
+    }
+
+    protected static byte [] serializeObjectWithoutStrategy(Object object) throws Exception { 
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        
+        oos.writeObject(new SerializablePlaceholderResolverStrategy.ObjectId(System.identityHashCode(object)));
+        oos.writeObject(object);
+        
+        oos.close();
+        byte [] result = baos.toByteArray();
+        baos.close();
+        return result;
+    }
+
+    protected static Object deserializeObjectWithStrategy(ObjectMarshallingStrategy strategy, byte [] data) throws Exception { 
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        
+        Object result = strategy.read(ois);
+        
+        ois.close();
+        bais.close();
+        return result;
+    }
+
+    /**
+     * =============
+     * Checking values: helper methods 
+     * =============
+     */
+    
+    private static void assertThatByteArraysAreEqual(byte[] b1, byte[] b2) {
+        if (b1.length != b2.length) {
+            fail("byte [] length different: b1=" + b1.length + " b2=" + b2.length);
+        }
+    
+        for (int i = 0, length = b1.length; i < length; i++) {
+            if (b1[i] != b2[i]) {
+                fail("byte [] content different at byte " + i + ": [" + b1[i] + "] != [" + b2[i] + "]");
+            }
+        }
+    }
+
+    private static void verifyFieldValuesOfObject(Object [] vals, SuperHero superHero) { 
+        assertNotNull(superHero);
+        assertTrue(vals[0].equals(superHero.name));
+        assertTrue(vals[1].equals(superHero.age));
+        assertTrue(vals[2].equals(superHero.good));
+    }
+
+    /**
+     * =============
+     * Thread tests: helper objects and methods
+     * =============
+     */
+    
+    private class WrappedObject { 
+       Object obj; 
+    }
+    
+    private abstract class TestCase implements Runnable { 
+        
+        public byte [] data;
+        public Object originalObject;
+        public WrappedObject wrappedCachedObject;
+        public Object [] fieldVals;
+
+        boolean testFailed = false;
+        String failMessage;
+        
+        public TestCase(byte [] data, Object orig, WrappedObject wrappedObject, Object [] fieldVals ) { 
+            this.data = data;
+            this.originalObject = orig;
+            this.wrappedCachedObject = wrappedObject;
+            this.fieldVals = fieldVals;
+        }
+        
+    }
+    
+    /**
+     * This test class tries the read lock part of the strategy, and then waits.
+     */
+    private class ReadAndWaitTestCase extends TestCase {
+
+        public ReadAndWaitTestCase(byte[] data, Object orig, WrappedObject wrappedObject, Object[] fieldVals) {
+            super(data, orig, wrappedObject, fieldVals);
+        }
+        
+        public void run() {
+            try {
+                SuperHero objCopy = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+                if( objCopy == originalObject ) { testFailed = true; failMessage = "object different from original"; }
+                if( wrappedCachedObject.obj == null ) { 
+                    // other thread has saved object
+                    testFailed = true; 
+                    failMessage = "wrapped cached object empty"; 
+                 } 
+                if(objCopy != wrappedCachedObject.obj) { 
+                    // use object from other thread
+                    testFailed = true; 
+                    failMessage = "object from other thread not the same as retrieved object" ; 
+                } 
+                if( ! fieldValuesOfObjectAreCorrect(fieldVals, objCopy) ) { testFailed = true; failMessage = "object fields incorrect"; }
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail("Thread crashed due to " + e.getClass().getSimpleName() + " [" + e.getMessage() + "]");
+            }
+        }
+    }
+    
+    private class NormalReadTestCase extends TestCase { 
+       
+        public NormalReadTestCase(byte[] data, Object orig, WrappedObject wrappedObject, Object[] fieldVals) {
+            super(data, orig, wrappedObject, fieldVals);
+        }
+
+        public void run() {
+            try {
+                SuperHero objCopy = (SuperHero) deserializeObjectWithStrategy(strategy, data);
+                if( objCopy == null ) { testFailed = true; failMessage = "null object retrieved";} 
+                if( objCopy == originalObject ) { testFailed = true; failMessage = "object same than original"; } 
+                if( ! fieldValuesOfObjectAreCorrect(fieldVals, objCopy) ) { testFailed = true; failMessage = "fields different"; }
+                wrappedCachedObject.obj = objCopy; // save object for test in other thread
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail("Thread crashed due to " + e.getClass().getSimpleName() + " [" + e.getMessage() + "]");
+            }
+        }
+    }
+    
+    private static boolean fieldValuesOfObjectAreCorrect(Object [] vals, SuperHero superHero) { 
+        if(superHero == null) { return false; }
+        if( ! vals[0].equals(superHero.name) ) { return false; }
+        if( ! vals[1].equals(superHero.age) ) { return false; }
+        if( ! vals[2].equals(superHero.good) ) { return false; }
+        return true;
+    }
+    
+    /**
+     * The test object
+     */
+    
+    private final static String SUPER_HERO_FINALIZED = "superhero.finalized";
+
+    @SuppressWarnings("serial")
+    private static class SuperHero implements Serializable { 
+        public String name = "John";
+        public int age = 23;
+        public boolean good = true;
+        
+        public SuperHero(String name, Integer age, Boolean good)  { 
+            this.name = name;
+            this.age = age;
+            this.good = good;
+        }
+        
+        public SuperHero(Object [] fieldVals) { 
+            this((String) fieldVals[0], (Integer) fieldVals[1], (Boolean) fieldVals[2]);
+        }
+        
+        protected void finalize() throws Throwable { 
+            System.setProperty(SUPER_HERO_FINALIZED, Boolean.TRUE.toString());
+            super.finalize();
+            synchronized(WaitingReadWriteLockProxy.semaphore) { 
+                WaitingReadWriteLockProxy.semaphore.notifyAll();
+            }
+        }
+        
+    }
+
+    private static Object [] getFieldValues(SuperHero superHero) { 
+       Object [] fieldValues = new Object [3];
+       fieldValues[0] = superHero.name;
+       fieldValues[1] = superHero.age;
+       fieldValues[2] = superHero.good;
+       return fieldValues;
+    }
+
+    /**
+     * ============
+     * Locks: helper method
+     * ============
+     */
+    
+    private void verifyThatCacheLocksAreCleared() {
+        ReentrantReadWriteLock cacheLock = null;
+        if( SerializablePlaceholderResolverStrategy.cacheLock instanceof ReentrantReadWriteLock ) { 
+            cacheLock = (ReentrantReadWriteLock) SerializablePlaceholderResolverStrategy.cacheLock;
+        }
+        else if( Proxy.isProxyClass(SerializablePlaceholderResolverStrategy.cacheLock.getClass()) ) { 
+            WaitingReadWriteLockProxy handler = (WaitingReadWriteLockProxy) Proxy.getInvocationHandler(SerializablePlaceholderResolverStrategy.cacheLock);
+            cacheLock = (ReentrantReadWriteLock) handler.getMasterLock();
+        }
+        
+        // check locks
+        int stateInt = cacheLock.getReadLockCount();
+        assertTrue("There are still " + stateInt + " read locks!", stateInt == 0);
+        stateInt = cacheLock.getWriteHoldCount();
+        assertTrue("There are still " + stateInt + " write holds!", stateInt == 0);
+        assertTrue("There is still a write lock!", cacheLock.isWriteLocked() == false);
+        stateInt = cacheLock.getQueueLength(); 
+        assertTrue(stateInt + " threads are still waiting on a lock!", stateInt == 0);
+    }
+    
+}

--- a/drools-core/src/test/java/org/drools/marshalling/impl/SerializeableStrategyCacheGCTest.java
+++ b/drools-core/src/test/java/org/drools/marshalling/impl/SerializeableStrategyCacheGCTest.java
@@ -1,0 +1,158 @@
+package org.drools.marshalling.impl;
+
+import static junit.framework.Assert.assertTrue;
+import static org.drools.marshalling.impl.SerializablePlaceholderResolverStrategyTest.*;
+
+import java.io.Serializable;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+/**
+ * Putting this test into debug will cause it to fail.
+ */
+public class SerializeableStrategyCacheGCTest implements Serializable { 
+
+    /** Generated serial version UID */
+    private static final long serialVersionUID = 5112894963562141093L;
+    private transient Logger logger = LoggerFactory.getLogger(SerializeableStrategyCacheGCTest.class);
+
+    private transient SerializablePlaceholderResolverStrategy strategy;
+        
+    @Test
+    public void testCacheAndGarbageCollectionAfterRead() throws Exception { 
+        // setup
+        strategy = new SerializablePlaceholderResolverStrategy(ClassObjectMarshallingStrategyAcceptor.DEFAULT);
+        Object obj = new SerializeableStrategyCacheGCTest();
+        byte [] data = serializeObjectWithoutStrategy(obj);
+        
+        int originalCacheSize = SerializablePlaceholderResolverStrategy.objectCache.size();
+        logger.debug("Cache size: " + originalCacheSize);
+       
+        // insert object (via read) into cache
+        deserializeObjectWithStrategy(strategy, data);
+        int cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after read: " + cacheSize);
+        
+        serializeObjectWithStrategy(strategy, obj);
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after write: " + cacheSize);
+      
+        serializeObjectWithStrategy(strategy, obj);
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after second write: " + cacheSize);
+        
+        deserializeObjectWithStrategy(strategy, data);
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after second read: " + cacheSize);
+     
+        // clear references
+        obj = null;
+        
+        logger.debug("Running garbage collection.");
+        System.gc();
+        logger.debug("Waiting for garbage collection to finish.");
+        Object propVal = null;
+        while(propVal == null ) { 
+            propVal = System.getProperty(FINALIZE_PROPERTY_NAME);
+            Thread.sleep(1000);
+        }
+        logger.debug("GC done, cleaning cache of size " + SerializablePlaceholderResolverStrategy.objectCache.size() );
+        SerializablePlaceholderResolverStrategy.cleanupCache();
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue("Original object not garbage collected or clean up has failed: " + cacheSize + " > " + originalCacheSize, 
+                cacheSize <= originalCacheSize);
+        verifyThatCacheLocksAreCleared();
+    }
+
+    @Test
+    public void testCacheAndGarbageCollectionAfterWrite() throws Exception { 
+        // setup
+        strategy = new SerializablePlaceholderResolverStrategy(ClassObjectMarshallingStrategyAcceptor.DEFAULT);
+        Object obj = new SerializeableStrategyCacheGCTest();
+        
+        int originalCacheSize = SerializablePlaceholderResolverStrategy.objectCache.size();
+        logger.debug("Cache size: " + originalCacheSize);
+       
+        // Insert object (via write) into cache
+        byte [] data = serializeObjectWithStrategy(strategy, obj);
+        int cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after write: " + cacheSize);
+      
+        deserializeObjectWithStrategy(strategy, data);
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after read: " + cacheSize);
+        
+        serializeObjectWithStrategy(strategy, obj);
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after second write: " + cacheSize);
+
+        deserializeObjectWithStrategy(strategy, data);
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue( "Cache size " + cacheSize, cacheSize == originalCacheSize + 1);
+        logger.debug("Cache size after second read: " + cacheSize);
+        
+        // clear references
+        obj = null;
+        
+        logger.debug("Running garbage collection.");
+        System.gc();
+        logger.debug("Waiting for garbage collection to finish.");
+        Object propVal = null;
+        while(propVal == null ) { 
+            propVal = System.getProperty(FINALIZE_PROPERTY_NAME);
+            Thread.sleep(1000);
+        }
+        logger.debug("GC done, cleaning cache of size " + SerializablePlaceholderResolverStrategy.objectCache.size() );
+        SerializablePlaceholderResolverStrategy.cleanupCache();
+        cacheSize = SerializablePlaceholderResolverStrategy.objectCache.size(); 
+        assertTrue("Original object not garbage collected or clean up has failed: " + cacheSize + " > " + originalCacheSize, 
+                cacheSize <= originalCacheSize);
+        verifyThatCacheLocksAreCleared();
+    }
+    
+    /**
+     * The test object
+     */
+   
+    private final static String FINALIZE_PROPERTY_NAME = "finalized";
+    protected void finalize() throws Throwable {
+        System.setProperty(FINALIZE_PROPERTY_NAME, Boolean.TRUE.toString());
+        super.finalize();
+    }
+
+    /**
+     * ============
+     * Locks: helper method
+     * ============
+     */
+    
+    private void verifyThatCacheLocksAreCleared() {
+        ReentrantReadWriteLock cacheLock = null;
+        if( SerializablePlaceholderResolverStrategy.cacheLock instanceof ReentrantReadWriteLock ) { 
+            cacheLock = (ReentrantReadWriteLock) SerializablePlaceholderResolverStrategy.cacheLock;
+        }
+        else { 
+            throw new RuntimeException("Unexpected lock type: " 
+                    + SerializablePlaceholderResolverStrategy.cacheLock.getClass().getSimpleName() );
+        }
+        
+        // check locks
+        int stateInt = cacheLock.getReadLockCount();
+        assertTrue("There are still " + stateInt + " read locks!", stateInt == 0);
+        stateInt = cacheLock.getWriteHoldCount();
+        assertTrue("There are still " + stateInt + " write holds!", stateInt == 0);
+        assertTrue("There is still a write lock!", cacheLock.isWriteLocked() == false);
+        stateInt = cacheLock.getQueueLength(); 
+        assertTrue(stateInt + " threads are still waiting on a lock!", stateInt == 0);
+    }
+    
+}

--- a/drools-core/src/test/java/org/drools/marshalling/impl/WaitingReadWriteLockProxy.java
+++ b/drools-core/src/test/java/org/drools/marshalling/impl/WaitingReadWriteLockProxy.java
@@ -1,0 +1,146 @@
+package org.drools.marshalling.impl;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WaitingReadWriteLockProxy implements InvocationHandler { 
+   
+    private static Logger logger = LoggerFactory.getLogger(WaitingReadWriteLockProxy.class);
+   
+    public static Object semaphore = new Object();
+    
+    public static Object newInstance( ReadWriteLock readWriteLock ) {
+        return Proxy.newProxyInstance(
+                readWriteLock.getClass().getClassLoader(), 
+                getAllInterfaces(readWriteLock),
+                new WaitingReadWriteLockProxy(readWriteLock));
+    }
+    
+    public static Object newInstance( Lock readOrWriteLock ) {
+        return Proxy.newProxyInstance(
+                readOrWriteLock.getClass().getClassLoader(), 
+                getAllInterfaces(readOrWriteLock),
+                new WaitingReadWriteLockProxy(readOrWriteLock));
+    }
+    
+    /**
+     * This method is used in the {@link #newInstance(Object)} method to retrieve all applicable interfaces
+     *   that the proxy object must conform to. 
+     * @param obj The object that will be proxied. 
+     * @return Class<?> [] an array of all applicable interfaces.
+     */
+    protected static Class<?> [] getAllInterfaces( Object obj ) { 
+        Class<?> [] interfaces = new Class [0];
+        Class<?> superClass = obj.getClass();
+        while( superClass != null ) { 
+            Class<?> [] addThese = superClass.getInterfaces();
+            if( addThese.length > 0 ) { 
+                Class<?> [] moreinterfaces = new Class [interfaces.length + addThese.length];
+                System.arraycopy(interfaces, 0, moreinterfaces, 0, interfaces.length);
+                System.arraycopy(addThese, 0, moreinterfaces, interfaces.length, addThese.length);
+                interfaces = moreinterfaces;
+            }
+            superClass = superClass.getSuperclass();
+        }
+        return interfaces;
+    }
+    
+
+    ReadWriteLock master = null;
+    ReadLock reader = null;
+    WriteLock writer = null;
+    Lock readerInstance = null;
+    Lock writerInstance = null;
+    
+    private WaitingReadWriteLockProxy(ReadWriteLock readWriteLock) { 
+        this.master = readWriteLock;
+        this.readerInstance = (Lock) newInstance(master.readLock());
+        this.writerInstance = (Lock) newInstance(master.writeLock());
+    }
+    
+    private WaitingReadWriteLockProxy(Lock readerOrWriter) { 
+        if( readerOrWriter instanceof ReadLock ) { 
+            this.reader = (ReadLock) readerOrWriter;
+        }
+        else if( readerOrWriter instanceof WriteLock ) { 
+            this.writer = (WriteLock) readerOrWriter;
+        }
+        else { 
+            throw new UnsupportedOperationException("Lock type not appropriate for this proxy: " + readerOrWriter.getClass().getSimpleName() );
+        }
+    }
+    
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object result = null;
+        String methodName = method.getName();
+        
+        if( "readLock".equals(methodName) ) { 
+           return readerInstance;
+        }
+        if( "writeLock".equals(methodName) ) { 
+           return writerInstance;
+        }
+        if( "unlock".equals(methodName) ) { 
+           if( reader != null ) { 
+               reader.unlock();
+               synchronized(semaphore) { 
+                   StackTraceElement [] ste = Thread.currentThread().getStackTrace();
+                   for( int i = 0; i < ste.length; ++i ) { 
+                       if( (SerializablePlaceholderResolverStrategyTest.class.getName() + "$ReadAndWaitTestCase")
+                            .equals(ste[i].getClassName()) ) {
+                           semaphore.wait();
+                           break;
+                       }
+                   }
+               }
+           }
+           else if( writer != null ) { 
+               writer.unlock();
+           }
+           else { 
+                throw new UnsupportedOperationException("No real objects available to invoke method " + methodName );
+           }
+        }
+        else { 
+            if( master != null ) { 
+                result = invoke(method, master, args);
+            }
+            else if( reader != null ) { 
+                result = invoke(method, reader, args);
+            }
+            else if( writer != null ) { 
+                result = invoke(method, writer, args);
+            }
+            else { 
+                throw new UnsupportedOperationException("No real objects available to invoke method " + methodName );
+            }
+        }
+        
+        return result;
+    }
+
+    private Object invoke( Method method, Object object, Object[] args) throws Throwable { 
+        Object result = null;
+        try { 
+            result = method.invoke(object, args);
+        } catch( InvocationTargetException ite ) { 
+           logger.warn(method.getName() + " threw " + ite.getClass().getSimpleName() + ": " + ite.getMessage());
+           throw ite;
+        }
+        return result;
+    }
+    
+    public ReadWriteLock getMasterLock() { 
+        return master;
+    }
+    
+}

--- a/drools-core/src/test/resources/log4j.xml
+++ b/drools-core/src/test/resources/log4j.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out"/>
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%-4r %d{dd/MM HH:mm:ss,SSS}[%t] %-5p %c{3}.%M %x - %m%n"/>
+		</layout>
+	</appender>
+
+	<logger name="org.drools">
+		<level value="INFO"/>
+	</logger>
+  
+	<root>
+		<priority value="INFO"/>
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</log4j:configuration>


### PR DESCRIPTION
While this commit solves the [JBPM-3300](https://issues.jboss.org/browse/JBPM-3300) problem, it also causes the tests listed below to fail. 

_JBPM-3300 problem_: 
When we insert an object into a knowledge session and _also_ into a work item and/or a process, then users expect the modifications to the object in the process to be mirrored in the state of the object in the ksession. 

However, unmarshalling/deserialization (which uses SerializedPlaceholderResolverStrategy) breaks the "link" between the object in the ksession and the process, and recreates one object for the ksession and another for the process. Modifications to "the object" by either the ksession, process or user after that point then cause problems, obviously. 

_Failing Tests_: 
Unfortunately, I don't understand enough about  Drools internals why the tests failing below are failing. Debugging has pointed to a number of things, including (possibly?) agenda items and (concurrent) node memories. 

Help would be appreciated. :) 

```
Failed tests: 
      testMarshallEntryPointsWithSlidingTimeWindow(org.drools.integrationtests.marshalling.MarshallingTest)
      testMarshallEntryPointsWithSlidingLengthWindow(org.drools.integrationtests.marshalling.MarshallingTest)

Tests in error: 
      testCollect(org.drools.integrationtests.FirstOrderLogicTest)
      testCollectNodeSharing(org.drools.integrationtests.FirstOrderLogicTest)
      testCollectResultConstraints(org.drools.integrationtests.FirstOrderLogicTest)
      testCollectFromMVELAfterOr(org.drools.integrationtests.FirstOrderLogicTest)
      testInsertionOrderTwo(org.drools.integrationtests.BackwardChainingTest)
      testAccumulate(org.drools.integrationtests.marshalling.MarshallingTest)
```
