### PR TITLE
test case for JBRULES-3666

### DIFF
--- a/drools-core/src/test/java/org/drools/event/knowledgebase/KnowledgeBaseEventSupportLeakTest.java
+++ b/drools-core/src/test/java/org/drools/event/knowledgebase/KnowledgeBaseEventSupportLeakTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.event.knowledgebase;
+
+import static org.junit.Assert.assertEquals;
+
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.impl.KnowledgeBaseImpl;
+import org.junit.Test;
+
+public class KnowledgeBaseEventSupportLeakTest {
+
+    @Test
+    public void testKnowledgeBaseEventSupportLeak() throws Exception {
+        // JBRULES-3666
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        KnowledgeBaseEventListener listener = new DefaultKnowledgeBaseEventListener();
+        kbase.addEventListener(listener);
+        kbase.addEventListener(listener);
+        assertEquals(1, ((KnowledgeBaseImpl) kbase).getRuleBase().getRuleBaseEventListeners().size());
+        kbase.removeEventListener(listener);
+        assertEquals(0, ((KnowledgeBaseImpl) kbase).getRuleBase().getRuleBaseEventListeners().size());
+    }
+
+}


### PR DESCRIPTION
A test case for JBRULES-3666, assuming the same EventListener should be added only once.
