### PR TITLE
Standardizing commands

### DIFF
--- a/drools-core/src/main/java/org/drools/command/IdentifiableResult.java
+++ b/drools-core/src/main/java/org/drools/command/IdentifiableResult.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2011 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.command;
+
+/**
+ *
+ * @author salaboy
+ */
+public interface IdentifiableResult {
+    public String getOutIdentifier();
+    public void setOutIdentifier(String outIdentifier);
+    
+}

--- a/drools-core/src/main/java/org/drools/command/impl/CommandFactoryServiceImpl.java
+++ b/drools-core/src/main/java/org/drools/command/impl/CommandFactoryServiceImpl.java
@@ -115,7 +115,6 @@ public class CommandFactoryServiceImpl implements CommandFactoryService {
 
     public Command newSetGlobal(String identifier, Object object, boolean out) {
         SetGlobalCommand cmd = new SetGlobalCommand(identifier, object);
-        cmd.setOut(out);
         return cmd;
     }
 

--- a/drools-core/src/main/java/org/drools/command/runtime/GetGlobalCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/GetGlobalCommand.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
@@ -30,7 +31,7 @@ import org.drools.runtime.impl.ExecutionResultImpl;
 @XmlAccessorType(XmlAccessType.NONE)
 public class GetGlobalCommand
     implements
-    GenericCommand<Object> {
+    GenericCommand<Object>, IdentifiableResult {
 
     private static final long serialVersionUID = 510l;
 

--- a/drools-core/src/main/java/org/drools/command/runtime/SetGlobalCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/SetGlobalCommand.java
@@ -18,23 +18,22 @@ package org.drools.command.runtime;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
 import org.drools.runtime.StatefulKnowledgeSession;
-import org.drools.xml.jaxb.util.JaxbListAdapter;
 import org.drools.xml.jaxb.util.JaxbUnknownAdapter;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class SetGlobalCommand
     implements
-    GenericCommand<Object> {
+    GenericCommand<Object> , IdentifiableResult{
 
     @XmlAttribute(required=true)
     private String  identifier;

--- a/drools-core/src/main/java/org/drools/command/runtime/SetGlobalCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/SetGlobalCommand.java
@@ -44,9 +44,6 @@ public class SetGlobalCommand
 
     @XmlAttribute(name="out-identifier")
     private String  outIdentifier;
-
-    @XmlAttribute
-    private boolean out;
     
     public SetGlobalCommand() {
     }
@@ -60,8 +57,8 @@ public class SetGlobalCommand
     public Object execute(Context context) {
         StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
 
-        if ( this.out ) {
-            ((StatefulKnowledgeSessionImpl) ksession).session.getExecutionResult().getResults().put( (this.outIdentifier != null) ? this.outIdentifier : this.identifier,
+        if ( this.outIdentifier != null ) {
+            ((StatefulKnowledgeSessionImpl) ksession).session.getExecutionResult().getResults().put( this.outIdentifier ,
                                                                                                      object );
         }
 
@@ -92,15 +89,6 @@ public class SetGlobalCommand
 
     public void setOutIdentifier(String outIdentifier) {
         this.outIdentifier = outIdentifier;
-        this.out = true;
-    }
-
-    public boolean isOut() {
-        return this.out;
-    }
-
-    public void setOut(boolean out) {
-        this.out = out;
     }
 
     public String toString() {

--- a/drools-core/src/main/java/org/drools/command/runtime/process/CreateProcessInstanceCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/process/CreateProcessInstanceCommand.java
@@ -28,6 +28,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.runtime.StatefulKnowledgeSession;
@@ -36,7 +37,7 @@ import org.drools.runtime.process.ProcessInstance;
 import org.drools.xml.jaxb.util.JaxbMapAdapter;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class CreateProcessInstanceCommand implements GenericCommand<ProcessInstance> {
+public class CreateProcessInstanceCommand implements GenericCommand<ProcessInstance>, IdentifiableResult {
 
     @XmlAttribute(required = true)
     private String processId;

--- a/drools-core/src/main/java/org/drools/command/runtime/process/StartProcessCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/process/StartProcessCommand.java
@@ -28,6 +28,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.runtime.StatefulKnowledgeSession;
@@ -36,7 +37,7 @@ import org.drools.runtime.process.ProcessInstance;
 import org.drools.xml.jaxb.util.JaxbMapAdapter;
 
 @XmlAccessorType(XmlAccessType.NONE)
-public class StartProcessCommand implements GenericCommand<ProcessInstance> {
+public class StartProcessCommand implements GenericCommand<ProcessInstance>, IdentifiableResult {
 
     @XmlAttribute(required = true)
     private String processId;

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/FireAllRulesCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/FireAllRulesCommand.java
@@ -19,9 +19,9 @@ package org.drools.command.runtime.rule;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
@@ -32,7 +32,7 @@ import org.drools.runtime.rule.AgendaFilter;
 @XmlAccessorType(XmlAccessType.NONE)
 public class FireAllRulesCommand
     implements
-    GenericCommand<Integer> {
+    GenericCommand<Integer>, IdentifiableResult {
 
     @XmlAttribute
     private int          max          = -1;

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/GetObjectCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/GetObjectCommand.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.common.DefaultFactHandle;
@@ -31,7 +32,7 @@ import org.drools.runtime.rule.FactHandle;
 @XmlAccessorType(XmlAccessType.NONE)
 public class GetObjectCommand
     implements
-    GenericCommand<Object> {
+    GenericCommand<Object>, IdentifiableResult {
 
     private FactHandle factHandle;
     private String     outIdentifier;

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/GetObjectsCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/GetObjectsCommand.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
@@ -37,7 +38,7 @@ import org.drools.runtime.StatefulKnowledgeSession;
 @XmlAccessorType(XmlAccessType.NONE)
 public class GetObjectsCommand
     implements
-    GenericCommand<Collection> {
+    GenericCommand<Collection>, IdentifiableResult {
 
     public String getOutIdentifier() {
         return outIdentifier;

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/GetWorkingMemoryEntryPointCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/GetWorkingMemoryEntryPointCommand.java
@@ -19,10 +19,8 @@ package org.drools.command.runtime.rule;
 import org.drools.command.Context;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
-import org.drools.reteoo.ReteooWorkingMemory;
 import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.rule.WorkingMemoryEntryPoint;
-import org.drools.time.SessionClock;
 
 public class GetWorkingMemoryEntryPointCommand
     implements

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/GetWorkingMemoryEntryPointsCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/GetWorkingMemoryEntryPointsCommand.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import org.drools.command.Context;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
-import org.drools.reteoo.ReteooWorkingMemory;
 import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.rule.WorkingMemoryEntryPoint;
 

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/GetWorkingMemoryEventListenersCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/GetWorkingMemoryEventListenersCommand.java
@@ -22,8 +22,6 @@ import org.drools.command.Context;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.event.rule.WorkingMemoryEventListener;
-import org.drools.reteoo.ReteooWorkingMemory;
-import org.drools.runtime.Globals;
 import org.drools.runtime.StatefulKnowledgeSession;
 
 public class GetWorkingMemoryEventListenersCommand

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/HaltCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/HaltCommand.java
@@ -19,7 +19,6 @@ package org.drools.command.runtime.rule;
 import org.drools.command.Context;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
-import org.drools.reteoo.ReteooWorkingMemory;
 import org.drools.runtime.StatefulKnowledgeSession;
 
 public class HaltCommand

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/InsertElementsCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/InsertElementsCommand.java
@@ -22,13 +22,12 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlMixed;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.core.util.StringUtils;
@@ -37,13 +36,11 @@ import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.rule.FactHandle;
 import org.drools.runtime.rule.WorkingMemoryEntryPoint;
 import org.drools.xml.jaxb.util.JaxbCollectionAdapter;
-import org.drools.xml.jaxb.util.JaxbListAdapter;
-import org.drools.xml.jaxb.util.JaxbListWrapper;
 
 @XmlAccessorType( XmlAccessType.NONE )
 public class InsertElementsCommand
     implements
-    GenericCommand<Collection<FactHandle>> {
+    GenericCommand<Collection<FactHandle>>, IdentifiableResult {
 
     private static final long serialVersionUID = 510l;
 

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/InsertObjectCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/InsertObjectCommand.java
@@ -24,10 +24,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.common.DefaultFactHandle;
-import org.drools.common.DisconnectedFactHandle;
 import org.drools.core.util.StringUtils;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
 import org.drools.reteoo.ReteooWorkingMemory;
@@ -38,7 +38,7 @@ import org.drools.xml.jaxb.util.JaxbUnknownAdapter;
 @XmlAccessorType(XmlAccessType.NONE)
 public class InsertObjectCommand
     implements
-    GenericCommand<FactHandle> {
+    GenericCommand<FactHandle>, IdentifiableResult {
 
     private static final long serialVersionUID = 510l;
 

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/InsertObjectInEntryPointCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/InsertObjectInEntryPointCommand.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.common.DefaultFactHandle;
@@ -32,7 +33,7 @@ import org.drools.runtime.rule.WorkingMemoryEntryPoint;
 @XmlAccessorType(XmlAccessType.NONE)
 public class InsertObjectInEntryPointCommand
         implements
-        GenericCommand<FactHandle> {
+        GenericCommand<FactHandle>, IdentifiableResult {
 
     private static final long serialVersionUID = 510l;
     @XmlElement
@@ -89,13 +90,6 @@ public class InsertObjectInEntryPointCommand
         this.outIdentifier = outIdentifier;
     }
 
-    public boolean isReturnObject() {
-        return returnObject;
-    }
-
-    public void setReturnObject(boolean returnObject) {
-        this.returnObject = returnObject;
-    }
 
     public String toString() {
         return "session.insert(" + object + ");";

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/QueryCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/QueryCommand.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 import org.drools.command.Context;
+import org.drools.command.IdentifiableResult;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
@@ -34,7 +35,7 @@ import org.drools.runtime.rule.QueryResults;
 import org.drools.runtime.rule.Variable;
 
 @XmlAccessorType( XmlAccessType.NONE )
-public class QueryCommand  implements GenericCommand<QueryResults> {
+public class QueryCommand  implements GenericCommand<QueryResults>, IdentifiableResult {
 
     private static final long serialVersionUID = 510l;
 

--- a/drools-core/src/main/java/org/drools/runtime/help/impl/XStreamJSon.java
+++ b/drools-core/src/main/java/org/drools/runtime/help/impl/XStreamJSon.java
@@ -865,11 +865,7 @@ public class XStreamJSon {
                 writer.startNode( "out-identifier" );
                 writer.setValue( cmd.getOutIdentifier() );
                 writer.endNode();
-            } else if ( cmd.isOut() ) {
-                writer.startNode( "out" );
-                writer.setValue( Boolean.toString( cmd.isOut() ) );
-                writer.endNode();
-            }
+            } 
             writeValue( writer,
                         context,
                         "object",
@@ -907,9 +903,7 @@ public class XStreamJSon {
 
             if ( outIdentifier != null ) {
                 cmd.setOutIdentifier( outIdentifier );
-            } else if ( out != null ) {
-                cmd.setOut( Boolean.parseBoolean( out ) );
-            }
+            } 
             return cmd;
         }
 

--- a/drools-core/src/main/java/org/drools/runtime/help/impl/XStreamXML.java
+++ b/drools-core/src/main/java/org/drools/runtime/help/impl/XStreamXML.java
@@ -351,10 +351,7 @@ public static class SetGlobalConverter extends AbstractCollectionConverter
       if ( cmd.getOutIdentifier() != null ) {
           writer.addAttribute( "out-identifier",
                                cmd.getOutIdentifier() );
-      } else if ( cmd.isOut() ) {
-          writer.addAttribute( "out",
-                               Boolean.toString( cmd.isOut() ) );
-      }
+      } 
 
       writeItem( cmd.getObject(),
                  context,
@@ -376,9 +373,7 @@ public static class SetGlobalConverter extends AbstractCollectionConverter
                                                    object );
       if ( identifierOut != null ) {
           cmd.setOutIdentifier( identifierOut );
-      } else if ( out != null ) {
-          cmd.setOut( Boolean.parseBoolean( out ) );
-      }
+      } 
       return cmd;
   }
 


### PR DESCRIPTION
I've extracted an interface called IdentifiableResults to mark all the commands that uses the OutIdentifier property to return a value. 
In a different commit I've modify the SetGlobal Command to not use the out boolean and work in the same way at the other commands that uses the OutIdentifier. Notice that the out boolean was set True and no one else was using it.
This is the first step to improve and standardize the commands
