### PR TITLE
Fix: indented keywords would fail template expansion.

### DIFF
--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
@@ -77,7 +77,7 @@ public class DefaultTemplateContainer implements TemplateContainer {
                         inHeader = true;
                     } else if (trimmed.startsWith("template")) {
                         inTemplate = true;
-                        String quotedName = line.substring(8).trim();
+                        String quotedName = trimmed.substring(8).trim();
                         quotedName = quotedName.substring(1, quotedName
                                 .length() - 1);
                         template = new RuleTemplate(quotedName, this);

--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
@@ -71,10 +71,11 @@ public class DefaultTemplateContainer implements TemplateContainer {
             RuleTemplate template = null;
             StringBuffer contents = new StringBuffer();
             while ((line = templateReader.readLine()) != null) {
-                if (line.trim().length() > 0) {
-                    if (line.startsWith("template header")) {
+                String trimmed = line.trim();
+                if (trimmed.length() > 0) {
+                    if (trimmed.startsWith("template header")) {
                         inHeader = true;
-                    } else if (line.startsWith("template")) {
+                    } else if (trimmed.startsWith("template")) {
                         inTemplate = true;
                         String quotedName = line.substring(8).trim();
                         quotedName = quotedName.substring(1, quotedName
@@ -82,7 +83,7 @@ public class DefaultTemplateContainer implements TemplateContainer {
                         template = new RuleTemplate(quotedName, this);
                         addTemplate(template);
 
-                    } else if (line.startsWith("package")) {
+                    } else if (trimmed.startsWith("package")) {
                         if (inHeader == false) {
                             throw new DecisionTableParseException(
                                     "Missing header");
@@ -90,13 +91,13 @@ public class DefaultTemplateContainer implements TemplateContainer {
                         inHeader = false;
                         header.append(line).append("\n");
                     } else if (inHeader) {
-                        addColumn(cf.getColumn(line.trim()));
+                        addColumn(cf.getColumn(trimmed));
                     } else if (!inTemplate && !inHeader) {
                         header.append(line).append("\n");
-                    } else if (!inContents && line.startsWith("rule")) {
+                    } else if (!inContents && trimmed.startsWith("rule")) {
                         inContents = true;
                         contents.append(line).append("\n");
-                    } else if (line.equals("end template")) {
+                    } else if (trimmed.equals("end template")) {
                         template.setContents(contents.toString());
                         contents.setLength(0);
                         inTemplate = false;
@@ -104,7 +105,7 @@ public class DefaultTemplateContainer implements TemplateContainer {
                     } else if (inContents) {
                         contents.append(line).append("\n");
                     } else if (inTemplate) {
-                        template.addColumn(line.trim());
+                        template.addColumn(trimmed);
                     }
                 }
 

--- a/drools-templates/src/test/java/org/drools/template/DataProviderCompilerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/DataProviderCompilerTest.java
@@ -128,6 +128,16 @@ public class DataProviderCompilerTest {
         assertEqualsIgnoreWhitespace( EXPECTED_RULES.toString(),
                                       drl );
     }
+    
+    @Test
+    public void testCompileIndentedKeywords() throws Exception {
+        TestDataProvider tdp = new TestDataProvider( rows );
+        final DataProviderCompiler converter = new DataProviderCompiler();
+        final String drl = converter.compile( tdp,
+                                              "/templates/rule_template_indented.drl" );
+        assertEqualsIgnoreWhitespace( EXPECTED_RULES.toString(),
+                                      drl );
+    }
 
     @Test
     public void testCompilerMaps() throws Exception {

--- a/drools-templates/src/test/java/org/drools/template/parser/DefaultTemplateContainerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/DefaultTemplateContainerTest.java
@@ -32,6 +32,17 @@ public class DefaultTemplateContainerTest {
         assertTrue(contents.endsWith("then\nend\n"));
     }
 
+    /*
+     * Smoke-test to verify it's possible to load a template containing 
+     * indented keywords without exception
+     */
+    @Test
+    public void testParseTemplateIndentedKeywords() {
+        InputStream is = DefaultTemplateContainerTest.class
+                .getResourceAsStream("/templates/rule_template_indented.drl");
+        new DefaultTemplateContainer(is);
+    }
+    
     @Test
     public void testParseTemplateConditions() {
         InputStream is = DefaultTemplateContainerTest.class

--- a/drools-templates/src/test/resources/templates/rule_template_indented.drl
+++ b/drools-templates/src/test/resources/templates/rule_template_indented.drl
@@ -1,0 +1,35 @@
+	template header
+	FEE_SCHEDULE_ID
+	FEE_SCHEDULE_TYPE
+	FEE_MODE_TYPE
+	ENTITY_BRANCH
+	PRODUCT_TYPE
+	ACTIVITY_TYPE
+	FEE_TYPE
+	OWNING_PARTY
+	CCY
+	LC_AMOUNT
+	AMOUNT
+	
+	
+	package org.drools.decisiontable;
+	//generated from Decision Table
+	
+	global FeeResult result;
+	
+	template "Fee Schedule"
+	rule "Fee Schedule_@{row.rowNumber}"
+	    agenda-group "@{FEE_SCHEDULE_TYPE}"
+	    when
+	        FeeEvent(productType == "@{PRODUCT_TYPE}",
+	            activityType == "@{ACTIVITY_TYPE}",
+	            feeType == "@{FEE_TYPE}",
+	            txParty == "@{OWNING_PARTY}",
+	            entityBranch == "@{ENTITY_BRANCH}",
+	            amount @{LC_AMOUNT},
+	            ccy == "@{CCY}"
+	        )
+	    then
+	        result.setSchedule(new FeeSchedule("@{FEE_SCHEDULE_ID}", "@{FEE_SCHEDULE_TYPE}", @{AMOUNT}));
+	end
+	end template


### PR DESCRIPTION
# Issue description

In template files, whitespaces before keywords would cause exceptions.

I don't have a JIRA issue for this, but here's a link to a discussion about this issue on the Drools user mailing list:

http://drools.46999.n3.nabble.com/Why-are-indented-keywords-in-template-causing-NPE-or-DecisionTableParseException-tp4021193.html (TL;DR - "Response: Patch welcome")
## Example of indented "template" keyword

`template header
age
type
log`

Gives the exception:
org.drools.template.parser.DecisionTableParseException: Missing header 
at org.drools.template.parser.DefaultTemplateContainer.parseTemplate(DefaultTemplateContainer.java:87)
## Example of indented "rule" keyword

`rule "Cheese fans_@{row.rowNumber}"
when
   Person(age == @{age})`

Gives the exception:
java.lang.NullPointerException
at org.drools.template.parser.DefaultTemplateColumn.createCellCondition(DefaultTemplateColumn.java:67)
# Patch description
- Altered the DefaultTemplateContainer.java to trim lines before comparison.
- Added simple unit-tests to expose bug / confirm patch
