### PR TITLE
JBRULES-3388: KnowledgeAgent custom classloader not working for PKG resources

### DIFF
--- a/drools-core/src/main/java/org/drools/agent/impl/KnowledgeAgentImpl.java
+++ b/drools-core/src/main/java/org/drools/agent/impl/KnowledgeAgentImpl.java
@@ -35,6 +35,7 @@ import org.drools.ChangeSet;
 import org.drools.KnowledgeBase;
 import org.drools.KnowledgeBaseFactory;
 import org.drools.RuleBase;
+import org.drools.RuleBaseConfiguration;
 import org.drools.SystemEventListener;
 import org.drools.SystemEventListenerFactory;
 import org.drools.agent.KnowledgeAgent;
@@ -742,7 +743,17 @@ public class KnowledgeAgentImpl
             KnowledgePackageImp kpkg = null;
             try {
                 is = resource.getInputStream();
-                Object object = DroolsStreamUtils.streamIn( is );
+                
+                ClassLoader classLoader = null;
+                if ( this.isUseKBaseClassLoaderForCompiling() ) {
+                    classLoader = ((InternalRuleBase)((KnowledgeBaseImpl)this.kbase).ruleBase).getRootClassLoader();
+                }else if ( this.builderConfiguration != null ) {
+                    this.listener.warning("Even if a custom KnowledgeBuilderConfiguration was provided, "
+                            + " the Knowledge Agent will not use any specific classloader while deserializing packages."
+                            + " Expect ClassNotFoundExceptions.");
+                } 
+                
+                Object object = DroolsStreamUtils.streamIn( is, classLoader );
                 if ( object instanceof KnowledgePackageImp ) {
                     kpkg = ((KnowledgePackageImp) object);
                 } else {

--- a/drools-core/src/main/java/org/drools/agent/impl/KnowledgeAgentImpl.java
+++ b/drools-core/src/main/java/org/drools/agent/impl/KnowledgeAgentImpl.java
@@ -35,7 +35,6 @@ import org.drools.ChangeSet;
 import org.drools.KnowledgeBase;
 import org.drools.KnowledgeBaseFactory;
 import org.drools.RuleBase;
-import org.drools.RuleBaseConfiguration;
 import org.drools.SystemEventListener;
 import org.drools.SystemEventListenerFactory;
 import org.drools.agent.KnowledgeAgent;

--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/Chapter-Quick_Start/Section-More_On_Building_And_Deploying.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/Chapter-Quick_Start/Section-More_On_Building_And_Deploying.xml
@@ -116,13 +116,24 @@ ResourceFactory.getResourceChangeScannerService().start();</programlisting>
       for agent's kbuilder or force the agent to use the same classloader that
       its kbase has.</para>
       <section>
-      <title>Custom ClassLoaders for KnowledgeBuilder</title>
+      <title>Custom ClassLoaders from KnowledgeBuilder</title>
         <para>Knowledge Agent uses KnowledgeBuilder internally in order to
         compile managed resources. If you need to pass custom configuration to
         these compilers you could pass a KnowledgeBuilderConfiguration object
         to KnowledgeAgentFactory.newKnowledgeAgent(). This object will be used
         in every builder the agent creates. Using a KnowledgeBuilderConfiguration
         you can specify a custom classloader.</para>
+        <important>
+            <para>The usage of a KnowledgeBuilder to specify the CL the agent
+            must use is discouraged. See the next section for the best solution
+            to this problem.</para>
+        </important>
+        <warning>
+            <para>If the agent is handling binary resources (packages), then
+            using a KnowledgeBuilder to specify the CL that must be used will
+            not work. In this case the only solution is to pass a kbase that 
+            uses the custom CL. See next section for more details.</para>
+        </warning>
       </section>
       <section>
       <title>Reuse KnowledgeBase ClassLoader</title>


### PR DESCRIPTION
- When a pkg is deserialized the classloader of the provided kbase (if any) is used.
- Update documentation.
