### PR TITLE
JBRULES-3296: org.drools.io.impl.ClassPathResource lastRead not getting set

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/ClassPathResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/ClassPathResource.java
@@ -103,6 +103,9 @@ public class ClassPathResource extends BaseResource
      * @see java.lang.Class#getResourceAsStream(String)
      */
     public InputStream getInputStream() throws IOException {
+	//update the lastRead field
+	this.lastRead = this.getLastModified();
+
         //Some ClassLoaders caches the result of getResourceAsStream() this is
         //why we get the Input Stream from the URL of the resource
         //@see JBRULES-2960

--- a/drools-core/src/main/java/org/drools/io/impl/ClassPathResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/ClassPathResource.java
@@ -103,8 +103,8 @@ public class ClassPathResource extends BaseResource
      * @see java.lang.Class#getResourceAsStream(String)
      */
     public InputStream getInputStream() throws IOException {
-	//update the lastRead field
-	this.lastRead = this.getLastModified();
+        //update the lastRead field
+        this.lastRead = this.getLastModified();
 
         //Some ClassLoaders caches the result of getResourceAsStream() this is
         //why we get the Input Stream from the URL of the resource


### PR DESCRIPTION
- lastRead is now modified when the IputStream of the resource is accessed. This was the behavior until the last modification of this class (where this bug was introduced).
