### PR TITLE
[DROOLS-380] Example 4.20 file logger newFileLogger

### DIFF
--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/ApiReference/KieRunning.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/ApiReference/KieRunning.xml
@@ -737,7 +737,7 @@ ksession.setGlobal("list", list);           </programlisting>
       <title>FileLogger</title>
 
       <programlisting language="java">KieRuntimeLogger logger =
-  KieServices.Factory.get().newFileLogger(ksession, "logdir/mylogfile");
+  KieServices.Factory.get().getLoggers().newFileLogger(ksession, "logdir/mylogfile");
 ...
 logger.close();</programlisting>
     </example>


### PR DESCRIPTION
Ref. https://issues.jboss.org/browse/DROOLS-380

In the documentation [1] example 4.20 mention the following code snippet.
KieRuntimeLogger logger = KieServices.Factory.get().newFileLogger(ksession, "logdir/mylogfile");
However that doesn't compile. I believe is missing a .getLoggers() so the proper snippet, I believe, was intended as
KieRuntimeLogger logger = KieServices.Factory.get().getLoggers().newFileLogger(ksession, "logdir/mylogfile");
Ciao
MM
References:
[1] http://docs.jboss.org/drools/release/6.0.0.Final/drools-docs/html_single/#d0e1904
