### PR TITLE
Fix in MavenRepository for NPE caused by Profile.getActivation() returning null

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/MavenRepository.java
+++ b/kie-ci/src/main/java/org/kie/scanner/MavenRepository.java
@@ -52,7 +52,7 @@ public class MavenRepository {
     private static void initSettings() {
         Settings settings = MavenSettings.getSettings();
         for (Profile profile : settings.getProfiles()) {
-            if (profile.getActivation().isActiveByDefault()) {
+            if (profile.getActivation() != null && profile.getActivation().isActiveByDefault()) {
                 for (Repository repository : profile.getRepositories()) {
                     addExtraRepository( new RemoteRepository( repository.getId(), "default", repository.getUrl() ) );
                 }


### PR DESCRIPTION
This came to my attention because of the tests I have here: 

https://github.com/droolsjbpm/droolsjbpm-integration/blob/6.0.x/kie-remote/kie-services-client/src/test/java/org/kie/services/client/builder/KieModuleDeploymentHelperTest.java

In particular, testSingleDeploymentHelper() was throwing an NPE: 

```
java.lang.NullPointerException
at org.kie.scanner.MavenRepository.initSettings(MavenRepository.java:55)
at org.kie.scanner.MavenRepository.getMavenRepository(MavenRepository.java:47)
at org.kie.scanner.ArtifactResolver.getMavenProjectForGAV(ArtifactResolver.java:78)
at org.kie.scanner.ArtifactResolver.getResolverFor(ArtifactResolver.java:56)
at org.kie.scanner.MavenClassLoaderResolver.getClassLoader(MavenClassLoaderResolver.java:48)
at org.drools.compiler.kie.builder.impl.KieModuleKieProject.<init>(KieModuleKieProject.java:50)
at org.drools.compiler.kie.builder.impl.KieModuleKieProject.<init>(KieModuleKieProject.java:38)
at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildAll(KieBuilderImpl.java:190)
at org.kie.services.client.deployment.KieModuleDeploymentHelperImpl.internalCreateKieJar(KieModuleDeploymentHelperImpl.java:313)
at org.kie.services.client.deployment.KieModuleDeploymentHelperImpl.internalCreateAndDeployKjarToMaven(KieModuleDeploymentHelperImpl.java:245)
at org.kie.services.client.deployment.KieModuleDeploymentHelperImpl.createKieJarAndDeployToMaven(KieModuleDeploymentHelperImpl.java:214)
at org.kie.services.client.builder.KieModuleDeploymentHelperTest.testSingleDeploymentHelper(KieModuleDeploymentHelperTest.java:67)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
```
