### PR TITLE
Added test case for losing POJO fact metadata.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/PositionAnnotatedEvent.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/PositionAnnotatedEvent.java
@@ -1,0 +1,23 @@
+package org.drools.compiler;
+
+import org.drools.definition.type.Position;
+
+/**
+ * Sample event annotated with @Position metadata.
+ */
+public class PositionAnnotatedEvent {
+
+    @Position(1)
+    private String arg1;
+
+    @Position(0)
+    private String arg0;
+
+    public String getArg1() {
+        return arg1;
+    }
+
+    public String getArg0() {
+        return arg0;
+    }
+}


### PR DESCRIPTION
Added test case for losing fact metadata declared in POJO when adding other metadata (such as @Role) in DRL.
