### PR TITLE
JBPM-3512 - Allow developer-defined correlationId in addition to process...

### DIFF
--- a/drools-compiler/src/test/java/org/drools/testframework/MockWorkingMemory.java
+++ b/drools-compiler/src/test/java/org/drools/testframework/MockWorkingMemory.java
@@ -599,4 +599,17 @@ public class MockWorkingMemory implements InternalWorkingMemory {
         return null;
     }
 
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
 }

--- a/drools-core/src/main/java/org/drools/WorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/WorkingMemory.java
@@ -247,6 +247,11 @@ public interface WorkingMemory extends WorkingMemoryEventManager, WorkingMemoryE
      * Starts a new process instance for the process with the given id.
      */
     ProcessInstance startProcess(String processId, Map<String, Object> parameters);
+    
+    /**
+     * Starts a new process instance for the process with the given id and custom business key.
+     */
+    ProcessInstance startProcess(String processId, String businessKey, Map<String, Object> parameters);
 
     /**
      * Returns the list of process instances of this working memory.
@@ -260,6 +265,12 @@ public interface WorkingMemory extends WorkingMemoryEventManager, WorkingMemoryE
      * @return the process instance with the given id
      */
     public ProcessInstance getProcessInstance(long id);
+    
+    /**
+     * Returns the process instance identified by given businessKey.
+     * @return the process instance identified by given businesKey
+     */
+    public ProcessInstance getProcessInstance(String businessKey);
 
     public WorkItemManager getWorkItemManager();
 

--- a/drools-core/src/main/java/org/drools/command/impl/CommandBasedStatefulKnowledgeSession.java
+++ b/drools-core/src/main/java/org/drools/command/impl/CommandBasedStatefulKnowledgeSession.java
@@ -41,6 +41,7 @@ import org.drools.command.runtime.process.AbortWorkItemCommand;
 import org.drools.command.runtime.process.CompleteWorkItemCommand;
 import org.drools.command.runtime.process.CreateProcessInstanceCommand;
 import org.drools.command.runtime.process.GetProcessEventListenersCommand;
+import org.drools.command.runtime.process.GetProcessInstanceByKeyCommand;
 import org.drools.command.runtime.process.GetProcessInstanceCommand;
 import org.drools.command.runtime.process.GetProcessInstancesCommand;
 import org.drools.command.runtime.process.GetWorkItemCommand;
@@ -93,8 +94,8 @@ import org.kie.runtime.rule.FactHandle;
 import org.kie.runtime.rule.LiveQuery;
 import org.kie.runtime.rule.QueryResults;
 import org.kie.runtime.rule.RuleFlowGroup;
-import org.kie.runtime.rule.ViewChangedEventListener;
 import org.kie.runtime.rule.SessionEntryPoint;
+import org.kie.runtime.rule.ViewChangedEventListener;
 import org.kie.time.SessionClock;
 
 public class CommandBasedStatefulKnowledgeSession
@@ -116,6 +117,12 @@ public class CommandBasedStatefulKnowledgeSession
     public ProcessInstance getProcessInstance(long id) {
         GetProcessInstanceCommand command = new GetProcessInstanceCommand();
         command.setProcessInstanceId( id );
+        return commandService.execute( command );
+    }
+    
+    public ProcessInstance getProcessInstance(String businessKey) {
+        GetProcessInstanceByKeyCommand command = new GetProcessInstanceByKeyCommand();
+        command.setBusinessKey( businessKey );
         return commandService.execute( command );
     }
 
@@ -211,19 +218,30 @@ public class CommandBasedStatefulKnowledgeSession
 
     public ProcessInstance startProcess(String processId,
                                         Map<String, Object> parameters) {
+        return startProcess(processId, null, parameters);
+    }
+    
+    public ProcessInstance startProcess(String processId, String businessKey,  Map<String, Object> parameters) {
         StartProcessCommand command = new StartProcessCommand();
         command.setProcessId( processId );
         command.setParameters( parameters );
+        command.setBusinessKey(businessKey);
         return commandService.execute( command );
     }
 
 	public ProcessInstance createProcessInstance(String processId,
 			                                     Map<String, Object> parameters) {
+        return createProcessInstance(processId, null, parameters);
+	}
+	
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
         CreateProcessInstanceCommand command = new CreateProcessInstanceCommand();
         command.setProcessId( processId );
         command.setParameters( parameters );
+        command.setBusinessKey(businessKey);
         return commandService.execute( command );
-	}
+    }
 
 	public ProcessInstance startProcessInstance(long processInstanceId) {
         StartProcessInstanceCommand command = new StartProcessInstanceCommand();

--- a/drools-core/src/main/java/org/drools/command/runtime/process/CreateProcessInstanceCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/process/CreateProcessInstanceCommand.java
@@ -50,6 +50,8 @@ public class CreateProcessInstanceCommand implements GenericCommand<ProcessInsta
     private List<Object> data = null;
     @XmlAttribute(name="out-identifier")
     private String outIdentifier;
+    @XmlAttribute
+    private String businessKey;
 
     public CreateProcessInstanceCommand() {
     }
@@ -121,7 +123,7 @@ public class CreateProcessInstanceCommand implements GenericCommand<ProcessInsta
                 ksession.insert(o);
             }
         }
-        ProcessInstance processInstance = (ProcessInstance) ksession.createProcessInstance(processId, parameters);
+        ProcessInstance processInstance = (ProcessInstance) ksession.createProcessInstance(processId, businessKey, parameters);
         if ( this.outIdentifier != null ) {
             ((ExecutionResultImpl) ((KnowledgeCommandContext) context).getExecutionResults()).getResults().put(this.outIdentifier,
                                                                                                                processInstance.getId());
@@ -142,5 +144,13 @@ public class CreateProcessInstanceCommand implements GenericCommand<ProcessInsta
         }
         result += "]);";
         return result;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
 }

--- a/drools-core/src/main/java/org/drools/command/runtime/process/GetProcessInstanceByKeyCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/process/GetProcessInstanceByKeyCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.command.runtime.process;
+
+import org.drools.command.impl.GenericCommand;
+import org.drools.command.impl.KnowledgeCommandContext;
+import org.kie.command.Context;
+import org.kie.runtime.StatefulKnowledgeSession;
+import org.kie.runtime.process.ProcessInstance;
+
+public class GetProcessInstanceByKeyCommand implements GenericCommand<ProcessInstance> {
+
+    private String businessKey;
+
+    public GetProcessInstanceByKeyCommand() {}
+
+    public GetProcessInstanceByKeyCommand(String businessKey) {
+        this.businessKey = businessKey;
+    }
+
+    public ProcessInstance execute(Context context) {
+        StatefulKnowledgeSession ksession = ((KnowledgeCommandContext) context).getStatefulKnowledgesession();
+        if (businessKey == null) {
+            return null;
+        }
+        return ksession.getProcessInstance(businessKey);
+    }
+
+    public String toString() {
+        return "session.getProcessInstance(" + businessKey + ");";
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
+    }
+
+}

--- a/drools-core/src/main/java/org/drools/command/runtime/process/StartProcessCommand.java
+++ b/drools-core/src/main/java/org/drools/command/runtime/process/StartProcessCommand.java
@@ -50,6 +50,8 @@ public class StartProcessCommand implements GenericCommand<ProcessInstance>, Ide
     private List<Object> data = null;
     @XmlAttribute(name="out-identifier")
     private String outIdentifier;
+    @XmlAttribute
+    private String businessKey;
 
     public StartProcessCommand() {
     }
@@ -117,7 +119,7 @@ public class StartProcessCommand implements GenericCommand<ProcessInstance>, Ide
                 ksession.insert(o);
             }
         }
-        ProcessInstance processInstance = (ProcessInstance) ksession.startProcess(processId, parameters);
+        ProcessInstance processInstance = (ProcessInstance) ksession.startProcess(processId, businessKey, parameters);
         if ( this.outIdentifier != null ) {
             ((ExecutionResultImpl) ((KnowledgeCommandContext) context).getExecutionResults()).getResults().put(this.outIdentifier,
                                                                                                                processInstance.getId());
@@ -138,5 +140,13 @@ public class StartProcessCommand implements GenericCommand<ProcessInstance>, Ide
         }
         result += "]);";
         return result;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
 }

--- a/drools-core/src/main/java/org/drools/common/AbstractWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/common/AbstractWorkingMemory.java
@@ -1015,11 +1015,21 @@ public abstract class AbstractWorkingMemory
         return processRuntime.startProcess( processId,
                                             parameters );
     }
+    
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        return processRuntime.startProcess( processId, businessKey, parameters );
+    }
 
 	public ProcessInstance createProcessInstance(String processId,
 			                                     Map<String, Object> parameters) {
 		return processRuntime.createProcessInstance(processId, parameters);
 	}
+	
+    public ProcessInstance createProcessInstance(String processId, String businessKey, 
+            Map<String, Object> parameters) {
+        return processRuntime.createProcessInstance(processId, businessKey, parameters);
+    }
 
 	public ProcessInstance startProcessInstance(long processInstanceId) {
 		return processRuntime.startProcessInstance(processInstanceId);
@@ -1031,6 +1041,10 @@ public abstract class AbstractWorkingMemory
 
     public ProcessInstance getProcessInstance(long processInstanceId) {
         return processRuntime.getProcessInstance( processInstanceId );
+    }
+    
+    public ProcessInstance getProcessInstance(String businessKey) {
+        return processRuntime.getProcessInstance( businessKey );
     }
 
     public WorkItemManager getWorkItemManager() {

--- a/drools-core/src/main/java/org/drools/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/impl/StatefulKnowledgeSessionImpl.java
@@ -871,4 +871,23 @@ public class StatefulKnowledgeSessionImpl
         return this.session.getLastIdleTimestamp();
     }
 
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        
+        return this.session.startProcess(processId, businessKey, parameters);
+    }
+
+    @Override
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
+        
+        return this.session.createProcessInstance(processId, businessKey, parameters);
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {        
+        return this.session.getProcessInstance(businessKey);
+    }
+
 }

--- a/drools-core/src/main/java/org/drools/reteoo/DisposedReteooWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/reteoo/DisposedReteooWorkingMemory.java
@@ -551,4 +551,21 @@ public class DisposedReteooWorkingMemory implements ReteooWorkingMemoryInterface
     public long getLastIdleTimestamp() {
         throw new IllegalStateException( ERRORMSG );
     }
+
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        throw new IllegalStateException( ERRORMSG );
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        throw new IllegalStateException( ERRORMSG );
+    }
+
+    @Override
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
+        throw new IllegalStateException( ERRORMSG );
+    }
 }

--- a/drools-core/src/main/java/org/drools/reteoo/ReteooWorkingMemoryInterface.java
+++ b/drools-core/src/main/java/org/drools/reteoo/ReteooWorkingMemoryInterface.java
@@ -32,6 +32,8 @@ public interface ReteooWorkingMemoryInterface extends InternalWorkingMemoryActio
     void fireUntilHalt( AgendaFilter agendaFilterWrapper );
 
     ProcessInstance createProcessInstance( String processId, Map<String, Object> parameters );
+    
+    ProcessInstance createProcessInstance( String processId, String businessKey, Map<String, Object> parameters );
 
     ProcessInstance startProcessInstance( long processInstanceId );
 

--- a/drools-core/src/test/java/org/drools/Person.java
+++ b/drools-core/src/test/java/org/drools/Person.java
@@ -43,6 +43,10 @@ public class Person {
     public Person() {
     }
     
+    public Person(String name) {
+        this.name = name;
+    }
+    
     public Person(final String name,
                   final int age) {
         this( name, age, null );

--- a/drools-templates/src/test/java/org/drools/template/parser/ExternalSheetListenerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/ExternalSheetListenerTest.java
@@ -419,6 +419,17 @@ public class ExternalSheetListenerTest {
                     return 0;
                 }
 
+                public ProcessInstance startProcess(String processId,
+                        String businessKey, Map<String, Object> parameters) {
+                    // TODO Auto-generated method stub
+                    return null;
+                }
+                
+                public ProcessInstance getProcessInstance(String businessKey) {
+                    // TODO Auto-generated method stub
+                    return null;
+                }
+
             };
         }
     }


### PR DESCRIPTION
...InstanceId
pull requests (2/3 as it goes through kie-api, drools-\* and jbpm-\* modules) that allows to assign user defined business key while starting process and then to get access to it using same business key, including bam data. Business key should be unique on runtime meaning only one instance can have given business key however bam method returns list for the same business key as there might be a need to have same business key used in different process engines, etc
