### PR TITLE
Added test for DROOLS-66.

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
@@ -193,7 +193,7 @@ public class UrlResource extends BaseResource
     }
 
     private InputStream grabStream() throws IOException {
-        URLConnection con = this.url.openConnection();
+        URLConnection con = this.openURLConnection();
         con.setUseCaches( false );
 
         if ( con instanceof HttpURLConnection) {
@@ -210,10 +210,22 @@ public class UrlResource extends BaseResource
         return con.getInputStream();
     }
 
+    /**
+     * Opens URLConnection for the current {@link #url}.
+     * This method is intended to be overriden in unit tests.
+     * <p/>
+     * Default implementation calls <pre>this.url.openConnection()</pre>.
+     * 
+     * @return URLConnection that will be used to connect to the current url
+     */
+    protected URLConnection openURLConnection() throws IOException {
+        return this.url.openConnection();
+    }
+
     public Reader getReader() throws IOException {
         return new InputStreamReader( getInputStream() );
     }
-
+   
     /**
      * Determine a cleaned URL for the given original URL.
      * @param originalUrl the original URL
@@ -275,7 +287,7 @@ public class UrlResource extends BaseResource
             File file = getFile();
             return file.lastModified();
         } else {
-            URLConnection conn = getURL().openConnection();
+            URLConnection conn = this.openURLConnection();
             if ( conn instanceof HttpURLConnection) {
                 ((HttpURLConnection) conn).setRequestMethod( "HEAD" );
             }

--- a/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
@@ -162,7 +162,7 @@ public class UrlResource extends BaseResource
        return new FileInputStream(fi);
     }
 
-    private File getCacheFile()  {
+    File getCacheFile()  {
         try {
             return new File(CACHE_DIR, URLEncoder.encode(this.url.toString(), "UTF-8"));
         } catch (UnsupportedEncodingException e) {

--- a/drools-core/src/test/java/org/drools/io/impl/UrlResourceTest.java
+++ b/drools-core/src/test/java/org/drools/io/impl/UrlResourceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.io.impl;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Basic tests for UrlResource caching logic.
+ * <p/>
+ * Focused on https://issues.jboss.org/browse/DROOLS-66.
+ */
+public class UrlResourceTest {
+
+    private static final Charset CHARSET = Charset.forName("UTF-8");
+
+    private static final File TEMP_DIR = new File(System.getProperty("java.io.tmpdir"));
+
+    /**
+     * Tests reading a UrlResource contents over HTTP with local cache turned on.
+     */
+    @Test
+    public void testHttpWithCache() throws IOException {
+        final File origCacheDir = UrlResource.CACHE_DIR;
+        UrlResource.CACHE_DIR = TEMP_DIR;
+        try {
+            this.doTestGetInputStream(new URL("http://localhost/fakeResourceHttp"),
+                                      "mock http response");
+        } finally {
+            UrlResource.CACHE_DIR = origCacheDir;
+        }
+    }
+
+    /**
+     * Tests reading a UrlResource contents over HTTPS with local cache turned on.
+     */
+    @Test
+    public void testHttpsWithCache() throws IOException {
+        final File origCacheDir = UrlResource.CACHE_DIR;
+        UrlResource.CACHE_DIR = TEMP_DIR;
+        try {
+            this.doTestGetInputStream(new URL("https://localhost/fakeResourceHttps"),
+                                      "mock https response");
+        } finally {
+            UrlResource.CACHE_DIR = origCacheDir;
+        }
+    }
+
+    /**
+     * Tests reading a UrlResource contents over HTTP with local cache turned off.
+     */
+    @Test
+    public void testHttpWithNoCache() throws IOException {
+        final File origCacheDir = UrlResource.CACHE_DIR;
+        UrlResource.CACHE_DIR = null;
+        try {
+            this.doTestGetInputStream(new URL("http://localhost/fakeResourceHttp"),
+                                      "mock http response");
+        } finally {
+            UrlResource.CACHE_DIR = origCacheDir;
+        }
+    }
+
+    /**
+     * Tests reading a UrlResource contents over HTTPS with local cache turned off.
+     */
+    @Test
+    public void testHttpsWithNoCache() throws IOException {
+        final File origCacheDir = UrlResource.CACHE_DIR;
+        UrlResource.CACHE_DIR = null;
+        try {
+            this.doTestGetInputStream(new URL("https://localhost/fakeResourceHttps"),
+                                      "mock https response");
+        } finally {
+            UrlResource.CACHE_DIR = origCacheDir;
+        }
+    }
+
+    /**
+     * Executes single UrlResource test with given url which returns expectedResponse.
+     */
+    private void doTestGetInputStream(final URL url, final String expectedResponse) throws IOException {
+        final UrlResource urlResource = getTestableUrlResource(url, expectedResponse);
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(urlResource.getInputStream(), CHARSET));
+        final String actualResponse = reader.readLine();
+        
+        assertEquals("Unexpected response", expectedResponse, actualResponse);        
+    }
+    
+    /**
+     * Creates UrlResource returning given response instead of real connecting to given URL.
+     */
+    private UrlResource getTestableUrlResource(final URL url, final String response) {
+        return new UrlResource(url) {
+
+            @Override
+            protected URLConnection openURLConnection() throws IOException {
+                return mockURLConnection(response);
+            }
+        };
+    }
+
+    /**
+     * Returns mock URLConnection returning fixed response String and
+     * lastModified value.
+     * 
+     * @param response String to be returned by the InputStream of this connection
+     * @return mocked URLConnection
+     */
+    private URLConnection mockURLConnection(final String response) {
+        final URLConnection mockURLConnection = Mockito.mock(URLConnection.class);
+        try {
+            Mockito.when(mockURLConnection.getLastModified()).thenReturn(1L);
+            Mockito.when(mockURLConnection.getInputStream()).thenReturn(
+                    new ByteArrayInputStream(response.getBytes(CHARSET)));
+
+        } catch (IOException e) {
+            throw new RuntimeException("Exception during mocking.", e);
+        }
+
+        return mockURLConnection;
+    }
+}


### PR DESCRIPTION
Added test verifying https://issues.jboss.org/browse/DROOLS-66 (and related BZ 913252). Enhanced org.drools.io.impl.UrlResource to allow more convenient testing.
