### PR TITLE
DROOLS-139: Infinispan based Drools and jBPM persistence

### DIFF
--- a/drools-persistence-infinispan/pom.xml
+++ b/drools-persistence-infinispan/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.drools</groupId>
+    <artifactId>drools-multiproject</artifactId>
+    <version>6.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>drools-persistence-infinispan</artifactId>
+
+  <name>Drools :: Persistence :: Infinispan</name>
+  <description>Infinispan implementation for Drools</description>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+      <testResource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+    
+    <plugins>
+      <plugin>
+        <!--  ensure that db files are deleted before _any_ run 
+              otherwise we get tests failing because of leftover db's -->
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+         <filesets>
+            <fileset>
+              <directory>${basedir}</directory>
+              <includes>
+                <include>btm*</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>org.drools.persistence.info.EntityHolder</directory>
+            </fileset>
+            <fileset>
+              <directory>org.drools.persistence.jta.TransactionTestObject</directory>
+            </fileset>
+         </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-jpa</artifactId>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-query</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+      <version>3.6.2</version><!-- TODO see how to connect -->
+    </dependency>
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency><!-- For unit test logging: configure in src/test/resources/logback-test.xml -->
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- test -->
+    <dependency>
+      <groupId>org.codehaus.btm</groupId>
+      <artifactId>btm</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-compiler</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jdt.core.compiler</groupId>
+      <artifactId>ecj</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>antlr</groupId>
+      <artifactId>antlr</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr-runtime</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Extra test -->
+   <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jetty-embedded</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!--
+     These are properties used in the database profiles. Some of them must be initialized
+     them to be empty so that Maven applies them via filtering to the resources. 
+     -->
+  <properties>
+    <maven.btm.maxPoolSize>16</maven.btm.maxPoolSize>
+    <maven.datasource.classname>bitronix.tm.resource.jdbc.lrc.LrcXADataSource</maven.datasource.classname>
+  </properties>
+
+</project>

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanJDKTimerService.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanJDKTimerService.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.persistence.infinispan;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.drools.core.command.CommandService;
+import org.drools.core.command.impl.GenericCommand;
+import org.drools.core.time.InternalSchedulerService;
+import org.drools.core.time.Job;
+import org.drools.core.time.JobContext;
+import org.drools.core.time.SelfRemovalJob;
+import org.drools.core.time.SelfRemovalJobContext;
+import org.drools.core.time.Trigger;
+import org.drools.core.time.impl.DefaultTimerJobInstance;
+import org.drools.core.time.impl.JDKTimerService;
+import org.drools.core.time.impl.TimerJobInstance;
+import org.kie.internal.command.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A default Scheduler implementation that uses the
+ * JDK built-in ScheduledThreadPoolExecutor as the
+ * scheduler and the system clock as the clock.
+ */
+public class InfinispanJDKTimerService extends JDKTimerService {
+
+    private static Logger logger = LoggerFactory.getLogger( InfinispanTimerJobInstance.class );
+    
+    private CommandService              commandService;
+
+    private Map<Long, TimerJobInstance> timerInstances;
+
+    public void setCommandService(CommandService commandService) {
+        this.commandService = commandService;
+    }
+
+    public InfinispanJDKTimerService() {
+        this( 1 );
+        timerInstances = new ConcurrentHashMap<Long, TimerJobInstance>();
+    }
+
+    public InfinispanJDKTimerService(int size) {
+        super( size );
+        timerInstances = new ConcurrentHashMap<Long, TimerJobInstance>();
+    }
+
+    protected Callable<Void> createCallableJob(Job job,
+                                               JobContext ctx,
+                                               Trigger trigger,
+                                               JDKJobHandle handle,
+                                               InternalSchedulerService scheduler) {
+        InfinispanJDKCallableJob jobInstance = new InfinispanJDKCallableJob( new SelfRemovalJob( job ),
+                                                               new SelfRemovalJobContext( ctx,
+                                                                                          timerInstances ),
+                                                               trigger,
+                                                               handle,
+                                                               scheduler );
+
+        this.timerInstances.put( handle.getId(),
+                                 jobInstance );
+        return jobInstance;
+    }
+
+    public Collection<TimerJobInstance> getTimerJobInstances() {
+        return timerInstances.values();
+    }
+
+    public class InfinispanJDKCallableJob extends DefaultTimerJobInstance {
+
+        public InfinispanJDKCallableJob(Job job,
+                                 JobContext ctx,
+                                 Trigger trigger,
+                                 JDKJobHandle handle,
+                                 InternalSchedulerService scheduler) {
+            super( job,
+                   ctx,
+                   trigger,
+                   handle,
+                   scheduler );
+        }
+
+        public Void call() throws Exception {
+            try { 
+                JDKCallableJobCommand command = new JDKCallableJobCommand( this );
+                commandService.execute( command );
+            } catch(Exception e ) { 
+                logger.error("Unable to execute job!", e);
+                throw e;
+            }
+            
+            return null;
+        }
+
+        private Void internalCall() throws Exception {
+            return super.call();
+        }
+    }
+
+    public static class JDKCallableJobCommand
+        implements
+        GenericCommand<Void> {
+
+        private static final long serialVersionUID = 4L;
+
+        private InfinispanJDKCallableJob job;
+
+        public JDKCallableJobCommand(InfinispanJDKCallableJob job) {
+            this.job = job;
+        }
+
+        public Void execute(Context context) {
+            try {
+                return job.internalCall();
+            } catch ( Exception e ) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanPersistenceContext.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanPersistenceContext.java
@@ -1,0 +1,126 @@
+package org.drools.persistence.infinispan;
+
+import org.drools.persistence.PersistenceContext;
+import org.drools.persistence.info.EntityHolder;
+import org.drools.persistence.info.SessionInfo;
+import org.drools.persistence.info.WorkItemInfo;
+import org.infinispan.Cache;
+
+public class InfinispanPersistenceContext implements PersistenceContext {
+	
+	private static int SESSIONINFO_KEY = 1;
+	private static long WORKITEMINFO_KEY = 1;
+	private static final Object syncObject = new Object();
+	
+    private Cache<String, Object> cache;
+    private boolean isJTA;
+    
+    public InfinispanPersistenceContext(Cache<String, Object> cache) {
+        this(cache, true);
+    }
+    
+    public InfinispanPersistenceContext(Cache<String, Object> cache, boolean isJTA) {
+        this.cache = cache;
+        this.isJTA = isJTA;
+    }
+
+    public void persist(SessionInfo entity) {
+    	if (entity.getId() == null) {
+    		entity.setId(generateSessionInfoId());
+    	}
+    	String key = createSessionKey(entity.getId());
+    	entity.update();
+        this.cache.put(key , new EntityHolder(key, entity) );
+    }
+    
+    private Integer generateSessionInfoId() {
+    	synchronized (syncObject) {
+    		while (cache.containsKey("sessionInfo" + SESSIONINFO_KEY)) {
+    			SESSIONINFO_KEY++;
+    		}
+    	}
+    	return SESSIONINFO_KEY;
+    }
+    
+    private Long generateWorkItemInfoId() {
+    	synchronized (syncObject) {
+    		while (cache.containsKey("workItem" + WORKITEMINFO_KEY)) {
+    			WORKITEMINFO_KEY++;
+    		}
+    	}
+    	return WORKITEMINFO_KEY;
+    }
+
+	private String createSessionKey(Integer id) {
+		return "sessionInfo" + safeId(id);
+	}
+	
+	private String createWorkItemKey(Long id) {
+		return "workItem" + safeId(id);
+	}
+	
+	private String safeId(Number id) {
+		return String.valueOf(id); //TODO
+	}
+
+    public SessionInfo findSessionInfo(Integer id) {
+    	EntityHolder holder = (EntityHolder) this.cache.get( createSessionKey(id) );
+    	if (holder == null) {
+    		return null;
+    	}
+        return holder.getSessionInfo();
+    }
+
+    @Override
+    public void remove(SessionInfo sessionInfo) {
+        cache.remove( createSessionKey(sessionInfo.getId()) );
+        cache.evict( createSessionKey(sessionInfo.getId()) );
+    }
+
+    public boolean isOpen() {
+    	//cache doesn't close
+        return true;
+    }
+
+    public void joinTransaction() {
+    	if (isJTA) {
+    		//cache.getAdvancedCache().getTransactionManager().getTransaction().???? TODO
+    	}
+    }
+
+    public void close() {
+        //cache doesn't close
+    }
+
+    public void persist(WorkItemInfo workItemInfo) {
+    	if (workItemInfo.getId() == null) {
+    		workItemInfo.setId(generateWorkItemInfoId());
+    	}
+    	String key = createWorkItemKey(workItemInfo.getId());
+    	workItemInfo.update();
+    	cache.put(key, new EntityHolder(key, workItemInfo));
+    }
+
+    public WorkItemInfo findWorkItemInfo(Long id) {
+    	EntityHolder holder = (EntityHolder) cache.get(createWorkItemKey(id));
+    	if (holder == null) {
+    		return null;
+    	}
+    	return holder.getWorkItemInfo();
+    }
+
+    public void remove(WorkItemInfo workItemInfo) {
+        cache.remove( createWorkItemKey(workItemInfo.getId()) );
+        cache.evict( createWorkItemKey(workItemInfo.getId()) );
+    }
+
+    public WorkItemInfo merge(WorkItemInfo workItemInfo) {
+    	String key = createWorkItemKey(workItemInfo.getId());
+    	workItemInfo.update();
+    	return ((EntityHolder) cache.put(key, new EntityHolder(key, workItemInfo))).getWorkItemInfo();
+    }
+    
+    public Cache<String, Object> getCache() {
+		return cache;
+	}
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanPersistenceContextManager.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanPersistenceContextManager.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2011 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.drools.persistence.infinispan;
+
+import org.drools.persistence.PersistenceContext;
+import org.drools.persistence.PersistenceContextManager;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+
+public class InfinispanPersistenceContextManager
+    implements
+    PersistenceContextManager {
+    Environment                  env;
+
+    private DefaultCacheManager cm;
+
+    private Cache<String, Object> appScopedCache;
+    protected Cache<String, Object> cmdScopedCache;
+
+    private boolean              internalAppScopedCache;
+    private boolean              internalCmdScopedCache;
+
+    public InfinispanPersistenceContextManager(Environment env) {
+        this.env = env;
+        this.cm = ( DefaultCacheManager ) env.get( EnvironmentName.ENTITY_MANAGER_FACTORY );
+    }
+    
+    @SuppressWarnings("unchecked")
+    public PersistenceContext getApplicationScopedPersistenceContext() {
+        if ( this.appScopedCache == null ) {
+            // Use the App scoped EntityManager if the user has provided it, and it is open.
+            this.appScopedCache = (Cache<String, Object>) this.env.get( EnvironmentName.APP_SCOPED_ENTITY_MANAGER );
+            
+            if ( this.appScopedCache == null ) {
+                internalAppScopedCache = true;
+                this.appScopedCache = this.cm.getCache("jbpm-configured-cache");
+                this.env.set( EnvironmentName.APP_SCOPED_ENTITY_MANAGER, this.appScopedCache );
+            } else {
+                internalAppScopedCache = false;
+            }
+        }
+        return new InfinispanPersistenceContext( appScopedCache );
+    }
+
+    public PersistenceContext getCommandScopedPersistenceContext() {
+        return new InfinispanPersistenceContext( this.cmdScopedCache );
+    }
+
+    public void beginCommandScopedEntityManager() {
+    	@SuppressWarnings("unchecked")
+        Cache<String, Object> cmdScopedCache = (Cache<String, Object>) env.get( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER );
+        if ( cmdScopedCache == null) {
+            internalCmdScopedCache = true;
+            this.cmdScopedCache = this.cm.getCache("jbpm-configured-cache");
+            this.env.set( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER, this.cmdScopedCache );
+            cmdScopedCache = this.cmdScopedCache;
+        } else {
+            internalCmdScopedCache = false;
+        }
+        //cmdScopedCache.joinTransaction();?? TODO
+        //appScopedCache.joinTransaction();?? TODO
+    }
+
+    public void endCommandScopedEntityManager() {
+        if ( this.internalCmdScopedCache ) {
+            this.env.set( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER, null );
+        }
+    }
+
+    public void dispose() {
+        if ( this.internalAppScopedCache ) {
+            this.internalAppScopedCache = false;
+            this.env.set( EnvironmentName.APP_SCOPED_ENTITY_MANAGER, null );
+            this.appScopedCache = null;
+        }
+        
+        if ( this.internalCmdScopedCache ) {
+            this.internalCmdScopedCache = false;
+            this.env.set( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER, null );
+            this.cmdScopedCache = null;
+        }
+    }
+
+    public void clearPersistenceContext() {
+        /*if (this.cmdScopedCache != null) {
+            this.cmdScopedCache.clear();
+        }*/ //TODO do nothing for now
+        
+    }
+
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanTimeJobFactoryManager.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanTimeJobFactoryManager.java
@@ -1,0 +1,70 @@
+package org.drools.persistence.infinispan;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.drools.core.command.CommandService;
+import org.drools.core.time.InternalSchedulerService;
+import org.drools.core.time.Job;
+import org.drools.core.time.JobContext;
+import org.drools.core.time.JobHandle;
+import org.drools.core.time.SelfRemovalJob;
+import org.drools.core.time.SelfRemovalJobContext;
+import org.drools.core.time.Trigger;
+import org.drools.core.time.impl.TimerJobFactoryManager;
+import org.drools.core.time.impl.TimerJobInstance;
+
+public class InfinispanTimeJobFactoryManager
+    implements
+    TimerJobFactoryManager {
+
+    private CommandService              commandService;
+
+    private Map<Long, TimerJobInstance> timerInstances;
+
+    public void setCommandService(CommandService commandService) {
+        this.commandService = commandService;
+    }
+
+    public InfinispanTimeJobFactoryManager() {
+        timerInstances = new ConcurrentHashMap<Long, TimerJobInstance>();
+    }
+
+    public TimerJobInstance createTimerJobInstance(Job job,
+                                                   JobContext ctx,
+                                                   Trigger trigger,
+                                                   JobHandle handle,
+                                                   InternalSchedulerService scheduler) {
+        ctx.setJobHandle( handle );
+        InfinispanTimerJobInstance jobInstance = new InfinispanTimerJobInstance( new SelfRemovalJob( job ),
+                                                                   new SelfRemovalJobContext( ctx,
+                                                                                              timerInstances ),
+                                                                   trigger,
+                                                                   handle,
+                                                                   scheduler);
+
+        return jobInstance;
+    }
+    
+    public void addTimerJobInstance(TimerJobInstance instance) {
+
+        this.timerInstances.put( instance.getJobHandle().getId(),
+                                 instance );        
+    }
+    
+    public void removeTimerJobInstance(TimerJobInstance instance) {
+
+        this.timerInstances.remove( instance.getJobHandle().getId() );        
+    }
+    
+
+    public Collection<TimerJobInstance> getTimerJobInstances() {
+        return timerInstances.values();
+    }
+
+    public CommandService getCommandService() {
+        return commandService;
+    }
+
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanTimerJobInstance.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/InfinispanTimerJobInstance.java
@@ -1,0 +1,45 @@
+package org.drools.persistence.infinispan;
+
+import org.drools.core.command.CommandService;
+import org.drools.core.time.AcceptsTimerJobFactoryManager;
+import org.drools.core.time.InternalSchedulerService;
+import org.drools.core.time.Job;
+import org.drools.core.time.JobContext;
+import org.drools.core.time.JobHandle;
+import org.drools.core.time.Trigger;
+import org.drools.core.time.impl.DefaultTimerJobInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfinispanTimerJobInstance extends DefaultTimerJobInstance {       
+
+    private static Logger logger = LoggerFactory.getLogger( InfinispanTimerJobInstance.class );
+    
+    public InfinispanTimerJobInstance(Job job,
+                               JobContext ctx,
+                               Trigger trigger,
+                               JobHandle handle,
+                               InternalSchedulerService scheduler) {
+        super( job,
+               ctx,
+               trigger,
+               handle,
+               scheduler );
+    }
+
+    public Void call() throws Exception {
+        try { 
+            JDKCallableJobCommand command = new JDKCallableJobCommand( this );
+            CommandService commandService = ((AcceptsTimerJobFactoryManager)scheduler).getTimerJobFactoryManager().getCommandService();
+            commandService.execute( command );
+            return null;
+        } catch( Exception e ) { 
+            logger.error("Unable to execute timer job!", e);
+            throw e;
+        }
+    }
+
+    Void internalCall() throws Exception {
+        return super.call();
+    }
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/JDKCallableJobCommand.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/JDKCallableJobCommand.java
@@ -1,0 +1,27 @@
+package org.drools.persistence.infinispan;
+
+import org.drools.core.command.impl.GenericCommand;
+import org.kie.internal.command.Context;
+
+public class JDKCallableJobCommand
+    implements
+    GenericCommand<Void> {
+
+    private static final long   serialVersionUID = 4L;
+
+    private InfinispanTimerJobInstance job;
+
+    public JDKCallableJobCommand(InfinispanTimerJobInstance job) {
+        this.job = job;
+    }
+
+    public Void execute(Context context) {
+        try {
+            return job.internalCall();
+        } catch ( Exception e ) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/KnowledgeStoreServiceImpl.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/KnowledgeStoreServiceImpl.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.drools.persistence.infinispan;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
+
+import org.drools.core.SessionConfiguration;
+import org.drools.core.command.CommandService;
+import org.drools.core.command.Interceptor;
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.core.process.instance.WorkItemManagerFactory;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.infinispan.processinstance.InfinispanWorkItemManagerFactory;
+import org.drools.persistence.jta.JtaTransactionManager;
+import org.kie.api.KieBase;
+import org.kie.api.persistence.jpa.KieStoreServices;
+import org.kie.api.runtime.CommandExecutor;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.TimerJobFactoryOption;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class KnowledgeStoreServiceImpl
+    implements
+    KieStoreServices {
+
+    private Class< ? extends CommandExecutor>               commandServiceClass;
+    private Class< ? extends WorkItemManagerFactory>        workItemManagerFactoryClass;
+
+    private Properties                                      configProps = new Properties();
+
+    public KnowledgeStoreServiceImpl() {
+        setDefaultImplementations();
+    }
+
+    protected void setDefaultImplementations() {
+        setCommandServiceClass( SingleSessionCommandService.class );
+        setProcessInstanceManagerFactoryClass( "org.jbpm.persistence.processinstance.InfinispanProcessInstanceManagerFactory" );
+        setWorkItemManagerFactoryClass( InfinispanWorkItemManagerFactory.class );
+        setProcessSignalManagerFactoryClass( "org.jbpm.persistence.processinstance.InfinispanSignalManagerFactory" );
+    }
+
+    public StatefulKnowledgeSession newKieSession(KieBase kbase,
+                                                  KieSessionConfiguration configuration,
+                                                  Environment environment) {
+        if ( configuration == null ) {
+            configuration = new SessionConfiguration();
+        }
+
+        if ( environment == null ) {
+            throw new IllegalArgumentException( "Environment cannot be null" );
+        }
+
+        
+        CommandService commandService = (CommandService) buildCommandService( kbase, mergeConfig( configuration ), environment );
+        if (commandService instanceof SingleSessionCommandService) {
+        	((SingleSessionCommandService) commandService).
+        		addInterceptor(new ManualPersistInterceptor((SingleSessionCommandService) commandService));
+        	try {
+        		Class<?> clazz = Class.forName("org.jbpm.persistence.ManualPersistProcessInterceptor");
+        		Constructor<?> c = clazz.getConstructor(SingleSessionCommandService.class);
+        		Interceptor interceptor = (Interceptor) c.newInstance(commandService);
+        		((SingleSessionCommandService) commandService).addInterceptor(interceptor);
+        	} catch (ClassNotFoundException e) {
+        		//Expected of non-jbpm based projects
+        	} catch (Exception e) {
+        		//something unexpected happened
+        		throw new RuntimeException("Something wrong initializing manual process persistor interceptor", e);
+        	}
+        }
+        
+        return new CommandBasedStatefulKnowledgeSession( commandService );
+    }
+
+    public StatefulKnowledgeSession loadKieSession(int id,
+                                                   KieBase kbase,
+                                                   KieSessionConfiguration configuration,
+                                                   Environment environment) {
+        if ( configuration == null ) {
+            configuration = new SessionConfiguration();
+        }
+
+        if ( environment == null ) {
+            throw new IllegalArgumentException( "Environment cannot be null" );
+        }
+
+        CommandService commandService = (CommandService) buildCommandService( id, kbase, mergeConfig( configuration ), environment );
+        if (commandService instanceof SingleSessionCommandService) {
+        	((SingleSessionCommandService) commandService).
+        		addInterceptor(new ManualPersistInterceptor((SingleSessionCommandService) commandService));
+        	try {
+        		Class<?> clazz = Class.forName("org.jbpm.persistence.ManualPersistProcessInterceptor");
+        		Constructor<?> c = clazz.getConstructor(SingleSessionCommandService.class);
+        		Interceptor interceptor = (Interceptor) c.newInstance(commandService);
+        		((SingleSessionCommandService) commandService).addInterceptor(interceptor);
+        	} catch (ClassNotFoundException e) {
+        		//Expected of non-jbpm based projects
+        	} catch (Exception e) {
+        		//something unexpected happened
+        		throw new RuntimeException("Something wrong initializing manual process persistor interceptor", e);
+        	}
+        }
+        
+        return new CommandBasedStatefulKnowledgeSession( commandService );
+    }
+
+    private CommandExecutor buildCommandService(Integer sessionId,
+                                                KieBase kbase,
+                                                KieSessionConfiguration conf,
+                                                Environment env) {
+
+    	env = mergeEnvironment(env);
+        try {
+            Class< ? extends CommandExecutor> serviceClass = getCommandServiceClass();
+            Constructor< ? extends CommandExecutor> constructor = serviceClass.getConstructor( Integer.class,
+                                                                                              KieBase.class,
+                                                                                              KieSessionConfiguration.class,
+                                                                                              Environment.class );
+            return constructor.newInstance( sessionId,
+                                            kbase,
+                                            conf,
+                                            env );
+        } catch ( SecurityException e ) {
+            throw new IllegalStateException( e );
+        } catch ( NoSuchMethodException e ) {
+            throw new IllegalStateException( e );
+        } catch ( IllegalArgumentException e ) {
+            throw new IllegalStateException( e );
+        } catch ( InstantiationException e ) {
+            throw new IllegalStateException( e );
+        } catch ( IllegalAccessException e ) {
+            throw new IllegalStateException( e );
+        } catch ( InvocationTargetException e ) {
+            throw new IllegalStateException( e );
+        }
+    }
+
+    private Environment mergeEnvironment(Environment env) {
+    	if (env == null) {
+    		env = KnowledgeBaseFactory.newEnvironment();
+    	}
+    	if (env.get(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER) == null) {
+    		try {
+    			Class<?> clazz = Class.forName("org.jbpm.persistence.InfinispanProcessPersistenceContextManager");
+    			Constructor<?> c = clazz.getConstructor(Environment.class);
+    			env.set(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER, c.newInstance(env));
+    		} catch (ClassNotFoundException e) {
+    			env.set(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER, new InfinispanPersistenceContextManager(env));
+    		} catch (Exception e) {
+    			e.printStackTrace();
+    			env.set(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER, new InfinispanPersistenceContextManager(env));
+    		}
+    	}
+    	Object tm = env.get(EnvironmentName.TRANSACTION_MANAGER);
+    	if (tm != null && tm instanceof javax.transaction.TransactionManager) {
+    		Object ut = env.get(EnvironmentName.TRANSACTION);
+    		if (ut == null && tm instanceof javax.transaction.Transaction) {
+    			ut = tm;
+    		}
+    		Object tsr = env.get(EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY);
+    		env.set(EnvironmentName.TRANSACTION_MANAGER, new JtaTransactionManager(ut, tsr, tm));
+    	}
+    	return env;
+    }
+    
+    private CommandExecutor buildCommandService(KieBase kbase,
+                                                KieSessionConfiguration conf,
+                                                Environment env) {
+    	env = mergeEnvironment(env);
+        Class< ? extends CommandExecutor> serviceClass = getCommandServiceClass();
+        try {
+            Constructor< ? extends CommandExecutor> constructor = serviceClass.getConstructor( KieBase.class,
+                                                                                              KieSessionConfiguration.class,
+                                                                                              Environment.class );
+            return constructor.newInstance( kbase,
+                                            conf,
+                                            env );
+        } catch ( SecurityException e ) {
+            throw new IllegalStateException( e );
+        } catch ( NoSuchMethodException e ) {
+            throw new IllegalStateException( e );
+        } catch ( IllegalArgumentException e ) {
+            throw new IllegalStateException( e );
+        } catch ( InstantiationException e ) {
+            throw new IllegalStateException( e );
+        } catch ( IllegalAccessException e ) {
+            throw new IllegalStateException( e );
+        } catch ( InvocationTargetException e ) {
+            throw new IllegalStateException( e );
+        }
+    }
+
+    private KieSessionConfiguration mergeConfig(KieSessionConfiguration configuration) {
+        ((SessionConfiguration) configuration).addDefaultProperties(configProps);
+        configuration.setOption(TimerJobFactoryOption.get("jpa"));
+        return configuration;
+    }
+
+    public long getStatefulKnowledgeSessionId(StatefulKnowledgeSession ksession) {
+        if ( ksession instanceof CommandBasedStatefulKnowledgeSession ) {
+            SingleSessionCommandService commandService = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) ksession).getCommandService();
+            return commandService.getSessionId();
+        }
+        throw new IllegalArgumentException( "StatefulKnowledgeSession must be an a CommandBasedStatefulKnowledgeSession" );
+    }
+
+    public void setCommandServiceClass(Class< ? extends CommandExecutor> commandServiceClass) {
+        if ( commandServiceClass != null ) {
+            this.commandServiceClass = commandServiceClass;
+            configProps.put( "drools.commandService",
+                             commandServiceClass.getName() );
+        }
+    }
+
+    public Class< ? extends CommandExecutor> getCommandServiceClass() {
+        return commandServiceClass;
+    }
+
+
+    public void setProcessInstanceManagerFactoryClass(String processInstanceManagerFactoryClass) {
+        configProps.put( "drools.processInstanceManagerFactory",
+                         processInstanceManagerFactoryClass );
+    }
+
+    public void setWorkItemManagerFactoryClass(Class< ? extends WorkItemManagerFactory> workItemManagerFactoryClass) {
+        if ( workItemManagerFactoryClass != null ) {
+            this.workItemManagerFactoryClass = workItemManagerFactoryClass;
+            configProps.put( "drools.workItemManagerFactory",
+                             workItemManagerFactoryClass.getName() );
+        }
+    }
+
+    public Class< ? extends WorkItemManagerFactory> getWorkItemManagerFactoryClass() {
+        return workItemManagerFactoryClass;
+    }
+
+    public void setProcessSignalManagerFactoryClass(String processSignalManagerFactoryClass) {
+        configProps.put( "drools.processSignalManagerFactory",
+                         processSignalManagerFactoryClass );
+    }
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/ManualPersistInterceptor.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/ManualPersistInterceptor.java
@@ -1,0 +1,78 @@
+package org.drools.persistence.infinispan;
+
+import org.drools.core.command.CommandService;
+import org.drools.core.command.impl.AbstractInterceptor;
+import org.drools.core.command.impl.GenericCommand;
+import org.drools.core.command.runtime.DisposeCommand;
+import org.drools.persistence.PersistenceContext;
+import org.drools.persistence.PersistenceContextManager;
+import org.drools.persistence.SessionMarshallingHelper;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.info.SessionInfo;
+import org.kie.api.command.Command;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.command.Context;
+import org.kie.internal.runtime.KnowledgeContext;
+
+public class ManualPersistInterceptor extends AbstractInterceptor {
+
+	private final SingleSessionCommandService interceptedService;
+	
+	public ManualPersistInterceptor(SingleSessionCommandService decorated) {
+		this.interceptedService = decorated;
+	}
+	
+	public <T> T execute(Command<T> command) {
+		T result = executeNext(command);
+		try {
+	    	java.lang.reflect.Field sessionInfoField = SingleSessionCommandService.class.getDeclaredField("sessionInfo");
+	    	sessionInfoField.setAccessible(true);
+	    	Object sessionInfo = sessionInfoField.get(interceptedService);
+	    	java.lang.reflect.Field jpmField = SingleSessionCommandService.class.getDeclaredField("jpm");
+	    	jpmField.setAccessible(true);
+	    	Object jpm = jpmField.get(interceptedService);
+	    	java.lang.reflect.Field ksessionField = SingleSessionCommandService.class.getDeclaredField("ksession");
+	    	ksessionField.setAccessible(true);
+	    	Object ksession = ksessionField.get(interceptedService);
+	    	if (!(command instanceof DisposeCommand)) {
+	    		executeNext(new PersistCommand(command, sessionInfo, jpm, ksession));
+	    	}
+		} catch (Exception e) {
+			throw new RuntimeException("Couldn't force persistence of session info", e);
+		}
+		return result;
+	}
+
+	public static class PersistCommand<T> implements GenericCommand<T> {
+		
+		private final Command<T> command;
+		private final SessionInfo sessionInfo;
+		private final PersistenceContext persistenceContext;
+		private final KieSession ksession;
+		
+		public PersistCommand(Command<T> command, Object sessionInfo, Object jpm, Object ksession) {
+			this.command = command;
+			this.sessionInfo = (SessionInfo) sessionInfo;
+			this.persistenceContext = ((PersistenceContextManager) jpm).getApplicationScopedPersistenceContext();
+			this.ksession = (KieSession) ksession;
+		}
+		
+		@Override
+		public T execute(Context context) {
+			sessionInfo.setJPASessionMashallingHelper(new SessionMarshallingHelper(ksession, ksession.getSessionConfiguration()));
+			sessionInfo.update();
+			persistenceContext.persist(sessionInfo);
+			return null;
+		}
+	}
+
+	public CommandService getInterceptedService() {
+		return interceptedService;
+	}
+	
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/marshaller/InfinispanPlaceholderResolverStrategy.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/marshaller/InfinispanPlaceholderResolverStrategy.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2010 salaboy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * under the License.
+ */
+package org.drools.persistence.infinispan.marshaller;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.persistence.Id;
+
+import org.drools.core.common.DroolsObjectInputStream;
+import org.hibernate.search.annotations.Indexed;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfinispanPlaceholderResolverStrategy implements ObjectMarshallingStrategy {
+    private static Logger log = LoggerFactory.getLogger(InfinispanPlaceholderResolverStrategy.class);
+    private Environment env;
+    
+    public InfinispanPlaceholderResolverStrategy(Environment env) {
+        this.env = env;
+    }
+    
+    public boolean accept(Object object) {
+        return isEntity(object) && isIndexed(object); //left for markup purposes
+    }
+
+	public void write(ObjectOutputStream os, Object object) throws IOException {
+    	os.writeObject(getTypeString(object) + getClassIdValue(object));
+    }
+
+    public Object read(ObjectInputStream is) throws IOException, ClassNotFoundException {
+        Object id = is.readObject();
+        DefaultCacheManager cm = (DefaultCacheManager) env.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        Cache<?, ?> cache = cm.getCache("jbpm-configured-cache");
+        return cache.get(id);
+    }
+
+    public byte[] marshal(Context context,
+                          ObjectOutputStream os, 
+                          Object object) throws IOException {
+        ByteArrayOutputStream buff = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream( buff );
+        oos.writeObject(getTypeString(object) + getClassIdValue(object));
+        
+        oos.close();
+        return buff.toByteArray();
+    }
+
+    public Object unmarshal(Context context,
+                            ObjectInputStream ois,
+                            byte[] object,
+                            ClassLoader classloader) throws IOException,
+                                                    ClassNotFoundException {
+        DroolsObjectInputStream is = new DroolsObjectInputStream( new ByteArrayInputStream( object ), classloader );
+        Object id = is.readObject();
+        DefaultCacheManager cm = (DefaultCacheManager) env.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        Cache<?, ?> cache = cm.getCache("jbpm-configured-cache");
+        return cache.get(id);
+    }
+    
+    public Context createContext() {
+        // no need for context
+        return null;
+    }
+    
+    public static String getTypeString(Object o) {
+    	String typeValue = null;
+    	try {
+    		Field[] fields = o.getClass().getDeclaredFields();
+    		for (int i = 0; i < fields.length && typeValue == null; i++) {
+    			Field field = fields[i];
+    			if (field.getName().equals("type")) {
+    				try {
+    					String methodName = "get" + Character.toUpperCase(field.getName().charAt(0))
+                            + field.getName().substring(1);
+                        typeValue = (String) o.getClass().getMethod(methodName, (Class[]) null).invoke(o, new Object[]{});
+                    } catch (NoSuchMethodException e) {
+                        typeValue = (String) field.get(o);
+                    }
+    			}
+    		}
+    	} catch (Exception e) {
+    		log.error(e.getMessage(), e);
+    	}
+    	if (typeValue == null) {
+    		typeValue = "";
+    	}
+    	return typeValue;
+    }
+    
+    public static Serializable getClassIdValue(Object o)  {
+        Class<? extends Object> varClass = o.getClass();
+        Serializable idValue = null;
+        try{
+            do {
+                Field[] fields = varClass.getDeclaredFields();
+                for (int i = 0; i < fields.length && idValue == null; i++) {
+                    Field field = fields[i];
+                    Id id = field.getAnnotation(Id.class);
+                    if (id != null) {
+                        try {
+                            idValue = callIdMethod(o, "get"
+                                    + Character.toUpperCase(field.getName().charAt(0))
+                                    + field.getName().substring(1));
+                        } catch (NoSuchMethodException e) {
+                            idValue = (Serializable) field.get(o);
+                        }
+                    }
+                }
+            } while ((varClass = varClass.getSuperclass()) != null && idValue == null);
+            if (idValue == null) {
+                varClass = o.getClass();
+                do {
+                    Method[] methods = varClass.getMethods();
+                    for (int i = 0; i < methods.length && idValue == null; i++) {
+                        Method method = methods[i];
+                        Id id = method.getAnnotation(Id.class);
+                        if (id != null) {
+                            idValue = (Serializable) method.invoke(o);
+                        }
+                    }
+                } while ((varClass = varClass.getSuperclass()) != null && idValue == null);
+            }
+        }
+        catch(Exception ex){
+            log.error(ex.getMessage());
+        }
+        return idValue;
+    }
+
+    private static Serializable callIdMethod(Object target, String methodName) throws IllegalArgumentException,
+            SecurityException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        return (Serializable) target.getClass().getMethod(methodName, (Class[]) null).invoke(target, new Object[]{});
+    }
+    
+    private static boolean isIndexed(Object o) {
+        Class<? extends Object> varClass = o.getClass();
+        do {
+        	Indexed idx = varClass.getAnnotation(Indexed.class);
+        	if (idx != null) {
+        		return true;
+        	}
+        } while ((varClass = varClass.getSuperclass()) != null);
+        return false;
+	}
+    
+    private static boolean isEntity(Object o){
+    	
+        Class<? extends Object> varClass = o.getClass();
+        do {
+                Field[] fields = varClass.getDeclaredFields();
+                for (int i = 0; i < fields.length; i++) {
+                    Field field = fields[i];
+                    Id id = field.getAnnotation(Id.class);
+                    if (id != null) {
+                       return true;
+                    }
+                }
+        } while ((varClass = varClass.getSuperclass()) != null);
+        varClass = o.getClass();
+        do {
+                    Method[] methods = varClass.getMethods();
+                    for (int i = 0; i < methods.length; i++) {
+                        Method method = methods[i];
+                        Id id = method.getAnnotation(Id.class);
+                        if (id != null) {
+                            return true;
+                        }
+                    }
+        } while ((varClass = varClass.getSuperclass()) != null );
+        
+        return false;
+    }
+
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/processinstance/InfinispanWorkItemManagerFactory.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/infinispan/processinstance/InfinispanWorkItemManagerFactory.java
@@ -1,0 +1,13 @@
+package org.drools.persistence.infinispan.processinstance;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.drools.core.process.instance.WorkItemManager;
+import org.drools.core.process.instance.WorkItemManagerFactory;
+
+public class InfinispanWorkItemManagerFactory implements WorkItemManagerFactory {
+
+    public WorkItemManager createWorkItemManager(InternalKnowledgeRuntime kruntime) {
+        return new InfinispanWorkItemManager(kruntime);
+    }
+
+}

--- a/drools-persistence-infinispan/src/main/java/org/drools/persistence/info/EntityHolder.java
+++ b/drools-persistence-infinispan/src/main/java/org/drools/persistence/info/EntityHolder.java
@@ -1,0 +1,152 @@
+package org.drools.persistence.info;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.drools.core.util.codec.Base64;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class EntityHolder {
+
+	@Id @DocumentId @Field 
+	private String key;
+	@Field
+	private String type;
+	@Field
+	private Integer sessionInfoId;
+	@Field
+	private Integer sessionInfoVersion;
+	@Field
+	private String sessionInfoData;
+	@Field
+	private Date sessionInfoLastModificationDate;
+	@Field
+	private Date sessionInfoStartDate;
+	@Field
+	private Long workItemInfoId;
+	@Field
+	private String workItemInfoName;
+	@Field
+	private Integer workItemInfoVersion;
+	@Field
+	private Long workItemInfoProcessInstanceId;
+	@Field
+	private Long workItemInfoState;
+	@Field
+	private Date workItemInfoCreationDate;
+	@Field
+	private String workItemInfoByteArray;
+
+	public EntityHolder(String key, SessionInfo sessionInfo) {
+		this.key = key;
+		this.type = "sessionInfo";
+		this.sessionInfoId = sessionInfo.getId();
+		this.sessionInfoVersion = sessionInfo.getVersion();
+		sessionInfo.update();
+		this.sessionInfoData = Base64.encodeBase64String(sessionInfo.getData());
+		this.sessionInfoLastModificationDate = sessionInfo.getLastModificationDate();
+		this.sessionInfoStartDate = sessionInfo.getStartDate();
+	}
+	
+	public EntityHolder(String key, WorkItemInfo workItemInfo) {
+		this.key = key;
+		this.type = "workItemInfo";
+		workItemInfo.update();
+		this.workItemInfoId = workItemInfo.getId();
+		this.workItemInfoName = workItemInfo.getName();
+		this.workItemInfoVersion = workItemInfo.getVersion();
+		this.workItemInfoProcessInstanceId = workItemInfo.getProcessInstanceId();
+		this.workItemInfoState = workItemInfo.getState();
+		this.workItemInfoCreationDate = workItemInfo.getCreationDate();
+		this.workItemInfoByteArray = Base64.encodeBase64String(workItemInfo.getWorkItemByteArray());
+	}
+	
+	protected EntityHolder(String key, String type) {
+		this.key = key;
+		this.type = type;
+	}
+
+	public String getKey() {
+		return key;
+	}
+	
+	public void setKey(String key) {
+		this.key = key;
+	}
+	
+	public SessionInfo getSessionInfo() {
+		SessionInfo sessionInfo = new SessionInfo();
+		sessionInfo.setId(this.sessionInfoId);
+		sessionInfo.setData(Base64.decodeBase64(this.sessionInfoData));
+		sessionInfo.setLastModificationDate(this.sessionInfoLastModificationDate);
+		try {
+			java.lang.reflect.Field versionField = SessionInfo.class.getField("version");
+			versionField.setAccessible(true);
+			versionField.set(sessionInfo, this.sessionInfoVersion);
+			java.lang.reflect.Field startDateField = SessionInfo.class.getField("startDate");
+			startDateField.setAccessible(true);
+			startDateField.set(sessionInfo, this.sessionInfoStartDate);
+		} catch (Exception e) { /* TODO */ }
+		
+		return sessionInfo;
+	}
+	
+	public void setSessionInfo(SessionInfo sessionInfo) {
+		this.sessionInfoId = sessionInfo.getId();
+		this.sessionInfoVersion = sessionInfo.getVersion();
+		sessionInfo.update();
+		this.sessionInfoData = Base64.encodeBase64String(sessionInfo.getData());
+		this.sessionInfoLastModificationDate = sessionInfo.getLastModificationDate();
+		this.sessionInfoStartDate = sessionInfo.getStartDate();
+	}
+	
+	public WorkItemInfo getWorkItemInfo() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setName(this.workItemInfoName);
+		workItem.setProcessInstanceId(this.workItemInfoProcessInstanceId);
+		WorkItemInfo workItemInfo = new WorkItemInfo(workItem, null);
+		workItemInfo.setId(this.workItemInfoId);
+		try {
+			java.lang.reflect.Field versionField = WorkItemInfo.class.getField("version");
+			versionField.setAccessible(true);
+			versionField.set(workItemInfo, this.workItemInfoVersion);
+			java.lang.reflect.Field stateField = WorkItemInfo.class.getField("state");
+			stateField.setAccessible(true);
+			stateField.set(workItemInfo, this.workItemInfoState);
+			java.lang.reflect.Field creationDateField = WorkItemInfo.class.getField("creationDate");
+			creationDateField.setAccessible(true);
+			creationDateField.set(workItemInfo, this.workItemInfoCreationDate);
+			java.lang.reflect.Field workItemByteArrayField = WorkItemInfo.class.getField("workItemByteArray");
+			workItemByteArrayField.setAccessible(true);
+			workItemByteArrayField.set(workItemInfo, Base64.decodeBase64(this.workItemInfoByteArray));
+		} catch (Exception e) { /* TODO */ }
+
+		return workItemInfo;
+	}
+	
+	public String getType() {
+		return type;
+	}
+	
+	public void setType(String type) {
+		this.type = type;
+	}
+	
+	public void setWorkItemInfo(WorkItemInfo workItemInfo) {
+		workItemInfo.update();
+		this.workItemInfoId = workItemInfo.getId();
+		this.workItemInfoName = workItemInfo.getName();
+		this.workItemInfoVersion = workItemInfo.getVersion();
+		this.workItemInfoProcessInstanceId = workItemInfo.getProcessInstanceId();
+		this.workItemInfoState = workItemInfo.getState();
+		this.workItemInfoCreationDate = workItemInfo.getCreationDate();
+		this.workItemInfoByteArray = Base64.encodeBase64String(workItemInfo.getWorkItemByteArray());
+	}
+}

--- a/drools-persistence-infinispan/src/main/java/org/kie/internal/persistence/infinispan/InfinispanKnowledgeService.java
+++ b/drools-persistence-infinispan/src/main/java/org/kie/internal/persistence/infinispan/InfinispanKnowledgeService.java
@@ -1,0 +1,54 @@
+package org.kie.internal.persistence.infinispan;
+
+import org.kie.api.KieBase;
+import org.kie.api.persistence.jpa.KieStoreServices;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class InfinispanKnowledgeService {
+    private static KieStoreServices provider;
+
+    public static StatefulKnowledgeSession newStatefulKnowledgeSession(KieBase kbase,
+                                                                       KieSessionConfiguration configuration,
+                                                                       Environment environment) {
+        return (StatefulKnowledgeSession)getInfinispanKnowledgeServiceProvider().newKieSession(kbase,
+                configuration,
+                environment);
+    }
+
+    public static StatefulKnowledgeSession loadStatefulKnowledgeSession(int id,
+                                                                        KieBase kbase,
+                                                                        KieSessionConfiguration configuration,
+                                                                        Environment environment) {
+        return (StatefulKnowledgeSession)getInfinispanKnowledgeServiceProvider().loadKieSession(id,
+                kbase,
+                configuration,
+                environment);
+    }
+
+    private static synchronized void setInfinispanKnowledgeServiceProvider(KieStoreServices provider) {
+        InfinispanKnowledgeService.provider = provider;
+    }
+
+    private static synchronized KieStoreServices getInfinispanKnowledgeServiceProvider() {
+        if ( provider == null ) {
+            loadProvider();
+        }
+        return provider;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void loadProvider() {
+        try {
+            // we didn't find anything in properties so lets try and us reflection
+            Class<KieStoreServices> cls = (Class<KieStoreServices>) Class.forName( "org.drools.persistence.infinispan.KnowledgeStoreServiceImpl" );
+            setInfinispanKnowledgeServiceProvider( cls.newInstance() );
+        } catch ( Exception e ) {
+            throw new RuntimeException( "Provider org.drools.persistence.infinispan.KnowledgeStoreServiceImpl could not be set.",
+                                        e );
+        }
+    }
+
+
+}

--- a/drools-persistence-infinispan/src/main/resources/infinispan.xml
+++ b/drools-persistence-infinispan/src/main/resources/infinispan.xml
@@ -1,0 +1,25 @@
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:5.1 http://www.infinispan.org/schemas/infinispan-config-5.1.xsd"
+      xmlns="urn:infinispan:config:5.1">
+
+   <global>
+      <globalJmxStatistics enabled="true" allowDuplicateDomains="true" />
+   </global>
+
+   <namedCache name="jbpm-configured-cache">
+      <eviction strategy="NONE" />
+      <transaction transactionMode="TRANSACTIONAL" lockingMode="OPTIMISTIC" autoCommit="false"
+                   syncRollbackPhase="false" syncCommitPhase="false" useEagerLocking="false"
+                   useSynchronization="true" use1PcForAutoCommitTransactions="false"
+                   transactionManagerLookupClass="org.infinispan.transaction.lookup.BitronixTransactionManagerLookup"/>
+      <indexing enabled="true" indexLocalOnly="true">
+         <properties>
+            <property name="jta.UserTransaction" value="java:comp/UserTransaction" />
+            <property name="hibernate.search.default.directory_provider" value="filesystem" />
+            <property name="hibernate.search.default.exclusive_index_use" value="false" />
+         </properties>
+      </indexing>
+   </namedCache>
+   
+</infinispan>

--- a/drools-persistence-infinispan/src/test/filtered-resources/datasource.properties
+++ b/drools-persistence-infinispan/src/test/filtered-resources/datasource.properties
@@ -1,0 +1,11 @@
+
+allowLocalTransactions=true
+# JDBC/Database properties that are set in the maven pom
+#
+#   the below variable names (i.e. "${maven.datasource.classname}) are
+# automagically replaced with their values (defined in the pom.xml)
+# because of the fact that <filtering> is set to true in for the
+# src/test/resources directory in the pom.
+#
+makeBaseDb=false
+testMarshalling=false

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/command/KBuilderBatchExecutionPersistenceTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/command/KBuilderBatchExecutionPersistenceTest.java
@@ -1,0 +1,37 @@
+package org.drools.persistence.command;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.cleanUp;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+
+import java.util.HashMap;
+
+import org.drools.compiler.command.KBuilderBatchExecutionTest;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class KBuilderBatchExecutionPersistenceTest extends KBuilderBatchExecutionTest {
+
+    private HashMap<String, Object> context;
+    
+    @After
+    public void cleanUpPersistence() throws Exception {
+        disposeKSession();
+        cleanUp(context);
+        context = null;
+    }
+
+    protected StatefulKnowledgeSession createKnowledgeSession(KnowledgeBase kbase) {
+        if( context == null ) { 
+            context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        }
+        KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, ksconf, createEnvironment(context));
+    }  
+    
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/command/MoreBatchExecutionPersistenceTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/command/MoreBatchExecutionPersistenceTest.java
@@ -1,0 +1,37 @@
+package org.drools.persistence.command;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.cleanUp;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+
+import java.util.HashMap;
+
+import org.drools.compiler.command.MoreBatchExecutionTest;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class MoreBatchExecutionPersistenceTest extends MoreBatchExecutionTest {
+
+    private HashMap<String, Object> context;
+    
+    @After
+    public void cleanUpPersistence() throws Exception {
+        disposeKSession();
+        cleanUp(context);
+        context = null;
+    }
+
+    protected StatefulKnowledgeSession createKnowledgeSession(KnowledgeBase kbase) {
+        if( context == null ) { 
+            context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        }
+        KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, ksconf, createEnvironment(context));
+    }  
+    
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/command/SimpleBatchExecutionPersistenceTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/command/SimpleBatchExecutionPersistenceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.command;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.cleanUp;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+
+import java.util.HashMap;
+
+import org.drools.compiler.command.SimpleBatchExecutionTest;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class SimpleBatchExecutionPersistenceTest extends SimpleBatchExecutionTest {
+
+    private HashMap<String, Object> context;
+ 
+    @After
+    public void cleanUpPersistence() throws Exception {
+        disposeKSession();
+        cleanUp(context);
+        context = null;
+    }
+
+    protected StatefulKnowledgeSession createKnowledgeSession(KnowledgeBase kbase) { 
+        if( context == null ) { 
+            context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        }
+        KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, ksconf, createEnvironment(context));
+    }  
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.jta;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.drools.persistence.util.PersistenceUtil.getValueOfField;
+import static org.drools.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.fail;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.TransactionManager;
+import org.drools.persistence.infinispan.InfinispanPersistenceContextManager;
+import org.drools.persistence.infinispan.marshaller.InfinispanPlaceholderResolverStrategy;
+import org.drools.persistence.info.EntityHolder;
+import org.drools.persistence.util.PersistenceUtil;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JtaTransactionManagerTest {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    // Datasource (setup & clean up)
+    private HashMap<String, Object> context;
+    private DefaultCacheManager cm;
+
+    private static String simpleRule = "package org.kie.test\n"
+            + "global java.util.List list\n" 
+            + "rule rule1\n" 
+            + "when\n"
+            + "  Integer(intValue > 0)\n" 
+            + "then\n" 
+            + "  list.add( 1 );\n"
+            + "end\n" 
+            + "\n";
+
+    @Before
+    public void setup() {
+        // This test does only plays with tx's, it doesn't actually persist
+        // any interersting (wrt marshalling) SessionInfo objects
+        boolean testMarshalling = false;
+
+        context = setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME, testMarshalling);
+        cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+    }
+
+    @After
+    public void tearDown() {
+        PersistenceUtil.tearDown(context);
+    }
+
+    private KnowledgeBase initializeKnowledgeBase(String rule) { 
+        // Initialize knowledge base/session/etc..
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(rule.getBytes()), ResourceType.DRL);
+
+        if (kbuilder.hasErrors()) {
+            fail(kbuilder.getErrors().toString());
+        }
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+       
+        return kbase;
+    }
+   
+    public static final String DEFAULT_USER_TRANSACTION_NAME = "java:comp/UserTransaction";
+
+    protected UserTransaction findUserTransaction() {
+        try {
+            InitialContext context = new InitialContext();
+            return (UserTransaction) context.lookup( DEFAULT_USER_TRANSACTION_NAME );
+        } catch ( NamingException ex ) {
+            logger.debug( "No UserTransaction found at JNDI location [{}]",
+                          DEFAULT_USER_TRANSACTION_NAME,
+                          ex );
+            return null;
+        }
+    }
+
+    private String getTestName() { 
+        StackTraceElement [] ste = Thread.currentThread().getStackTrace();
+        String methodName =  ste[2].getMethodName();
+        return methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
+    }
+
+    @Test
+    public void basicTransactionManagerTest() {
+        String testName = getTestName();
+        
+        // Setup the JtaTransactionmanager
+        Environment env = createEnvironment(context);
+        //TransactionManager txm = (TransactionManager) env.get( EnvironmentName.TRANSACTION_MANAGER );
+        javax.transaction.TransactionManager tm = (javax.transaction.TransactionManager) env.get( EnvironmentName.TRANSACTION_MANAGER );
+        TransactionManager txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+                env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+                tm ); 
+           
+        // Create linked transactionTestObjects 
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("main" + testName);
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("sub" + testName);
+        mainObject.setSubObject(subObject);
+      
+        // Commit the mainObject after "commiting" the subObject
+        Cache<Serializable, Object> cache = cm.getCache("jbpm-configured-cache");
+        try { 
+            // Begin the real trasnaction
+            boolean txOwner = txm.begin();
+      
+            // Do the "sub" transaction 
+            // - the txm doesn't really commit, 
+            //   because we keep track of who's the tx owner.
+            boolean notTxOwner = txm.begin();
+            cache.put(generateId(mainObject), mainObject);
+            txm.commit(notTxOwner);
+       
+            // Finish the transaction off
+            cache.put(generateId(subObject), subObject);
+            txm.commit(txOwner);
+        }
+        catch( Throwable t ) { 
+            fail( "No exception should have been thrown: " + t.getMessage() );
+        }
+    }
+   
+    @Test
+    public void basicTransactionRollbackTest() {
+        Environment env = createEnvironment(context);
+        //TransactionManager txm = (TransactionManager) env.get( EnvironmentName.TRANSACTION_MANAGER );
+        javax.transaction.TransactionManager tm = (javax.transaction.TransactionManager) env.get( EnvironmentName.TRANSACTION_MANAGER );
+        TransactionManager txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+                env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+                tm ); 
+           
+        // Create linked transactionTestObjects 
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("main");
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("sub");
+        mainObject.setSubObject(subObject);
+       
+        Cache<Serializable, Object> cache = cm.getCache("jbpm-configured-cache");
+        boolean txOwner = false;
+        try { 
+            txOwner = txm.begin();
+            
+            boolean notTxOwner = txm.begin();
+            cache.put(generateId(mainObject), mainObject);
+            txm.rollback(notTxOwner);
+        } catch ( Exception e ) {
+        	fail("There should not be an exception thrown here: " + e.getMessage());
+        }
+        try {
+            cache.put(generateId(subObject), subObject);
+            txm.rollback(txOwner);
+        } catch( Exception e ) {
+        	//Infinispan tries to commit every put, so an exception will be thrown here
+        }
+        
+    }
+
+    public static String COMMAND_ENTITY_MANAGER = "drools.persistence.test.command.EntityManager";
+    public static String COMMAND_ENTITY_MANAGER_FACTORY = "drools.persistence.test.EntityManagerFactory";
+    
+    @Test
+    public void testSingleSessionCommandServiceAndJtaTransactionManagerTogether() { 
+            
+        // Initialize drools environment stuff
+        Environment env = createEnvironment(context);
+        KnowledgeBase kbase = initializeKnowledgeBase(simpleRule);
+        StatefulKnowledgeSession commandKSession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        SingleSessionCommandService commandService = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) commandKSession).getCommandService();
+        InfinispanPersistenceContextManager jpm = (InfinispanPersistenceContextManager) getValueOfField("jpm", commandService);
+
+        jpm.getApplicationScopedPersistenceContext();
+        @SuppressWarnings("unchecked")
+        Cache<String, EntityHolder> cache = (Cache<String, EntityHolder>) getValueOfField("appScopedCache", jpm);
+        
+        TransactionTestObject mainObject = new TransactionTestObject();
+        mainObject.setName("mainCommand");
+        TransactionTestObject subObject = new TransactionTestObject();
+        subObject.setName("subCommand");
+        mainObject.setSubObject(subObject);
+       
+        HashMap<String, Object> emEnv = new HashMap<String, Object>();
+        emEnv.put(COMMAND_ENTITY_MANAGER_FACTORY, cm);
+        emEnv.put(COMMAND_ENTITY_MANAGER, cache);
+        
+        TransactionTestCommand txTestCmd = new TransactionTestCommand(mainObject, subObject, emEnv);
+       
+        
+        commandKSession.execute(txTestCmd);
+        
+    }
+
+    private static int id=1;
+    
+    protected static Serializable generateId(TransactionTestObject obj) {
+    	Serializable s = InfinispanPlaceholderResolverStrategy.getClassIdValue(obj);
+    	return (s == null) ? new Integer(++id) : s;
+    }
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.jta;
+
+import static org.drools.persistence.jta.JtaTransactionManagerTest.COMMAND_ENTITY_MANAGER;
+import static org.drools.persistence.jta.JtaTransactionManagerTest.COMMAND_ENTITY_MANAGER_FACTORY;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+import org.drools.core.base.MapGlobalResolver;
+import org.drools.core.command.impl.GenericCommand;
+import org.drools.core.command.impl.KnowledgeCommandContext;
+import org.drools.core.impl.EnvironmentFactory;
+import org.drools.persistence.infinispan.marshaller.InfinispanPlaceholderResolverStrategy;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.command.Context;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import bitronix.tm.TransactionManagerServices;
+
+
+/**
+ * Please make sure you understand foreign keys 
+ * and how they work with regards to JPA before continuing further: 
+ * - http://download.oracle.com/javaee/5/tutorial/doc/bnbqa.html#bnbqj
+ * - http://en.wikipedia.org/wiki/Foreign_key
+ * 
+ *
+ */
+public class TransactionTestCommand implements GenericCommand<Void> {
+
+    private static final long serialVersionUID = -7640078670024414748L;
+    
+    private Object mainObject;
+    private Object subObject;
+    private Cache<Serializable, Object> cache;
+    private DefaultCacheManager cm;
+    
+    public TransactionTestCommand(Object mainObject, Object subObject, HashMap<String, Object> env) { 
+      this.mainObject = mainObject;
+      this.subObject = subObject; 
+      setPersistenceFields(env);
+    }
+    
+    public TransactionTestCommand(Object mainObject, HashMap<String, Object> env) { 
+      this.mainObject = mainObject;
+      this.subObject = null;
+      setPersistenceFields(env);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setPersistenceFields(HashMap<String, Object> env) { 
+        this.cache = (Cache<Serializable, Object>) env.get(COMMAND_ENTITY_MANAGER);
+        this.cm = (DefaultCacheManager) env.get(COMMAND_ENTITY_MANAGER_FACTORY);
+    }
+    
+    private HashMap<String, Object> getPersistenceEnvironment() { 
+        HashMap<String, Object> env = new HashMap<String, Object>();
+        env.put(COMMAND_ENTITY_MANAGER, this.cache);
+        env.put(COMMAND_ENTITY_MANAGER_FACTORY, this.cm);
+        return env;
+    }
+    
+    public Void execute(Context context) {
+        //cache.joinTransaction();TODO
+    	TransactionTestObject obj = (TransactionTestObject) mainObject;
+    	if (obj.getId() == null) {
+    		obj.setId(generateId());
+    	}
+        cache.put(InfinispanPlaceholderResolverStrategy.getClassIdValue(mainObject), mainObject);
+
+        if( subObject != null ) { 
+            KieSession ksession = ((KnowledgeCommandContext) context).getKieSession();
+  
+            // THe following 3 lines are the important ones! (See below for an explanation)
+            KnowledgeBase cleanKBase = KnowledgeBaseFactory.newKnowledgeBase();
+            cleanKBase.addKnowledgePackages(((KnowledgeBase)ksession.getKieBase()).getKnowledgePackages());
+            StatefulKnowledgeSession commandKSession = InfinispanKnowledgeService.newStatefulKnowledgeSession( cleanKBase, null, initializeEnvironment() );
+
+            /**
+             *  Here's what's going on: 
+             *  If the SingleSessionCommandService (SSCS) & JtaTransactionManager (JTM) were _not_ aware of transactions, 
+             *  -> then inserting the mainObject _before_ having inserted the subObject
+             *     would cause the operation/persist to fail and the transaction to fail. 
+             *     - This is because the mainObject contains a foreign key referring to the subObject.
+             *     
+             *  However, the SSCS & JTM check whether or not they're owners of the transaction
+             *  when starting and when committing the transaction they use. 
+             *  -> So that when we insert the mainObject here (via a _new_ CommandBasedStatefulKnowledgeSession), 
+             *     it does _not_ mess with the transaction state and the operation succeeds.  
+             */ 
+            TransactionTestCommand transactionTestSubCommand 
+                = new TransactionTestCommand(this.subObject, getPersistenceEnvironment()); commandKSession.execute(transactionTestSubCommand);
+        }
+
+        return null;
+    }
+ 
+    private static long value = 1;
+    
+    private static Long generateId() {
+    	return ++value;
+    }
+    
+    private Environment initializeEnvironment() {
+        Environment env = EnvironmentFactory.newEnvironment();
+        env.set(EnvironmentName.ENTITY_MANAGER_FACTORY, cm);
+        env.set(EnvironmentName.GLOBALS, new MapGlobalResolver());
+        env.set(EnvironmentName.TRANSACTION_MANAGER,
+                TransactionManagerServices.getTransactionManager());
+        
+        return env;
+    }
+    
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/TransactionTestObject.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/TransactionTestObject.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.jta;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * This class is used to test transactions. 
+ * It specifically has a 
+ * 
+ *
+ */
+@Entity
+@Indexed
+public class TransactionTestObject implements Serializable {
+
+    private static final long serialVersionUID = 8991032325499307158L;
+
+    @Id @DocumentId @Field
+    @Column(name="ID")
+    private Long id;
+    @Field
+    private String name;
+
+    @Field @FieldBridge(impl=TransactionTestObjectBridge.class)
+	private TransactionTestObject subObject;
+	
+    public TransactionTestObject(){}
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setSubObject(TransactionTestObject subObject) {
+        if( subObject == this ) { 
+            // no-op
+            return;
+        }
+        this.subObject = subObject;
+    }
+
+    public TransactionTestObject getSubObject() {
+        return subObject;
+    }
+    
+    public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/TransactionTestObjectBridge.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/jta/TransactionTestObjectBridge.java
@@ -1,0 +1,36 @@
+package org.drools.persistence.jta;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.bridge.LuceneOptions;
+
+public class TransactionTestObjectBridge implements FieldBridge {
+
+	@Override
+	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+		if (value != null) {
+			try {
+				TransactionTestObject obj = (TransactionTestObject) value;
+				Long objId = obj.getId();
+				String objName = obj.getName();
+				
+				ByteArrayOutputStream baout = new ByteArrayOutputStream();
+				ObjectOutputStream oout = new ObjectOutputStream(baout);
+				oout.writeObject(objId);
+				oout.writeUTF(objName);
+				Field field = new Field(name, baout.toByteArray());
+				field.setBoost(luceneOptions.getBoost());
+				
+				document.add(field);
+			} catch (Exception e) {
+				throw new RuntimeException("problem bridging SessionInfo", e);
+			}
+		}
+
+	}
+
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/kie/persistence/session/InfinispanPersistentStatefulSessionTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/kie/persistence/session/InfinispanPersistentStatefulSessionTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.kie.persistence.session;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.naming.InitialContext;
+import javax.transaction.UserTransaction;
+
+import org.drools.compiler.Person;
+import org.drools.core.SessionConfiguration;
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.core.command.impl.FireAllRulesInterceptor;
+import org.drools.core.command.impl.LoggingInterceptor;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.command.CommandFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfinispanPersistentStatefulSessionTest {
+
+    private static Logger logger = LoggerFactory.getLogger(InfinispanPersistentStatefulSessionTest.class);
+    
+    private HashMap<String, Object> context;
+    private Environment env;
+
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        env = createEnvironment(context);
+    }
+        
+    @After
+    public void tearDown() throws Exception {
+        PersistenceUtil.tearDown(context);
+    }
+
+
+    @Test
+    public void testFactHandleSerialization() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "import java.util.concurrent.atomic.AtomicInteger\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += " $i: AtomicInteger(intValue > 0)\n";
+        str += "then\n";
+        str += " list.add( $i );\n";
+        str += "end\n";
+        str += "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        ks.newKieBuilder( kfs ).buildAll();
+
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                            list );
+
+        AtomicInteger value = new AtomicInteger(4);
+        FactHandle atomicFH = ksession.insert( value );
+
+        ksession.fireAllRules();
+
+        assertEquals( 1,
+                      list.size() );
+
+        value.addAndGet(1);
+        ksession.update(atomicFH, value);
+        ksession.fireAllRules();
+        
+        assertEquals( 2,
+                list.size() );
+        String externalForm = atomicFH.toExternalForm();
+        
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksession.getId(), kbase, null, env);
+        
+        atomicFH = ksession.execute(CommandFactory.fromExternalFactHandleCommand(externalForm));
+        
+        value.addAndGet(1);
+        ksession.update(atomicFH, value);
+        
+        ksession.fireAllRules();
+        
+        list = (List<?>) ksession.getGlobal("list");
+        
+        assertEquals( 3,
+                list.size() );
+        
+    }
+    
+    @Test
+    public void testLocalTransactionPerStatement() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        ks.newKieBuilder( kfs ).buildAll();
+
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                            list );
+
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+
+        ksession.fireAllRules();
+
+        assertEquals( 3,
+                      list.size() );
+
+    }
+
+    @Test
+    public void testUserTransactions() throws Exception {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  $i : Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( $i );\n";
+        str += "end\n";
+        str += "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        ks.newKieBuilder( kfs ).buildAll();
+
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        ut.commit();
+
+        List<?> list = new ArrayList<Object>();
+
+        // insert and commit
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.setGlobal( "list",
+                            list );
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.fireAllRules();
+        ut.commit();
+
+        // insert and rollback
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 3 );
+        ut.rollback();
+
+        // check we rolled back the state changes from the 3rd insert
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.fireAllRules();
+        ut.commit();
+        assertEquals( 2,
+                      list.size() );
+
+        // insert and commit
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 3 );
+        ksession.insert( 4 );
+        ut.commit();
+
+        ksession.fireAllRules();
+        assertEquals( 4,
+        		      list.size() );
+
+        
+        // rollback again, this is testing that we can do consecutive rollbacks and commits without issue
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 5 );
+        ksession.insert( 6 );
+        ut.rollback();
+
+        ksession.fireAllRules();
+
+        assertEquals( 4,
+                      list.size() );
+        
+        // now load the ksession
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( ksession.getId(), kbase, null, env );
+        
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 7 );
+        ksession.insert( 8 );
+        ut.commit();
+
+        ksession.fireAllRules();
+
+        assertEquals( 6,
+                      list.size() );
+    }
+
+    @Test
+    public void testInterceptor() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "  System.out.println(\"ADDED\");\n";
+        str += "end\n";
+        str += "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        ks.newKieBuilder( kfs ).buildAll();
+
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        SingleSessionCommandService sscs = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) ksession).getCommandService();
+        sscs.addInterceptor(new LoggingInterceptor());
+        sscs.addInterceptor(new FireAllRulesInterceptor());
+        sscs.addInterceptor(new LoggingInterceptor());
+        List<?> list = new ArrayList<Object>();
+        ksession.setGlobal( "list", list );
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+        ksession.getWorkItemManager().completeWorkItem(0, null);
+        assertEquals( 3, list.size() );
+    }
+
+    @Test
+    public void testSetFocus() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "agenda-group \"badfocus\"";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        ks.newKieBuilder( kfs ).buildAll();
+
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+    
+        ksession.setGlobal( "list",
+                            list );
+    
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+        ksession.getAgenda().getAgendaGroup("badfocus").setFocus();
+    
+        ksession.fireAllRules();
+    
+        assertEquals( 3,
+                      list.size() );
+    }
+    
+    @Test
+    public void testSharedReferences() {
+        KieServices ks = KieServices.Factory.get();
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+
+        Person x = new Person( "test" );
+        List test = new ArrayList();
+        List test2 = new ArrayList();
+        test.add( x );
+        test2.add( x );
+
+        assertSame( test.get( 0 ), test2.get( 0 ) );
+
+        ksession.insert( test );
+        ksession.insert( test2 );
+        ksession.fireAllRules();
+
+        KieSession ksession2 = InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksession.getId(), kbase, null, env);
+
+        Iterator c = ksession2.getObjects().iterator();
+        List ref1 = (List) c.next();
+        List ref2 = (List) c.next();
+
+        assertSame( ref1.get( 0 ), ref2.get( 0 ) );
+
+    }
+
+    @Test
+    public void testMergeConfig() {
+        // JBRULES-3155
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  $i : Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( $i );\n";
+        str += "end\n";
+        str += "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        ks.newKieBuilder( kfs ).buildAll();
+
+        KieBase kbase = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).getKieBase();
+
+        Properties properties = new Properties();
+        properties.put("drools.processInstanceManagerFactory", "com.example.CustomInfinispanProcessInstanceManagerFactory");
+        KieSessionConfiguration config = KnowledgeBaseFactory.newKnowledgeSessionConfiguration(properties);
+
+        KieSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, config, env );
+        SessionConfiguration sessionConfig = (SessionConfiguration)ksession.getSessionConfiguration();
+
+        assertEquals("com.example.CustomInfinispanProcessInstanceManagerFactory", sessionConfig.getProcessInstanceManagerFactory());
+    }
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/map/impl/Buddy.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/map/impl/Buddy.java
@@ -1,0 +1,43 @@
+package org.drools.persistence.map.impl;
+
+import java.io.Serializable;
+
+public class Buddy implements Serializable{
+
+    private String name;
+
+    public Buddy() {
+    }
+
+    public Buddy(String string) {
+        this.name = string;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        Buddy other = (Buddy) obj;
+        if ( name == null ) {
+            if ( other.name != null ) return false;
+        } else if ( !name.equals( other.name ) ) return false;
+        return true;
+    }
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/map/impl/InfinispanBasedPersistenceTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/map/impl/InfinispanBasedPersistenceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.map.impl;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME; 
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+import static org.kie.api.runtime.EnvironmentName.TRANSACTION_MANAGER;
+
+import java.util.HashMap;
+
+import org.apache.lucene.search.Query;
+import org.drools.persistence.info.EntityHolder;
+import org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy;
+import org.drools.persistence.jta.JtaTransactionManager;
+import org.drools.persistence.util.PersistenceUtil;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.SearchManager;
+import org.junit.After;
+import org.junit.Before;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfinispanBasedPersistenceTest extends MapPersistenceTest {
+
+    private static Logger logger = LoggerFactory.getLogger(JPAPlaceholderResolverStrategy.class);
+    
+    private HashMap<String, Object> context;
+    private DefaultCacheManager cm;
+    private JtaTransactionManager txm;
+    private boolean useTransactions = false;
+    
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+        this.txm = (JtaTransactionManager) context.get(TRANSACTION_MANAGER);
+        /*
+        if( useTransactions() ) { 
+            useTransactions = true;
+            Environment env = createEnvironment(context);
+            Object tm = env.get( EnvironmentName.TRANSACTION_MANAGER );
+            this.txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+                env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+                tm ); 
+        }*/ //TODO
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        PersistenceUtil.tearDown(context);
+    }
+    
+
+    @Override
+    protected StatefulKnowledgeSession createSession(KnowledgeBase kbase) {
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, createEnvironment(context) );
+    }
+
+    @Override
+    protected StatefulKnowledgeSession disposeAndReloadSession(StatefulKnowledgeSession ksession,
+                                                               KnowledgeBase kbase) {
+        int ksessionId = ksession.getId();
+        ksession.dispose();
+        return InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksessionId, kbase, null, createEnvironment(context));
+    }
+
+    @Override
+    protected long getSavedSessionsCount() {
+    	return cm.getCache("jbpm-configured-cache").size();
+    }
+
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/InfinispanPersistenceTraitTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/InfinispanPersistenceTraitTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.persistence.session;
+
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import org.drools.core.factmodel.traits.TraitFactory;
+import org.drools.core.factmodel.traits.TraitableBean;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+
+public class InfinispanPersistenceTraitTest {
+
+    private HashMap<String, Object> context;
+    private Environment env;
+
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        env = createEnvironment(context);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        PersistenceUtil.tearDown(context);
+    }
+
+
+
+    @Test
+    public void testTripleBasedTraitsWithInfinispan() {
+        String str = "package org.drools.trait.test; \n" +
+                "global java.util.List list; \n" +
+                "" +
+                "declare TBean \n" +
+                "  @Traitable \n" +
+                "  fld : String \n" +
+                "end \n " +
+                "" +
+                "declare trait Mask \n" +
+                "  @propertyReactive \n" +
+                "  fld : String \n" +
+                "  xyz : int  \n" +
+                "end \n" +
+                "\n " +
+                "declare trait Cloak \n" +
+                "  @propertyReactive \n" +
+                "  fld : String \n" +
+                "  ijk : String  \n" +
+                "end \n" +
+                "" +
+                "rule Init \n" +
+                "when \n" +
+                "then \n" +
+                "  insert( new TBean(\"abc\") ); \n" +
+                "end \n" +
+                "" +
+                "rule Don \n" +
+                "no-loop \n" +
+                "when \n" +
+                "  $b : TBean( ) \n" +
+                "then \n" +
+                "  Mask m = don( $b, Mask.class ); \n" +
+                "  modify (m) { setXyz( 10 ); } \n" +
+                "  list.add( m ); \n" +
+                "  System.out.println( \"Don result : \" + m ); \n " +
+                "end \n" +
+                "\n" +
+                "rule Don2 \n" +
+                "no-loop \n" +
+                "when \n" +
+                "  $b : TBean( ) \n" +
+                "then \n" +
+                "  Cloak c = don( $b, Cloak.class ); \n" +
+                "  modify (c) { setIjk( \"ijklmn\" ); } \n" +
+                "  list.add( c ); \n" +
+                "  System.out.println( \"Don result : \" + c ); \n " +
+                "end \n" +
+                "";
+
+
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(str.getBytes()),
+                ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, null, env);
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal("list",
+                list);
+
+        ksession.fireAllRules();
+
+        assertEquals( 2,
+                list.size() );
+        int id = ksession.getId();
+
+
+        StatefulKnowledgeSession ksession2 = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+
+        ksession2.fireAllRules();
+
+
+        Collection x = ksession2.getObjects();
+        assertEquals( 4, x.size() );
+
+        TraitableBean core = null;
+        for ( Object o : x ) {
+            if ( o instanceof TraitableBean ) {
+                core = (TraitableBean) o;
+                break;
+            }
+        }
+        assertNotNull( core );
+        assertEquals( 2, core._getDynamicProperties().size() );
+        assertNotNull( core.getTrait( "org.drools.core.factmodel.traits.Thing" ) );
+        assertNotNull( core.getTrait( "org.drools.trait.test.Mask" ) );
+        assertNotNull( core.getTrait( "org.drools.trait.test.Cloak" ) );
+
+    }
+
+
+
+    @Test
+    public void testMapBasedTraitsWithInfinispan() {
+        String str = "package org.drools.trait.test; \n" +
+                "global java.util.List list; \n" +
+                "" +
+                "declare TBean2 \n" +
+                "  @Traitable \n" +
+                "  fld : String \n" +
+                "end \n " +
+                "" +
+                "declare trait Mask2 \n" +
+                "  @propertyReactive \n" +
+                "  fld : String \n" +
+                "  xyz : int  \n" +
+                "end \n" +
+                "\n " +
+                "declare trait Cloak2 \n" +
+                "  @propertyReactive \n" +
+                "  fld : String \n" +
+                "  ijk : String  \n" +
+                "end \n" +
+                "" +
+                "rule Init \n" +
+                "when \n" +
+                "then \n" +
+                "  insert( new TBean2(\"abc\") ); \n" +
+                "end \n" +
+                "" +
+                "rule Don \n" +
+                "no-loop \n" +
+                "when \n" +
+                "  $b : TBean2( ) \n" +
+                "then \n" +
+                "  Mask2 m = don( $b, Mask2.class ); \n" +
+                "  modify (m) { setXyz( 10 ); } \n" +
+                "  list.add( m ); \n" +
+                "  System.out.println( \"Don result : \" + m ); \n " +
+                "end \n" +
+                "\n" +
+                "rule Don2 \n" +
+                "no-loop \n" +
+                "when \n" +
+                "  $b : TBean2( ) \n" +
+                "then \n" +
+                "  Cloak2 c = don( $b, Cloak2.class ); \n" +
+                "  modify (c) { setIjk( \"ijklmn\" ); } \n" +
+                "  list.add( c ); \n" +
+                "  System.out.println( \"Don result : \" + c ); \n " +
+                "end \n" +
+                "";
+
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        TraitFactory.setMode( TraitFactory.VirtualPropertyMode.MAP, kbase );
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal("list",
+                list);
+
+        ksession.fireAllRules();
+
+        assertEquals( 2,
+                list.size() );
+        int id = ksession.getId();
+
+
+        StatefulKnowledgeSession ksession2 = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+
+        ksession2.fireAllRules();
+
+
+        Collection x = ksession2.getObjects();
+        assertEquals( 4, x.size() );
+
+        TraitableBean core = null;
+        for ( Object o : x ) {
+            if ( o instanceof TraitableBean ) {
+                core = (TraitableBean) o;
+                break;
+            }
+        }
+        assertNotNull( core );
+        assertEquals( 2, core._getDynamicProperties().size() );
+        assertNotNull( core.getTrait( "org.drools.core.factmodel.traits.Thing" ) );
+        assertNotNull( core.getTrait( "org.drools.trait.test.Mask2" ) );
+        assertNotNull( core.getTrait( "org.drools.trait.test.Cloak2" ) );
+
+    }
+
+
+
+
+    public void traitsLegacyWrapperWithInfinispan( TraitFactory.VirtualPropertyMode mode ) {
+        String str = "package org.drools.trait.test; \n" +
+                "global java.util.List list; \n" +
+                "" +                "" +
+                "declare TBean \n" +
+                "  fld : String \n" +
+                "end \n " +
+                "" +
+                "declare trait Mask \n" +
+                "  @propertyReactive \n" +
+                "  fld : String \n" +
+                "  xyz : int  \n" +
+                "end \n" +
+                "\n " +
+                "rule Init \n" +
+                "when \n" +
+                "then \n" +
+                "  insert( new TBean(\"abc\") ); \n" +
+                "end \n" +
+                "" +
+                "rule Don \n" +
+                "no-loop \n" +
+                "when \n" +
+                "  $b : TBean( ) \n" +
+                "then \n" +
+                "  System.out.println( \"Din Don Dan: \"  ); \n " +
+                "  Mask m = don( $b, Mask.class ); \n" +
+                "  modify (m) { setXyz( 10 ); } \n" +
+                "  list.add( m ); \n" +
+                "  System.out.println( \"Don result : \" + m ); \n " +
+                "end \n" +
+                "\n" +
+                "";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        TraitFactory.setMode( mode, ksession.getKieBase() );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal("list",
+                list);
+
+        ksession.fireAllRules();
+
+        assertEquals( 1,
+                list.size() );
+        int id = ksession.getId();
+
+
+        Collection yOld = ksession.getObjects();
+        TraitableBean coreOld = null;
+        for ( Object o : yOld ) {
+            if ( o instanceof TraitableBean ) {
+                coreOld = (TraitableBean) o;
+                break;
+            }
+        }
+        assertNotNull( coreOld );
+
+
+        StatefulKnowledgeSession ksession2 = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+
+        ksession2.fireAllRules();
+
+
+        Collection y = ksession2.getObjects();
+        assertEquals( 3, y.size() );
+
+        TraitableBean core = null;
+        for ( Object o : y ) {
+            if ( o instanceof TraitableBean ) {
+                core = (TraitableBean) o;
+                break;
+            }
+        }
+        assertNotNull( core );
+        assertEquals( 1, core._getDynamicProperties().size() );
+        assertNotNull( core.getTrait( "org.drools.core.factmodel.traits.Thing" ) );
+        assertNotNull( core.getTrait( "org.drools.trait.test.Mask" ) );
+
+    }
+
+
+    @Test
+    public void testTraitsOnLegacyInfinispanTriple() {
+        traitsLegacyWrapperWithInfinispan( TraitFactory.VirtualPropertyMode.TRIPLES );
+    }
+
+    @Test
+    public void testTraitsOnLegacyInfinispanMap() {
+        traitsLegacyWrapperWithInfinispan( TraitFactory.VirtualPropertyMode.MAP );
+    }
+
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/InfinispanPersistentStatefulSessionTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/InfinispanPersistentStatefulSessionTest.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.session;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.naming.InitialContext;
+import javax.transaction.UserTransaction;
+
+import org.drools.compiler.Person;
+import org.drools.core.SessionConfiguration;
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.core.command.impl.FireAllRulesInterceptor;
+import org.drools.core.command.impl.LoggingInterceptor;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.command.CommandFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.rule.FactHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfinispanPersistentStatefulSessionTest {
+
+    private static Logger logger = LoggerFactory.getLogger(InfinispanPersistentStatefulSessionTest.class);
+    
+    private HashMap<String, Object> context;
+    private Environment env;
+
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        env = createEnvironment(context);
+    }
+        
+    @After
+    public void tearDown() throws Exception {
+        PersistenceUtil.tearDown(context);
+    }
+
+
+    @Test
+    public void testFactHandleSerialization() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "import java.util.concurrent.atomic.AtomicInteger\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += " $i: AtomicInteger(intValue > 0)\n";
+        str += "then\n";
+        str += " list.add( $i );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                            list );
+
+        AtomicInteger value = new AtomicInteger(4);
+        FactHandle atomicFH = ksession.insert( value );
+
+        ksession.fireAllRules();
+
+        assertEquals( 1,
+                      list.size() );
+
+        value.addAndGet(1);
+        ksession.update(atomicFH, value);
+        ksession.fireAllRules();
+        
+        assertEquals( 2,
+                list.size() );
+        String externalForm = atomicFH.toExternalForm();
+        
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksession.getId(), kbase, null, env);
+        
+        atomicFH = ksession.execute(CommandFactory.fromExternalFactHandleCommand(externalForm));
+        
+        value.addAndGet(1);
+        ksession.update(atomicFH, value);
+        
+        ksession.fireAllRules();
+        
+        list = (List<?>) ksession.getGlobal("list");
+        
+        assertEquals( 3,
+                list.size() );
+        
+    }
+    
+    @Test
+    public void testLocalTransactionPerStatement() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                            list );
+
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+
+        ksession.fireAllRules();
+
+        assertEquals( 3,
+                      list.size() );
+
+    }
+
+    @Test
+    public void testUserTransactions() throws Exception {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  $i : Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( $i );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        ut.commit();
+
+        List<?> list = new ArrayList<Object>();
+
+        // insert and commit
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.setGlobal( "list",
+                            list );
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.fireAllRules();
+        ut.commit();
+
+        // insert and rollback
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 3 );
+        ut.rollback();
+
+        // check we rolled back the state changes from the 3rd insert
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.fireAllRules();
+        ut.commit();
+        assertEquals( 2,
+                      list.size() );
+
+        // insert and commit
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 3 );
+        ksession.insert( 4 );
+        ut.commit();
+        
+        ksession.fireAllRules();
+        
+        assertEquals( 4, 
+        			  list.size() );
+
+        // rollback again, this is testing that we can do consecutive rollbacks and commits without issue
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 5 );
+        ksession.insert( 6 );
+        ut.rollback();
+
+        ksession.fireAllRules();
+
+        assertEquals( 4,
+                      list.size() );
+        
+        // now load the ksession
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( ksession.getId(), kbase, null, env );
+        
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 7 );
+        ksession.insert( 8 );
+        ut.commit();
+
+        ksession.fireAllRules();
+
+        assertEquals( 6,
+                      list.size() );
+    }
+
+    @Test
+    public void testInterceptor() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        SingleSessionCommandService sscs = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) ksession).getCommandService();
+        sscs.addInterceptor(new LoggingInterceptor());
+        sscs.addInterceptor(new FireAllRulesInterceptor());
+        sscs.addInterceptor(new LoggingInterceptor());
+        List<?> list = new ArrayList<Object>();
+        ksession.setGlobal( "list", list );
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+        ksession.getWorkItemManager().completeWorkItem(0, null);
+        assertEquals( 3, list.size() );
+    }
+    
+    @Test
+    public void testSetFocus() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "agenda-group \"badfocus\"";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+    
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+    
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+    
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+    
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+    
+        ksession.setGlobal( "list",
+                            list );
+    
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+        ksession.getAgenda().getAgendaGroup("badfocus").setFocus();
+    
+        ksession.fireAllRules();
+    
+        assertEquals( 3,
+                      list.size() );
+    }
+    
+    @Test
+    public void testSharedReferences() {
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+
+        Person x = new Person( "test" );
+        List test = new ArrayList();
+        List test2 = new ArrayList();
+        test.add( x );
+        test2.add( x );
+
+        assertSame( test.get( 0 ), test2.get( 0 ) );
+
+        ksession.insert( test );
+        ksession.insert( test2 );
+        ksession.fireAllRules();
+
+        StatefulKnowledgeSession ksession2 = InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksession.getId(), kbase, null, env);
+
+        Iterator c = ksession2.getObjects().iterator();
+        List ref1 = (List) c.next();
+        List ref2 = (List) c.next();
+
+        assertSame( ref1.get( 0 ), ref2.get( 0 ) );
+
+    }
+
+    @Test
+    public void testMergeConfig() {
+        // JBRULES-3155
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        Properties properties = new Properties();
+        properties.put("drools.processInstanceManagerFactory", "com.example.CustomInfinispanProcessInstanceManagerFactory");
+        KieSessionConfiguration config = KnowledgeBaseFactory.newKnowledgeSessionConfiguration(properties);
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, config, env );
+        SessionConfiguration sessionConfig = (SessionConfiguration)ksession.getSessionConfiguration();
+
+        assertEquals("com.example.CustomInfinispanProcessInstanceManagerFactory", sessionConfig.getProcessInstanceManagerFactory());
+    }
+
+    @Test
+    public void testCreateAndDestroySession() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(str.getBytes()),
+                ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                list );
+
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+
+        ksession.fireAllRules();
+
+        assertEquals( 3, list.size() );
+
+        int ksessionId = ksession.getId();
+        ksession.destroy();
+
+        try {
+            InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksessionId, kbase, null, env);
+            fail("There should not be any session with id " + ksessionId);
+        } catch (Exception e) {
+
+        }
+    }
+
+    @Test
+    public void testCreateAndDestroyNonPersistentSession() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                list );
+
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+
+        ksession.fireAllRules();
+
+        assertEquals( 3, list.size() );
+
+        int ksessionId = ksession.getId();
+        ksession.destroy();
+
+        try {
+            ksession.fireAllRules();
+            fail("Session should already be disposed " + ksessionId);
+        } catch (IllegalStateException e) {
+
+        }
+    }
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2011 Red Hat Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.session;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Random;
+
+import org.drools.core.common.DefaultFactHandle;
+import org.drools.persistence.PersistenceContextManager;
+import org.drools.persistence.util.PersistenceUtil;
+import org.infinispan.manager.DefaultCacheManager;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kie.api.event.rule.DefaultAgendaEventListener;
+import org.kie.api.event.rule.DefaultWorkingMemoryEventListener;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class ReloadSessionTest {
+
+    // Datasource (setup & clean up)
+    private HashMap<String, Object> context;
+    private DefaultCacheManager cm;
+
+    private static String simpleRule = "package org.kie.test\n"
+            + "global java.util.List list\n" 
+            + "rule rule1\n" 
+            + "when\n"
+            + "  Integer(intValue > 0)\n" 
+            + "then\n" 
+            + "  list.add( 1 );\n"
+            + "end\n" 
+            + "\n";
+
+    @Before
+    public void setup() {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+    }
+
+    @After
+    public void cleanUp() {
+        PersistenceUtil.tearDown(context);
+    }
+
+    private KnowledgeBase initializeKnowledgeBase(String rule) { 
+        // Initialize knowledge base/session/etc..
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(rule.getBytes()), ResourceType.DRL);
+
+        if (kbuilder.hasErrors()) {
+            fail(kbuilder.getErrors().toString());
+        }
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+       
+        return kbase;
+    }
+    
+    @Test 
+    public void reloadKnowledgeSessionTest() { 
+        
+        // Initialize drools environment stuff
+        Environment env = createEnvironment(context);
+        KnowledgeBase kbase = initializeKnowledgeBase(simpleRule);
+        StatefulKnowledgeSession commandKSession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        assertTrue("There should be NO facts present in a new (empty) knowledge session.", commandKSession.getFactHandles().isEmpty());
+        
+        // Persist a facthandle to the database
+        Integer integerFact = (new Random()).nextInt(Integer.MAX_VALUE-1) + 1;
+        commandKSession.insert( integerFact );
+       
+        // At this point in the code, the fact has been persisted to the database
+        //  (within a transaction via the SingleSessionCommandService) 
+        Collection<FactHandle> factHandles =  commandKSession.getFactHandles();
+        assertTrue("At least one fact should have been inserted by the ksession.insert() method above.", !factHandles.isEmpty());
+        FactHandle origFactHandle = factHandles.iterator().next();
+        assertTrue("The stored fact should contain the same number as the value inserted (but does not).", 
+                Integer.parseInt(((DefaultFactHandle) origFactHandle).getObject().toString()) == integerFact.intValue() );
+        
+        // Save the sessionInfo id in order to retrieve it later
+        int sessionInfoId = commandKSession.getId();
+        
+        // Clean up the session, environment, etc.
+        PersistenceContextManager pcm = (PersistenceContextManager) commandKSession.getEnvironment().get(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER);
+        commandKSession.dispose();
+        pcm.dispose();
+     
+        // Reload session from the cache
+        env = createEnvironment(context);
+       
+        // Re-initialize the knowledge session:
+        StatefulKnowledgeSession newCommandKSession
+            = InfinispanKnowledgeService.loadStatefulKnowledgeSession(sessionInfoId, kbase, null, env);
+       
+        // Test that the session has been successfully reinitialized
+        factHandles =  newCommandKSession.getFactHandles();
+        assertTrue("At least one fact should have been persisted by the ksession.insert above.", 
+                !factHandles.isEmpty() && factHandles.size() == 1);
+        FactHandle retrievedFactHandle = factHandles.iterator().next();
+        assertTrue("If the retrieved and original FactHandle object are the same, then the knowledge session has NOT been reloaded!", 
+                origFactHandle != retrievedFactHandle);
+        assertTrue("The retrieved fact should contain the same info as the original (but does not).", 
+                Integer.parseInt(((DefaultFactHandle) retrievedFactHandle).getObject().toString()) == integerFact.intValue() );
+        
+        // Test to see if the (retrieved) facts can be processed
+        ArrayList<Object>list = new ArrayList<Object>();
+        newCommandKSession.setGlobal( "list", list );
+        newCommandKSession.fireAllRules();
+        assertEquals( 1, list.size() );
+    }
+
+    @Test @Ignore
+    public void testListenersAfterSessionReload() {
+        // https://bugzilla.redhat.com/show_bug.cgi?id=826952
+        Environment env = createEnvironment(context);
+        KnowledgeBase kbase = initializeKnowledgeBase(simpleRule);
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+
+        ksession.addEventListener(new DefaultAgendaEventListener());
+        ksession.addEventListener(new DefaultWorkingMemoryEventListener());
+
+        assertEquals(1, ksession.getWorkingMemoryEventListeners().size());
+        assertEquals(1, ksession.getAgendaEventListeners().size());
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession(ksession.getId(), kbase, null, env);
+
+        assertEquals(1, ksession.getWorkingMemoryEventListeners().size());
+        assertEquals(1, ksession.getAgendaEventListeners().size());
+    }
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.session;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.core.command.impl.GenericCommand;
+import org.drools.core.command.impl.KnowledgeCommandContext;
+import org.drools.core.io.impl.ClassPathResource;
+import org.drools.persistence.util.PersistenceUtil;
+import org.drools.core.runtime.rule.impl.InternalAgenda;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.command.Context;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieSession;
+
+public class RuleFlowGroupRollbackTest {
+    
+    private HashMap<String, Object> context;
+
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+    }
+	
+	@After
+	public void tearDown() {
+		PersistenceUtil.tearDown(context);
+	}
+
+    @Test	
+	public void testRuleFlowGroupRollback() throws Exception {
+		
+		CommandBasedStatefulKnowledgeSession ksession = createSession();
+		
+		List<String> list = new ArrayList<String>();
+		list.add("Test");
+		
+		ksession.insert(list);
+		ksession.execute(new ActivateRuleFlowCommand("ruleflow-group"));
+		assertEquals(1, ksession.fireAllRules());
+		
+		try {
+			ksession.execute(new ExceptionCommand());
+			fail("Process must throw an exception");
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		
+		ksession.insert(list);
+		ksession.execute(new ActivateRuleFlowCommand("ruleflow-group"));
+		assertEquals(1, ksession.fireAllRules());
+		
+	}
+	
+	private CommandBasedStatefulKnowledgeSession createSession() {
+		
+		KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource("ruleflowgroup_rollback.drl"), ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        Environment env = createEnvironment(context);
+        return (CommandBasedStatefulKnowledgeSession) InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+	}
+	
+	@SuppressWarnings("serial")
+	public class ActivateRuleFlowCommand implements GenericCommand<Object> {
+		
+		private String ruleFlowGroupName;
+		
+		public ActivateRuleFlowCommand(String ruleFlowGroupName){
+			this.ruleFlowGroupName = ruleFlowGroupName;
+		}
+
+	    public Void execute(Context context) {
+	        KieSession ksession = ((KnowledgeCommandContext) context).getKieSession();
+	        ((InternalAgenda) ksession.getAgenda()).activateRuleFlowGroup(ruleFlowGroupName);
+	        return null;
+	    }
+
+	}
+	
+	@SuppressWarnings("serial")
+	public class ExceptionCommand implements GenericCommand<Object> {
+
+	    public Void execute(Context context) {
+	    	throw new RuntimeException();
+	    }
+
+	}
+	
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/timer/integrationtests/TimerAndCalendarTest.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/timer/integrationtests/TimerAndCalendarTest.java
@@ -1,0 +1,299 @@
+package org.drools.persistence.timer.integrationtests;
+
+import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.PersistenceUtil.createEnvironment;
+import static org.drools.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.drools.persistence.util.PersistenceUtil.tearDown;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.drools.core.ClockType;
+import org.drools.core.time.SessionPseudoClock;
+import org.infinispan.manager.DefaultCacheManager;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.KieBaseConfiguration;
+import org.kie.api.conf.EventProcessingOption;
+import org.kie.api.definition.type.FactType;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.api.time.SessionClock;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderError;
+import org.kie.internal.builder.KnowledgeBuilderErrors;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.definition.KnowledgePackage;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class TimerAndCalendarTest {
+    private DefaultCacheManager cm;
+
+    @Test
+    public void testTimerRuleAfterIntReloadSession() throws Exception {
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        StatefulKnowledgeSession ksession = createSession( kbase );
+
+        // must advance time or it won't save.
+        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 300,
+                           TimeUnit.MILLISECONDS );
+
+        // if we do not call 'ksession.fireAllRules()', this test will run successfully.
+        ksession.fireAllRules();
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 300,
+                           TimeUnit.MILLISECONDS );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 300,
+                           TimeUnit.MILLISECONDS );
+
+        // build timer rule, if the rule is fired, the list size will increase every 500ms
+        String timerRule = "package org.drools.test\n" +
+                           "global java.util.List list \n" +
+                           "rule TimerRule \n" +
+                           "   timer (int:1000 500) \n" +
+                           "when \n" + "then \n" +
+                           "        list.add(list.size()); \n" +
+                           " end";
+        Resource resource = ResourceFactory.newByteArrayResource(timerRule.getBytes());
+        Collection<KnowledgePackage> kpackages = buildKnowledgePackage( resource,
+                                                                        ResourceType.DRL );
+        kbase.addKnowledgePackages( kpackages );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 10,
+                           TimeUnit.MILLISECONDS );
+        ksession.fireAllRules();
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 10,
+                           TimeUnit.MILLISECONDS );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 10,
+                           TimeUnit.MILLISECONDS );
+
+        List<Integer> list = Collections.synchronizedList( new ArrayList<Integer>() );
+        ksession.setGlobal( "list",
+                            list );
+        Assert.assertEquals( 0,
+                             list.size() );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 1700,
+                           TimeUnit.MILLISECONDS );
+        Assert.assertEquals( 2,
+                             list.size() );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+        ksession.setGlobal( "list",
+                            list );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 1000,
+                           TimeUnit.MILLISECONDS );
+
+        // if the rule is fired, the list size will greater than one.
+        Assert.assertEquals( 4,
+                             list.size() );
+    }
+
+    @Test
+    public void testTimerRuleAfterCronReloadSession() throws Exception {
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        StatefulKnowledgeSession ksession = createSession( kbase );
+
+        // must advance time or it won't save.
+        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 300,
+                           TimeUnit.MILLISECONDS );
+
+        // if we do not call 'ksession.fireAllRules()', this test will run successfully.
+        ksession.fireAllRules();
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 300,
+                           TimeUnit.MILLISECONDS );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 300,
+                           TimeUnit.MILLISECONDS );
+
+        // build timer rule, if the rule is fired, the list size will increase every 300ms
+        String timerRule = "package org.drools.test\n" +
+                           "global java.util.List list \n" +
+                           "rule TimerRule \n" +
+                           "   timer (cron: * * * * * ?) \n" +
+                           "when \n" + "then \n" +
+                           "        list.add(list.size()); \n" +
+                           " end";
+        Resource resource = ResourceFactory.newByteArrayResource( timerRule.getBytes() );
+        Collection<KnowledgePackage> kpackages = buildKnowledgePackage( resource,
+                                                                        ResourceType.DRL );
+        kbase.addKnowledgePackages( kpackages );
+
+        List<Integer> list = Collections.synchronizedList( new ArrayList<Integer>() );
+        ksession.setGlobal( "list",
+                            list );
+
+        ksession.setGlobal( "list",
+                            list );
+        clock.advanceTime( 10,
+                           TimeUnit.MILLISECONDS );
+        ksession.fireAllRules();
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 10,
+                           TimeUnit.MILLISECONDS );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+        ksession.setGlobal( "list",
+                            list );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 10,
+                           TimeUnit.MILLISECONDS );
+
+        Assert.assertEquals( 1,
+                             list.size() );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 3,
+                           TimeUnit.SECONDS );
+        Assert.assertEquals( 4,
+                             list.size() );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+        ksession.setGlobal( "list",
+                            list );
+
+        clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+        clock.advanceTime( 2,
+                           TimeUnit.SECONDS );
+
+        // if the rule is fired, the list size will greater than one.
+        Assert.assertEquals( 6,
+                             list.size() );
+    }
+
+    @Test
+    public void testEventExpires() throws Exception {
+        String timerRule = "package org.drools.test\n" +
+                           "declare TestEvent \n" +
+                           "    @role( event )\n" +
+                           "    @expires( 10s )\n" +
+                           "end\n" +
+                           "" +
+                           "rule TimerRule \n" +
+                           "    when \n" +
+                           "        TestEvent( ) from entry-point \"Test\"\n" +
+                           "    then \n" +
+                           "end";
+        KieBaseConfiguration kbconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+        kbconf.setOption( EventProcessingOption.STREAM );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase( kbconf );
+        Resource resource = ResourceFactory.newByteArrayResource( timerRule.getBytes() );
+        Collection<KnowledgePackage> kpackages = buildKnowledgePackage( resource,
+                                                                        ResourceType.DRL );
+        kbase.addKnowledgePackages( kpackages );
+        StatefulKnowledgeSession ksession = createSession( kbase );
+
+        FactType type = kbase.getFactType( "org.drools.test",
+                                           "TestEvent" );
+        Assert.assertNotNull( "could not get type",
+                              type );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+        ksession.getEntryPoint( "Test" ).insert( type.newInstance() );
+        ksession.fireAllRules();
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+
+        ksession = disposeAndReloadSession( ksession,
+                                            kbase );
+    }
+
+    private HashMap<String, Object> context;
+    
+    @Before
+    public void before() throws Exception {
+        context = setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+    }
+
+    @After
+    public void after() throws Exception {
+        tearDown(context);
+    }
+
+    private StatefulKnowledgeSession createSession(KieBase kbase) {
+        final KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase,
+                                                                                             conf,
+                                                                                             createEnvironment(context) );
+        return ksession;
+    }
+
+    private StatefulKnowledgeSession disposeAndReloadSession(StatefulKnowledgeSession ksession,
+                                                             KieBase kbase) {
+        int ksessionId = ksession.getId();
+        ksession.dispose();
+
+        final KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+
+        StatefulKnowledgeSession newksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( ksessionId,
+                                                                                                 kbase,
+                                                                                                 conf,
+                                                                                                 createEnvironment(context) );
+        return newksession;
+    }
+
+    private Collection<KnowledgePackage> buildKnowledgePackage(Resource resource,
+                                                               ResourceType resourceType) {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( resource,
+                      resourceType );
+        KnowledgeBuilderErrors errors = kbuilder.getErrors();
+        if ( errors != null && errors.size() > 0 ) {
+            for ( KnowledgeBuilderError error : errors ) {
+                System.err.println( "Error: " + error.getMessage() );
+            }
+            Assert.fail( "KnowledgeBase did not build" );
+        }
+        Collection<KnowledgePackage> packages = kbuilder.getKnowledgePackages();
+        return packages;
+    }
+
+}

--- a/drools-persistence-infinispan/src/test/java/org/drools/persistence/util/PersistenceUtil.java
+++ b/drools-persistence-infinispan/src/test/java/org/drools/persistence/util/PersistenceUtil.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Properties;
+
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.drools.core.base.MapGlobalResolver;
+import org.drools.core.impl.EnvironmentFactory;
+import org.infinispan.AdvancedCache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.persistence.jpa.JPAKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.TransactionManagerServices;
+
+public class PersistenceUtil {
+
+    private static Logger logger = LoggerFactory.getLogger( PersistenceUtil.class );
+
+    private static boolean TEST_MARSHALLING = true;
+    
+    // Persistence and data source constants
+    public static final String DROOLS_PERSISTENCE_UNIT_NAME = "drools-configured-cache";
+    public static final String JBPM_PERSISTENCE_UNIT_NAME = "jbpm-configured-cache";
+        
+    protected static final String DATASOURCE_PROPERTIES = "/datasource.properties";
+    
+    // Setup and marshalling setup constants
+    public static String DATASOURCE = "org.droolsjbpm.persistence.datasource";
+
+    /**
+     * @see #setupWithPoolingDataSource(String, String, boolean)
+     * @param persistenceUnitName The name of the persistence unit to be used.
+     * @return test context
+     */
+    public static HashMap<String, Object> setupWithPoolingDataSource(String persistenceUnitName) {
+        return setupWithPoolingDataSource(persistenceUnitName, true);
+    }
+    
+    /**
+     * @see #setupWithPoolingDataSource(String, String, boolean)
+     * @param persistenceUnitName The name of the persistence unit to be used.
+     * @return test context
+     */
+    public static HashMap<String, Object> setupWithPoolingDataSource(String persistenceUnitName, boolean testMarshalling) {
+        HashMap<String, Object> context = new HashMap<String, Object>();
+
+        // set the right jdbc url
+        Properties dsProps = getDatasourceProperties();
+        Object testMarshallingProperty = dsProps.get("testMarshalling"); 
+        if( "true".equals(testMarshallingProperty) ) { 
+            TEST_MARSHALLING = true;
+           if( !testMarshalling ) { 
+               TEST_MARSHALLING = false;
+           }
+        } 
+        else { 
+            TEST_MARSHALLING = false;
+        }
+
+        if( TEST_MARSHALLING ) {
+            Class<?> testClass = null;
+            StackTraceElement [] ste = Thread.currentThread().getStackTrace();
+            int i = 1;
+            do { 
+                try {
+                    testClass = Class.forName(ste[i++].getClassName());
+                } catch (ClassNotFoundException e) {
+                    // do nothing.. 
+                }
+            } while ( PersistenceUtil.class.equals(testClass) && i < ste.length );
+            assertNotNull("Unable to resolve test class!", testClass);
+        }
+
+        // Setup persistence
+        try {
+	    	DefaultCacheManager cm = new DefaultCacheManager("infinispan.xml");
+	    	AdvancedCache<?, ?> ac = cm.getCache("jbpm-configured-cache").getAdvancedCache();
+	    	if (TEST_MARSHALLING) {
+	        	try {
+	        		
+	        		UserTransaction ut = (UserTransaction) ac.getTransactionManager().getTransaction();
+	        		context.put(EnvironmentName.TRANSACTION, ut);
+	        		//cm.start();
+	        	} catch (SystemException e) {
+	        		//TODO
+	        	}
+	    		context.put(EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY, TransactionManagerServices.getTransactionSynchronizationRegistry());
+
+	        }
+	    	context.put(EnvironmentName.ENTITY_MANAGER_FACTORY, cm);
+        } catch (IOException e) {
+        	//TODO
+        }
+
+        return context;
+    }
+
+    /**
+     * Please use {@link #cleanUp(HashMap)} because tearDown() ends up conflicting with Junit methods at times. 
+     * @see {@link PersistenceUtil#cleanUp(HashMap)}
+     */
+    @Deprecated
+    public static void tearDown(HashMap<String, Object> context) {
+       cleanUp(context);     
+    }
+    
+    /**
+     * This method should be called in the @After method of a test to clean up
+     * the persistence unit and datasource.
+     * 
+     * @param context
+     *            A HashMap generated by
+     *            {@link org.kie.api.persistence.util.PersistenceUtil setupWithPoolingDataSource(String)}
+     * 
+     */
+    public static void cleanUp(HashMap<String, Object> context) {
+        if (context != null) {
+            
+            BitronixTransactionManager txm = TransactionManagerServices.getTransactionManager();
+            if( txm != null ) { 
+                txm.shutdown();
+            }
+            
+            Object cmObject = context.remove(EnvironmentName.ENTITY_MANAGER_FACTORY);
+            if (cmObject != null) {
+                try {
+                	DefaultCacheManager cm = (DefaultCacheManager) cmObject;
+                    //cm.stop();
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+        
+    }
+    
+    /**
+     * This reads in the (maven filtered) datasource properties from the test
+     * resource directory.
+     * 
+     * @return Properties containing the datasource properties.
+     */
+    public static Properties getDatasourceProperties() { 
+        String propertiesNotFoundMessage = "Unable to load datasource properties [" + DATASOURCE_PROPERTIES + "]";
+
+        // Central place to set additional H2 properties
+        System.setProperty("h2.lobInDatabase", "true");
+        
+        InputStream propsInputStream = PersistenceUtil.class.getResourceAsStream(DATASOURCE_PROPERTIES);
+        assertNotNull(propertiesNotFoundMessage, propsInputStream);
+        Properties props = new Properties();
+        if (propsInputStream != null) {
+            try {
+                props.load(propsInputStream);
+            } catch (IOException ioe) {
+                logger.warn("Unable to find properties, using default H2 properties: " + ioe.getMessage());
+                ioe.printStackTrace();
+            }
+        }
+        return props;
+    }
+
+    /**
+     * Reflection method when doing ugly hacks in tests.
+     * 
+     * @param fieldname
+     *            The name of the field to be retrieved.
+     * @param source
+     *            The object containing the field to be retrieved.
+     * @return The value (object instance) stored in the field requested from
+     *         the given source object.
+     */
+    public static Object getValueOfField(String fieldname, Object source) {
+        String sourceClassName = source.getClass().getSimpleName();
+    
+        Field field = null;
+        try {
+            field = source.getClass().getDeclaredField(fieldname);
+            field.setAccessible(true);
+        } catch (SecurityException e) {
+            fail("Unable to retrieve " + fieldname + " field from " + sourceClassName + ": " + e.getCause());
+        } catch (NoSuchFieldException e) {
+            fail("Unable to retrieve " + fieldname + " field from " + sourceClassName + ": " + e.getCause());
+        }
+    
+        assertNotNull("." + fieldname + " field is null!?!", field);
+        Object fieldValue = null;
+        try {
+            fieldValue = field.get(source);
+        } catch (IllegalArgumentException e) {
+            fail("Unable to retrieve value of " + fieldname + " from " + sourceClassName + ": " + e.getCause());
+        } catch (IllegalAccessException e) {
+            fail("Unable to retrieve value of " + fieldname + " from " + sourceClassName + ": " + e.getCause());
+        }
+        return fieldValue;
+    }
+
+    public static Environment createEnvironment(HashMap<String, Object> context) { 
+        Environment env = EnvironmentFactory.newEnvironment();
+        
+        UserTransaction ut = (UserTransaction) context.get(EnvironmentName.TRANSACTION);
+        if( ut != null ) { 
+            env.set( EnvironmentName.TRANSACTION, ut);
+        }
+        
+        env.set( EnvironmentName.ENTITY_MANAGER_FACTORY, context.get(EnvironmentName.ENTITY_MANAGER_FACTORY) );
+        TransactionManager tm = TransactionManagerServices.getTransactionManager();
+        env.set( EnvironmentName.TRANSACTION_MANAGER, tm );
+        env.set( EnvironmentName.GLOBALS, new MapGlobalResolver() );
+        
+        return env;
+    }
+    
+   public static StatefulKnowledgeSession createKnowledgeSessionFromKBase(KieBase kbase, HashMap<String, Object> context) {
+       KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+       StatefulKnowledgeSession knowledgeSession = JPAKnowledgeService.newStatefulKnowledgeSession(kbase, ksconf, createEnvironment(context));
+       return knowledgeSession;
+   }
+   
+}

--- a/drools-persistence-infinispan/src/test/java/org/infinispan/transaction/lookup/BitronixTransactionManagerLookup.java
+++ b/drools-persistence-infinispan/src/test/java/org/infinispan/transaction/lookup/BitronixTransactionManagerLookup.java
@@ -1,0 +1,20 @@
+package org.infinispan.transaction.lookup;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import bitronix.tm.TransactionManagerServices;
+
+public class BitronixTransactionManagerLookup implements
+		TransactionManagerLookup {
+
+	@Override
+	public TransactionManager getTransactionManager() throws Exception {
+		return TransactionManagerServices.getTransactionManager();
+	}
+	
+	public UserTransaction getUserTransaction() throws Exception {
+		return TransactionManagerServices.getTransactionManager();
+	}
+
+}

--- a/drools-persistence-infinispan/src/test/resources/META-INF/beans.xml
+++ b/drools-persistence-infinispan/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/drools-persistence-infinispan/src/test/resources/META-INF/kmodule.xml
+++ b/drools-persistence-infinispan/src/test/resources/META-INF/kmodule.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns="http://jboss.org/kie/6.0.0/kmodule">
+         
+    <kbase name="cdiexample">
+        <ksession name="ksession1"/>
+    </kbase>  
+    
+</kmodule>

--- a/drools-persistence-infinispan/src/test/resources/cdiexample/test.drl
+++ b/drools-persistence-infinispan/src/test/resources/cdiexample/test.drl
@@ -1,0 +1,10 @@
+package org.kie.test
+
+global java.util.List list
+
+rule rule1
+when
+  Integer(intValue > 0)
+then
+  list.add( 1 );
+end

--- a/drools-persistence-infinispan/src/test/resources/jndi.properties
+++ b/drools-persistence-infinispan/src/test/resources/jndi.properties
@@ -1,0 +1,2 @@
+java.naming.factory.initial=bitronix.tm.jndi.BitronixInitialContextFactory
+bitronix.tm.jndi.userTransactionName=java:comp/TransactionManager

--- a/drools-persistence-infinispan/src/test/resources/logback-test.xml
+++ b/drools-persistence-infinispan/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="info"/>
+
+  <!--  marshalling utils -->
+  <logger name="org.kie.api.marshalling.util" level="debug"/>
+  <logger name="org.kie.api.marshalling.util.CompareViaReflectionUtil" level="info"/>
+
+  <!-- bitronix -->
+  <logger name="bitronix.tm.twopc.Preparer" level="error"/>
+
+  <!--  hibernate  -->
+  <logger name="org.hibernate" level="warn"/>
+  <logger name="org.hibernate.cfg.search" level="warn"/>
+  <logger name="org.hibernate.cfg.annotations" level="warn"/>
+  <logger name="org.hibernate.cfg.AnnotationBinder" level="warn"/>
+  <logger name="org.hibernate.cfg.SettingsFactory" level="warn"/>
+  <logger name="org.hibernate.tool.hbm2ddl" level="warn"/>
+
+  <root level="info"><!-- TODO We probably want to set default level to warn instead -->
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>
+

--- a/drools-persistence-infinispan/src/test/resources/marshalling/.gitignore
+++ b/drools-persistence-infinispan/src/test/resources/marshalling/.gitignore
@@ -1,0 +1,2 @@
+/testData.*
+/baseData.h2.db

--- a/drools-persistence-infinispan/src/test/resources/org/drools/persistence/command/empty.drl
+++ b/drools-persistence-infinispan/src/test/resources/org/drools/persistence/command/empty.drl
@@ -1,0 +1,6 @@
+package com.sample
+
+rule "EmptyRule" 
+    when
+    then
+end 

--- a/drools-persistence-infinispan/src/test/resources/ruleflowgroup_rollback.drl
+++ b/drools-persistence-infinispan/src/test/resources/ruleflowgroup_rollback.drl
@@ -1,0 +1,11 @@
+package org.jbpm;
+
+import java.util.List;
+
+rule "Test Process Rule"
+	ruleflow-group "ruleflow-group"
+	when
+	    $list : List()
+	then 
+	    System.out.println("list size: " + $list.size());
+end

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <module>drools-jsr94</module>
     <module>drools-verifier</module>
     <module>drools-persistence-jpa</module>
+    <module>drools-persistence-infinispan</module>
     <module>drools-templates</module>
     <module>drools-decisiontables</module>
     <module>drools-examples</module>


### PR DESCRIPTION
I’ve worked on an infinispan based persistence scheme for drools objects.
The whole idea is to give both a possibility for Infinispan users to have a way to persist these contents in something different than JPA, as well as to give an example of how to build your own persistence scheme for drools and jbpm objects.
