### PR TITLE
Prevent NPE when there is a null value in a list used by a from element

### DIFF
--- a/drools-core/src/main/java/org/drools/reteoo/FromNode.java
+++ b/drools-core/src/main/java/org/drools/reteoo/FromNode.java
@@ -166,7 +166,7 @@ public class FromNode extends LeftTupleSource
                                                                                context,
                                                                                memory.providerContext ); it.hasNext(); ) {
             final Object object = it.next();
-            if ( !resultClass.isAssignableFrom( object.getClass() ) ) {
+            if ( (object == null) || !resultClass.isAssignableFrom( object.getClass() ) ) {
                 continue; // skip anything if it not assignable
             }
 


### PR DESCRIPTION
If a list contains a null object, `FromNode.assertLeftTuple` will throw an null pointer exception (see stack trace below) when used in a rule like the one below:

```
declare OtherClass
end

declare ListHolder
    listAttr : List 
end

rule "CheckListHolder"
    no-loop
    when
        $lh : ListHolder ( ) 
        $other : OtherClass ( ) from $lh.listAttr 
    then
        modify ( $other ) {
            // Some modification
        }
end
```

I just added a check for a null object to prevent this.

============= Stack trace ============
java.lang.NullPointerException
    at org.drools.reteoo.FromNode.assertLeftTuple(FromNode.java:155)
    at org.drools.reteoo.CompositeLeftTupleSinkAdapter.doPropagateAssertLeftTuple(CompositeLeftTupleSinkAdapter.java:232)
    at org.drools.reteoo.CompositeLeftTupleSinkAdapter.createAndPropagateAssertLeftTuple(CompositeLeftTupleSinkAdapter.java:116)
    at org.drools.reteoo.LeftInputAdapterNode.assertObject(LeftInputAdapterNode.java:154)
    at org.drools.reteoo.SingleObjectSinkAdapter.propagateAssertObject(SingleObjectSinkAdapter.java:59)
    at org.drools.reteoo.ObjectTypeNode.assertObject(ObjectTypeNode.java:235)
    at org.drools.reteoo.EntryPointNode.assertObject(EntryPointNode.java:240)
    at org.drools.common.NamedEntryPoint.insert(NamedEntryPoint.java:337)
    at org.drools.common.NamedEntryPoint.insert(NamedEntryPoint.java:298)
    at org.drools.common.AbstractWorkingMemory.insert(AbstractWorkingMemory.java:888)
    at org.drools.common.AbstractWorkingMemory.insert(AbstractWorkingMemory.java:847)
    at org.drools.impl.StatefulKnowledgeSessionImpl.insert(StatefulKnowledgeSessionImpl.java:269)
    at org.drools.command.runtime.rule.InsertObjectCommand.execute(InsertObjectCommand.java:84)
    at org.drools.command.runtime.rule.InsertObjectCommand.execute(InsertObjectCommand.java:38)
    at org.drools.command.runtime.BatchExecutionCommandImpl.execute(BatchExecutionCommandImpl.java:155)
    at org.drools.command.runtime.BatchExecutionCommandImpl.execute(BatchExecutionCommandImpl.java:76)
    at org.drools.impl.StatelessKnowledgeSessionImpl.execute(StatelessKnowledgeSessionImpl.java:264)
