### PR TITLE
BZ1034030 : 0 byte local cache file in UrlResource

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
@@ -170,12 +170,20 @@ public class UrlResource extends BaseResource
         }
     }
 
+    private File getTemproralCacheFile()  {
+        try {
+            return new File(CACHE_DIR, URLEncoder.encode(this.url.toString(), "UTF-8") + "_tmp");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Save a copy in the local cache - in case remote source is not available in future.
      */
     private void cacheStream() {
         try {
-            File fi = getCacheFile();
+            File fi = getTemproralCacheFile();
             if (fi.exists()) fi.delete();
             FileOutputStream fout = new FileOutputStream(fi);
             InputStream in = grabStream();
@@ -187,6 +195,9 @@ public class UrlResource extends BaseResource
             fout.flush();
             fout.close();
             in.close();
+
+            File cacheFile = getCacheFile();
+            fi.renameTo(cacheFile);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This fix defers cache file update until completely reading InputStream. So the "0 byte" risk would be minimized.
