### PR TITLE
CCE storing session with activations in agenda

### DIFF
--- a/drools-core/src/main/java/org/drools/common/ActivationIterator.java
+++ b/drools-core/src/main/java/org/drools/common/ActivationIterator.java
@@ -54,9 +54,9 @@ public class ActivationIterator
     }
 
     public Object next() {
-        Activation acc = null;
+        Object obj = null;
         if ( this.currentLeftTuple != null ) {
-            acc = (Activation) currentLeftTuple.getObject();
+            obj = currentLeftTuple.getObject();
             this.currentLeftTuple = ( LeftTuple ) leftTupleIter.next();
 
             while ( currentLeftTuple == null  && (node = (TerminalNode) nodeIter.next()) != null ) {
@@ -68,7 +68,7 @@ public class ActivationIterator
             }
         }
 
-        return acc;
+        return (obj == null || obj instanceof Activation) ? obj : null;
     }
 
 }


### PR DESCRIPTION
When trying to persist (serialize) a session that has an activated agenda, a ClassCastException occurs like this when calling fireAllRules(). This solution avoids this issue by not returning something different from an Activation inside ActivationIterator
