### PR TITLE
BZ1034588 : stale local cache file in UrlResource

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
@@ -141,6 +141,8 @@ public class UrlResource extends BaseResource
                     //lets grab a copy and cache it in case we need it in future...
                     cacheStream();
                     lastMod = getCacheFile().lastModified();
+                    this.lastRead = lastMod;
+                    return fromCache();
                 }
             }
             this.lastRead = lastMod;


### PR DESCRIPTION
This fix prevents UrlResource.getInputStream() from reading stream twice.
