### PR TITLE
Corrected names of Drools book authors in recommended reading

### DIFF
--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/Chapter-Introduction/Section-AIKnowledgeRepresentation.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/Chapter-Introduction/Section-AIKnowledgeRepresentation.xml
@@ -508,7 +508,7 @@ then
 
         <itemizedlist>
           <listitem>
-            <para>Paul Brown</para>
+            <para>Paul Browne</para>
           </listitem>
         </itemizedlist>
       </listitem>
@@ -518,7 +518,7 @@ then
 
         <itemizedlist>
           <listitem>
-            <para>Michali Bali</para>
+            <para>Michal Bali</para>
           </listitem>
         </itemizedlist>
       </listitem>


### PR DESCRIPTION
Michal Bali and Paul Browne were both suffering from mis-typed names.
