### PR TITLE
CCE when using other Map than HashMap

### DIFF
--- a/drools-core/src/main/java/org/drools/command/impl/CommandBasedStatefulKnowledgeSession.java
+++ b/drools-core/src/main/java/org/drools/command/impl/CommandBasedStatefulKnowledgeSession.java
@@ -219,7 +219,7 @@ public class CommandBasedStatefulKnowledgeSession
                                         Map<String, Object> parameters) {
         StartProcessCommand command = new StartProcessCommand();
         command.setProcessId( processId );
-        command.setParameters( (HashMap<String, Object>) parameters );
+        command.setParameters( parameters );
         return commandService.execute( command );
     }
 
@@ -227,7 +227,7 @@ public class CommandBasedStatefulKnowledgeSession
 			                                     Map<String, Object> parameters) {
         CreateProcessInstanceCommand command = new CreateProcessInstanceCommand();
         command.setProcessId( processId );
-        command.setParameters( (HashMap<String, Object>) parameters );
+        command.setParameters( parameters );
         return commandService.execute( command );
 	}
 

--- a/drools-core/src/main/java/org/drools/command/impl/CommandFactoryServiceImpl.java
+++ b/drools-core/src/main/java/org/drools/command/impl/CommandFactoryServiceImpl.java
@@ -164,7 +164,7 @@ public class CommandFactoryServiceImpl implements CommandFactoryService {
             Map<String, Object> parameters) {
         StartProcessCommand startProcess = new StartProcessCommand();
         startProcess.setProcessId(processId);
-        startProcess.setParameters((HashMap<String, Object>) parameters);
+        startProcess.setParameters(parameters);
         return startProcess;
     }
 

--- a/drools-core/src/main/java/org/drools/command/runtime/process/CreateProcessInstanceCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/process/CreateProcessInstanceCommand.java
@@ -86,7 +86,7 @@ public class CreateProcessInstanceCommand implements GenericCommand<ProcessInsta
     }
 
     public void setParameters(Map<String, Object> parameters) {
-        this.parameters = parameters;
+        this.parameters = new HashMap<String, Object>(parameters);
     }
 
     public void putParameter(String key, Object value) {


### PR DESCRIPTION
When other type of map was used, the CCE was thrown at CommandBasedStatefulKnowledgeSession.java:222. This should fix the problem while not breaking anything else.

You can get this exception by calling
'ksession.startProcess("processId", Collections.singletonMap("var", new Object()));'
