### PR TITLE
Adding test for BZ-917720

### DIFF
--- a/drools-compiler/src/test/java/org/drools/lang/dsl/DefaultExpanderTest.java
+++ b/drools-compiler/src/test/java/org/drools/lang/dsl/DefaultExpanderTest.java
@@ -134,6 +134,21 @@ public class DefaultExpanderTest {
         //System.err.println(( (ExpanderException) ex.getErrors().get( 0 )).getMessage());
     }
 
+    @Test(timeout=100)
+    public void testExpandInfiniteLoop() throws Exception {
+        DSLMappingFile file = new DSLTokenizedMappingFile();
+        String dsl = "[when]Foo with {var} bars=Foo( bars == {var} )";
+        file.parseAndLoad( new StringReader( dsl ) );
+        assertEquals( 0, file.getErrors().size() );
+
+        DefaultExpander ex = new DefaultExpander();
+        ex.addDSLMapping( file.getMapping() );
+        String source = "rule 'dsl rule'\nwhen\n    Foo with {var} bars\nthen\n\nend";
+        ex.expand( source );
+        assertTrue( ex.hasErrors() );
+        assertEquals( 1, ex.getErrors().size() );
+    }
+
     @Test
     public void testANTLRExpandFailure() throws Exception {
 


### PR DESCRIPTION
The test case demonstrates a combination of DSL configuration and DSL rule under which DefaultExpander will fall into an infinite loop. The test will not get past line 147 until the bug is fixed. The test has a timeout set so that it doesn't run forever.
