### PR TITLE
BZ1027221 When Guvnor is down, KnowledgeAgent keeps rebuilding kbase fro...

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
@@ -140,6 +140,7 @@ public class UrlResource extends BaseResource
                 if (CACHE_DIR != null && (url.getProtocol().equals("http") || url.getProtocol().equals("https"))) {
                     //lets grab a copy and cache it in case we need it in future...
                     cacheStream();
+                    lastMod = getCacheFile().lastModified();
                 }
             }
             this.lastRead = lastMod;


### PR DESCRIPTION
This fix makes sure UrlResource.lastRead == cacheFile's lastModified.

Verified with manual test.
