### PR TITLE
Disconnected ExecuteCommand results

### DIFF
--- a/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
+++ b/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
@@ -52,11 +52,16 @@ public class ExecuteCommand
         this.outIdentifier = identifier;
         this.disconnected = disconnected;
     }
+    
+    public ExecuteCommand(Command  command, boolean disconnected) {
+        this.command = command;
+        this.disconnected = disconnected;
+    }
 
     public ExecutionResults execute(Context context) {
         StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
         
-        ExecutionResults kresults = ksession.execute( this.command );
+        ExecutionResults kresults = ((StatefulKnowledgeSessionImpl)ksession).execute(context, this.command );
         if ( this.outIdentifier != null ) {
             ((ExecutionResultImpl)((KnowledgeCommandContext) context ).getExecutionResults()).getResults().put( this.outIdentifier, kresults );
         }

--- a/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
+++ b/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
@@ -16,10 +16,12 @@
 
 package org.drools.command;
 
+import java.util.HashMap;
 import org.drools.command.Command;
 import org.drools.command.Context;
 import org.drools.command.impl.GenericCommand;
 import org.drools.command.impl.KnowledgeCommandContext;
+import org.drools.common.DefaultFactHandle;
 import org.drools.common.InternalFactHandle;
 import org.drools.impl.StatefulKnowledgeSessionImpl;
 import org.drools.reteoo.ReteooWorkingMemory;
@@ -34,7 +36,8 @@ public class ExecuteCommand
 
     private String   outIdentifier;
     private Command<ExecutionResults>  command;
-
+    private boolean disconnected = false;
+    
     public ExecuteCommand(Command  command) {
         this.command = command;
     }
@@ -43,6 +46,12 @@ public class ExecuteCommand
         this.command = command;
         this.outIdentifier = identifier;
     }
+    
+    public ExecuteCommand(String identifier, Command  command, boolean disconnected) {
+        this.command = command;
+        this.outIdentifier = identifier;
+        this.disconnected = disconnected;
+    }
 
     public ExecutionResults execute(Context context) {
         StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
@@ -50,6 +59,21 @@ public class ExecuteCommand
         ExecutionResults kresults = ksession.execute( this.command );
         if ( this.outIdentifier != null ) {
             ((ExecutionResultImpl)((KnowledgeCommandContext) context ).getExecutionResults()).getResults().put( this.outIdentifier, kresults );
+        }
+        if (disconnected) {
+            ExecutionResultImpl disconnectedResults = new ExecutionResultImpl();
+            HashMap<String, Object> disconnectedHandles = new HashMap<String, Object>();
+            for (String key : kresults.getIdentifiers()) {
+                FactHandle handle = (FactHandle) kresults.getFactHandle(key);
+                if (handle != null) {
+                    DefaultFactHandle disconnectedHandle = ((DefaultFactHandle) handle).clone();
+                    disconnectedHandle.disconnect();
+                    disconnectedHandles.put(key, disconnectedHandle);
+                }
+            }
+            disconnectedResults.setFactHandles(disconnectedHandles);
+            disconnectedResults.setResults((HashMap)((ExecutionResultImpl)kresults).getResults());
+            return disconnectedResults;
         }
         
         return kresults;

--- a/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
+++ b/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
@@ -61,7 +61,7 @@ public class ExecuteCommand
     public ExecutionResults execute(Context context) {
         StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
         
-        ExecutionResults kresults = ((StatefulKnowledgeSessionImpl)ksession).execute(context, this.command );
+        ExecutionResults kresults = ksession.execute(this.command );
         if ( this.outIdentifier != null ) {
             ((ExecutionResultImpl)((KnowledgeCommandContext) context ).getExecutionResults()).getResults().put( this.outIdentifier, kresults );
         }

--- a/drools-core/src/main/java/org/drools/command/impl/ContextImpl.java
+++ b/drools-core/src/main/java/org/drools/command/impl/ContextImpl.java
@@ -61,6 +61,9 @@ public class ContextImpl
     }
 
     public Object get(String identifier) {
+        if(identifier == null || identifier.equals("")){
+            return null;
+        }
         Object object = context.get( identifier );
         if ( object == null && parent != null ) {
             object = this.parent.get( identifier );

--- a/drools-core/src/main/java/org/drools/command/runtime/rule/QueryCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/rule/QueryCommand.java
@@ -103,7 +103,9 @@ public class QueryCommand  implements GenericCommand<QueryResults>, Identifiable
         QueryResults results = ksession.getQueryResults( name, this.arguments.toArray() );
         
         if ( this.outIdentifier != null ) {
-            ((StatefulKnowledgeSessionImpl)ksession).session.getExecutionResult().getResults().put( this.outIdentifier, results );
+            if(((StatefulKnowledgeSessionImpl)ksession).session.getExecutionResult() != null){
+                ((StatefulKnowledgeSessionImpl)ksession).session.getExecutionResult().getResults().put( this.outIdentifier, results );
+            }    
         }
 
         return results;

--- a/drools-core/src/test/java/org/drools/comand/runtime/rule/ExecuteCommandDisconnectedTest.java
+++ b/drools-core/src/test/java/org/drools/comand/runtime/rule/ExecuteCommandDisconnectedTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.comand.runtime.rule;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.*;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.command.BatchExecutionCommand;
+import org.drools.command.CommandFactory;
+import org.drools.command.ExecuteCommand;
+import org.drools.command.impl.ContextImpl;
+import org.drools.command.impl.DefaultCommandService;
+import org.drools.command.impl.FixedKnowledgeCommandContext;
+import org.drools.command.runtime.rule.InsertObjectCommand;
+import org.drools.common.DefaultFactHandle;
+import org.drools.runtime.ExecutionResults;
+import org.drools.runtime.impl.ExecutionResultImpl;
+
+/**
+ *
+ * @author salaboy
+ */
+public class ExecuteCommandDisconnectedTest {
+
+    private StatefulKnowledgeSession ksession;
+    private DefaultCommandService commandService;
+    
+    public ExecuteCommandDisconnectedTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() {
+        
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void executeDisconnected() {
+        
+       
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        
+
+        ksession = kbase.newStatefulKnowledgeSession();
+        ExecutionResultImpl localKresults = new ExecutionResultImpl();
+        
+        FixedKnowledgeCommandContext kContext 
+            = new FixedKnowledgeCommandContext( new ContextImpl( "ksession", null ), null, null, this.ksession, localKresults );
+        
+        commandService = new DefaultCommandService(kContext);
+        
+        
+        
+        List cmds = new ArrayList();
+        cmds.add(new InsertObjectCommand(new String("Hi!"), "handle"));
+        BatchExecutionCommand batchCmd = CommandFactory.newBatchExecution(cmds, "kresults");
+        ExecuteCommand execCmd = new ExecuteCommand(batchCmd,true);
+        
+        ExecutionResults results = commandService.execute(execCmd);
+        
+        Assert.assertNotNull(results);
+        
+        Assert.assertNotNull(results.getFactHandle("handle"));
+        
+        Assert.assertTrue(((DefaultFactHandle)results.getFactHandle("handle")).isDisconnected());
+        
+        
+        
+        cmds = new ArrayList();
+        cmds.add(new InsertObjectCommand(new String("Hi!"), "handle"));
+        batchCmd = CommandFactory.newBatchExecution(cmds, "kresults");
+        execCmd = new ExecuteCommand(batchCmd);
+        
+        results = commandService.execute(execCmd);
+        
+        Assert.assertNotNull(results);
+        
+        Assert.assertNotNull(results.getFactHandle("handle"));
+        
+        Assert.assertFalse(((DefaultFactHandle)results.getFactHandle("handle")).isDisconnected());
+        
+    }
+}

--- a/drools-core/src/test/java/org/drools/comand/runtime/rule/QueryCommandNoBatchTest.java
+++ b/drools-core/src/test/java/org/drools/comand/runtime/rule/QueryCommandNoBatchTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.comand.runtime.rule;
+
+import org.junit.*;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.command.*;
+import org.drools.command.impl.ContextImpl;
+import org.drools.command.impl.DefaultCommandService;
+import org.drools.command.runtime.rule.QueryCommand;
+import org.drools.runtime.ExecutionResults;
+import org.drools.runtime.impl.ExecutionResultImpl;
+import org.drools.runtime.rule.impl.NativeQueryResults;
+import org.drools.world.impl.WorldImpl;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author salaboy
+ */
+public class QueryCommandNoBatchTest {
+
+    private StatefulKnowledgeSession ksession;
+    private DefaultCommandService commandService;
+
+    public QueryCommandNoBatchTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void executeQueryNoBatch() {
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        ksession = kbase.newStatefulKnowledgeSession();
+        ExecutionResultImpl localKresults = new ExecutionResultImpl();
+        WorldImpl worldImpl = new WorldImpl();
+        worldImpl.createContext("__TEMP__");
+        worldImpl.getContext("__TEMP__").set("__TEMP__", new ContextImpl("__TEMP__", null));
+        ResolvingKnowledgeCommandContext kContext = new ResolvingKnowledgeCommandContext(worldImpl);
+        kContext.set("localResults", localKresults);
+        kContext.set("ksession", ksession);
+
+        commandService = new DefaultCommandService(kContext);
+        
+        QueryCommand queryCommand = new QueryCommand("out", "myQuery", new Object[]{});
+        SetVariableCommandFromCommand setVariableCmd = new SetVariableCommandFromCommand("__TEMP__", "query123", queryCommand);
+        
+        KnowledgeContextResolveFromContextCommand resolveFromContextCommand = new KnowledgeContextResolveFromContextCommand(setVariableCmd,
+                null, null, "ksession", "localResults");
+        ExecutionResults results = (ExecutionResults) commandService.execute(resolveFromContextCommand);
+
+        // I'm not expecting any results here
+        assertNull(results);
+
+        GetVariableCommand getVariableCmd = new GetVariableCommand("query123", "__TEMP__");
+        resolveFromContextCommand = new KnowledgeContextResolveFromContextCommand(getVariableCmd,
+                null, null, "ksession", "localResults");
+        NativeQueryResults queryResults = (NativeQueryResults) commandService.execute(resolveFromContextCommand);
+
+        assertNotNull(queryResults);
+
+        assertEquals(0, queryResults.size());
+
+    }
+}


### PR DESCRIPTION
- check for null inside ContextImpl get()
- disconnected execute command

Note:  the execute command is not mapped using JAXB
