### PR TITLE
getLoggers missing in FileLogger example

### DIFF
--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/ApiReference/KieRunning.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/ApiReference/KieRunning.xml
@@ -737,7 +737,7 @@ ksession.setGlobal("list", list);           </programlisting>
       <title>FileLogger</title>
 
       <programlisting language="java">KieRuntimeLogger logger =
-  KieServices.Factory.get().newFileLogger(ksession, "logdir/mylogfile");
+  KieServices.Factory.get().getLoggers().newFileLogger(ksession, "logdir/mylogfile");
 ...
 logger.close();</programlisting>
     </example>


### PR DESCRIPTION
There is a minor error in KieRunning.xml where getLoggers() is missing in the creation of a FileLogger.
