### PR TITLE
[BZ1007529] add test reproducing the issue + fix

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectUtil.java
@@ -712,7 +712,7 @@ public final class DialectUtil {
             String methodName = exprStr.substring(0, endMethodName).trim();
             String propertyName = setter2property(methodName);
 
-            int endMethodArgs = findEndMethodArgs(exprStr, endMethodName);
+            int endMethodArgs = findEndOfMethodArgsIndex(exprStr, endMethodName);
             String methodParams = exprStr.substring(endMethodName+1, endMethodArgs).trim();
             List<String> args = splitArgumentsList(methodParams);
             int argsNr = args.size();

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/DrlParserTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/DrlParserTest.java
@@ -13,6 +13,7 @@ import org.drools.compiler.lang.dsl.DSLMappingFile;
 import org.drools.compiler.lang.dsl.DSLTokenizedMappingFile;
 import org.drools.compiler.lang.dsl.DefaultExpander;
 import org.drools.compiler.lang.dsl.DefaultExpanderResolver;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderErrors;
@@ -55,6 +56,17 @@ public class DrlParserTest {
         String result = parser.getExpandedDRL( drl, resolver);
         assertEqualsIgnoreWhitespace( "rule 'foo' \n when \n Something() \n then \n another(); \nend", result );
     }
+
+    private void assertEqualsIgnoreWhitespace(final String expected,
+                                              final String actual) {
+        final String cleanExpected = expected.replaceAll( "\\s+",
+                                                          "" );
+        final String cleanActual = actual.replaceAll( "\\s+",
+                                                      "" );
+
+        assertEquals( cleanExpected,
+                      cleanActual );
+    }
     
     @Test
     public void testDeclaredSuperType() throws Exception {
@@ -89,12 +101,7 @@ public class DrlParserTest {
                      + "then \n"
                      + "end";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        assertEquals( 0,
-                      errors.size() );
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
     }
 
     @Test
@@ -109,12 +116,7 @@ public class DrlParserTest {
                      + "then \n"
                      + "end";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        assertEquals( 0,
-                      errors.size() );
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
     }
 
     @Test
@@ -129,12 +131,7 @@ public class DrlParserTest {
                      + "then \n"
                      + "end";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        assertEquals( 0,
-                      errors.size() );
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
     }
 
     @Test
@@ -149,12 +146,7 @@ public class DrlParserTest {
                      + "then \n"
                      + "end";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource(new StringReader(drl)),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        assertEquals( 0,
-                      errors.size() );
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
     }
 
     @Test
@@ -169,12 +161,7 @@ public class DrlParserTest {
                      + "then \n"
                      + "end";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        assertEquals( 0,
-                      errors.size() );
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
     }
 
     @Test
@@ -189,22 +176,60 @@ public class DrlParserTest {
                      + "then \n"
                      + "end";
 
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
+    }
+
+    @Test
+    public void testParseConsequenceWithSingleQuoteInsideDoubleQuotesFollowedByUpdate() {
+        String drl = "declare Person\n" +
+                "    name: String\n" +
+                "end\n" +
+                "\n" +
+                "rule \"test\"\n" +
+                "when\n" +
+                "    $p: Person()\n" +
+                "then\n" +
+                "    $p.setName(\"Some name with' single quote inside\");\n" +
+                "    update($p);\n" +
+                "end";
+
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
+    }
+
+    @Test
+    public void testParseConsequenceWithEscapedDoubleQuoteInsideDoubleQuotesFollowedByUpdate() {
+        String drl = "declare Person\n" +
+                "    name: String\n" +
+                "end\n" +
+                "\n" +
+                "rule \"test\"\n" +
+                "when\n" +
+                "    $p: Person()\n" +
+                "then\n" +
+                "    $p.setName(\"Some name with\\\" escaped double quote inside double quotes\");\n" +
+                "    update($p);\n" +
+                "end";
+
+        createKBuilderAddDrlAndAssertHasNoErrors( drl );
+    }
+
+    private void createKBuilderAddDrlAndAssertHasNoErrors(String drl) {
+        KnowledgeBuilder kbuilder = createKBuilderWithSpecifiedDrl( drl );
+        assertHasNoErrors( kbuilder );
+    }
+
+    private KnowledgeBuilder createKBuilderWithSpecifiedDrl( String drl ) {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
+        kbuilder.add( ResourceFactory.newReaderResource( new StringReader(drl) ),
                       ResourceType.DRL );
+        return kbuilder;
+    }
+
+    private void assertHasNoErrors(KnowledgeBuilder kbuilder) {
         KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        assertEquals( 0,
+        assertEquals( "Expected no build errors, but got: " + errors.toString(),
+                      0,
                       errors.size() );
     }
 
-    private void assertEqualsIgnoreWhitespace(final String expected,
-                                              final String actual) {
-        final String cleanExpected = expected.replaceAll( "\\s+",
-                                                          "" );
-        final String cleanActual = actual.replaceAll( "\\s+",
-                                                      "" );
-
-        assertEquals( cleanExpected,
-                      cleanActual );
-    }
 }

--- a/drools-core/src/test/java/org/drools/core/util/StringUtilsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/StringUtilsTest.java
@@ -1,0 +1,48 @@
+package org.drools.core.util;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testFindEndOfMethodArgsIndex() {
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"myId\")", 12);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"myId\").call()", 12);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('myId')", 12);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('myId').call()", 12);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'Id\")", 13);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'Id\").call()", 13);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'Id'\")", 14);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'Id'\").call()", 14);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('my\"Id\"')", 14);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('my\"Id\"').call()", 14);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('my\"Id')", 13);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('my\"Id').call()", 13);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my\\\"Id\")", 14);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my\\\"Id\").call()", 14);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId('myId', 'something')", 25);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"myId\", \"something\")", 25);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'Id\", \"somet'hing\")", 27);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'Id'\", \"somet'hing\")", 28);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setId(\"my'(Id\", \"somet'(hing'\")", 30);
+
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setObject(new Object())", 22);
+        findEndOfMethodArgsIndexAndAssertItEqualsToExpected("setObject(new Object(\"string param\"))", 36);
+    }
+
+    private void findEndOfMethodArgsIndexAndAssertItEqualsToExpected(String strExpr, int expectedIndex) {
+        int actualIndex = StringUtils.findEndOfMethodArgsIndex(strExpr, strExpr.indexOf('('));
+        Assert.assertEquals("Expected and actual end of method args index for expr '" + strExpr + "' are not equal!",
+                expectedIndex, actualIndex);
+    }
+}


### PR DESCRIPTION
I have added test case that reproduces the issue both on DRL (kbuilder) level and direct method call level. 

I have also fixed the issue by updating the StringUtils.findEndOfMethodArgsIndex() to correctly handle nested quotes.
