### PR TITLE
Throw exception if no transaction was found

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
@@ -121,7 +121,7 @@ public class JtaTransactionManager
             logger.debug( "No UserTransaction found at JNDI location [{}]",
                           DEFAULT_USER_TRANSACTION_NAME,
                           ex );
-            return null;
+            throw new IllegalStateException("Unable to find transaction: " + ex.getMessage(), ex);
         }
     }
 


### PR DESCRIPTION
Instead of leaving ut set to null throw exception if mechanism for finding user transaction failed to find it as all subsequent operation will cause NPE (getStatus, begin, etc)
