### PR TITLE
A fix for compiler.PackageBuilder.getFullTypeName.

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/PackageBuilder.java
@@ -3208,6 +3208,8 @@ public class PackageBuilder
             return typeResolver.getFullTypeName(type);
         } catch (ClassNotFoundException e) {
             return type;
+        } catch (NoClassDefFoundError cnf) {
+            return type;
         }
     }
 


### PR DESCRIPTION
Nearly all tests (148 of 151) in drools-pmml fail for me (Mac OS X Mountain Lion - JDK 1.6) with error messages like this:

```
testFunctionsNested(org.drools.pmml.pmml_4_1.transformations.UserDefinedFunctionsTest)  Time elapsed: 0.604 sec  <<< ERROR!
java.lang.NoClassDefFoundError: org/dmg/pmml/pmml_4_1/descr/false (wrong name: org/dmg/pmml/pmml_4_1/descr/False)
    at java.lang.ClassLoader.defineClass1(Native Method)
```

By changing the 'false' value in a declare in pmml_compiler.drl to 'False' all tests but one (an apparently unrelated issue in SVMTest) pass.  I haven't any idea if this is the right way to fix this but thought I'd pass it along to save time in the event someone else runs into this.
