### PR TITLE
Jbrules 3304

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/info/WorkItemInfo.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/info/WorkItemInfo.java
@@ -16,6 +16,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 
+import org.drools.common.InternalRuleBase;
 import org.drools.marshalling.impl.InputMarshaller;
 import org.drools.marshalling.impl.MarshallerReaderContext;
 import org.drools.marshalling.impl.MarshallerWriteContext;
@@ -86,13 +87,13 @@ public class WorkItemInfo  {
        return workItemByteArray;
     }
     
-    public WorkItem getWorkItem(Environment env) {
+    public WorkItem getWorkItem(Environment env, InternalRuleBase ruleBase) {
         this.env = env;
         if ( workItem == null ) {
             try {
                 ByteArrayInputStream bais = new ByteArrayInputStream( workItemByteArray );
                 MarshallerReaderContext context = new MarshallerReaderContext( bais,
-                                                                               null,
+                                                                               ruleBase,
                                                                                null,
                                                                                null,
                                                                                env);


### PR DESCRIPTION
[JBRULES-3304](https://issues.jboss.org/browse/JBRULES-3304): 

Because the rulebase does not get inserted into the (marshaller) context that's used for unmarshalling a WorkItem(Info), when MarshallerReaderContext.resolveClass(ObjectStreamClass) get's called, it can not use the ruleBase's root class loader.

If necessary, I can supply a test case for this to show where it goes wrong – at the moment it disappeared with a stash I dropped so that I'll have to recreate it.

Based on the 5.3.x branch, please also cherry-pick to master. 
