### PR TITLE
BZ862325: Added tests for improper rule deactivation

### DIFF
--- a/drools-compiler/src/test/java/org/drools/integrationtests/activation/ActivationTest.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/activation/ActivationTest.java
@@ -1,0 +1,204 @@
+package org.drools.integrationtests.activation;
+
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.builder.KnowledgeBuilder;
+import org.drools.builder.KnowledgeBuilderFactory;
+import org.drools.builder.ResourceType;
+import org.drools.io.ResourceFactory;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests proper rule activation when the first firing rule modifies or otherwise
+ * manipulates with a fact which caused other rules to activate.
+ * The activation of other previously activated rules should not be canceled.
+ */
+public class ActivationTest {
+
+    private StatefulKnowledgeSession statefulSession;
+    
+    @Before
+    public void setUp() {
+        final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add(ResourceFactory.newClassPathResource("activation.drl", this.getClass()),
+                ResourceType.DRL);
+
+        if (kbuilder.hasErrors()) {
+            System.err.println(kbuilder.getErrors().toString());
+        }
+
+        final KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+        
+        this.statefulSession = kbase.newStatefulKnowledgeSession();
+    }
+
+    @After
+    public void cleanUp() {
+        if (this.statefulSession != null) {
+            this.statefulSession.dispose();
+        }
+    }
+
+    /**
+     * When the first rule, which fires first, modifies a fact which caused other rules to activate,
+     * all these rules should fire.
+     */
+    @Test
+    public void testFireWhenModified() {
+        final TrackingAgendaEventListener listener = new TrackingAgendaEventListener();
+        this.statefulSession.addEventListener(listener);
+
+        this.statefulSession.insert(new ActivationTestKind(ActivationTestKind.Kind.MODIFY));
+        this.statefulSession.insert(new ActivationTestFact());
+        this.statefulSession.fireAllRules();
+
+        assertTrue(listener.isRuleFired("rule1-modify"));
+        assertTrue(listener.isRuleFired("rule2-modify"));
+        assertTrue(listener.isRuleFired("rule3-modify"));
+    }
+
+    /**
+     * When the first rule, which fires first, retracts a fact which caused other rules to activate,
+     * all these rules should fire.
+     */
+    @Test
+    public void testFireWhenRetracted() {
+        final TrackingAgendaEventListener listener = new TrackingAgendaEventListener();
+        this.statefulSession.addEventListener(listener);
+
+        this.statefulSession.insert(new ActivationTestKind(ActivationTestKind.Kind.RETRACT));
+        this.statefulSession.insert(new ActivationTestFact());
+        this.statefulSession.fireAllRules();
+
+        assertTrue(listener.isRuleFired("rule1-retract"));
+        assertTrue(listener.isRuleFired("rule2-retract"));
+        assertTrue(listener.isRuleFired("rule3-retract"));
+    }
+
+    /**
+     * When the first rule, which fires first, inserts a fact which caused other rules to activate,
+     * all these rules should fire.
+     */
+    @Test
+    public void testFireWhenInserted() {
+        final TrackingAgendaEventListener listener = new TrackingAgendaEventListener();
+        this.statefulSession.addEventListener(listener);
+
+        this.statefulSession.insert(new ActivationTestKind(ActivationTestKind.Kind.INSERT));
+        this.statefulSession.fireAllRules();
+
+        assertTrue(listener.isRuleFired("rule1-insert"));
+        assertTrue(listener.isRuleFired("rule2-insert"));
+        assertTrue(listener.isRuleFired("rule3-insert"));
+    }
+
+    /**
+     * Fact used to determine kind of activation test.
+     */
+    public static class ActivationTestKind {
+        
+        private final Kind kind;
+        
+        public ActivationTestKind(final Kind kind) {
+            this.kind = kind;
+        }
+
+        public Kind getKind() {
+            return this.kind;
+        }
+
+        /**
+         * The kind of Activation test - whether fact modification, retraction
+         * or insertion is being tested.
+         */
+        public enum Kind {
+            MODIFY, RETRACT, INSERT;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 97 * hash + (this.kind != null ? this.kind.hashCode() : 0);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final ActivationTestKind other = (ActivationTestKind) obj;
+            if (this.kind != other.kind) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ActivationTestKind{" + "kind=" + kind + '}';
+        }
+        
+    }
+
+    /**
+     * Test fact inserted into KB to test activation.
+     */
+    public static class ActivationTestFact {
+        
+        private String value;
+        
+        public ActivationTestFact() {
+            this("default");
+        }
+        
+        public ActivationTestFact(final String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return this.value;
+        }
+        
+        public void setValue(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 97 * hash + (this.value != null ? this.value.hashCode() : 0);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final ActivationTestFact other = (ActivationTestFact) obj;
+            if ((this.value == null) ? (other.value != null) : !this.value.equals(other.value)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ActivationTestFact{" + "value=" + value + '}';
+        }
+        
+    }   
+}

--- a/drools-compiler/src/test/java/org/drools/integrationtests/activation/TrackingAgendaEventListener.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/activation/TrackingAgendaEventListener.java
@@ -1,0 +1,69 @@
+package org.drools.integrationtests.activation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.drools.event.rule.AfterActivationFiredEvent;
+import org.drools.event.rule.DefaultAgendaEventListener;
+
+/**
+ * AgendaEventListener to track fired rules.
+ * When rule is fired for the first time it's added to fired rules and
+ * when the rule fires afterwards the counter is incremented to make it
+ * possible to track how many times the rule was fired
+ *
+ */
+public class TrackingAgendaEventListener extends DefaultAgendaEventListener {
+
+    private Map<String, Integer> rulesFired = new HashMap<String, Integer>();
+
+    @Override
+    public void afterActivationFired(AfterActivationFiredEvent event) {
+        super.afterActivationFired(event);
+
+        String rule = event.getActivation().getRule().getName();
+        if (isRuleFired(rule)) {
+            rulesFired.put(rule, rulesFired.get(rule) + 1);
+        } else {
+            rulesFired.put(rule, 1);
+        }
+    }
+
+    /**
+     * Return true if the rule was fired at least once
+     *
+     * @param rule - name of the rule
+     * @return true if the rule was fired
+     */
+    public boolean isRuleFired(String rule) {
+        return rulesFired.containsKey(rule);
+    }
+
+    /**
+     * Returns number saying how many times the rule was fired
+     *
+     * @param rule - name of the rule
+     * @return number how many times rule was fired, 0 if rule wasn't fired
+     */
+    public int ruleFiredCount(String rule) {
+        if (isRuleFired(rule)) {
+            return rulesFired.get(rule);
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @return how many rules were fired
+     */
+    public int rulesCount() {
+        return rulesFired.size();
+    }
+
+    /**
+     * Clears all the information
+     */
+    public void clear() {
+        rulesFired.clear();
+    }
+}

--- a/drools-compiler/src/test/resources/org/drools/integrationtests/activation/activation.drl
+++ b/drools-compiler/src/test/resources/org/drools/integrationtests/activation/activation.drl
@@ -1,0 +1,95 @@
+package org.drools.integrationtests
+
+import org.drools.integrationtests.activation.ActivationTest.ActivationTestKind
+import org.drools.integrationtests.activation.ActivationTest.ActivationTestKind.Kind
+import org.drools.integrationtests.activation.ActivationTest.ActivationTestFact
+
+// MODIFICATION
+
+// this rule must fire before the other two
+rule "rule1-modify"
+when
+    ActivationTestKind( kind == Kind.MODIFY )
+    $fact : ActivationTestFact( value == "default" )
+then
+    insert( "first_fired" );
+    modify( $fact ) { setValue( "non-default" ) }
+end
+
+rule "rule2-modify"
+when
+    ActivationTestKind( kind == Kind.MODIFY )
+    String( this == "first_fired" )
+    $fact : ActivationTestFact( value == "default" )
+then
+    // empty consequence
+end
+
+rule "rule3-modify"
+when
+    ActivationTestKind( kind == Kind.MODIFY )
+    String( this == "first_fired" )
+    $fact : ActivationTestFact( value == "default" )
+then
+    // empty consequence
+end
+
+// RETRACT
+
+// this rule must fire before the other two
+rule "rule1-retract"
+when
+    ActivationTestKind( kind == Kind.RETRACT )
+    $fact : ActivationTestFact( value == "default" )
+then
+    insert( "first_fired" );
+    retract( $fact );
+end
+
+rule "rule2-retract"
+when
+    ActivationTestKind( kind == Kind.RETRACT )
+    String( this == "first_fired" )
+    $fact : ActivationTestFact( value == "default" )
+then
+    // empty consequence
+end
+
+rule "rule3-retract"
+when
+    ActivationTestKind( kind == Kind.RETRACT )
+    String( this == "first_fired" )
+    $fact : ActivationTestFact( value == "default" )
+then
+    // empty consequence
+end
+
+// INSERT
+
+// this rule must fire before the other two
+rule "rule1-insert"
+when
+    ActivationTestKind( kind == Kind.INSERT )
+    not ($fact : ActivationTestFact( value == "default" ))
+then
+    insert( "first_fired" );
+    insert( new ActivationTestFact() );
+end
+
+rule "rule2-insert"
+when
+    ActivationTestKind( kind == Kind.INSERT )
+    String( this == "first_fired" )
+    not ($fact : ActivationTestFact( value == "default" ))
+then
+    // empty consequence
+end
+
+rule "rule3-insert"
+when
+    ActivationTestKind( kind == Kind.INSERT )
+    String( this == "first_fired" )
+    not ($fact : ActivationTestFact( value == "default" ))
+then
+    // empty consequence
+end


### PR DESCRIPTION
Added 3 test cases for Bugzilla issue 862325: one for fact modification, the other two for fact retraction and insert. The test cases do not pass (including the one for fact modification which should be already fixed according to Bugzilla comment).

Please review the proposed tests, either they are not correct, or the fix to 862325 is not yet complete.
