### PR TITLE
Updated the documentation about negative patterns in stream mode

### DIFF
--- a/drools-docs/drools-fusion-docs/src/main/docbook/en-US/Chapter-Features/Chapter-EventProcessingModes/Section-EventProcessingModes_StreamMode.xml
+++ b/drools-docs/drools-fusion-docs/src/main/docbook/en-US/Chapter-Features/Chapter-EventProcessingModes/Section-EventProcessingModes_StreamMode.xml
@@ -139,5 +139,25 @@ then
     // sound the alarm
 end</programlisting>
       </example>
+	  
+	  <para>The following rule expects every 10 seconds at least one
+	  “Heartbeat” event, if not the rule fires. The special case in this rule
+	  is that we use the same type of the object in the first pattern and in
+	  the negative pattern. The negative pattern has the temporal constraint to
+	  wait between 0 to 10 seconds before firing and it excludes the Heartbeat
+	  bound to $h. Excluding the bound Heartbeat is important since the
+	  temporal constraint [0s, ...] does not exclude by itself the bound event
+	  $h from being matched again, thus preventing the rule to fire.</para>
+	  <example>
+        <title>excluding bound events in negativ patterns</title>
+
+        <programlisting>rule "Sound the alarm"
+when
+    $h: Heartbeat( ) from entry-point "MonitoringStream"
+    not( Heartbeat( this != $h, this after[0s,10s] $h ) from entry-point "MonitoringStream" )
+then
+    // Sound the alarm
+end</programlisting>
+      </example>
   </section>
 </section>


### PR DESCRIPTION
I updated the documentation for drools-fusion to describe the behaviour of excluding objects in negative patterns. See also following discussion: http://drools.46999.n3.nabble.com/rules-users-Problem-with-Negative-Patterns-and-Temporal-Constraints-tt3663344.html#none
