### PR TITLE
Added logging for more useful error messages

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
@@ -46,6 +46,9 @@ public class MemoryFileSystem
 
     private Set<String>                modifiedFilesSinceLastMark;
 
+    private final org.slf4j.Logger log =
+    		org.slf4j.LoggerFactory.getLogger(MemoryFileSystem.class);
+
     public MemoryFileSystem() {
         folders = new HashMap<String, Set<Resource>>();
         fileContents = new HashMap<String, byte[]>();
@@ -395,6 +398,7 @@ public class MemoryFileSystem
                     out.close();
                 }
             } catch ( IOException e ) {
+				log.error(e.getMessage(), e);
             }
         }
     }
@@ -437,6 +441,11 @@ public class MemoryFileSystem
                 out.putNextEntry( entry );
 
                 byte[] contents = getFileContents( (MemoryFile) rs );
+                if (contents == null) {
+                	IOException e = new IOException("No content found for: " + rs); 
+					log.error(e.getMessage(), e);
+					throw e;
+				}
                 out.write( contents );
                 out.closeEntry();
             }


### PR DESCRIPTION
the only message returned by the output stream when passed a null arg is "null".  this should provide better debugging/error trapping
