### PR TITLE
JBRULES-3122: ClassLoader.getResources() returns null - fixed

### DIFF
--- a/drools-core/src/main/java/org/drools/rule/JavaDialectRuntimeData.java
+++ b/drools-core/src/main/java/org/drools/rule/JavaDialectRuntimeData.java
@@ -41,10 +41,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 
 import org.drools.RuntimeDroolsException;
-import org.drools.common.DroolsObjectInputStream;
-import org.drools.core.util.DroolsClassLoader;
 import org.drools.core.util.KeyStoreHelper;
 import org.drools.core.util.StringUtils;
 import org.drools.spi.Wireable;
@@ -594,8 +593,16 @@ public class JavaDialectRuntimeData
             return null;
         }
         
-        public Enumeration<URL> getResources(String name) throws IOException {
-            return null;
+		public Enumeration<URL> getResources(String name) throws IOException {
+			return new Enumeration<URL>() {
+				public boolean hasMoreElements() {
+					return false;
+				}
+
+				public URL nextElement() {
+					throw new NoSuchElementException();
+				}
+			};
         }
 
     }

--- a/drools-core/src/main/java/org/drools/rule/JavaDialectRuntimeData.java
+++ b/drools-core/src/main/java/org/drools/rule/JavaDialectRuntimeData.java
@@ -41,10 +41,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 
 import org.drools.RuntimeDroolsException;
-import org.drools.common.DroolsObjectInputStream;
-import org.drools.core.util.DroolsClassLoader;
 import org.drools.core.util.KeyStoreHelper;
 import org.drools.core.util.StringUtils;
 import org.drools.spi.Wireable;
@@ -595,7 +594,15 @@ public class JavaDialectRuntimeData
         }
         
         public Enumeration<URL> getResources(String name) throws IOException {
-            return null;
+            return new Enumeration<URL>() {
+                public boolean hasMoreElements() {
+                    return false;
+                }
+
+                public URL nextElement() {
+                    throw new NoSuchElementException();
+                }
+            };
         }
 
     }

--- a/drools-core/src/test/java/org/drools/factmodel/ClassBuilderTest.java
+++ b/drools-core/src/test/java/org/drools/factmodel/ClassBuilderTest.java
@@ -525,4 +525,31 @@ public class ClassBuilderTest {
         }
 
     }
+
+    @Test
+    public void testGetResourcesJBRULES3122() {
+        try {
+            ClassBuilder builder = ClassBuilderFactory.getBeanClassBuilderService();
+
+            ClassDefinition classDef = new ClassDefinition("org.drools.TestClass4", null, new String[] {});
+            // FieldDefinition intDef = new FieldDefinition( "intAttr",
+            // "int",
+            // true );
+            // classDef.addField( intDef );
+
+            Class clazz = build(builder, classDef);
+            // intDef.setReadWriteAccessor( store.getAccessor( clazz,
+            // intDef.getName(),
+            // classLoader ) );
+            //
+            ClassLoader cl = clazz.getClassLoader();
+
+            // We expect normal classloader stuff to work
+            assertFalse(cl.getResources("not-there.txt").hasMoreElements());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception not expected: " + e.getMessage());
+        }
+    }
+
 }

--- a/drools-core/src/test/java/org/drools/factmodel/ClassBuilderTest.java
+++ b/drools-core/src/test/java/org/drools/factmodel/ClassBuilderTest.java
@@ -525,4 +525,31 @@ public class ClassBuilderTest {
         }
 
     }
+
+	@Test
+	public void testGetResourcesJBRULES3122() {
+		try {
+			ClassBuilder builder = ClassBuilderFactory.getBeanClassBuilderService();
+
+			ClassDefinition classDef = new ClassDefinition("org.drools.TestClass4", null, new String[] {});
+			// FieldDefinition intDef = new FieldDefinition( "intAttr",
+			// "int",
+			// true );
+			// classDef.addField( intDef );
+
+			Class clazz = build(builder, classDef);
+			// intDef.setReadWriteAccessor( store.getAccessor( clazz,
+			// intDef.getName(),
+			// classLoader ) );
+			//
+			ClassLoader cl = clazz.getClassLoader();
+
+			// We expect normal classloader stuff to work
+			assertFalse(cl.getResources("not-there.txt").hasMoreElements());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Exception not expected: " + e.getMessage());
+		}
+	}
+
 }


### PR DESCRIPTION
I've added a simple test case which checks the getResources() call in PackageClassLoader, and supplied the fix also. ClassLoader.getResources() cannot return a null value, according to the spec.
