### PR TITLE
Added ScannerChangeSetTest which scans CSV resource file for changes.

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/FileManager.java
+++ b/drools-core/src/main/java/org/drools/core/util/FileManager.java
@@ -19,9 +19,11 @@ package org.drools.core.util;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.UUID;
 
@@ -191,6 +193,20 @@ public class FileManager {
                text );
 
         return f;
+    }
+    
+    public String readInputStreamReaderAsString(InputStreamReader in) throws IOException {
+        StringBuffer fileData = new StringBuffer(1000);
+        BufferedReader reader = new BufferedReader(in);
+        char[] buf = new char[1024];
+        int numRead = 0;
+        while ((numRead = reader.read(buf)) != -1) {
+            String readData = String.valueOf(buf, 0, numRead);
+            fileData.append(readData);
+            buf = new char[1024];
+        }
+        reader.close();
+        return fileData.toString();
     }
 
 }

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/ScannerChangeSetTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/ScannerChangeSetTest.java
@@ -1,0 +1,94 @@
+package org.drools.decisiontable;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.drools.KnowledgeBase;
+import org.drools.agent.KnowledgeAgent;
+import org.drools.agent.KnowledgeAgentFactory;
+import org.drools.core.util.FileManager;
+import org.drools.io.ResourceChangeScannerConfiguration;
+import org.drools.io.ResourceFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ScannerChangeSetTest {
+
+	FileManager fileManager;
+
+	@Before
+	public void setUp() throws Exception {
+		fileManager = new FileManager();
+		fileManager.setUp();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		fileManager.tearDown();
+	}
+
+	@Test
+	public void testCSVByResourceChangeScanner() throws InterruptedException,
+			IOException {
+
+		// load contents of resource decision tables
+		String first = fileManager
+				.readInputStreamReaderAsString(new InputStreamReader(getClass()
+						.getResourceAsStream("changeSetTestCSV.csv")));
+		String second = fileManager
+				.readInputStreamReaderAsString(new InputStreamReader(getClass()
+						.getResourceAsStream("changeSetTestCSV2.csv")));
+		System.out.println(first);
+		System.out.println(second);
+		
+		// write first version of the decision table rules
+		File file = new File(
+				"src/test/resources/org/drools/decisiontable/scannerChangeSetTestCSV.csv");
+		file.delete();
+		fileManager.write(file, first);
+		Thread.sleep(1100);
+		
+		// start scanning service with interval 1s
+		ResourceChangeScannerConfiguration config = ResourceFactory
+				.getResourceChangeScannerService()
+				.newResourceChangeScannerConfiguration();
+		config.setProperty("drools.resource.scanner.interval", "1");
+		ResourceFactory.getResourceChangeScannerService().configure(config);
+		ResourceFactory.getResourceChangeNotifierService().start();
+		ResourceFactory.getResourceChangeScannerService().start();
+
+		// load knowledge base via knowledge agent
+		KnowledgeAgent kagent = KnowledgeAgentFactory
+				.newKnowledgeAgent("csv agent");
+		kagent.applyChangeSet(ResourceFactory.newClassPathResource(
+				"scannerChangeSetTestCSV.xml", getClass()));
+		KnowledgeBase kbase = kagent.getKnowledgeBase();
+
+		assertEquals(1, kbase.getKnowledgePackages().size());
+		assertEquals(3, kbase.getKnowledgePackages().iterator().next()
+				.getRules().size());
+
+		// after some waiting we change number of rules in decision table,
+		// scanner should notice the change
+		Thread.sleep(1100);
+		file.delete();
+		fileManager.write(file, second);
+		Thread.sleep(1100);
+
+		try {
+			kbase = kagent.getKnowledgeBase();
+			// fails here - see surefire report, knowledge agent fails to load the change
+			assertEquals(1, kbase.getKnowledgePackages().size());
+			assertEquals(2, kbase.getKnowledgePackages().iterator().next()
+					.getRules().size());
+		} finally {
+			ResourceFactory.getResourceChangeNotifierService().stop();
+			ResourceFactory.getResourceChangeScannerService().stop();
+			file.delete();
+		}
+	}
+}

--- a/drools-decisiontables/src/test/resources/org/drools/decisiontable/changeSetTestCSV2.csv
+++ b/drools-decisiontables/src/test/resources/org/drools/decisiontable/changeSetTestCSV2.csv
@@ -1,0 +1,12 @@
+,
+"RuleSet","org.drools.decisiontable"
+"Import","org.drools.decisiontable.Person"
+"Notes",
+,
+"RuleTable Age change",
+"CONDITION","ACTION"
+"person:Person","person"
+"age == $param","setAge($param)"
+"age","new Age"
+0,1
+1,2

--- a/drools-decisiontables/src/test/resources/org/drools/decisiontable/scannerChangeSetTestCSV.xml
+++ b/drools-decisiontables/src/test/resources/org/drools/decisiontable/scannerChangeSetTestCSV.xml
@@ -1,0 +1,10 @@
+<change-set xmlns='http://drools.org/drools-5.0/change-set'
+            xmlns:xs='http://www.w3.org/2001/XMLSchema-instance'
+            xs:schemaLocation='http://drools.org/drools-5.0/change-set http://anonsvn.jboss.org/repos/labs/labs/jbossrules/trunk/drools-api/src/main/resources/change-set-1.0.0.xsd'>
+
+  <add>
+    <resource source="classpath:org/drools/decisiontable/scannerChangeSetTestCSV.csv" type="DTABLE">
+      <decisiontable-conf input-type="CSV" worksheet-name="Tables"/>
+    </resource>
+  </add>
+</change-set>


### PR DESCRIPTION
This is a test case for
https://bugzilla.redhat.com/show_bug.cgi?id=751326

Which has most probably the same root cause as
https://bugzilla.redhat.com/show_bug.cgi?id=741219

The same problem - some resources like CSV, XLS, BPMN and PKG are not hotdeployable.
