### PR TITLE
Fix for https://issues.jboss.org/browse/JBRULES-2936

### DIFF
--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/ExcelParser.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/ExcelParser.java
@@ -75,6 +75,7 @@ public class ExcelParser
     public void parseFile(InputStream inStream) {
         try {
             WorkbookSettings ws = new WorkbookSettings();
+            ws.setEncoding("ISO-8859-1"); // Workaround for bug in JXL regarding compressed Unicode format
             Workbook workbook = Workbook.getWorkbook( inStream, ws);
 
             if ( _useFirstSheet ) {


### PR DESCRIPTION
Fix ExcelParser.java as per the JIRA - Workaround for compressed unicode reading bug in JXL

https://issues.jboss.org/browse/JBRULES-2936
