### PR TITLE
BZ-1044529 Memory leak (caused by kbase.getStatefulKnowledgeSessions())

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -20,6 +20,7 @@ import org.drools.core.RuleBase;
 import org.drools.core.SessionConfiguration;
 import org.drools.core.StatefulSession;
 import org.drools.core.common.AbstractWorkingMemory;
+import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.common.InternalRuleBase;
 import org.drools.core.definitions.impl.KnowledgePackageImp;
 import org.drools.core.definitions.rule.impl.RuleImpl;
@@ -186,7 +187,10 @@ public class KnowledgeBaseImpl
         if (sss != null) {
             for (StatefulSession ss : sss) {
                 if (ss instanceof AbstractWorkingMemory) {
-                    c.add(new StatefulKnowledgeSessionImpl((AbstractWorkingMemory)ss, this));
+                    InternalKnowledgeRuntime kruntime = ((AbstractWorkingMemory) ss).getKnowledgeRuntime();
+                    if( kruntime instanceof StatefulKnowledgeSession ) { 
+                        c.add((StatefulKnowledgeSessionImpl) kruntime);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Most users do not expect the .getStatefulKnowledgeSessions() to create a new SKSimpl. 

However, creating a new SKSImpl leads to a memory leak (when using jBPM), illustrated by this test: 

https://github.com/mrietveld/jbpm/blob/5fc93b38a6ed15de5d5433f48586c7502a72362d/jbpm-bpmn2/src/test/java/org/jbpm/leak/MemoryLeakTest.java

We can circumvent that problem by the changes in this pull request.
