### PR TITLE
JBPM-4101 - Retry interceptor on optimistic lock exception

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/OptimisticLockRetryInterceptor.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/OptimisticLockRetryInterceptor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.persistence.jpa;
+
+import org.drools.core.command.impl.AbstractInterceptor;
+import org.kie.api.command.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interceptor that is capable of retrying command execution. It is intended to retry only if right exception
+ * has been thrown. By default it will look for <code>org.hibernate.StaleObjectStateException</code> and only
+ * then attempt to retry.
+ * Since this is Hibernate specific class another can be given as system property to override default. Name of the
+ * system property <code>org.kie.optlock.exclass</code> and its value should be fully qualified class name of the
+ * exception that indicates OptimisticLocking.
+ * By default it will:
+ * <ul>
+ *  <li>Retry 3 times</li>
+ *  <li>First retry will be attempted after 50 milliseconds</li>
+ *  <li>next retries will be calculated as last sleep time multiplied by a factor (default factor is 4)</li>
+ * </ul>
+ * In case all retries failed origin exception will be thrown.
+ *
+ */
+public class OptimisticLockRetryInterceptor extends AbstractInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(OptimisticLockRetryInterceptor.class);
+
+    private int retries = 3;
+    private long delay = 50;
+    private long delayFactor = 4;
+
+    protected Class<?> targetExceptionClass;
+
+    public OptimisticLockRetryInterceptor() {
+        String clazz = System.getProperty("org.kie.optlock.exclass", "org.hibernate.StaleObjectStateException");
+        try {
+            targetExceptionClass = Class.forName(clazz);
+        } catch (ClassNotFoundException e) {
+            logger.error("Optimistic locking exception class not found {}", clazz, e);
+        }
+    }
+
+    @Override
+    public <T> T execute(Command<T> command) {
+        int attempt = 1;
+        long sleepTime = delay;
+        RuntimeException originException = null;
+
+        while (attempt <= retries) {
+            if (attempt > 1) {
+                logger.trace("retrying (attempt {})...", attempt);
+            }
+            try {
+
+                return executeNext(command);
+
+            } catch (RuntimeException ex) {
+
+                if (!isCausedByOptimisticLockingFailure(ex)) {
+                    throw ex;
+                }
+                attempt++;
+                logger.trace("Command failed due to optimistic locking {} waiting {} millis before retry", ex, sleepTime);
+                // save origin exception in case it needs to be rethrown
+                if (originException == null) {
+                    originException = ex;
+                }
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e1) {
+                    logger.trace("retry sleeping got interrupted");
+                }
+
+                sleepTime *= delayFactor;
+            }
+        }
+        logger.warn("Retry failed after {} attempts", attempt);
+        throw originException;
+
+    }
+
+    protected boolean isCausedByOptimisticLockingFailure(Throwable throwable) {
+        if (targetExceptionClass == null) {
+            logger.warn("targetExceptionClass not configured, the retry interceptor is disabled.");
+            return false;
+        }
+
+        while (throwable != null) {
+            if (targetExceptionClass.isAssignableFrom(throwable.getClass())) {
+                return true;
+            } else {
+                throwable = throwable.getCause();
+            }
+        }
+
+        return false;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public void setRetries(int retries) {
+        this.retries = retries;
+    }
+
+    public long getDelay() {
+        return delay;
+    }
+
+    public void setDelay(long delay) {
+        this.delay = delay;
+    }
+
+    public long getDelayFactor() {
+        return delayFactor;
+    }
+
+    public void setDelayFactor(long delayFactor) {
+        this.delayFactor = delayFactor;
+    }
+
+    public Class<?> getTargetExceptionClass() {
+        return targetExceptionClass;
+    }
+
+    public void setTargetExceptionClass(Class<?> targetExceptionClass) {
+        this.targetExceptionClass = targetExceptionClass;
+    }
+
+}

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaOptLockPersistentStatefulSessionTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/session/JpaOptLockPersistentStatefulSessionTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.persistence.session;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.jpa.OptimisticLockRetryInterceptor;
+import org.drools.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.Environment;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.persistence.jpa.JPAKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.drools.persistence.util.PersistenceUtil.*;
+import static org.junit.Assert.*;
+
+
+public class JpaOptLockPersistentStatefulSessionTest {
+
+    private static Logger logger = LoggerFactory.getLogger(JpaOptLockPersistentStatefulSessionTest.class);
+
+    private HashMap<String, Object> context;
+    private Environment env;
+
+    public JpaOptLockPersistentStatefulSessionTest() {
+    }
+    
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        env = createEnvironment(context);
+    }
+        
+    @After
+    public void tearDown() throws Exception {
+        PersistenceUtil.cleanUp(context);
+    }
+
+    @Test
+    public void testOptimisticLockInterceptor() {
+        String str = "";
+        str += "package org.kie.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = JPAKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+        for (int i = 0; i < 2; i++) {
+            new InsertAndFireThread(ksession.getId(), kbase, list).start();
+        }
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        assertEquals( 6, list.size() );
+        ksession.dispose();
+    }
+
+    private class InsertAndFireThread extends Thread {
+
+        private int ksessionId;
+        private KnowledgeBase kbase;
+        private List<?> list;
+
+        InsertAndFireThread(int ksessionId, KnowledgeBase kbase, List<?> list) {
+            this.ksessionId = ksessionId;
+            this.kbase = kbase;
+            this.list = list;
+        }
+
+        @Override
+        public void run() {
+            StatefulKnowledgeSession ksession2 = JPAKnowledgeService.loadStatefulKnowledgeSession(ksessionId, kbase, null, createEnvironment(context) );
+            SingleSessionCommandService sscs = (SingleSessionCommandService)((CommandBasedStatefulKnowledgeSession) ksession2).getCommandService();
+            sscs.addInterceptor(new OptimisticLockRetryInterceptor());
+
+            ksession2.setGlobal( "list", list );
+            ksession2.insert( 1 );
+            ksession2.insert( 2 );
+            ksession2.insert( 3 );
+            ksession2.getWorkItemManager().completeWorkItem(0, null);
+            ksession2.fireAllRules();
+
+            ksession2.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Adds implementation of the Interceptor that allows to retry command execution in case optimistic lock exception has been thrown. Allows configuration of the actual exception class that indicates optimistic lock exception and defaults to hibernate's org.hibernate.StaleObjectStateException.

It's not turned on by default so it needs to be added whenever is needed.

Additionally logic of SingleSessionCommandService has been moved to TransactionalInterceptor to ensure retry will be done on new transaction.

Once merged retry interceptor will be used by default by jBPM runtime manager with persistence enabled
