### PR TITLE
BZ848855 - Transaction rollback failure after concurrent access: no tran...

### DIFF
--- a/drools-core/src/main/java/org/drools/reteoo/BetaNode.java
+++ b/drools-core/src/main/java/org/drools/reteoo/BetaNode.java
@@ -412,7 +412,7 @@ public abstract class BetaNode extends LeftTupleSource
                         }                                                
                         behavior.retractRightTuple( memory.getBehaviorContext(),
                                                     rightTuple,
-                                                    workingMemories[i] );
+                                                    workingMemory );
                         
                         memory.getRightTupleMemory().remove( rightTuple );
                         rightTuple.unlinkFromRightParent();                        

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/PersistenceContextManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/PersistenceContextManager.java
@@ -8,6 +8,8 @@ public interface PersistenceContextManager {
     void beginCommandScopedEntityManager();
     
     void endCommandScopedEntityManager();
+    
+    void clearPersistenceContext();
 
     void dispose();
 }

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -425,6 +425,8 @@ public class SingleSessionCommandService
             // always cleanup thread local whatever the result
             Object removedSynchronization = SingleSessionCommandService.synchronizations.remove( this.service );
             
+            this.service.jpm.clearPersistenceContext();
+            
             this.service.jpm.endCommandScopedEntityManager();
 
             StatefulKnowledgeSession ksession = this.service.ksession;
@@ -436,7 +438,7 @@ public class SingleSessionCommandService
                 }
                 ((JPAWorkItemManager) ksession.getWorkItemManager()).clearWorkItems();
             }
-
+            
         }
 
         public void beforeCompletion() {

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
@@ -112,10 +112,6 @@ public class JpaPersistenceContextManager
     }
 
     public void clearPersistenceContext() {
-        if (this.appScopedEntityManager != null && this.appScopedEntityManager.isOpen()) {
-            this.appScopedEntityManager.clear();
-        }
-        
         if (this.cmdScopedEntityManager != null && this.cmdScopedEntityManager.isOpen()) {
             this.cmdScopedEntityManager.clear();
         }

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JpaPersistenceContextManager.java
@@ -111,4 +111,15 @@ public class JpaPersistenceContextManager
         }
     }
 
+    public void clearPersistenceContext() {
+        if (this.appScopedEntityManager != null && this.appScopedEntityManager.isOpen()) {
+            this.appScopedEntityManager.clear();
+        }
+        
+        if (this.cmdScopedEntityManager != null && this.cmdScopedEntityManager.isOpen()) {
+            this.cmdScopedEntityManager.clear();
+        }
+        
+    }
+
 }

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/map/MapPersistenceContextManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/map/MapPersistenceContextManager.java
@@ -31,4 +31,8 @@ public class MapPersistenceContextManager
         persistenceContext.close();
     }
 
+    public void clearPersistenceContext() {
+
+    }
+
 }


### PR DESCRIPTION
...saction

Ensure that persistence context is cleared after transaction completion to avoid cached entities on hibernate session level which will cause org.hibernate.StaleObjectStateException.
By default when EntityManagerFactory is created using Persistence.createEntityManagerFactory it will create it with extended persistence context type which means that entities will be shared between transactions and in case there are more processes sharing same data base they will get org.hibernate.StaleObjectStateException on following operation:
- getProcessInstance - StaleObjectStateException on ProcessInstanceInfo entity
- startProcess - StaleObjectStateException - on SessionInfo entity
