### PR TITLE
Fix deprecated jUnit imports and methods

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/TypeDeclarationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/TypeDeclarationTest.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.compiler;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.definitions.impl.KnowledgePackageImp;
 import org.drools.core.marshalling.impl.ProtobufMessages;
@@ -23,9 +23,9 @@ import org.kie.api.io.ResourceType;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.mvel2.asm.Type;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;

--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
@@ -16,7 +16,7 @@
 
 package org.drools.compiler.factmodel.traits;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.compiler.CommonTestMethodBase;
 import org.drools.compiler.Person;
 import org.drools.core.common.InternalFactHandle;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
@@ -16,8 +16,8 @@
 
 package org.drools.compiler.integrationtests;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ChangesetUndoTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ChangesetUndoTest.java
@@ -15,10 +15,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ChangesetUndoTest {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesChangesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesChangesTest.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.integrationtests;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 import java.util.ArrayList;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExecutionFlowControlTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExecutionFlowControlTest.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.drools.compiler.Cell;
 import org.drools.compiler.Cheese;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExtendsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExtendsTest.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.compiler.CommonTestMethodBase;
 import org.drools.compiler.lang.DrlDumper;
 import org.drools.compiler.lang.api.DescrFactory;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/GlobalsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/GlobalsTest.java
@@ -30,8 +30,8 @@ import org.kie.internal.runtime.StatelessKnowledgeSession;
 
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class GlobalsTest {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieContainerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieContainerTest.java
@@ -16,8 +16,8 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.drools.compiler.integrationtests.IncrementalCompilationTest.createAndDeployJar;
 
 public class KieContainerTest {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieLoggersTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieLoggersTest.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.integrationtests;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KnowledgeBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KnowledgeBuilderTest.java
@@ -1,6 +1,6 @@
 package org.drools.compiler.integrationtests;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.*;
 
 import java.io.InputStream;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MessageImplTests.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MessageImplTests.java
@@ -9,7 +9,7 @@ import org.kie.api.builder.Results;
 import org.kie.internal.builder.IncrementalResults;
 import org.kie.internal.builder.InternalKieBuilder;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 /**
  * Tests for MessageImpl

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
@@ -16,7 +16,7 @@
 
 package org.drools.compiler.integrationtests;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.compiler.Address;
 import org.drools.compiler.Cheese;
 import org.drools.compiler.CommonTestMethodBase;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleExtensionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleExtensionTest.java
@@ -30,9 +30,9 @@ import java.util.List;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RuleExtensionTest {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SegmentMemoryPrototypeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SegmentMemoryPrototypeTest.java
@@ -14,7 +14,7 @@ import org.kie.internal.io.ResourceFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.drools.compiler.integrationtests.DynamicRulesChangesTest.*;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/UnmarshallingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/UnmarshallingTest.java
@@ -7,7 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.io.StringReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.kie.api.KieBaseConfiguration;

--- a/drools-compiler/src/test/java/org/drools/compiler/kproject/KieModuleModelTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kproject/KieModuleModelTest.java
@@ -19,8 +19,8 @@ import org.kie.api.runtime.conf.ClockTypeOption;
 
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.drools.compiler.kproject.models.KieModuleModelImpl.fromXML;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;

--- a/drools-compiler/src/test/java/org/drools/compiler/phreak/RemoveRuleTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/phreak/RemoveRuleTest.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static junit.framework.TestCase.assertNotSame;
 import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertEquals;

--- a/drools-compiler/src/test/java/org/drools/compiler/rule/builder/dialect/asm/InvokerGeneratorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/rule/builder/dialect/asm/InvokerGeneratorTest.java
@@ -7,7 +7,7 @@ import org.junit.*;
 
 import java.util.*;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 public class InvokerGeneratorTest {
 

--- a/drools-core/src/test/java/org/drools/core/reteoo/test/ReteDslTestEngine.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/test/ReteDslTestEngine.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import junit.framework.AssertionFailedError;
-
 import org.antlr.runtime.ANTLRInputStream;
 import org.antlr.runtime.ANTLRReaderStream;
 import org.antlr.runtime.ANTLRStringStream;

--- a/drools-core/src/test/java/org/drools/core/util/HierarchyTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/HierarchyTest.java
@@ -27,9 +27,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class HierarchyTest {
 

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/integrationtests/IncrementalCompilationTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/integrationtests/IncrementalCompilationTest.java
@@ -10,7 +10,7 @@ import org.kie.internal.builder.InternalKieBuilder;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 public class IncrementalCompilationTest {
 

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/jta/JtaTransactionManagerTest.java
@@ -15,7 +15,7 @@
  */
 package org.drools.persistence.jta;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.drools.persistence.util.PersistenceUtil.*;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/marshalling/util/MarshalledData.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/marshalling/util/MarshalledData.java
@@ -35,7 +35,7 @@ import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.drools.core.util.DroolsStreamUtils;
 import org.drools.persistence.info.SessionInfo;

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/marshalling/util/MarshallingTestUtil.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/marshalling/util/MarshallingTestUtil.java
@@ -40,7 +40,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.transaction.TransactionManager;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 
 import org.drools.core.SessionConfiguration;

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/PMMLUsageDemoTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/PMMLUsageDemoTest.java
@@ -1,6 +1,6 @@
 package org.drools.pmml.pmml_4_1;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -12,8 +12,8 @@ import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.Variable;
 import org.kie.internal.io.ResourceFactory;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class PMMLUsageDemoTest extends DroolsAbstractPMMLTest {

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/global/ConstrainedDataDictionaryTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/global/ConstrainedDataDictionaryTest.java
@@ -27,8 +27,8 @@ import org.kie.api.runtime.ClassObjectFilter;
 
 import java.util.Collection;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 public class ConstrainedDataDictionaryTest extends DroolsAbstractPMMLTest {

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/global/DataDictionaryTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/global/DataDictionaryTest.java
@@ -17,7 +17,7 @@
 package org.drools.pmml.pmml_4_1.global;
 
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.pmml.pmml_4_1.DroolsAbstractPMMLTest;
 import org.junit.After;
 import org.junit.Test;
@@ -25,7 +25,7 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.ClassObjectFilter;
 import org.kie.api.runtime.rule.EntryPoint;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 
 public class DataDictionaryTest extends DroolsAbstractPMMLTest {

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/predictive/models/CleanupTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/predictive/models/CleanupTest.java
@@ -17,7 +17,7 @@
 package org.drools.pmml.pmml_4_1.predictive.models;
 
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.pmml.pmml_4_1.DroolsAbstractPMMLTest;
 import org.drools.pmml.pmml_4_1.ModelMarker;
 import org.junit.Test;
@@ -103,7 +103,7 @@ public class CleanupTest extends DroolsAbstractPMMLTest {
         getKSession().getEntryPoint( "in_SepalWid" ).insert(30);
         getKSession().fireAllRules();
 
-        Assert.assertEquals( 24.0, queryIntegerField( "OutSepLen", "Neuiris" ) );
+        Assert.assertEquals( 24.0, queryIntegerField( "OutSepLen", "Neuiris" ), 0.0);
 
         assertEquals( 38, getKSession().getObjects().size() );
 

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/predictive/models/NaiveBayesTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/predictive/models/NaiveBayesTest.java
@@ -17,7 +17,7 @@
 package org.drools.pmml.pmml_4_1.predictive.models;
 
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.pmml.pmml_4_1.DroolsAbstractPMMLTest;
 import org.junit.After;
 import org.junit.Test;

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/predictive/models/NeuralNetworkTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/predictive/models/NeuralNetworkTest.java
@@ -17,7 +17,7 @@
 package org.drools.pmml.pmml_4_1.predictive.models;
 
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.pmml.pmml_4_1.DroolsAbstractPMMLTest;
 import org.drools.pmml.pmml_4_1.PMML4Helper;
 import org.junit.After;
@@ -80,7 +80,7 @@ public class NeuralNetworkTest extends DroolsAbstractPMMLTest {
         //System.err.println(reportWMObjects(getKSession()));
 
 
-        Assert.assertEquals( 828.0, Math.floor( queryDoubleField( "OutAmOfClaims", "NeuralInsurance" ) ) );
+        Assert.assertEquals( 828.0, Math.floor( queryDoubleField( "OutAmOfClaims", "NeuralInsurance" ) ), 0.0);
 
     }
 
@@ -269,11 +269,11 @@ public class NeuralNetworkTest extends DroolsAbstractPMMLTest {
 
 
         Assert.assertEquals(1.542,
-                truncN(getDoubleFieldValue(t4), 3));
+                truncN(getDoubleFieldValue(t4), 3), 0.0);
         Assert.assertEquals(0.0,
-                truncN(getDoubleFieldValue(t5), 3));
+                truncN(getDoubleFieldValue(t5), 3), 0.0);
         Assert.assertEquals(3.0,
-                truncN(getDoubleFieldValue(t6), 3));
+                truncN(getDoubleFieldValue(t6), 3), 0.0);
 
         checkFirstDataFieldOfTypeStatus(getKbase().getFactType(packageName ,"OutSpecies"),
                                                 true, false,"Test_MLP","versicolor");
@@ -306,7 +306,7 @@ public class NeuralNetworkTest extends DroolsAbstractPMMLTest {
 
         //System.err.println(reportWMObjects(getKSession()));
 
-        Assert.assertEquals(24.0, queryIntegerField("OutSepLen", "Neuiris"));
+        Assert.assertEquals(24.0, queryIntegerField("OutSepLen", "Neuiris"), 0.0);
 
     }
 

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/transformations/UserDefinedFunctionsTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_1/transformations/UserDefinedFunctionsTest.java
@@ -24,7 +24,7 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.ClassObjectFilter;
 import org.kie.api.runtime.rule.FactHandle;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 
 public class UserDefinedFunctionsTest extends DroolsAbstractPMMLTest {

--- a/drools-scorecards/src/test/java/org/drools/scorecards/DrlFromPMMLTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/DrlFromPMMLTest.java
@@ -14,11 +14,11 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.io.ResourceType;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.drools.scorecards.ScorecardCompiler.DrlType.INTERNAL_DECLARED_TYPES;
 
 public class DrlFromPMMLTest {

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ExternalObjectModelTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ExternalObjectModelTest.java
@@ -29,11 +29,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.drools.scorecards.ScorecardCompiler.DrlType.EXTERNAL_OBJECT_MODEL;
 
 public class ExternalObjectModelTest {
@@ -121,7 +121,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = 0, age = 30, validLicence -1
-        assertEquals(29.0,applicant.getTotalScore());
+        assertEquals(29.0,applicant.getTotalScore(), 0.0);
 
         session = kbase.newKieSession();
         applicant = new Applicant();
@@ -131,7 +131,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = -10, age = +10, validLicense = -1;
-        assertEquals(-1.0, applicant.getTotalScore());
+        assertEquals(-1.0, applicant.getTotalScore(), 0.0);
 
         session = kbase.newKieSession();
         applicant = new Applicant();
@@ -143,7 +143,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = +10, age = +40, state = -10, validLicense = 1
-        assertEquals(41.0,applicant.getTotalScore());
+        assertEquals(41.0,applicant.getTotalScore(), 0.0);
     }
 
     @Test
@@ -182,7 +182,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = 0, age = 30, validLicence -1, initialScore=100
-        assertEquals(129.0,applicant.getTotalScore());
+        assertEquals(129.0,applicant.getTotalScore(), 0.0);
 
         session = kbase.newKieSession();
         applicant = new Applicant();
@@ -192,7 +192,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = -10, age = +10, validLicense = -1, initialScore=100;
-        assertEquals(99.0, applicant.getTotalScore());
+        assertEquals(99.0, applicant.getTotalScore(), 0.0);
 
         session = kbase.newKieSession();
         applicant = new Applicant();
@@ -204,7 +204,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = +10, age = +40, state = -10, validLicense = 1, initialScore=100
-        assertEquals(141.0,applicant.getTotalScore());
+        assertEquals(141.0,applicant.getTotalScore(), 0.0);
     }
 
     @Test
@@ -247,7 +247,7 @@ public class ExternalObjectModelTest {
         //session.addEventListener(new DebugWorkingMemoryEventListener());
         session.fireAllRules();
         //occupation = 0, age = 30, validLicence -1, initialScore=100
-        assertEquals( 129.0,applicant.getTotalScore() );
+        assertEquals( 129.0,applicant.getTotalScore(), 0.0 );
         assertEquals( "VL0099", applicant.getReasonCodes() );
 
         Object scorecardInternals = session.getObjects( new ClassObjectFilter( scorecardInternalsType.getFactClass() ) ).iterator().next();
@@ -268,7 +268,7 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = -10, age = +10, validLicense = -1, initialScore=100;
-        assertEquals(99.0, applicant.getTotalScore());
+        assertEquals(99.0, applicant.getTotalScore(), 0.0);
 
         session = kbase.newKieSession();
         applicant = new Applicant();
@@ -280,6 +280,6 @@ public class ExternalObjectModelTest {
         session.fireAllRules();
         session.dispose();
         //occupation = +10, age = +40, state = -10, validLicense = 1, initialScore=100
-        assertEquals(141.0,applicant.getTotalScore());
+        assertEquals(141.0,applicant.getTotalScore(), 0.0);
     }
 }

--- a/drools-scorecards/src/test/java/org/drools/scorecards/PMMLDocumentTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/PMMLDocumentTest.java
@@ -1,13 +1,13 @@
 package org.drools.scorecards;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.dmg.pmml.pmml_4_1.descr.*;
 import org.drools.pmml.pmml_4_1.extensions.PMMLExtensionNames;
 import org.drools.scorecards.pmml.ScorecardPMMLUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 import static org.drools.scorecards.ScorecardCompiler.DrlType.INTERNAL_DECLARED_TYPES;
 
 public class PMMLDocumentTest {

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardParseErrorsTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardParseErrorsTest.java
@@ -1,10 +1,10 @@
 package org.drools.scorecards;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.drools.scorecards.ScorecardCompiler.DrlType.INTERNAL_DECLARED_TYPES;
 
 public class ScorecardParseErrorsTest {

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderPMMLTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderPMMLTest.java
@@ -25,7 +25,7 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.io.InputStream;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 import static org.kie.internal.builder.ScoreCardConfiguration.SCORECARD_INPUT_TYPE;
 
 

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderTest.java
@@ -19,10 +19,10 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.io.InputStream;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
 
 public class ScorecardProviderTest {

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardsKModuleTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardsKModuleTest.java
@@ -8,8 +8,8 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ScorecardsKModuleTest {
 

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScoringStrategiesTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScoringStrategiesTest.java
@@ -21,7 +21,7 @@ import org.kie.api.runtime.StatelessKieSession;
 
 import java.io.InputStream;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 import static org.drools.scorecards.ScorecardCompiler.DrlType.INTERNAL_DECLARED_TYPES;
 
 public class ScoringStrategiesTest {
@@ -59,7 +59,7 @@ public class ScoringStrategiesTest {
 
         double finalScore = executeAndFetchScore("scorecards");
         //age==10 (30), validLicense==FALSE (-1)
-        assertEquals(29.0, finalScore);
+        assertEquals(29.0, finalScore, 0.0);
     }
 
     @Test
@@ -68,14 +68,14 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_avg");
         //age==10 (30), validLicense==FALSE (-1)
         //count = 2
-        assertEquals(14.5, finalScore);
+        assertEquals(14.5, finalScore, 0.0);
     }
 
     @Test
     public void testMinimum() throws Exception {
         double finalScore = executeAndFetchScore("scorecards_min");
         //age==10 (30), validLicense==FALSE (-1)
-        assertEquals(-1.0, finalScore);
+        assertEquals(-1.0, finalScore, 0.0);
     }
 
     @Test
@@ -83,7 +83,7 @@ public class ScoringStrategiesTest {
 
         double finalScore = executeAndFetchScore("scorecards_max");
         //age==10 (30), validLicense==FALSE (-1)
-        assertEquals(30.0, finalScore);
+        assertEquals(30.0, finalScore, 0.0);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ScoringStrategiesTest {
 
         double finalScore = executeAndFetchScore("scorecards_w_aggregate");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
-        assertEquals(599.0, finalScore);
+        assertEquals(599.0, finalScore, 0.0);
     }
 
     @Test
@@ -99,7 +99,7 @@ public class ScoringStrategiesTest {
 
         double finalScore = executeAndFetchScore("scorecards_w_avg");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
-        assertEquals(299.5, finalScore);
+        assertEquals(299.5, finalScore, 0.0);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class ScoringStrategiesTest {
 
         double finalScore = executeAndFetchScore("scorecards_w_max");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
-        assertEquals(600.0, finalScore);
+        assertEquals(600.0, finalScore, 0.0);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class ScoringStrategiesTest {
 
         double finalScore = executeAndFetchScore("scorecards_w_min");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
-        assertEquals(-1.0, finalScore);
+        assertEquals(-1.0, finalScore, 0.0);
     }
 
     /* Tests with Initial Score */
@@ -125,7 +125,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_initial_score");
         //age==10 (30), validLicense==FALSE (-1)
         //initialScore = 100
-        assertEquals(129.0, finalScore);
+        assertEquals(129.0, finalScore, 0.0);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ScoringStrategiesTest {
         //age==10 (30), validLicense==FALSE (-1)
         //count = 2
         //initialScore = 100
-        assertEquals(114.5, finalScore);
+        assertEquals(114.5, finalScore, 0.0);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_min_initial_score");
         //age==10 (30), validLicense==FALSE (-1)
         //initialScore = 100
-        assertEquals(99.0, finalScore);
+        assertEquals(99.0, finalScore, 0.0);
     }
 
     @Test
@@ -151,7 +151,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_max_initial_score");
         //age==10 (30), validLicense==FALSE (-1)
         //initialScore = 100
-        assertEquals(130.0, finalScore);
+        assertEquals(130.0, finalScore, 0.0);
     }
 
     @Test
@@ -160,7 +160,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_w_aggregate_initial");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
         //initialScore = 100
-        assertEquals(699.0, finalScore);
+        assertEquals(699.0, finalScore, 0.0);
     }
 
     @Test
@@ -169,7 +169,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_w_avg_initial");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
         //initialScore = 100
-        assertEquals(399.5, finalScore);
+        assertEquals(399.5, finalScore, 0.0);
     }
 
     @Test
@@ -178,7 +178,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_w_max_initial");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
         //initialScore = 100
-        assertEquals(700.0, finalScore);
+        assertEquals(700.0, finalScore, 0.0);
     }
 
     @Test
@@ -187,7 +187,7 @@ public class ScoringStrategiesTest {
         double finalScore = executeAndFetchScore("scorecards_w_min_initial");
         //age==10 (score=30, w=20), validLicense==FALSE (score=-1, w=1)
         //initialScore = 100
-        assertEquals(99.0, finalScore);
+        assertEquals(99.0, finalScore, 0.0);
     }
 
     /* Internal functions */

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.MethodInfo;
@@ -61,7 +61,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;

--- a/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/GuidedScoreCardDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/GuidedScoreCardDRLPersistenceTest.java
@@ -28,7 +28,7 @@ import org.drools.workbench.models.guided.scorecard.shared.Characteristic;
 import org.drools.workbench.models.guided.scorecard.shared.ScoreCardModel;
 import org.junit.Test;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 public class GuidedScoreCardDRLPersistenceTest {
 

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleBuilderTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleBuilderTest.java
@@ -16,7 +16,7 @@ import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 public class KieModuleBuilderTest extends AbstractKieCiTest {
 

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleIncrementalCompilationTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleIncrementalCompilationTest.java
@@ -12,7 +12,7 @@ import org.kie.api.builder.ReleaseId;
 import org.kie.internal.builder.IncrementalResults;
 import org.kie.internal.builder.InternalKieBuilder;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 @Ignore
 public class KieModuleIncrementalCompilationTest extends AbstractKieCiTest {

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleMetaDataTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleMetaDataTest.java
@@ -22,9 +22,9 @@ import java.util.Collection;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static junit.framework.TestCase.assertFalse;
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.generatePomXml;
 import static org.junit.Assert.fail;


### PR DESCRIPTION
I basically just replaced the deprecated `junit.framework.*` imports with `org.junit.*`.

The asertEquals(double, double) was also deprecated and throws AssertionError so I replaced that with assertEquals(double, double, double) where the last double represents the maximum delta between expected and actual value. I used the value 0.0 as that won't change the behavior of the tests and I am also not sure what the correct delta is.

All tests passed locally.
