### PR TITLE
Propagating executeCommand context

### DIFF
--- a/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
+++ b/drools-core/src/main/java/org/drools/command/ExecuteCommand.java
@@ -61,7 +61,7 @@ public class ExecuteCommand
     public ExecutionResults execute(Context context) {
         StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
         
-        ExecutionResults kresults = ksession.execute(this.command );
+        ExecutionResults kresults = ((StatefulKnowledgeSessionImpl)ksession).execute(context, this.command );
         if ( this.outIdentifier != null ) {
             ((ExecutionResultImpl)((KnowledgeCommandContext) context ).getExecutionResults()).getResults().put( this.outIdentifier, kresults );
         }

--- a/drools-core/src/test/java/org/drools/comand/runtime/rule/ExecuteCommandDisconnectedTest.java
+++ b/drools-core/src/test/java/org/drools/comand/runtime/rule/ExecuteCommandDisconnectedTest.java
@@ -32,10 +32,7 @@ import org.drools.runtime.impl.ExecutionResultImpl;
 import org.drools.runtime.rule.impl.NativeQueryResults;
 import org.drools.world.impl.WorldImpl;
 import static org.junit.Assert.*;
-/**
- *
- * @author salaboy
- */
+
 public class ExecuteCommandDisconnectedTest {
 
     private StatefulKnowledgeSession ksession;


### PR DESCRIPTION
- Adding a test which fails if the context is not propagated
