### PR TITLE
don't rollback transaction when session was not found

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SessionNotFoundException.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SessionNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2011 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence;
+
+public class SessionNotFoundException extends RuntimeException {
+
+    public SessionNotFoundException(String message) {
+        super(message);
+    }
+
+    public SessionNotFoundException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -201,6 +201,10 @@ public class SingleSessionCommandService
                           persistenceContext );
 
             txm.commit( transactionOwner );
+        } catch (SessionNotFoundException e){
+          // do not rollback transaction otherwise it will mark it as aborted
+          // making the whole operation to fail
+            throw e;
         } catch ( RuntimeException re ) {
             rollbackTransaction( re,
                                  transactionOwner );
@@ -226,12 +230,12 @@ public class SingleSessionCommandService
         try {
             this.sessionInfo = persistenceContext.findSessionInfo( sessionId );
         } catch ( Exception e ) {
-            throw new RuntimeException( "Could not find session data for id " + sessionId,
+            throw new SessionNotFoundException( "Could not find session data for id " + sessionId,
                                         e );
         }
 
         if ( sessionInfo == null ) {
-            throw new RuntimeException( "Could not find session data for id " + sessionId );
+            throw new SessionNotFoundException( "Could not find session data for id " + sessionId );
         }
 
         if ( this.marshallingHelper == null ) {


### PR DESCRIPTION
avoid rollbacking transaction when session was not found and just throw runtime exception. This will give the caller (for example runtime manager) to take decision on creating new session in such situation. Exception is dedicated to indicate that session was not found and it extends RuntimeException which should rollback transaction anyway if not handled properly.

Especially valid in environments where transaction is managed outside of jbpm/drools control like CDI/EJB.
