### PR TITLE
Adds a .signalEvent(type, event) and .signalEvent(type, event processIns...

### DIFF
--- a/drools-core/src/main/java/org/drools/core/command/impl/CommandBasedStatefulKnowledgeSession.java
+++ b/drools-core/src/main/java/org/drools/core/command/impl/CommandBasedStatefulKnowledgeSession.java
@@ -183,6 +183,18 @@ public class CommandBasedStatefulKnowledgeSession
                 public void internalExecuteWorkItem(WorkItem workItem) {
                     throw new UnsupportedOperationException();
                 }
+
+                @Override
+                public void signalEvent(String type, Object event) {
+                    SignalEventCommand command = new SignalEventCommand(type, event);
+                    commandService.execute(command);
+                }
+
+                @Override
+                public void signalEvent(String type, Object event, long processInstanceId) {
+                    SignalEventCommand command = new SignalEventCommand(processInstanceId, type, event);
+                    commandService.execute(command);
+                }
             };
         }
         return workItemManager;

--- a/drools-core/src/main/java/org/drools/core/process/instance/WorkItemManager.java
+++ b/drools-core/src/main/java/org/drools/core/process/instance/WorkItemManager.java
@@ -31,5 +31,9 @@ public interface WorkItemManager extends org.kie.api.runtime.process.WorkItemMan
     WorkItem getWorkItem(long id);
 
     void clear();
+    
+    public void signalEvent(String type, Object event);
+    
+    public void signalEvent(String type, Object event, long processInstanceId);
 
 }

--- a/drools-core/src/main/java/org/drools/core/process/instance/impl/DefaultWorkItemManager.java
+++ b/drools-core/src/main/java/org/drools/core/process/instance/impl/DefaultWorkItemManager.java
@@ -155,5 +155,14 @@ public class DefaultWorkItemManager implements WorkItemManager, Externalizable {
     public void clear() {
         this.workItems.clear();
     }
+    
+    public void signalEvent(String type, Object event) { 
+        this.kruntime.signalEvent(type, event);
+    } 
+    
+    public void signalEvent(String type, Object event, long processInstanceId) { 
+        this.kruntime.signalEvent(type, event, processInstanceId);
+    }
+
 
 }

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/processinstance/JPAWorkItemManager.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/processinstance/JPAWorkItemManager.java
@@ -219,4 +219,12 @@ public class JPAWorkItemManager implements WorkItemManager {
     public void clear() {
         clearWorkItems();
     }
+    
+    public void signalEvent(String type, Object event) { 
+        this.kruntime.signalEvent(type, event);
+    } 
+    
+    public void signalEvent(String type, Object event, long processInstanceId) { 
+        this.kruntime.signalEvent(type, event, processInstanceId);
+    }
 }


### PR DESCRIPTION
...tId) method to the (drools) WorkItemManager and impl's of that.
- This would help with exception handling in jBPM. It would allow processes to be able to trigger other parts of the process when a WorkItemHandler fails, which is even a part of the BPMN2 spec.
