### PR TITLE
unit test that exercises bad expression binding type discovery

### DIFF
--- a/drools-compiler/src/test/java/org/drools/integrationtests/AccumulateTest.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/AccumulateTest.java
@@ -1931,4 +1931,59 @@ public class AccumulateTest {
         ksession.fireAllRules();
         ksession.dispose();
     }
+
+    public static class MyObj {
+        public static class NestedObj {
+            public long value;
+
+            public NestedObj(long value) {
+                this.value = value;
+            }
+        }
+
+        private NestedObj nestedObj;
+
+        public MyObj(long value) {
+            nestedObj = new NestedObj(value);
+        }
+
+        public NestedObj getNestedObj() {
+            return nestedObj;
+        }
+    }
+
+    @Test
+    public void testAccumulateWithBoundExpression() {
+        String drl = "package org.drools;\n" +
+                "import org.drools.integrationtests.AccumulateTest.MyObj;\n" +
+                "global java.util.List results\n" +
+                "rule init\n" +
+                "when\n" +
+                "then\n" +
+                "insert( new MyObj(5) );\n" +
+                "insert( new MyObj(4) );\n" +
+                "end\n" +
+                "rule foo\n" +
+                "salience -10\n" +
+                "when\n" +
+                "$n : Number() from accumulate( MyObj( $val : nestedObj.value ),\n" +
+                "sum( $val ) )\n" +
+                "then\n" +
+                "System.out.println($n);\n" +
+                "results.add($n);\n" +
+                "end";
+
+        KnowledgeBase kbase = loadKnowledgeBaseFromString( drl );
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+        final List<String> results = new ArrayList<String>();
+        ksession.setGlobal( "results",
+                            results );
+        ksession.fireAllRules();
+        ksession.dispose();
+        assertEquals( 1,
+                      results.size() );
+        assertEquals( 9.0,
+                      results.get( 0 ) );
+    }
 }


### PR DESCRIPTION
When run, this test fails with the following assertion error:

java.lang.AssertionError: Unable to generate rule invoker. : [Accumulate: input=[AND [[Pattern: id=null; objectType=MyObj]] ]]
    org/drools/Rule_foo_3191b39fd6ce40eaac55301df07acc19AccumulateExpression0Invoker.java (19:754) : Cannot cast from Object to long
