### PR TITLE
JBPM-3785: Exception handling

### DIFF
--- a/drools-core/src/main/java/org/drools/exception/ExceptionHandlingInterceptor.java
+++ b/drools-core/src/main/java/org/drools/exception/ExceptionHandlingInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.exception;
+
+import org.drools.command.impl.AbstractInterceptor;
+import org.kie.command.Command;
+
+/**
+ * This interceptor contains the basic logic to handle an exception thrown by the engine. </p>
+ * If the interceptor is meant to catch and handle any exceptions thrown, then there are 
+ * 2 things that should have been done beforehand:<ul>
+ * <li>In the "cause-chain" (e.g. from Throwable.getCause()), a {@link HandlerRuntimeException} should be present.</li>
+ * <li>The {@link HandlerRuntimeException} instance should contain a {@link JavaExceptionHandler} implementation that
+ * will be able to handle this type of exception.</li>
+ * </ul>
+ */
+public class ExceptionHandlingInterceptor extends AbstractInterceptor {
+
+    /*
+     * (non-Javadoc)
+     * @see org.kie.runtime.CommandExecutor#execute(org.kie.command.Command)
+     */
+    public <T> T execute(Command<T> command) {
+        T result = null;
+        
+        try { 
+            result = executeNext(command);
+        } catch( RuntimeException exception ) {
+            result = handleThrowable(command, exception);
+        } catch( Error error) { 
+            result = handleThrowable(command, error);
+        }
+        
+        return result;
+    }
+
+    /**
+     * This method determines if there's a {@link JavaExceptionHandler} present, 
+     * and if so, executes it and returns what it returns. 
+     * 
+     * @param command The command that produced the exception.
+     * @param exception The exception thrown. 
+     * @return A result comparable with what would have been returned if the exception had not been thrown. 
+     */
+    protected <T> T handleThrowable(Command<T> command, Throwable exception) { 
+            JavaExceptionHandler exceptionHandler = getExceptionHandler(exception);
+            T result = null;
+            if( exceptionHandler != null && exceptionHandler.shouldBeHandled(command) ) { 
+                result = (T) exceptionHandler.handleException(getNext(), exception);
+            } else {
+                if( exception instanceof RuntimeException) { 
+                    throw (RuntimeException) exception;
+                } else if( exception instanceof Error ) { 
+                    throw (Error) exception;
+                }
+            }
+            return result;
+    } 
+    
+    /**
+     * Retrieve the {@link JavaExceptionHandler} from exception cause chain. 
+     * 
+     * @param exception The exception thrown. 
+     * @return The {@link JavaExceptionHandler} instance, if present. 
+     */
+    protected JavaExceptionHandler getExceptionHandler(Throwable exception) { 
+        Throwable cause = exception;
+        while( cause != null && ! (cause instanceof HandlerRuntimeException) ) { 
+            Throwable newCause = cause.getCause();
+            if( newCause == cause || newCause == null) { 
+                return null;
+            }
+            cause = newCause;
+        }
+        
+        return ((HandlerRuntimeException) cause).getExceptionHandler();
+    }
+    
+}

--- a/drools-core/src/main/java/org/drools/exception/HandlerRuntimeException.java
+++ b/drools-core/src/main/java/org/drools/exception/HandlerRuntimeException.java
@@ -1,0 +1,19 @@
+package org.drools.exception;
+
+public class HandlerRuntimeException extends RuntimeException {
+
+    /** Generated serial version UID **/
+    private static final long serialVersionUID = -6144303249955625507L;
+    
+    private final JavaExceptionHandler exceptionHandler;
+    
+    public HandlerRuntimeException(Throwable cause, JavaExceptionHandler exceptionHandler) {
+        super(cause);
+        this.exceptionHandler = exceptionHandler;
+    }
+    
+    public JavaExceptionHandler getExceptionHandler() { 
+        return exceptionHandler;
+    }
+    
+}

--- a/drools-core/src/main/java/org/drools/exception/JavaExceptionHandler.java
+++ b/drools-core/src/main/java/org/drools/exception/JavaExceptionHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.exception;
+
+import org.drools.command.CommandService;
+import org.kie.command.Command;
+import org.kie.runtime.StatefulKnowledgeSession;
+
+/**
+ * An instance of this class is used in order to handle Java exceptions thrown. 
+ */
+public interface JavaExceptionHandler {
+    
+    /**
+     * Return true for any command (for a {@link StatefulKnowledgeSession}) that this handler will handle exceptions for.  
+     * @return Whether or not this handler should handle an exception resulting from the command. 
+     */
+    public boolean shouldBeHandled(Command<?> command);
+    
+    /**
+     * This method is called when an exception occurs during a proxied method. 
+     * 
+     * @param ksession The {@link StatefulKnowledgeSession} used to handle the exception.
+     * @param exception The exception thrown. 
+     * @return boolean Whether or not the exception has been thrown 
+     *                 (which indicates whether the exception should continue to be thrown)
+     */
+    public Object handleException(CommandService commandService, Throwable exception);
+}

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -111,32 +111,9 @@ public class SingleSessionCommandService
 
         checkEnvironment( this.env );
 
-        this.sessionInfo = new SessionInfo();
-
         initTransactionManager( this.env );
-
-        // create session but bypass command service
-        this.ksession = kbase.newStatefulKnowledgeSession( conf,
-                                                           this.env );
-
-        this.kContext = new FixedKnowledgeCommandContext( null,
-                                                          null,
-                                                          null,
-                                                          this.ksession,
-                                                          null );
-
-        this.commandService = new DefaultCommandService( kContext );
-
-        ((AcceptsTimerJobFactoryManager) ((InternalKnowledgeRuntime) ksession).getTimerService()).getTimerJobFactoryManager().setCommandService( this );
-
-        this.marshallingHelper = new SessionMarshallingHelper( this.ksession,
-                                                               conf );
-        MarshallingConfigurationImpl config = (MarshallingConfigurationImpl) this.marshallingHelper.getMarshaller().getMarshallingConfiguration();
-        config.setMarshallProcessInstances( false );
-        config.setMarshallWorkItems( false );
-
-        this.sessionInfo.setJPASessionMashallingHelper( this.marshallingHelper );
-        ((InternalKnowledgeRuntime) this.ksession).setEndOperationListener( new EndOperationListenerImpl( this.sessionInfo ) );
+        
+        initNewKnowledgeSession(kbase, conf);
 
         // Use the App scoped EntityManager if the user has provided it, and it is open.
         // - open the entity manager before the transaction begins. 
@@ -167,6 +144,34 @@ public class SingleSessionCommandService
         ((InternalKnowledgeRuntime) ksession).setId( this.sessionInfo.getId() );
     }
 
+    protected void initNewKnowledgeSession(KnowledgeBase kbase, KieSessionConfiguration conf) { 
+        this.sessionInfo = new SessionInfo();
+
+        // create session but bypass command service
+        this.ksession = kbase.newStatefulKnowledgeSession( conf,
+                                                           this.env );
+
+        this.marshallingHelper = new SessionMarshallingHelper( this.ksession, conf );
+        
+        MarshallingConfigurationImpl config = (MarshallingConfigurationImpl) this.marshallingHelper.getMarshaller().getMarshallingConfiguration();
+        config.setMarshallProcessInstances( false );
+        config.setMarshallWorkItems( false );
+
+        this.sessionInfo.setJPASessionMashallingHelper( this.marshallingHelper );
+        
+        ((InternalKnowledgeRuntime) this.ksession).setEndOperationListener( new EndOperationListenerImpl( this.sessionInfo ) );
+        
+        this.kContext = new FixedKnowledgeCommandContext( null,
+                                                          null,
+                                                          null,
+                                                          this.ksession,
+                                                          null );
+
+        this.commandService = new DefaultCommandService(kContext);
+
+        ((AcceptsTimerJobFactoryManager) ((InternalKnowledgeRuntime) ksession).getTimerService()).getTimerJobFactoryManager().setCommandService( this );
+    }
+    
     public SingleSessionCommandService(Integer sessionId,
                                        KnowledgeBase kbase,
                                        KieSessionConfiguration conf,
@@ -191,7 +196,7 @@ public class SingleSessionCommandService
             registerRollbackSync();
 
             persistenceContext.joinTransaction();
-            initKsession( sessionId,
+            initExistingKnowledgeSession( sessionId,
                           kbase,
                           conf,
                           persistenceContext );
@@ -209,7 +214,7 @@ public class SingleSessionCommandService
         }
     }
 
-    protected void initKsession(Integer sessionId,
+    protected void initExistingKnowledgeSession(Integer sessionId,
                                 KnowledgeBase kbase,
                                 KieSessionConfiguration conf,
                                 PersistenceContext persistenceContext) {
@@ -267,7 +272,6 @@ public class SingleSessionCommandService
                                                               null );
         }
 
-        this.commandService = new DefaultCommandService( kContext );
         this.commandService = new DefaultCommandService(kContext);
     }
 
@@ -354,7 +358,7 @@ public class SingleSessionCommandService
             transactionOwner = txm.begin();
 
             persistenceContext.joinTransaction();
-            initKsession( this.sessionInfo.getId(),
+            initExistingKnowledgeSession( this.sessionInfo.getId(),
                           this.marshallingHelper.getKbase(),
                           this.marshallingHelper.getConf(),
                           persistenceContext );


### PR DESCRIPTION
What this code does is introduce a mechanism to have the drools/jbpm engine(s) automatically react to (java) exceptions thrown by the underlying ksession. 

A new Interceptor class is introduced, as well as modifications to the SingleSessionCommandService in order to add the interceptor to the commandService interceptor chain within the transaction. 

(Having the interceptor act outside of the transaction is ineffectual because of the effects of the transaction commit/synchronization logic). 

This code only introduces the framework for this mechanism -- no drools-specific implementation is added here. 

A jbpm-specific implementation can be found here: https://github.com/droolsjbpm/jbpm/pull/150 
