### PR TITLE
JBRULES-3656: Non removed associations issue

### DIFF
--- a/drools-core/src/main/java/org/drools/common/BaseNode.java
+++ b/drools-core/src/main/java/org/drools/common/BaseNode.java
@@ -106,9 +106,12 @@ public abstract class BaseNode
                        BaseNode node,
                        InternalWorkingMemory[] workingMemories) {
 
+        /*fix JBRULES-3656
         if (!context.addRemovedNode(this) && !(this instanceof LeftTupleSource)) {
             return;
-        }
+        }*/
+        context.addRemovedNode(this);
+        //END fix JBRULES-3656
 
         this.removeAssociation( context.getRule() );
         doRemove( context,


### PR DESCRIPTION
Non removed associations for NotNode caused the issue at JBRULES-3656.
This update would solve the issue but I would like someone who knows a
bit more to review it before commiting it to master.
