### PR TITLE
Query cep entry point

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -41,6 +42,7 @@ public class QueryCepTest {
         ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
     }
 
+    @Ignore
     @Test
     public void test() {
         

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepTest.java
@@ -1,0 +1,75 @@
+package org.drools.compiler.integrationtests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.model.KieBaseModel;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.conf.EventProcessingOption;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.api.runtime.rule.QueryResults;
+import org.kie.internal.io.ResourceFactory;
+
+public class QueryCepTest {
+    
+    private KieSession ksession;
+
+    @Before
+    public void prepare() {
+        final KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem();
+        KieModuleModel kmodule = ks.newKieModuleModel();
+
+        KieBaseModel baseModel = kmodule.newKieBaseModel("defaultKBase")
+                .setDefault(true)
+                .setEventProcessingMode(EventProcessingOption.STREAM);
+        baseModel.newKieSessionModel("defaultKSession")
+                .setDefault(true)
+                .setClockType(ClockTypeOption.get("pseudo"));
+
+        kfs.writeKModuleXML(kmodule.toXML());
+        kfs.write("src/main/resources/defaultKBase/resource1.drl",
+                  ResourceFactory.newClassPathResource("query-cep.drl", this.getClass()));
+
+        assertTrue(ks.newKieBuilder(kfs).buildAll().getResults().getMessages().isEmpty());
+        ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
+    }
+
+    @Test
+    public void test() {
+        
+        QueryResults results = ksession.getQueryResults("EventsFromStream");
+        
+        assertEquals(0, results.size());
+    }
+    
+    @After
+    public void cleanup() {
+        if (ksession != null) {
+            ksession.dispose();
+        }
+    }
+    
+    public static class TestEvent {
+        private final String name;
+        
+        public TestEvent(final String name) {
+            this.name = name;
+        }
+        
+        public String getName() {
+            return this.name;
+        }        
+        
+        @Override
+        public String toString() {
+            return "TestEvent[" + name + "]";
+        }
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepTest.java
@@ -3,6 +3,9 @@ package org.drools.compiler.integrationtests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.TimeUnit;
+
+import org.drools.core.time.SessionPseudoClock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -14,15 +17,21 @@ import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.internal.io.ResourceFactory;
 
 public class QueryCepTest {
     
     private KieSession ksession;
+    
+    private SessionPseudoClock clock;
+    
+    private EntryPoint firstEntryPoint, secondEntryPoint;
 
     @Before
     public void prepare() {
+        
         final KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem();
         KieModuleModel kmodule = ks.newKieModuleModel();
@@ -40,25 +49,56 @@ public class QueryCepTest {
 
         assertTrue(ks.newKieBuilder(kfs).buildAll().getResults().getMessages().isEmpty());
         ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
+        
+        firstEntryPoint = ksession.getEntryPoint("FirstStream");
+        secondEntryPoint = ksession.getEntryPoint("SecondStream"); 
+        clock = ksession.getSessionClock();
     }
 
     @Ignore
     @Test
-    public void test() {
+    public void noResultTest() {
         
         QueryResults results = ksession.getQueryResults("EventsFromStream");
         
         assertEquals(0, results.size());
     }
     
+    @Ignore
+    @Test
+    public void withResultTest() {
+        
+        secondEntryPoint.insert(new TestEvent("minusOne"));
+
+        clock.advanceTime(5, TimeUnit.SECONDS);
+
+        firstEntryPoint.insert(new TestEvent("zero"));
+
+        secondEntryPoint.insert(new TestEvent("one"));
+
+        clock.advanceTime(10, TimeUnit.SECONDS);
+
+        secondEntryPoint.insert(new TestEvent("two"));
+
+        clock.advanceTime(10, TimeUnit.SECONDS);
+
+        secondEntryPoint.insert(new TestEvent("three"));
+        
+        QueryResults results = ksession.getQueryResults("ZeroToNineteenSeconds");
+        
+        assertEquals(2, results.size());
+    }
+    
     @After
     public void cleanup() {
+        
         if (ksession != null) {
             ksession.dispose();
         }
     }
     
     public static class TestEvent {
+        
         private final String name;
         
         public TestEvent(final String name) {

--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/query-cep.drl
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/query-cep.drl
@@ -1,0 +1,11 @@
+package org.drools.compiler.integrationtests
+
+import org.drools.compiler.integrationtests.QueryCepTest.TestEvent
+
+declare TestEvent
+    @role( event )
+end
+
+query EventsFromStream
+    $event : TestEvent() from entry-point FirstStream
+end

--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/query-cep.drl
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/query-cep.drl
@@ -9,3 +9,8 @@ end
 query EventsFromStream
     $event : TestEvent() from entry-point FirstStream
 end
+
+query ZeroToNineteenSeconds
+    $event : TestEvent() from entry-point FirstStream
+    $result : TestEvent ( this after [0s, 19s] $event) from entry-point SecondStream
+end


### PR DESCRIPTION
NPE when ksession.getQueryResults() should return empty result.
