### PR TITLE
Cherry-pick to master: indented keywords would fail template expansion

### DIFF
--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
@@ -77,7 +77,7 @@ public class DefaultTemplateContainer implements TemplateContainer {
                     } else if (trimmed.startsWith("template")) {
                         inTemplate = true;
                         inHeader = false;
-                        String quotedName = line.substring(8).trim();
+                        String quotedName = trimmed.substring(8).trim();
                         quotedName = quotedName.substring(1, quotedName.length() - 1);
                         template = new RuleTemplate(quotedName, this);
                         addTemplate(template);

--- a/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/DefaultTemplateContainer.java
@@ -70,10 +70,11 @@ public class DefaultTemplateContainer implements TemplateContainer {
             RuleTemplate template = null;
             StringBuffer contents = new StringBuffer();
             while ((line = templateReader.readLine()) != null) {
-                if (line.trim().length() > 0) {
-                    if (line.startsWith("template header")) {
+                String trimmed = line.trim();
+                if (trimmed.length() > 0) {
+                    if (trimmed.startsWith("template header")) {
                         inHeader = true;
-                    } else if (line.startsWith("template")) {
+                    } else if (trimmed.startsWith("template")) {
                         inTemplate = true;
                         inHeader = false;
                         String quotedName = line.substring(8).trim();
@@ -81,7 +82,7 @@ public class DefaultTemplateContainer implements TemplateContainer {
                         template = new RuleTemplate(quotedName, this);
                         addTemplate(template);
 
-                    } else if (line.startsWith("package")) {
+                    } else if (trimmed.startsWith("package")) {
                         if (inHeader == false) {
                             throw new DecisionTableParseException(
                                     "Missing header");
@@ -89,13 +90,13 @@ public class DefaultTemplateContainer implements TemplateContainer {
                         inHeader = false;
                         header.append(line).append("\n");
                     } else if (inHeader) {
-                        addColumn(cf.getColumn(line.trim()));
+                        addColumn(cf.getColumn(trimmed));
                     } else if (!inTemplate && !inHeader) {
                         header.append(line).append("\n");
-                    } else if (!inContents && line.startsWith("rule")) {
+                    } else if (!inContents && trimmed.startsWith("rule")) {
                         inContents = true;
                         contents.append(line).append("\n");
-                    } else if (line.equals("end template")) {
+                    } else if (trimmed.equals("end template")) {
                         template.setContents(contents.toString());
                         contents.setLength(0);
                         inTemplate = false;
@@ -103,7 +104,7 @@ public class DefaultTemplateContainer implements TemplateContainer {
                     } else if (inContents) {
                         contents.append(line).append("\n");
                     } else if (inTemplate) {
-                        template.addColumn(line.trim());
+                        template.addColumn(trimmed);
                     }
                 }
 

--- a/drools-templates/src/test/java/org/drools/template/DataProviderCompilerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/DataProviderCompilerTest.java
@@ -122,6 +122,16 @@ public class DataProviderCompilerTest {
         assertEqualsIgnoreWhitespace(EXPECTED_RULES.toString(),
                                      drl);
     }
+    
+    @Test
+    public void testCompileIndentedKeywords() throws Exception {
+        TestDataProvider tdp = new TestDataProvider( rows );
+        final DataProviderCompiler converter = new DataProviderCompiler();
+        final String drl = converter.compile( tdp,
+                                              "/templates/rule_template_indented.drl" );
+        assertEqualsIgnoreWhitespace( EXPECTED_RULES.toString(),
+                                      drl );
+    }
 
     @Test
     public void testCompilerMaps() throws Exception {

--- a/drools-templates/src/test/java/org/drools/template/parser/DefaultTemplateContainerTest.java
+++ b/drools-templates/src/test/java/org/drools/template/parser/DefaultTemplateContainerTest.java
@@ -54,6 +54,17 @@ public class DefaultTemplateContainerTest {
         assertTrue( contents.endsWith( "then\nend\n" ) );
     }
 
+    /*
+     * Smoke-test to verify it's possible to load a template containing 
+     * indented keywords without exception
+     */
+    @Test
+    public void testParseTemplateIndentedKeywords() {
+        InputStream is = DefaultTemplateContainerTest.class
+                .getResourceAsStream("/templates/rule_template_indented.drl");
+        new DefaultTemplateContainer(is);
+    }
+    
     @Test
     public void testParseTemplateConditions() {
         InputStream is = DefaultTemplateContainerTest.class.getResourceAsStream( "/templates/test_template_conditions.drl" );

--- a/drools-templates/src/test/resources/templates/rule_template_indented.drl
+++ b/drools-templates/src/test/resources/templates/rule_template_indented.drl
@@ -1,0 +1,35 @@
+	template header
+	FEE_SCHEDULE_ID
+	FEE_SCHEDULE_TYPE
+	FEE_MODE_TYPE
+	ENTITY_BRANCH
+	PRODUCT_TYPE
+	ACTIVITY_TYPE
+	FEE_TYPE
+	OWNING_PARTY
+	CCY
+	LC_AMOUNT
+	AMOUNT
+	
+	
+	package org.drools.decisiontable;
+	//generated from Decision Table
+	
+	global FeeResult result;
+	
+	template "Fee Schedule"
+	rule "Fee Schedule_@{row.rowNumber}"
+	    agenda-group "@{FEE_SCHEDULE_TYPE}"
+	    when
+	        FeeEvent(productType == "@{PRODUCT_TYPE}",
+	            activityType == "@{ACTIVITY_TYPE}",
+	            feeType == "@{FEE_TYPE}",
+	            txParty == "@{OWNING_PARTY}",
+	            entityBranch == "@{ENTITY_BRANCH}",
+	            amount @{LC_AMOUNT},
+	            ccy == "@{CCY}"
+	        )
+	    then
+	        result.setSchedule(new FeeSchedule("@{FEE_SCHEDULE_ID}", "@{FEE_SCHEDULE_TYPE}", @{AMOUNT}));
+	end
+	end template


### PR DESCRIPTION
There's a limitation / bug in templates that they cannot be parsed if they contain indented keywords

Forum link where this issue was discussed: http://drools.46999.n3.nabble.com/Fwd-drools-Fixing-issue-where-indented-keywords-would-fail-template-expansion-170-td4021476.html   

This is already fixed in 5.5.x by pull request https://github.com/droolsjbpm/drools/pull/170

This new pull request proposes to cherry-pick this fix to master
