### PR TITLE
releasing the lock only after transaction completion

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -18,6 +18,7 @@ package org.drools.persistence;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
@@ -73,9 +74,9 @@ public class SingleSessionCommandService
 
     private volatile boolean           doRollback;
 
-    private static Map<Object, Object> synchronizations = Collections.synchronizedMap( new IdentityHashMap<Object, Object>() );
+    private Map<Object, Object> synchronizations =  new HashMap<Object, Object>() ;
 
-    public static Map<Object, Object>  txManagerClasses = Collections.synchronizedMap( new IdentityHashMap<Object, Object>() );
+//    public Map<Object, Object>  txManagerClasses = new IdentityHashMap<Object, Object>() ;
 
     public void checkEnvironment(Environment env) {
         if ( env.get( EnvironmentName.ENTITY_MANAGER_FACTORY ) == null &&
@@ -426,7 +427,6 @@ public class SingleSessionCommandService
             synchronizations.put( this,
                                   this );
         }
-
     }
 
     private static class SynchronizationImpl
@@ -461,7 +461,7 @@ public class SingleSessionCommandService
                 }
 
                 // always cleanup thread local whatever the result
-                Object removedSynchronization = SingleSessionCommandService.synchronizations
+                Object removedSynchronization = synchronizations
                         .remove(this);
 
                 this.jpm.clearPersistenceContext();

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -355,7 +355,6 @@ public class SingleSessionCommandService
         boolean transactionOwner = false;
         try {
             transactionOwner = txm.begin();
-            registerRollbackSync();
 
             persistenceContext.joinTransaction();
             initKsession( this.sessionInfo.getId(),
@@ -364,7 +363,7 @@ public class SingleSessionCommandService
                           persistenceContext );
 
             this.jpm.beginCommandScopedEntityManager();
-
+            registerRollbackSync();
 
             T result = null;
             if( command instanceof BatchExecutionCommand ) { 
@@ -406,10 +405,9 @@ public class SingleSessionCommandService
         } catch ( Exception t2 ) {
             logger.error( "Could not rollback",
                           t2 );
+            clear(txm.getStatus());
             throw new RuntimeException( "Could not commit session or rollback",
                                         t2 );
-        }finally{
-            clear(txm.getStatus());
         }
     }
 

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -400,14 +400,16 @@ public class SingleSessionCommandService
                                      boolean transactionOwner) {
         try {
             logger.error( "Could not commit session",
-                          t1 );
-            clear(txm.getStatus());
+                          t1 );           
+            
             txm.rollback( transactionOwner );
         } catch ( Exception t2 ) {
             logger.error( "Could not rollback",
                           t2 );
             throw new RuntimeException( "Could not commit session or rollback",
                                         t2 );
+        }finally{
+            clear(txm.getStatus());
         }
     }
 


### PR DESCRIPTION
Fixing SingleSessionCommandService thread safety issue when it's not ghe JTA transaction owner. This fixes the issues seen at  https://issues.jboss.org/browse/JBPM-3814
