### PR TITLE
BZ734367 JBRULES-3217

### DIFF
--- a/drools-core/src/main/java/org/drools/impl/StatelessKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/impl/StatelessKnowledgeSessionImpl.java
@@ -285,6 +285,8 @@ public class StatelessKnowledgeSessionImpl
             }
         } finally {
             ((StatefulKnowledgeSessionImpl) ksession).session.endBatchExecution();
+            //endBatchExecution is not exclusive of the StatelessSession, so the dispose should be used outside it, like below
+            ksession.dispose();            
         }
     }
 


### PR DESCRIPTION
This is a small correction but complements the original fix proposed by JBRULES-3217/Bugzilla-734367. It fixes the memory leak caused by the execution of newBatchExecution - ksession.execute(CommandFactory.newBatchExecution(commands));
