### PR TITLE
Added DynamicImportPackage:* to fix OSGi class loading issues

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -181,6 +181,9 @@
                org.jbpm.process.instance.event;resolution:=optional,
                *
             </Import-Package>
+            <DynamicImport-Package>
+              *
+            </DynamicImport-Package>
             <Bundle-Activator>org.drools.core.osgi.Activator</Bundle-Activator>
             <_removeheaders>Private-Package</_removeheaders>
           </instructions>


### PR DESCRIPTION
Due to OSGi's class loading mechanism, drools-core is not able to load classes exported by other bundles when compiling rules, which leads to a class loading exception. "DynamicImport-Package: *" fixes this issue.
