### PR TITLE
Solve potential NPE

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
@@ -68,7 +68,7 @@ public class JpaPersistenceContextManager
     }
 
     public void beginCommandScopedEntityManager() {
-        EntityManager cmdScopedEntityManager = (EntityManager) env.get( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER );
+        this.cmdScopedEntityManager = (EntityManager) env.get( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER );
         if ( cmdScopedEntityManager == null || 
            ( this.cmdScopedEntityManager != null && !this.cmdScopedEntityManager.isOpen() )) {
             internalCmdScopedEntityManager = true;


### PR DESCRIPTION
We had a NullPointerException while working with jBPM5 and Drools. The NPE was caused within JpaPersistenceContextManager#beginCommandScopedEntityManager. The local CommandScopedEntityManager which was fetched form the environment was never used. instead the global CommandScopedEntityManager was always accessed. If the global CommandScopedEntityManager is null we get a NPE.
