### PR TITLE
DROOLS-64 + DROOLS-88

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/PackageBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/PackageBuilder.java
@@ -116,6 +116,7 @@ import org.drools.spi.InternalReadAccessor;
 import org.drools.type.DateFormats;
 import org.drools.type.DateFormatsImpl;
 import org.drools.util.CompositeClassLoader;
+import org.drools.util.HierarchySorter;
 import org.drools.xml.XmlChangeSetReader;
 import org.xml.sax.SAXException;
 
@@ -3362,127 +3363,49 @@ public class PackageBuilder implements DeepCloneable<PackageBuilder> {
      */
     public Collection<AbstractClassTypeDeclarationDescr> sortByHierarchy( List<AbstractClassTypeDeclarationDescr> typeDeclarations ) {
 
-        Node<AbstractClassTypeDeclarationDescr> root = new Node<AbstractClassTypeDeclarationDescr>( null );
-        Map<String, Node<AbstractClassTypeDeclarationDescr>> map = new HashMap<String, Node<AbstractClassTypeDeclarationDescr>>();
-        for ( AbstractClassTypeDeclarationDescr tdescr : typeDeclarations ) {
-            String typeName = tdescr.getType().getFullName();
+        HierarchySorter<QualifiedName> sorter = new HierarchySorter<QualifiedName>();
+        Map<QualifiedName, Collection<QualifiedName>> taxonomy = new HashMap<QualifiedName, Collection<QualifiedName>>();
+        Map<QualifiedName, AbstractClassTypeDeclarationDescr> cache = new HashMap<QualifiedName, AbstractClassTypeDeclarationDescr>();
 
-            Node<AbstractClassTypeDeclarationDescr> node = map.get( typeName );
-            if ( node == null ) {
-                node = new Node( typeName,
-                                 tdescr );
-                map.put( typeName,
-                         node );
-            } else if ( node.getData() == null ) {
-                node.setData( tdescr );
+        for ( AbstractClassTypeDeclarationDescr tdescr : typeDeclarations ) {
+            QualifiedName name = tdescr.getType();
+
+            cache.put( name, tdescr );
+
+            if ( taxonomy.get( name ) == null ) {
+                taxonomy.put( name, new ArrayList<QualifiedName>() );
             } else {
                 this.results.add( new TypeDeclarationError( tdescr,
-                                       "Found duplicate declaration for type " + tdescr.getTypeName() ) );
+                        "Found duplicate declaration for type " + tdescr.getTypeName() ) );
             }
 
-                if ( tdescr.getSuperTypes().isEmpty() ) {
-                    root.addChild( node );
-                } else {
-                    for ( QualifiedName qname : tdescr.getSuperTypes() ) {
-                        String superTypeName = qname.getFullName();
+            Collection<QualifiedName> supers = taxonomy.get( name );
 
-                        Node<AbstractClassTypeDeclarationDescr> superNode = map.get( superTypeName );
-                        if ( superNode == null ) {
-                            superNode = new Node<AbstractClassTypeDeclarationDescr>( superTypeName );
-                            map.put( superTypeName,
-                                    superNode );
-                        }
-                        superNode.addChild( node );
-                    }
-                }
+            supers.addAll( tdescr.getSuperTypes() );
+
             for ( TypeFieldDescr field : tdescr.getFields().values() ) {
-                String fieldTypeName = field.getPattern().getObjectType();
-
-                Node<AbstractClassTypeDeclarationDescr> superNode = map.get( fieldTypeName );
-                if ( superNode == null ) {
-                    superNode = new Node<AbstractClassTypeDeclarationDescr>( fieldTypeName );
-                    map.put( fieldTypeName,
-                             superNode );
+                QualifiedName typeName = new QualifiedName( field.getPattern().getObjectType() );
+                if ( ! typeName.equals( name ) && ! hasCircularDependency( name, typeName, taxonomy ) ) {
+                    supers.add( typeName );
                 }
-                superNode.addChild( node );
+
             }
 
         }
-
-
-        for ( Node<AbstractClassTypeDeclarationDescr> n : map.values() ) {
-            if ( n.getData() == null ) {
-                root.addChild(n);
-            }
+        List<QualifiedName> sorted = sorter.sort( taxonomy );
+        ArrayList list = new ArrayList( sorted.size() );
+        for ( QualifiedName name : sorted ) {
+            list.add( cache.get( name ) );
         }
 
-
-
-        List<AbstractClassTypeDeclarationDescr> sortedList = new LinkedList<AbstractClassTypeDeclarationDescr>();
-        root.accept( sortedList );
-
-        return sortedList;
+        return list;
     }
 
-    /**
-     * Utility class for the sorting algorithm
-     *
-     * @param <T>
-     */
-    private static class Node<T> {
-
-        private String        key;
-        private T             data;
-        private List<Node<T>> children;
-
-        public Node( String key ) {
-            this.key = key;
-            this.children = new LinkedList<Node<T>>();
+    private boolean hasCircularDependency( QualifiedName name, QualifiedName typeName, Map<QualifiedName, Collection<QualifiedName>> taxonomy) {
+        if ( taxonomy.containsKey( typeName ) ) {
+            return taxonomy.get( typeName ).contains( name );
         }
-
-        public Node( String key,
-                T content ) {
-            this( key );
-            this.data = content;
-        }
-
-        public void addChild( Node<T> child ) {
-            this.children.add( child );
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public T getData() {
-            return data;
-        }
-
-        public void setData( T content ) {
-            this.data = content;
-        }
-
-        public void accept( List<T> list ) {
-            accept( list, new Stack<T>() );
-        }
-
-        private void accept( List<T> list, Stack<T> stack ) {
-            if (this.data != null) {
-                list.remove( this.data );
-                list.add( this.data );
-                stack.push(this.data);
-            }
-
-            for (Node<T> child : children) {
-                if (!stack.contains(child.data)) {
-                    child.accept( list, stack );
-                }
-            }
-
-            if (this.data != null) {
-                stack.pop();
-            }
-        }
+        return false;
     }
 
     //Entity rules inherit package attributes

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/DoSomethingProxy.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/DoSomethingProxy.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 public class DoSomethingProxy<K,T> extends TraitProxy implements ISomethingWithBehaviour<K> {
 
+    private static final String traitType = ISomethingWithBehaviour.class.getName();
+
     private int age;
 
     private K core;
@@ -65,5 +67,10 @@ public class DoSomethingProxy<K,T> extends TraitProxy implements ISomethingWithB
     @Override
     public Object getObject() {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public String getTraitName() {
+        return traitType;
     }
 }

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/IStudent.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/IStudent.java
@@ -17,7 +17,7 @@
 package org.drools.factmodel.traits;
 
 @Trait
-public interface IStudent<K extends TraitableBean> extends IPerson<K>,Thing<K> {
+public interface IStudent<K extends TraitableBean> extends IPerson<K>,Thing<K>, TraitType {
 
     public String getSchool();
     public void setSchool( String school );

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/Imp2.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/Imp2.java
@@ -62,8 +62,16 @@ public class Imp2 implements TraitableBean<Imp2,Imp2> {
         return _getTraitMap().containsKey(type);
     }
 
-    public Thing removeTrait(String type) {
-        return _getTraitMap().remove( type );
+    public BitSet getCurrentTypeCode() {
+        return ((TraitTypeMap) __$$dynamic_traits_map$$).getCurrentTypeCode();
+    }
+
+    public Collection<Thing<Imp2>> removeTrait(String type) {
+        return ((TraitTypeMap)_getTraitMap()).removeCascade( type );
+    }
+
+    public Collection<Thing<Imp2>> removeTrait( BitSet typeCode ) {
+        return ((TraitTypeMap)_getTraitMap()).removeCascade( typeCode );
     }
 
     public Collection<String> getTraits() {

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/ImpCoreWrapper.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/ImpCoreWrapper.java
@@ -50,6 +50,11 @@ public class ImpCoreWrapper extends Imp implements CoreWrapper<Imp>, TraitableBe
         _getTraitMap().put( type, proxy );
     }
 
+    public BitSet getCurrentTypeCode() {
+        return ((TraitTypeMap) __$$dynamic_traits_map$$).getCurrentTypeCode();
+    }
+
+
 
 
     public void _setTraitMap(Map map) {
@@ -64,8 +69,12 @@ public class ImpCoreWrapper extends Imp implements CoreWrapper<Imp>, TraitableBe
         return _getTraitMap().containsKey( type );
     }
 
-    public Thing<Imp> removeTrait(String type) {
-        return _getTraitMap().remove( type );
+    public Collection<Thing<Imp>> removeTrait(String type) {
+        return ((TraitTypeMap)_getTraitMap()).removeCascade( type );
+    }
+
+    public Collection<Thing<Imp>> removeTrait( BitSet typeCode ) {
+        return ((TraitTypeMap)_getTraitMap()).removeCascade( typeCode );
     }
 
     public Collection<String> getTraits() {

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/StudentImpl.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/StudentImpl.java
@@ -31,7 +31,7 @@ public class StudentImpl implements IStudent<StudentImpl>, TraitableBean<Student
     private int age;
 
 
-    private Map<String,Thing<StudentImpl>> traitMap = new HashMap<String, Thing<StudentImpl>>();
+    private Map<String,Thing<StudentImpl>> traitMap = new TraitTypeMap<String, Thing<StudentImpl>, StudentImpl>( new HashMap() );;
 
     public StudentImpl() {
     }
@@ -40,8 +40,9 @@ public class StudentImpl implements IStudent<StudentImpl>, TraitableBean<Student
         this.school = school;
         this.name = name;
         this.age = age;
-
     }
+
+
 
     public String getSchool() {
         return school;
@@ -116,8 +117,12 @@ public class StudentImpl implements IStudent<StudentImpl>, TraitableBean<Student
         return traitMap.containsKey( type );
     }
 
-    public Thing removeTrait(String type) {
-        return traitMap.remove( type );
+    public Collection<Thing<StudentImpl>> removeTrait(String type) {
+        return ((TraitTypeMap) _getTraitMap()).removeCascade( type );
+    }
+
+    public Collection<Thing<StudentImpl>> removeTrait(BitSet typeCode) {
+        return ((TraitTypeMap) _getTraitMap()).removeCascade(typeCode);
     }
 
     public Collection<String> getTraits() {
@@ -134,5 +139,21 @@ public class StudentImpl implements IStudent<StudentImpl>, TraitableBean<Student
 
     public BitSet getBottomTypeCode() {
         return new BitSet();
+    }
+
+    public BitSet getCurrentTypeCode() {
+        return new BitSet();
+    }
+
+    public BitSet getTypeCode() {
+        return new BitSet();
+    }
+
+    public boolean isVirtual() {
+        return false;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    public String getTraitName() {
+        return IStudent.class.getName();
     }
 }

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/StudentProxy2.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/StudentProxy2.java
@@ -33,6 +33,7 @@ public class StudentProxy2 extends TraitProxy implements IStudent {
     public static InternalReadAccessor bit_reader;
     public static WriteAccessor bit_writer;
 
+    private static final String traitType = IStudent.class.getName();
 
 
     public StudentProxy2(Imp2 obj, Map<String, Object> m) {
@@ -56,6 +57,10 @@ public class StudentProxy2 extends TraitProxy implements IStudent {
 
     public Imp2 getCore() {
         return object;
+    }
+
+    public String getTraitName() {
+        return traitType;
     }
 
     public Object getObject() {

--- a/drools-compiler/src/test/java/org/drools/factmodel/traits/StudentProxy3.java
+++ b/drools-compiler/src/test/java/org/drools/factmodel/traits/StudentProxy3.java
@@ -29,6 +29,8 @@ import java.util.Map;
 
 public class StudentProxy3 extends TraitProxy implements IStudent {
 
+    private static final String traitType = IStudent.class.getName();
+
     private  TripleFactory tripleFactory = new TripleFactoryImpl();
 
     public final Imp2 object;
@@ -67,6 +69,11 @@ public class StudentProxy3 extends TraitProxy implements IStudent {
 
     public Imp2 getCore() {
         return object;
+    }
+
+    @Override
+    public String getTraitName() {
+        return traitType;
     }
 
     public Object getObject() {
@@ -171,4 +178,7 @@ public class StudentProxy3 extends TraitProxy implements IStudent {
         result = 31 * result + this.getFields().hashCode();
         return result;
     }
+
+
+
 }

--- a/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest2.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest2.java
@@ -1439,4 +1439,40 @@ public class MiscTest2 extends CommonTestMethodBase {
         assertEquals(1, ksession.fireAllRules());
     }
 
+    @Test
+    @Ignore
+    public void testMatchIntegers() {
+        // DROOLS-79
+        String str =
+                "global java.util.List list; \n" +
+                        "rule R when\n" +
+                        "    $i : Integer( this == 1 )\n" +
+                        "then\n" +
+                        "  list.add( $i );\n" +
+                        "end\n" +
+                        "rule S when\n" +
+                        "    $i : Integer( this == 2 )\n" +
+                        "then\n" +
+                        "  list.add( $i );\n" +
+                        "end\n" +
+                        "rule T when\n" +
+                        "    $i : Integer( this == 3 )\n" +
+                        "then\n" +
+                        "  list.add( $i );\n" +
+                        "end\n" +
+                        "";
+
+        KnowledgeBase kbase = loadKnowledgeBaseFromString(str);
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+        List list = new ArrayList();
+        ksession.setGlobal( "list", list );
+
+        ksession.insert( new Integer( 1 ) );
+        ksession.fireAllRules();
+
+    }
+
+
+
 }

--- a/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest2.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest2.java
@@ -28,12 +28,14 @@ import org.drools.common.DefaultFactHandle;
 import org.drools.core.util.FileManager;
 import org.drools.definition.KnowledgePackage;
 import org.drools.definition.type.Modifies;
+import org.drools.definition.type.Position;
 import org.drools.definition.type.PropertyReactive;
 import org.drools.event.knowledgebase.DefaultKnowledgeBaseEventListener;
 import org.drools.event.knowledgebase.KnowledgeBaseEventListener;
 import org.drools.event.rule.AgendaEventListener;
 import org.drools.impl.KnowledgeBaseImpl;
 import org.drools.io.ResourceFactory;
+import org.drools.io.impl.ByteArrayResource;
 import org.drools.reteoo.LeftTuple;
 import org.drools.reteoo.ObjectTypeNode;
 import org.drools.runtime.StatefulKnowledgeSession;
@@ -1470,6 +1472,97 @@ public class MiscTest2 extends CommonTestMethodBase {
 
         ksession.insert( new Integer( 1 ) );
         ksession.fireAllRules();
+
+    }
+
+
+
+
+
+    public static class Foo2 {
+        @Position(0)
+        public int x;
+        public int getX() {
+            return x;
+        }
+        public void setX(int x) {
+            this.x = x;
+        }
+    }
+
+
+    @Test
+    @Ignore
+    public void testSelfChangingRuleSet() {
+        // DROOLS-92
+        String str =
+                "package org.drools.integrationtests;\n" +
+                        "" +
+                        "import org.drools.integrationtests.MiscTest2.Foo2; \n" +
+                        "" +
+                        "global java.util.List list; \n" +
+                        "\n" +
+                        "rule \"Prep\" \n" +
+                        "when \n" +
+                        "  $packs : java.util.Collection() \n" +
+                        "then \n" +
+                        "   drools.getKnowledgeRuntime().getKnowledgeBase().addKnowledgePackages( $packs );" +
+                        "end \n" +
+                        "" +
+                        "rule \"Self-change\"\n" +
+                        "when\n" +
+                        "  String( this == \"go\" )\n" +
+                        "then\n" +
+                        "   drools.getKnowledgeRuntime().getKnowledgeBase().removeRule( \"org.drools.integrationtests\", \"React\" ); \n" +
+                        "end\n" +
+                        "\n" +
+                        "\n" +
+                        "rule \"Insert\"\n" +
+                        "when\n" +
+                        "  $i : Integer()\n" +
+                        "then\n" +
+                        "  Foo2 foo = new Foo2();\n " +
+                        "  foo.setX( $i ); \n" +
+                        "  insert( foo );\n" +
+                        "end\n" +
+                        "" +
+                        "";
+
+        String str2 =
+                "package org.drools.integrationtests;\n" +
+                        "" +
+                        "import org.drools.integrationtests.MiscTest2.Foo2; \n" +
+                        "global java.util.List list;\n " +
+                        "rule \"React\"\n" +
+                        "when\n" +
+                        "  $b : Foo2( x < 10 )\n" +
+                        "then\n" +
+                        "  System.out.println( \" Foo2 is in \" + $b.getX() );" +
+                        "  list.add( $b ); \n" +
+                        "end\n";
+
+        KnowledgeBuilder knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        knowledgeBuilder.add( new ByteArrayResource( str2.getBytes() ), ResourceType.DRL );
+
+        System.out.println(  knowledgeBuilder.getErrors() );
+
+        KnowledgeBase kbase = loadKnowledgeBaseFromString(str);
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+        List list = new ArrayList();
+        ksession.setGlobal( "list", list );
+        ksession.insert( knowledgeBuilder.getKnowledgePackages() );
+
+        ksession.insert( new Integer( 1 ) );
+        ksession.fireAllRules();
+
+        ksession.insert( "go" );
+        ksession.fireAllRules();
+
+        ksession.insert( new Integer( 2 ) );
+        ksession.fireAllRules();
+
+        assertEquals( 1, list.size() );
 
     }
 

--- a/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest2.java
+++ b/drools-compiler/src/test/java/org/drools/integrationtests/MiscTest2.java
@@ -1438,4 +1438,5 @@ public class MiscTest2 extends CommonTestMethodBase {
         ksession.insert(new Long(6));
         assertEquals(1, ksession.fireAllRules());
     }
+
 }

--- a/drools-compiler/src/test/resources/org/drools/factmodel/traits/testComplexDonShed.drl
+++ b/drools-compiler/src/test/resources/org/drools/factmodel/traits/testComplexDonShed.drl
@@ -1,0 +1,97 @@
+package test;
+import org.drools.factmodel.traits.*;
+
+declare trait A id : int end
+declare trait B extends A end
+declare trait C extends A end
+declare trait D extends B end
+declare trait E extends C end
+declare trait F extends E, B end
+declare trait G extends E, F end
+
+declare Kore
+@Traitable
+end
+
+global TraitableBean core;
+
+rule donA
+when
+    $s : String( this == "ent" )
+then
+    Entity k = new Entity();
+
+    drools.getKnowledgeRuntime().setGlobal( "core", k );
+
+    insert( k );
+    retract( $s );
+    don( k, A.class );
+end
+
+rule donK
+when
+    $s : String( this == "kor" )
+then
+    Kore k = new Kore();
+
+    drools.getKnowledgeRuntime().setGlobal( "core", k );
+
+    insert( k );
+    retract( $s );
+    don( k, A.class );
+end
+
+
+rule donB
+when
+    $s : String( this == "b" )
+    $x : TraitableBean( )
+then
+    retract( $s ); 
+    don( $x, B.class );
+end
+
+rule donC
+when
+    $s : String( this == "c" )
+    $x : TraitableBean( )
+then
+    retract( $s ); 
+    don( $x, C.class );
+end
+rule donE
+when
+    $s : String( this == "e" )
+    $x : TraitableBean( )
+then
+    retract( $s ); 
+    don( $x, E.class );
+end
+ 
+rule shedC
+when
+    $s : String( this == "-c" )
+    $x : TraitableBean( )
+then
+    retract( $s ); 
+    shed( $x, C.class );
+end
+
+rule shedF
+when
+    $s : String( this == "-f" )
+    $x : TraitableBean( )
+then
+    retract( $s ); 
+    shed( $x, F.class );
+end
+
+rule donDG
+when
+    $s : String( this == "dg" )
+    $x : TraitableBean( )
+then
+    retract( $s ); 
+    don( $x, D.class );
+    don( $x, G.class );
+end

--- a/drools-compiler/src/test/resources/org/drools/factmodel/traits/testTraitIsA.drl
+++ b/drools-compiler/src/test/resources/org/drools/factmodel/traits/testTraitIsA.drl
@@ -50,12 +50,12 @@ no-loop
 when
     $core: Imp( "adam", "skool" ;)
 then
-    Student<Imp> s = drools.<Student,Imp>don( $core, Student.class, true );
-    Thing<Imp> t = drools.<Thing,Imp>don( $core, Thing.class, true );
+    Student s = drools.don( $core, Student.class, true );
+    Thing t = drools.don( $core, Thing.class, true );
 
-    Worker<Imp> w = drools.<Worker,Imp>don( $core, Worker.class, true );
+    Worker w = drools.don( $core, Worker.class, true );
 
-    update( $core );
+    modify( $core ) {}
 end
 
 rule "Trait2"
@@ -63,7 +63,7 @@ no-loop
 when
     $core: Entity( )
 then
-    Student<Entity> s = drools.<Student,Entity>don( $core, Student.class, true );
+    Student s = drools.don( $core, Student.class, true );
     list.add( "0" );
 end
 
@@ -96,8 +96,6 @@ end
 
 
 
-
-
 rule "Worker Students v2"
 when
     $x1 := Worker( this isA Student )
@@ -126,6 +124,8 @@ when
 then
     list.add( "8" );
 end
+
+
 
 rule "Worker Students v6"
 when

--- a/drools-core/src/main/java/org/drools/factmodel/DefaultBeanClassBuilder.java
+++ b/drools-core/src/main/java/org/drools/factmodel/DefaultBeanClassBuilder.java
@@ -16,6 +16,7 @@
 
 package org.drools.factmodel;
 
+import org.drools.factmodel.traits.Thing;
 import org.drools.factmodel.traits.TraitTypeMap;
 import org.drools.factmodel.traits.TraitableBean;
 import org.mvel2.asm.*;
@@ -29,6 +30,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A builder to dynamically build simple Javabean(TM) classes
@@ -136,7 +138,7 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
             mv.visitFieldInsn( Opcodes.GETFIELD,
                     BuildUtils.getInternalType( classDef.getClassName() ),
                     TraitableBean.MAP_FIELD_NAME,
-                    "Ljava/util/Map;" );
+                    Type.getDescriptor( Map.class ) );
             mv.visitMethodInsn( INVOKEINTERFACE,
                     "java/io/ObjectOutput",
                     "writeObject",
@@ -147,14 +149,14 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
             mv.visitFieldInsn( Opcodes.GETFIELD,
                     BuildUtils.getInternalType( classDef.getClassName() ),
                     TraitableBean.TRAITSET_FIELD_NAME,
-                    "Ljava/util/Map;" );
+                    Type.getDescriptor( Map.class ) );
             mv.visitMethodInsn( INVOKEINTERFACE,
                     "java/io/ObjectOutput",
                     "writeObject",
                     "(Ljava/lang/Object;)V" );
 
             mv.visitInsn(RETURN);
-            mv.visitMaxs(2, 2);
+            mv.visitMaxs( 0, 0 );
             mv.visitEnd();
         }
         {
@@ -189,7 +191,7 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
             mv.visitFieldInsn( Opcodes.PUTFIELD,
                     BuildUtils.getInternalType( classDef.getClassName() ),
                     TraitableBean.MAP_FIELD_NAME,
-                    "Ljava/util/Map;" );
+                    Type.getDescriptor( Map.class ) );
 //
             mv.visitVarInsn( ALOAD, 0 );
             mv.visitVarInsn( ALOAD, 1 );
@@ -201,11 +203,11 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
             mv.visitFieldInsn( Opcodes.PUTFIELD,
                     BuildUtils.getInternalType( classDef.getClassName() ),
                     TraitableBean.TRAITSET_FIELD_NAME,
-                    "Ljava/util/Map;" );
+                    Type.getDescriptor( Map.class ) );
 
 
             mv.visitInsn( RETURN );
-            mv.visitMaxs( 3, 2 );
+            mv.visitMaxs( 0, 0 );
             mv.visitEnd();
         }
 
@@ -294,145 +296,183 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
      */
     protected void buildTraitMap(ClassWriter cw, ClassDefinition classDef) {
 
-//        FieldVisitor fv = cw.visitField( ACC_PRIVATE,
-//                                         TraitableBean.TRAITSET_FIELD_NAME,
-//                                         "Ljava/util/Map;",
-//                                         "Ljava/util/Map<Ljava/lang/String;+Lorg/drools/factmodel/traits/Thing;>;",
-//                                         null);
-//        fv.visitEnd();
-//
-//
-//        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC,
-//                "getTraits",
-//                "()Ljava/util/Map;",
-//                "()Ljava/util/Map<Ljava/lang/String;+Lorg/drools/factmodel/traits/Thing;>;",
-//                null);
-//
-//        mv.visitCode();
-//        mv.visitVarInsn(ALOAD, 0);
-//        mv.visitFieldInsn(GETFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, "Ljava/util/Map;");
-//        mv.visitInsn(ARETURN);
-//        mv.visitMaxs(1, 1);
-//        mv.visitEnd();
-
-
         FieldVisitor fv = cw.visitField( ACC_PRIVATE,
                 TraitableBean.TRAITSET_FIELD_NAME,
-                "Ljava/util/Map;",
+                Type.getDescriptor( Map.class ),
                 "Ljava/util/Map<Ljava/lang/String;Lorg/drools/factmodel/traits/Thing;>;",
                 null );
         fv.visitEnd();
 
         MethodVisitor mv;
 
-        mv = cw.visitMethod(ACC_PUBLIC, "_getTraitMap", "()Ljava/util/Map;", "()Ljava/util/Map<Ljava/lang/String;Lorg/drools/factmodel/traits/Thing;>;", null);
+        mv = cw.visitMethod( ACC_PUBLIC,
+                "_getTraitMap",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ),
+                "()Ljava/util/Map<Ljava/lang/String;Lorg/drools/factmodel/traits/Thing;>;",
+                null );
         mv.visitCode();
-//        mv.visitVarInsn(ALOAD, 0);
-//        mv.visitFieldInsn(GETFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, "Ljava/util/Map;");
-//        Label l0 = new Label();
-//        mv.visitJumpInsn(IFNONNULL, l0);
-//        mv.visitVarInsn(ALOAD, 0);
-//        mv.visitTypeInsn(NEW, "java/util/HashMap");
-//        mv.visitInsn(DUP);
-//        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V");
-//        mv.visitFieldInsn(PUTFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, "Ljava/util/Map;");
-//        mv.visitLabel(l0);
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitFieldInsn(GETFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, "Ljava/util/Map;");
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitFieldInsn( GETFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, Type.getDescriptor( Map.class ) );
         mv.visitInsn(ARETURN);
-        mv.visitMaxs(3, 1);
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
-        mv = cw.visitMethod(ACC_PUBLIC, "_setTraitMap", "(Ljava/util/Map;)V", null, null);
+        mv = cw.visitMethod( ACC_PUBLIC, "_setTraitMap", Type.getMethodDescriptor( Type.getType( void.class ), new Type[] { Type.getType( Map.class ) } ), null, null);
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitFieldInsn(PUTFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, "Ljava/util/Map;");
-        mv.visitInsn(RETURN);
-        mv.visitMaxs(2, 2);
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitVarInsn( ALOAD, 1 );
+        mv.visitFieldInsn( PUTFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, Type.getDescriptor( Map.class ));
+        mv.visitInsn( RETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
-        mv = cw.visitMethod(ACC_PUBLIC, "addTrait", "(Ljava/lang/String;Lorg/drools/factmodel/traits/Thing;)V", "(Ljava/lang/String;Lorg/drools/factmodel/traits/Thing;)V", null);
+        mv = cw.visitMethod( ACC_PUBLIC, "addTrait",
+                Type.getMethodDescriptor( Type.getType( void.class ), new Type[] { Type.getType( String.class ), Type.getType( Thing.class ) } ),
+                "(Ljava/lang/String;Lorg/drools/factmodel/traits/Thing;)V", null );
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", "()Ljava/util/Map;");
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitVarInsn(ALOAD, 2);
-        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-        mv.visitInsn(POP);
-        mv.visitInsn(RETURN);
-        mv.visitMaxs(3, 3);
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                BuildUtils.getInternalType( classDef.getName() ),
+                "_getTraitMap",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+        mv.visitVarInsn( ALOAD, 1 );
+        mv.visitVarInsn( ALOAD, 2 );
+        mv.visitMethodInsn( INVOKEINTERFACE,
+                Type.getInternalName( Map.class ),
+                "put",
+                Type.getMethodDescriptor( Type.getType( Object.class ), new Type[] { Type.getType( Object.class ), Type.getType( Object.class ) } ) );
+        mv.visitInsn( POP );
+        mv.visitInsn( RETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
-        mv = cw.visitMethod(ACC_PUBLIC, "getTrait", "(Ljava/lang/String;)Lorg/drools/factmodel/traits/Thing;", "(Ljava/lang/String;)Lorg/drools/factmodel/traits/Thing;", null);
+        mv = cw.visitMethod( ACC_PUBLIC,
+                "getTrait",
+                Type.getMethodDescriptor( Type.getType( Thing.class ), new Type[] { Type.getType( String.class ) } ),
+                Type.getMethodDescriptor( Type.getType( Thing.class ), new Type[] { Type.getType( String.class ) } ),
+                null );
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", "()Ljava/util/Map;");
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
-        mv.visitTypeInsn(CHECKCAST, "org/drools/factmodel/traits/Thing");
-        mv.visitInsn(ARETURN);
-        mv.visitMaxs(2, 2);
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                BuildUtils.getInternalType( classDef.getName() ),
+                "_getTraitMap",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+        mv.visitVarInsn( ALOAD, 1 );
+        mv.visitMethodInsn( INVOKEINTERFACE,
+                Type.getInternalName( Map.class ),
+                "get",
+                Type.getMethodDescriptor( Type.getType( Object.class ), new Type[] { Type.getType( Object.class ) } ) );
+        mv.visitTypeInsn( CHECKCAST, Type.getInternalName( Thing.class ) );
+        mv.visitInsn( ARETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
-        mv = cw.visitMethod(ACC_PUBLIC, "hasTrait", "(Ljava/lang/String;)Z", null, null);
+        mv = cw.visitMethod( ACC_PUBLIC,
+                "hasTrait",
+                Type.getMethodDescriptor( Type.getType( boolean.class ), new Type[] { Type.getType( String.class ) } ),
+                null,
+                null );
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", "()Ljava/util/Map;");
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                BuildUtils.getInternalType( classDef.getName() ),
+                "_getTraitMap",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
         Label l0 = new Label();
-        mv.visitJumpInsn(IFNONNULL, l0);
-        mv.visitInsn(ICONST_0);
-        mv.visitInsn(IRETURN);
-        mv.visitLabel(l0);
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", "()Ljava/util/Map;");
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "containsKey", "(Ljava/lang/Object;)Z");
-        mv.visitInsn(IRETURN);
-        mv.visitMaxs(2, 2);
+        mv.visitJumpInsn( IFNONNULL, l0 );
+        mv.visitInsn( ICONST_0 );
+        mv.visitInsn( IRETURN );
+        mv.visitLabel( l0 );
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                BuildUtils.getInternalType( classDef.getName() ),
+                "_getTraitMap",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+        mv.visitVarInsn( ALOAD, 1 );
+        mv.visitMethodInsn( INVOKEINTERFACE,
+                Type.getInternalName( Map.class ),
+                "containsKey",
+                Type.getMethodDescriptor( Type.getType( boolean.class ), new Type[] { Type.getType( Object.class ) } ) );
+        mv.visitInsn( IRETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
-        mv = cw.visitMethod(ACC_PUBLIC, "removeTrait", "(Ljava/lang/String;)Lorg/drools/factmodel/traits/Thing;", "(Ljava/lang/String;)Lorg/drools/factmodel/traits/Thing;", null);
+        mv = cw.visitMethod( ACC_PUBLIC, "removeTrait",
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( String.class ) } ),
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( String.class ) } ),
+                null );
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", "()Ljava/util/Map;");
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+        mv.visitTypeInsn( CHECKCAST, Type.getInternalName( TraitTypeMap.class ) );
         mv.visitVarInsn(ALOAD, 1);
-        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "remove", "(Ljava/lang/Object;)Ljava/lang/Object;");
-        mv.visitTypeInsn(CHECKCAST, "org/drools/factmodel/traits/Thing");
-        mv.visitInsn(ARETURN);
-        mv.visitMaxs(2, 2);
+        mv.visitMethodInsn( INVOKEVIRTUAL, Type.getInternalName( TraitTypeMap.class ), "removeCascade",
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( String.class )} ) );
+        mv.visitInsn( ARETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
-
-        mv = cw.visitMethod(ACC_PUBLIC, "getTraits", "()Ljava/util/Collection;", "()Ljava/util/Collection<Ljava/lang/String;>;", null);
+        mv = cw.visitMethod( ACC_PUBLIC, "removeTrait",
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( BitSet.class ) } ),
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( BitSet.class ) } ),
+                null );
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", "()Ljava/util/Map;");
-        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "keySet", "()Ljava/util/Set;");
-        mv.visitInsn(ARETURN);
-        mv.visitMaxs(1, 1);
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL, BuildUtils.getInternalType( classDef.getName() ), "_getTraitMap", Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+        mv.visitTypeInsn( CHECKCAST, Type.getInternalName( TraitTypeMap.class ) );
+        mv.visitVarInsn( ALOAD, 1 );
+        mv.visitMethodInsn( INVOKEVIRTUAL, Type.getInternalName( TraitTypeMap.class ), "removeCascade",
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( BitSet.class )} ) );
+        mv.visitInsn( ARETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
-        mv = cw.visitMethod( ACC_PUBLIC, "_setBottomTypeCode", "(" + Type.getDescriptor( BitSet.class )+ ")V", null, null );
+        mv = cw.visitMethod( ACC_PUBLIC,
+                "getTraits",
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { } ),
+                "()Ljava/util/Collection<Ljava/lang/String;>;",
+                null );
+        mv.visitCode();
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                BuildUtils.getInternalType( classDef.getName() ),
+                "_getTraitMap",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+        mv.visitMethodInsn( INVOKEINTERFACE,
+                Type.getInternalName( Map.class ),
+                "keySet",
+                Type.getMethodDescriptor( Type.getType( Set.class ), new Type[] {} ) );
+        mv.visitInsn( ARETURN );
+        mv.visitMaxs( 0, 0 );
+        mv.visitEnd();
+
+
+        mv = cw.visitMethod( ACC_PUBLIC,
+                "_setBottomTypeCode",
+                Type.getMethodDescriptor( Type.getType( void.class ), new Type[] { Type.getType( BitSet.class ) } ),
+                null, null );
         mv.visitCode();
         mv.visitVarInsn( ALOAD, 0 );
         mv.visitFieldInsn( GETFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME , Type.getDescriptor( Map.class ) );
         mv.visitTypeInsn( CHECKCAST, Type.getInternalName( TraitTypeMap.class ) );
         mv.visitVarInsn( ALOAD, 1 );
-        mv.visitMethodInsn( INVOKEVIRTUAL, Type.getInternalName( TraitTypeMap.class ), "setBottomCode", "(" + Type.getDescriptor( BitSet.class ) + ")V");
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                Type.getInternalName( TraitTypeMap.class ),
+                "setBottomCode",
+                Type.getMethodDescriptor( Type.getType( void.class ), new Type[] { Type.getType( BitSet.class ) } ) );
         mv.visitInsn( RETURN );
-        mv.visitMaxs( 0,0 );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
         mv = cw.visitMethod( ACC_PUBLIC,
                 "getMostSpecificTraits",
-                "()" + Type.getDescriptor( Collection.class ),
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { } ) ,
                 "()Ljava/util/Collection<Lorg/drools/factmodel/traits/Thing;>;",
                 null );
         mv.visitCode();
@@ -444,7 +484,23 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
         mv.visitMethodInsn( INVOKEVIRTUAL,
                 Type.getInternalName( TraitTypeMap.class ),
                 "getMostSpecificTraits",
-                "()" + Type.getDescriptor( Collection.class ) );
+                Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { } )  );
+        mv.visitInsn( ARETURN );
+        mv.visitMaxs( 0, 0 );
+        mv.visitEnd();
+
+        mv = cw.visitMethod( ACC_PUBLIC, "getCurrentTypeCode", Type.getMethodDescriptor( Type.getType( BitSet.class ), new Type[] { } ) , null, null );
+        mv.visitCode();
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitFieldInsn( GETFIELD,
+                BuildUtils.getInternalType( classDef.getName() ),
+                TraitableBean.TRAITSET_FIELD_NAME,
+                Type.getDescriptor( Map.class ) );
+        mv.visitTypeInsn( CHECKCAST, Type.getInternalName( TraitTypeMap.class ) );
+        mv.visitMethodInsn( INVOKEVIRTUAL,
+                Type.getInternalName( TraitTypeMap.class ),
+                "getCurrentTypeCode",
+                Type.getMethodDescriptor( Type.getType( BitSet.class ), new Type[] { } ) );
         mv.visitInsn( ARETURN );
         mv.visitMaxs( 0, 0 );
         mv.visitEnd();
@@ -467,36 +523,36 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
 
         FieldVisitor fv = cw.visitField( Opcodes.ACC_PRIVATE,
                 TraitableBean.MAP_FIELD_NAME,
-                "Ljava/util/Map;",
+                Type.getDescriptor( Map.class ) ,
                 "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;",
                 null);
         fv.visitEnd();
 
         MethodVisitor mv = cw.visitMethod( Opcodes.ACC_PUBLIC,
                 "_getDynamicProperties",
-                "()Ljava/util/Map;",
+                Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ),
                 "()Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;",
                 null);
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitFieldInsn(GETFIELD, BuildUtils.getInternalType(def.getName()), TraitableBean.MAP_FIELD_NAME, "Ljava/util/Map;");
-        mv.visitInsn(ARETURN);
-        mv.visitMaxs(1, 1);
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitFieldInsn( GETFIELD, BuildUtils.getInternalType(def.getName()), TraitableBean.MAP_FIELD_NAME, Type.getDescriptor( Map.class ) );
+        mv.visitInsn( ARETURN );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
 
 
         mv = cw.visitMethod( ACC_PUBLIC,
                 "_setDynamicProperties",
-                "(Ljava/util/Map;)V",
+                Type.getMethodDescriptor( Type.getType( void.class ), new Type[] { Type.getType( Map.class ) } ),
                 "(Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)V",
                 null);
         mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitFieldInsn(PUTFIELD, BuildUtils.getInternalType(def.getName()), TraitableBean.MAP_FIELD_NAME, "Ljava/util/Map;");
-        mv.visitInsn(RETURN);
-        mv.visitMaxs(2, 2);
+        mv.visitVarInsn( ALOAD, 0 );
+        mv.visitVarInsn( ALOAD, 1 );
+        mv.visitFieldInsn ( PUTFIELD, BuildUtils.getInternalType( def.getName() ), TraitableBean.MAP_FIELD_NAME, Type.getDescriptor( Map.class ) );
+        mv.visitInsn( RETURN) ;
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
     }
@@ -596,8 +652,7 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
                     l1,
                     0 );
         }
-        mv.visitMaxs( hasObjects ? 3 : 0,
-                hasObjects ? 1 : 0 );
+        mv.visitMaxs( 0, 0 );
         mv.visitEnd();
 
     }
@@ -709,16 +764,6 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
      * @param classDef
      */
     protected void initializeDynamicTypeStructures( MethodVisitor mv, ClassDefinition classDef) {
-//        mv.visitVarInsn(ALOAD, 0);
-//                        mv.visitTypeInsn(NEW, "java/util/HashMap");
-//                        mv.visitInsn(DUP);
-//                        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V");
-//                        mv.visitFieldInsn(PUTFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.MAP_FIELD_NAME, "Ljava/util/Map;");
-//                        mv.visitVarInsn(ALOAD, 0);
-//                        mv.visitTypeInsn(NEW, "java/util/HashMap");
-//                        mv.visitInsn(DUP);
-//                        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V");
-//                        mv.visitFieldInsn(PUTFIELD, BuildUtils.getInternalType( classDef.getName() ), TraitableBean.TRAITSET_FIELD_NAME, "Ljava/util/Map;");
 
     }
 
@@ -1172,7 +1217,7 @@ public class DefaultBeanClassBuilder implements Opcodes, BeanClassBuilder, Seria
             mv.visitVarInsn(ALOAD, 0);
             mv.visitMethodInsn(INVOKESTATIC, "java/lang/System", "identityHashCode", "(Ljava/lang/Object;)I");
             mv.visitInsn(IRETURN);
-            mv.visitMaxs(1, 1);
+            mv.visitMaxs( 0, 0 );
             mv.visitEnd();
         }
     }

--- a/drools-core/src/main/java/org/drools/factmodel/traits/Entity.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/Entity.java
@@ -85,12 +85,20 @@ public class Entity implements TraitableBean<Entity,Entity>, Serializable {
         return isTraitMapInitialized() && _getTraitMap().containsKey(type);
     }
 
-    public Thing removeTrait(String type) {
+    public Collection<Thing<Entity>> removeTrait( String type ) {
         if ( isTraitMapInitialized() ) {
-            return _getTraitMap().remove( type );
+            return ((TraitTypeMap)_getTraitMap()).removeCascade(type);
         } else {
             return null;
         }        
+    }
+
+    public Collection<Thing<Entity>> removeTrait( BitSet typeCode ) {
+        if ( isTraitMapInitialized() ) {
+            return ((TraitTypeMap)_getTraitMap()).removeCascade( typeCode );
+        } else {
+            return null;
+        }
     }
 
     public Collection<String> getTraits() {
@@ -103,6 +111,10 @@ public class Entity implements TraitableBean<Entity,Entity>, Serializable {
 
     public Collection<Thing> getMostSpecificTraits() {
         return ((TraitTypeMap) __$$dynamic_traits_map$$).getMostSpecificTraits();
+    }
+
+    public BitSet getCurrentTypeCode() {
+        return ((TraitTypeMap) __$$dynamic_traits_map$$).getCurrentTypeCode();
     }
 
     public boolean equals(Object o) {

--- a/drools-core/src/main/java/org/drools/factmodel/traits/NullTraitType.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/NullTraitType.java
@@ -16,14 +16,21 @@
 
 package org.drools.factmodel.traits;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.Map;
 
 
-public class NullTraitType implements TraitType, Thing {
+public class NullTraitType implements TraitType, Thing, Externalizable {
 
     private BitSet typeCode;
+
+    public NullTraitType() {
+    }
 
     public NullTraitType( BitSet code ) {
         typeCode = code;
@@ -37,6 +44,10 @@ public class NullTraitType implements TraitType, Thing {
         return true;
     }
 
+    public String getTraitName() {
+        return "";
+    }
+
     public void setTypeCode(BitSet typeCode) {
         this.typeCode = typeCode;
     }
@@ -47,5 +58,13 @@ public class NullTraitType implements TraitType, Thing {
 
     public Object getCore() {
         return null;
+    }
+
+    public void writeExternal(ObjectOutput objectOutput) throws IOException {
+        objectOutput.writeObject( typeCode );
+    }
+
+    public void readExternal(ObjectInput objectInput) throws IOException, ClassNotFoundException {
+        typeCode = (BitSet) objectInput.readObject();
     }
 }

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitCoreWrapperClassBuilderImpl.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitCoreWrapperClassBuilderImpl.java
@@ -246,18 +246,35 @@ public class TraitCoreWrapperClassBuilderImpl implements TraitCoreWrapperClassBu
         if ( coreKlazz == null || needsMethod( coreKlazz, "removeTrait", String.class ) ) {
             {
                 mv = cw.visitMethod( ACC_PUBLIC, "removeTrait",
-                        "(" + Type.getDescriptor( String.class ) + ")" + Type.getDescriptor( Thing.class ),
-                        "(" + Type.getDescriptor( String.class ) + ")" + Type.getDescriptor( Thing.class ),
+                        Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( String.class ) } ),
+                        Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( String.class ) } ),
                         null );
                 mv.visitCode();
                 mv.visitVarInsn( ALOAD, 0 );
-                mv.visitMethodInsn( INVOKEVIRTUAL, BuildUtils.getInternalType( wrapperName ), "_getTraitMap", "()" + Type.getDescriptor( Map.class ) );
-                mv.visitVarInsn( ALOAD, 1 );
-                mv.visitMethodInsn( INVOKEINTERFACE, Type.getInternalName( Map.class ), "remove", "(" + Type.getDescriptor( Object.class ) + ")" + Type.getDescriptor( Object.class ) );
-                mv.visitTypeInsn( CHECKCAST, Type.getInternalName( Thing.class ) );
+                mv.visitMethodInsn( INVOKEVIRTUAL, BuildUtils.getInternalType( wrapperName ), "_getTraitMap", Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+                mv.visitTypeInsn( CHECKCAST, Type.getInternalName( TraitTypeMap.class ) );
+                mv.visitVarInsn(ALOAD, 1);
+                mv.visitMethodInsn( INVOKEVIRTUAL, Type.getInternalName( TraitTypeMap.class ), "removeCascade",
+                        Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( String.class )} ) );
                 mv.visitInsn( ARETURN );
                 mv.visitMaxs( 0, 0 );
                 mv.visitEnd();
+
+                mv = cw.visitMethod( ACC_PUBLIC, "removeTrait",
+                        Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( BitSet.class ) } ),
+                        Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( BitSet.class ) } ),
+                        null );
+                mv.visitCode();
+                mv.visitVarInsn( ALOAD, 0 );
+                mv.visitMethodInsn( INVOKEVIRTUAL, BuildUtils.getInternalType( wrapperName ), "_getTraitMap", Type.getMethodDescriptor( Type.getType( Map.class ), new Type[] {} ) );
+                mv.visitTypeInsn( CHECKCAST, Type.getInternalName( TraitTypeMap.class ) );
+                mv.visitVarInsn(ALOAD, 1);
+                mv.visitMethodInsn( INVOKEVIRTUAL, Type.getInternalName( TraitTypeMap.class ), "removeCascade",
+                        Type.getMethodDescriptor( Type.getType( Collection.class ), new Type[] { Type.getType( BitSet.class )} ) );
+                mv.visitInsn( ARETURN );
+                mv.visitMaxs( 0, 0 );
+                mv.visitEnd();
+
             }
         }
         if ( coreKlazz == null || needsMethod( coreKlazz, "getTraits" ) ) {
@@ -283,6 +300,28 @@ public class TraitCoreWrapperClassBuilderImpl implements TraitCoreWrapperClassBu
                 mv.visitMethodInsn( INVOKEVIRTUAL, Type.getInternalName( TraitTypeMap.class ), "setBottomCode", "(" + Type.getDescriptor( BitSet.class ) + ")V");
                 mv.visitInsn( RETURN );
                 mv.visitMaxs( 0,0 );
+                mv.visitEnd();
+            }
+        }
+
+        if ( coreKlazz == null || needsMethod( coreKlazz, "getCurrentTypeCode" ) ) {
+
+            {
+                mv = cw.visitMethod( ACC_PUBLIC, "getCurrentTypeCode", "()" + Type.getDescriptor( BitSet.class ), null, null );
+                mv.visitCode();
+                mv.visitVarInsn( ALOAD, 0 );
+                mv.visitFieldInsn( GETFIELD,
+                        BuildUtils.getInternalType( wrapperName ),
+                        TraitableBean.TRAITSET_FIELD_NAME,
+                        Type.getDescriptor( Map.class ) );
+                mv.visitTypeInsn( CHECKCAST,
+                        Type.getInternalName( TraitTypeMap.class ) );
+                mv.visitMethodInsn( INVOKEVIRTUAL,
+                        Type.getInternalName( TraitTypeMap.class ),
+                        "getCurrentTypeCode",
+                        "()" + Type.getDescriptor( BitSet.class ) );
+                mv.visitInsn( ARETURN );
+                mv.visitMaxs( 0, 0 );
                 mv.visitEnd();
             }
         }

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitFactory.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitFactory.java
@@ -218,57 +218,27 @@ public class TraitFactory<T extends Thing<K>, K extends TraitableBean> implement
 
         ReteooComponentFactory rcf = ruleBase.getConfiguration().getComponentFactory();
 
-//        JavaDialectRuntimeData data = ruleBase.gett
-//
-//                ((JavaDialectRuntimeData) getPackage( tdef.getDefinedClass().getPackage().getName() ).getDialectRuntimeRegistry().
-//                getDialectData( "java" ));
-
-
 
         TraitPropertyWrapperClassBuilder propWrapperBuilder = (TraitPropertyWrapperClassBuilder) rcf.getClassBuilderFactory().getPropertyWrapperBuilder();
-//        switch ( mode ) {
-//            case TRIPLES    : propWrapperBuilder = new TraitTriplePropertyWrapperClassBuilderImpl();
-//                break;
-//            case MAP        : propWrapperBuilder = new TraitMapPropertyWrapperClassBuilderImpl();
-//                break;
-//            default         : throw new RuntimeException( " This should not happen : unexpected property wrapping method " + mode );
-//        }
+
         propWrapperBuilder.init( tdef, ruleBase.getTraitRegistry() );
         try {
             byte[] propWrapper = propWrapperBuilder.buildClass( cdef );
             ruleBase.registerAndLoadTypeDefinition( wrapperName, propWrapper );
-
-//            String resourceName = JavaDialectRuntimeData.convertClassToResourcePath( wrapperName );
-//            data.putClassDefinition( resourceName, propWrapper );
-//            data.write( resourceName, propWrapper );
-
         } catch (Exception e) {
             e.printStackTrace();
         }
 
 
         TraitProxyClassBuilder proxyBuilder = (TraitProxyClassBuilder) rcf.getClassBuilderFactory().getTraitProxyBuilder();
-//        switch ( mode ) {
-//            case TRIPLES    : proxyBuilder = new TraitTripleProxyClassBuilderImpl();
-//                break;
-//            case MAP        : proxyBuilder = new TraitMapProxyClassBuilderImpl();
-//                break;
-//            default         : throw new RuntimeException( " This should not happen : unexpected property wrapping method " + mode );
-//        }
+
         proxyBuilder.init( tdef, rcf.getBaseTraitProxyClass(), ruleBase.getTraitRegistry() );
         try {
             byte[] proxy = proxyBuilder.buildClass( cdef );
             ruleBase.registerAndLoadTypeDefinition( proxyName, proxy );
-
-//            String resourceName = JavaDialectRuntimeData.convertClassToResourcePath( proxyName );
-//            data.putClassDefinition( resourceName, proxy );
-//            data.write( resourceName, proxy );
-
         } catch (Exception e) {
             e.printStackTrace();
         }
-
-//        data.onBeforeExecute();
 
         try {
             long mask = ruleBase.getTraitRegistry().getFieldMask( trait.getName(), cdef.getDefinedClass().getName() );

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitMapProxyClassBuilderImpl.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitMapProxyClassBuilderImpl.java
@@ -136,6 +136,13 @@ public class TraitMapProxyClassBuilderImpl implements TraitProxyClassBuilder, Se
                   new String[]{ internalTrait, Type.getInternalName( Serializable.class ) } );
 
         {
+            fv = cw.visitField( ACC_PRIVATE + ACC_FINAL + ACC_STATIC,
+                    TraitType.traitNameField, Type.getDescriptor( String.class ),
+                    null, null );
+            fv.visitEnd();
+        }
+
+        {
             fv = cw.visitField( ACC_PUBLIC + ACC_FINAL, "object", descrCore, null, null );
             fv.visitEnd();
         }
@@ -152,6 +159,22 @@ public class TraitMapProxyClassBuilderImpl implements TraitProxyClassBuilder, Se
                 fv.visitEnd();
             }
         }
+
+        {
+            mv = cw.visitMethod( ACC_STATIC, "<clinit>", "()V", null, null );
+            mv.visitCode();
+            mv.visitLdcInsn( Type.getType( Type.getDescriptor( trait.getDefinedClass() ) ) );
+            mv.visitMethodInsn( INVOKEVIRTUAL,
+                    Type.getInternalName( Class.class ), "getName", "()" + Type.getDescriptor( String.class ) );
+            mv.visitFieldInsn( PUTSTATIC,
+                    internalProxy,
+                    TraitType.traitNameField,
+                    Type.getDescriptor( String.class ) );
+            mv.visitInsn( RETURN );
+            mv.visitMaxs( 0, 0 );
+            mv.visitEnd();
+        }
+
         {
             mv = cw.visitMethod( ACC_PUBLIC, "<init>", "()V", null, null );
             mv.visitCode();
@@ -254,6 +277,16 @@ public class TraitMapProxyClassBuilderImpl implements TraitProxyClassBuilder, Se
             mv.visitMaxs( 0, 0 );
             mv.visitEnd();
         }
+
+        {
+            mv = cw.visitMethod( ACC_PUBLIC, "getTraitName", "()" + Type.getDescriptor( String.class ), null, null);
+            mv.visitCode();
+            mv.visitFieldInsn( GETSTATIC, internalProxy, TraitType.traitNameField, Type.getDescriptor( String.class ) );
+            mv.visitInsn( ARETURN );
+            mv.visitMaxs( 0, 0 );
+            mv.visitEnd();
+        }
+
         {
             mv = cw.visitMethod( ACC_PUBLIC, "getCore", "()" + descrCore + "", null, null );
             mv.visitCode();

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitProxy.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitProxy.java
@@ -49,6 +49,9 @@ public abstract class TraitProxy implements Externalizable, TraitType {
     protected void setFields( Map<String, Object> m ) {
         fields = m;
     }
+
+    public abstract String getTraitName();
+
     
     public void writeExternal(ObjectOutput out) throws IOException {
         out.writeObject( fields );

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitTripleProxyClassBuilderImpl.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitTripleProxyClassBuilderImpl.java
@@ -139,6 +139,12 @@ public class TraitTripleProxyClassBuilderImpl implements TraitProxyClassBuilder,
                   new String[] { internalTrait, Type.getInternalName( Externalizable.class ) } );
 
         {
+            fv = cw.visitField( ACC_PRIVATE + ACC_FINAL + ACC_STATIC,
+                    TraitType.traitNameField, Type.getDescriptor( String.class ),
+                    null, null );
+            fv.visitEnd();
+        }
+        {
             fv = cw.visitField( ACC_PUBLIC, "object", descrCore, null, null );
             fv.visitEnd();
         }
@@ -159,6 +165,22 @@ public class TraitTripleProxyClassBuilderImpl implements TraitProxyClassBuilder,
                 fv.visitEnd();
             }
         }
+
+        {
+            mv = cw.visitMethod( ACC_STATIC, "<clinit>", "()V", null, null );
+            mv.visitCode();
+            mv.visitLdcInsn( Type.getType( Type.getDescriptor( trait.getDefinedClass() ) ) );
+            mv.visitMethodInsn( INVOKEVIRTUAL,
+                    Type.getInternalName( Class.class ), "getName", "()" + Type.getDescriptor( String.class ) );
+            mv.visitFieldInsn( PUTSTATIC,
+                    internalProxy,
+                    TraitType.traitNameField,
+                    Type.getDescriptor( String.class ) );
+            mv.visitInsn( RETURN );
+            mv.visitMaxs( 0, 0 );
+            mv.visitEnd();
+        }
+
         {
             mv = cw.visitMethod( ACC_PUBLIC, "<init>", "()V", null, null );
             mv.visitCode();
@@ -185,6 +207,14 @@ public class TraitTripleProxyClassBuilderImpl implements TraitProxyClassBuilder,
 
             mv.visitInsn( RETURN );
 //            mv.visitMaxs( 5 + size, 4 );
+            mv.visitMaxs( 0, 0 );
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod( ACC_PUBLIC, "getTraitName", "()" + Type.getDescriptor( String.class ), null, null);
+            mv.visitCode();
+            mv.visitFieldInsn( GETSTATIC, internalProxy, TraitType.traitNameField, Type.getDescriptor( String.class ) );
+            mv.visitInsn( ARETURN );
             mv.visitMaxs( 0, 0 );
             mv.visitEnd();
         }

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitType.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitType.java
@@ -25,4 +25,7 @@ public interface TraitType {
 
     public boolean isVirtual();
 
+    public static final String traitNameField = "__$$trait_Name";
+
+    public String getTraitName();
 }

--- a/drools-core/src/main/java/org/drools/factmodel/traits/TraitableBean.java
+++ b/drools-core/src/main/java/org/drools/factmodel/traits/TraitableBean.java
@@ -40,12 +40,16 @@ public interface TraitableBean<K, X extends TraitableBean> {
 
     public boolean hasTrait( String type );
 
-    public Thing<K> removeTrait( String type );
+    public Collection<Thing<K>> removeTrait( String type );
+
+    public Collection<Thing<K>> removeTrait( BitSet typeCode );
 
     public Collection<String> getTraits();
 
 
     public Collection<Thing> getMostSpecificTraits();
+
+    public BitSet getCurrentTypeCode();
 
     public void _setBottomTypeCode( BitSet code );
 

--- a/drools-core/src/main/java/org/drools/rule/constraint/MvelConstraint.java
+++ b/drools-core/src/main/java/org/drools/rule/constraint/MvelConstraint.java
@@ -122,7 +122,7 @@ public class MvelConstraint extends MutableTypeConstraint implements IndexableCo
         this.isUnification = isUnification;
     }
 
-    private String getAccessedClass() {
+    protected String getAccessedClass() {
         return extractor instanceof ClassFieldReader ? ((ClassFieldReader)extractor).getClassName() : null;
     }
 

--- a/drools-core/src/main/java/org/drools/util/CodedHierarchy.java
+++ b/drools-core/src/main/java/org/drools/util/CodedHierarchy.java
@@ -33,6 +33,8 @@ public interface CodedHierarchy<T> {
 
     public void removeMember( T val );
 
+    public void removeMember( BitSet key );
+
 
 
     public BitSet getCode( T val );

--- a/drools-core/src/main/java/org/drools/util/CodedHierarchyImpl.java
+++ b/drools-core/src/main/java/org/drools/util/CodedHierarchyImpl.java
@@ -198,7 +198,14 @@ public class CodedHierarchyImpl<T> implements CodedHierarchy<T>, Externalizable 
 
 
     public void removeMember( T val ) {
+        if ( val == null ) {
+            return;
+        }
         BitSet key = getCode( val );
+        removeMember( key );
+    }
+
+    public void removeMember( BitSet key ) {
         if ( ! hasKey( key ) ) {
             return;
         } else {
@@ -669,6 +676,13 @@ public class CodedHierarchyImpl<T> implements CodedHierarchy<T>, Externalizable 
     }
 
 
+    public static boolean supersetOrEqualset( BitSet n1, BitSet n2 ) {
+        BitSet x = new BitSet();
+        x.or( n1 );
+        x.and( n2 );
+        return x.equals( n2 );
+    }
+
     int superset( HierNode<T> n1, HierNode<T> n2 ) {
         return superset( n1.getBitMask(), n2.getBitMask() );
     }
@@ -677,14 +691,7 @@ public class CodedHierarchyImpl<T> implements CodedHierarchy<T>, Externalizable 
         if ( n1.equals( n2 ) ) {
             return 0;
         }
-        BitSet x = new BitSet();
-        x.or( n1 );
-        x.and( n2 );
-        if ( x.equals( n2 ) ) {
-            return 1;
-        } else {
-            return -1;
-        }
+        return supersetOrEqualset(n1, n2) ? 1 : -1;
     }
 
     int numBit( BitSet x ) {
@@ -875,6 +882,19 @@ public class CodedHierarchyImpl<T> implements CodedHierarchy<T>, Externalizable 
         public void readExternal(ObjectInput objectInput) throws IOException, ClassNotFoundException {
 
         }
+    }
+
+    public static BitSet stringToBitSet( String s ) {
+        BitSet b = new BitSet();
+        int n = s.length();
+        for( int j = 0; j < s.length(); j++ ) {
+            if ( s.charAt( j ) == '1' ) {
+                b.set( n - j - 1 );
+            } else if ( s.charAt( j ) != '0' ) {
+                throw new IllegalStateException( "The string " + s + " is not a valid bitset encoding" );
+            }
+        }
+        return b;
     }
 
 }

--- a/drools-core/src/main/java/org/drools/util/HierarchySorter.java
+++ b/drools-core/src/main/java/org/drools/util/HierarchySorter.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.util;
+
+import java.util.*;
+
+public class HierarchySorter<K> {
+
+
+    public List<K> sort( Map<K,Collection<K>> hierarchy ) {
+        Node<K,K> root = new Node<K,K>( null );
+        Map<K, Node<K,K>> map = new HashMap<K, Node<K,K>>();
+        for ( K element : hierarchy.keySet() ) {
+            K key = element;
+
+            Node<K,K> node = map.get( key );
+            if ( node == null ) {
+                node = new Node( key,
+                        element );
+                map.put( key,
+                        node );
+            } else if ( node.getData() == null ) {
+                node.setData( element );
+            }
+            Collection<K> px = hierarchy.get( key );
+            if ( px.isEmpty() ) {
+                root.addChild( node );
+            } else {
+                for ( K parentElement : px ) {
+
+                    K superKey = parentElement;
+
+                    Node<K,K> superNode = map.get( superKey );
+                    if ( superNode == null ) {
+                        superNode = new Node<K,K>( superKey );
+                        map.put( superKey,
+                                superNode );
+                    }
+                    if ( ! superNode.children.contains( node ) ) {
+                        superNode.addChild( node );
+                    }
+                }
+
+            }
+
+        }
+
+        Iterator<Node<K,K>> iter = map.values().iterator();
+        while ( iter.hasNext() ) {
+            Node<K,K> n = iter.next();
+            if ( n.getData() == null ) root.addChild( n );
+
+        }
+
+        List<K> sortedList = new LinkedList<K>();
+        root.accept( sortedList );
+
+        return sortedList;
+    }
+
+    /**
+     * Utility class for the sorting algorithm
+     *
+     * @param <T>
+     */
+    private static class Node<K,T> {
+        private K        key;
+        private T             data;
+        private List<Node<K,T>> children;
+
+        public Node(K key) {
+            this.key = key;
+            this.children = new LinkedList<Node<K,T>>();
+        }
+
+        public Node(K key,
+                    T content) {
+            this( key );
+            this.data = content;
+        }
+
+        public void addChild(Node<K,T> child) {
+            this.children.add( child );
+        }
+
+        public List<Node<K,T>> getChildren() {
+            return children;
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        public T getData() {
+            return data;
+        }
+
+        public void setData(T content) {
+            this.data = content;
+        }
+
+        public void accept(List<T> list) {
+            if ( this.data != null ) {
+                if ( list.contains( this.data ) ) {
+                    list.remove( this.data );
+                }
+                list.add( this.data );
+            }
+
+            for ( int j = 0; j < children.size(); j++ ) {
+                children.get( j ).accept( list );
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Node{" +
+                    "key='" + key + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals( Object o ) {
+            if ( this == o ) return true;
+            if ( o == null || getClass() != o.getClass() ) return false;
+
+            Node node = (Node) o;
+
+            if ( !key.equals( node.key ) ) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
DROOLS-64 (Trait modify should preserve type inheritance) + 
DROOLS-88 (Use generics in type declarations' fields)

Comes with two useful general purpose algorithms
- Hierarchy linearization (extracted from a previous, ad-hoc implementation for type declares)
- Incremental Hierarchy encoding for fast sub-sup queries/tests

Should be forward-ported to 6.x
