### PR TITLE
test case for JBRULES-3723 IDEOGRAPHIC SPACE (U+3000) in DSL fails

### DIFF
--- a/drools-compiler/src/test/java/org/drools/integrationtests/I18nTest.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/I18nTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.drools.CommonTestMethodBase;
 import org.drools.I18nPerson;
+import org.drools.Person;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.KnowledgeBase;
@@ -100,4 +101,32 @@ public class I18nTest extends CommonTestMethodBase {
         ksession.dispose();
     }
 
+    @Test
+    public void testIdeographicSpaceInDSL() throws Exception {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newClassPathResource( "test_I18n_expander.dsl", "UTF-8", getClass() ),
+                      ResourceType.DSL );
+        kbuilder.add( ResourceFactory.newClassPathResource( "test_I18n_expander.dslr", "UTF-8", getClass() ),
+                ResourceType.DSLR );
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+
+        List messages = new ArrayList();
+        ksession.setGlobal( "messages",
+                messages );
+
+        Person person = new Person();
+        person.setName("山本　太郎");
+        ksession.insert(person);
+        ksession.fireAllRules();
+
+        assertTrue(messages.contains("メッセージ　ルールにヒットしました"));
+
+        ksession.dispose();
+    }
 }

--- a/drools-compiler/src/test/resources/org/drools/integrationtests/test_I18n_expander.dsl
+++ b/drools-compiler/src/test/resources/org/drools/integrationtests/test_I18n_expander.dsl
@@ -1,0 +1,5 @@
+// For general i18n DSL test
+
+// Testing 'IDEOGRAPHIC SPACE' (U+3000)
+[when]名前が {firstName}=Person(name=="山本　{firstName}")
+[then]メッセージ {message}=messages.add("メッセージ　" + {message});

--- a/drools-compiler/src/test/resources/org/drools/integrationtests/test_I18n_expander.dslr
+++ b/drools-compiler/src/test/resources/org/drools/integrationtests/test_I18n_expander.dslr
@@ -1,0 +1,16 @@
+package test
+
+import org.drools.Person
+
+expander test_I18n.dsl
+
+global java.util.List messages;
+
+rule "IDEOGRAPHIC SPACE test"
+    when
+        // Person(name=="山本　太郎")
+        名前が 太郎
+    then
+        // messages.add("メッセージ　ルールにヒットしました");
+         メッセージ "ルールにヒットしました"
+end


### PR DESCRIPTION
'IDEOGRAPHIC SPACE' (U+3000) in DSL fails
https://issues.jboss.org/browse/JBRULES-3723

This pull request includes only a test case.

As a fix, I think adding '\u3000' to DSLMap.g and generating antlr artifacts would be fine but not 100% sure.
