### PR TITLE
[DROOLS-25] Add option to preload unmarshallstream before parsing header

### DIFF
--- a/drools-core/src/main/java/org/drools/marshalling/impl/PersisterHelper.java
+++ b/drools-core/src/main/java/org/drools/marshalling/impl/PersisterHelper.java
@@ -16,7 +16,9 @@
 
 package org.drools.marshalling.impl;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -233,6 +235,10 @@ public class PersisterHelper {
     public static ProtobufMessages.Header readFromStreamWithHeader( MarshallerReaderContext context, ExtensionRegistry registry ) throws IOException, ClassNotFoundException {
         ProtobufMessages.Header _header = ProtobufMessages.Header.parseFrom( context.stream, registry );
 
+        return loadStrategiesCheckSignature(context, _header);
+    }
+
+    private static ProtobufMessages.Header loadStrategiesCheckSignature(MarshallerReaderContext context, ProtobufMessages.Header _header) throws ClassNotFoundException, IOException {
         loadStrategiesIndex( context, _header );
 
         byte[] sessionbuff = _header.getPayload().toByteArray();
@@ -241,10 +247,31 @@ public class PersisterHelper {
         checkSignature( _header, sessionbuff );
         
         return _header;
+    }
 
+    public static ProtobufMessages.Header readFromStreamWithHeaderPreloaded( MarshallerReaderContext context, ExtensionRegistry registry ) throws IOException, ClassNotFoundException {
+        byte[] preloaded = preload(context.stream);
+        ProtobufMessages.Header _header = ProtobufMessages.Header.parseFrom( preloaded, registry );
+
+        return loadStrategiesCheckSignature(context, _header);
     }
     
-    private static void loadStrategiesIndex(MarshallerReaderContext context,
+    /* Method that preloads the source stream into a byte array to bypass the message size limitations in Protobuf unmarshalling.
+       (Protobuf does not enforce a message size limit when unmarshalling from a byte array)
+    */
+    private static byte[] preload(InputStream stream) throws IOException {
+        byte[] buf = new byte[4096];
+        ByteArrayOutputStream preloaded = new ByteArrayOutputStream();
+
+        int read;
+        while((read = stream.read(buf)) != -1) {
+            preloaded.write(buf, 0, read);
+        }
+
+        return preloaded.toByteArray();
+    }
+
+	private static void loadStrategiesIndex(MarshallerReaderContext context,
                                             ProtobufMessages.Header _header) throws IOException, ClassNotFoundException {
         for ( ProtobufMessages.Header.StrategyIndex _entry : _header.getStrategyList() ) {
             ObjectMarshallingStrategy strategyObject = context.resolverStrategyFactory.getStrategyObject( _entry.getName() );

--- a/drools-core/src/main/java/org/drools/marshalling/impl/ProtobufInputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/marshalling/impl/ProtobufInputMarshaller.java
@@ -81,6 +81,13 @@ import com.google.protobuf.ExtensionRegistry;
 public class ProtobufInputMarshaller {
     // NOTE: all variables prefixed with _ (underscore) are protobuf structs
 
+    /*
+    Toggle to force loading the source stream into memory before unmarshalling with
+    Protobuf. Use this to bypass the Protobuf message size limit when unmarshalling
+    large source streams.
+    */
+    public static boolean unmarshallPreloaded = false;
+
     private static ProcessMarshaller processMarshaller = createProcessMarshaller();
 
     private static ProcessMarshaller createProcessMarshaller() {
@@ -208,8 +215,13 @@ public class ProtobufInputMarshaller {
     private static ProtobufMessages.KnowledgeSession loadAndParseSession(MarshallerReaderContext context) throws IOException, ClassNotFoundException {
         ExtensionRegistry registry = PersisterHelper.buildRegistry( context, processMarshaller );
 
-        ProtobufMessages.Header _header = PersisterHelper.readFromStreamWithHeader( context, registry );
-        
+        ProtobufMessages.Header _header;
+        if (unmarshallPreloaded) {
+            _header = PersisterHelper.readFromStreamWithHeaderPreloaded(context, registry);
+        } else {
+            _header = PersisterHelper.readFromStreamWithHeader( context, registry );
+        }
+ 
         return ProtobufMessages.KnowledgeSession.parseFrom( _header.getPayload(), registry );
     }
 


### PR DESCRIPTION
Protobuf enforces a size limit for messages when unmarshalling from a stream.

see: https://issues.jboss.org/issues/DROOLS-25

When you marshall a large knowledge base in Drools, the messages tend to become huge. It then becomes impossible to later unmarshall them.

However, when you unmarshall Protobuf messages from a byte array, the message size limit is not enforced by Protobuf. 

As a workaround the size limitation impact on Drools, I've added the option to first preload the source stream into a byte array when unmarshalling a knowledge base.

I added the option as a static public boolean field in the ProtobufInputMarshaller class. The function is specific to the protobuf marshalling implementation. I can't see any place for it in any of the more generic classes or interfaces.
