### PR TITLE
JBRULES-3590 ClassCastException in RuleTerminalNode.retractLeftTuple()

### DIFF
--- a/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest.java
@@ -175,6 +175,7 @@ import org.drools.runtime.Globals;
 import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.conf.ClockTypeOption;
 import org.drools.runtime.rule.WorkingMemoryEntryPoint;
+import org.drools.runtime.rule.impl.AgendaImpl;
 import org.drools.spi.ConsequenceExceptionHandler;
 import org.drools.spi.GlobalResolver;
 import org.drools.spi.PropagationContext;
@@ -11401,5 +11402,37 @@ public class MiscTest extends CommonTestMethodBase {
         ksession.insert( c );
 
         ksession.fireAllRules();
+    }
+
+    @Test
+    public void testClassCastByRuleTerminalNode() throws Exception {
+        // JBRULES-3590
+        String str = "import org.drools.Person;\n" +
+                "import org.drools.Cheese;\n" +
+                "rule R1\n" +
+                "ruleflow-group \"group1\"\n" +
+                "lock-on-active true\n" +
+                "when\n" +
+                "   $p : Person()\n" +
+                "then\n" +
+                "   $p.setName(\"John\");\n" +
+                "   update( $p );\n" +
+                "end\n" +
+                "rule R2\n" +
+                "ruleflow-group \"group1\"\n" +
+                "lock-on-active true\n" +
+                "when\n" +
+                "   $p : Person( name == null )\n" +
+                "   forall ( Cheese ( type == \"cheddar\" ))\n" +
+                "then\n" +
+                "end\n";
+
+        KnowledgeBase kbase = loadKnowledgeBaseFromString(str);
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+        ksession.insert( new Person( ) );
+        ksession.insert( new Cheese( "gorgonzola") );
+        ((AgendaImpl)ksession.getAgenda()).activateRuleFlowGroup( "group1" );
+        assertEquals(1, ksession.fireAllRules());
+        ksession.dispose();
     }
 }

--- a/drools-core/src/main/java/org/drools/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/reteoo/RuleTerminalNode.java
@@ -306,12 +306,13 @@ public class RuleTerminalNode extends AbstractTerminalNode {
     public void retractLeftTuple(final LeftTuple leftTuple,
                                  final PropagationContext context,
                                  final InternalWorkingMemory workingMemory) {
-        final Activation activation = (Activation) leftTuple.getObject();
-
-        // activation can be null if the LeftTuple previous propagated into a no-loop
-        if ( activation == null ) {
+        // object can be a different type
+        Object obj = leftTuple.getObject();
+        if (obj == null || !(obj instanceof Activation)) {
             return;
         }
+
+        final Activation activation = (Activation)obj;
 
         activation.setMatched( false );
         


### PR DESCRIPTION
https://issues.jboss.org/browse/JBRULES-3590
Test case and fix.
