### PR TITLE
DROOLS-167: test case for Inaccurate comparison because of String to Dou...

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MiscTest2.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MiscTest2.java
@@ -2107,4 +2107,19 @@ public class MiscTest2 extends CommonTestMethodBase {
         assertTrue(list.containsAll(asList("B", "C")));
         list.clear();
     }
+
+    @Test
+    public void testStringCoercionComparison() {
+        // DROOLS-167
+        String str = "import " + Person.class.getName() + ";\n" +
+                     "rule R1 when\n" +
+                     "   $p : Person( name < \"90201304122000000000000017\" )\n" +
+                     "then end\n";
+
+        KnowledgeBase kbase = loadKnowledgeBaseFromString( str );
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+        ksession.insert( new Person( "90201304122000000000000015", 38 ) );
+        assertEquals( 1, ksession.fireAllRules() );
+    }
 }


### PR DESCRIPTION
Adding a test case for DROOLS-167 : Inaccurate comparison because of String to Double coercion 
