### PR TITLE
Exclude generated ProtobufMessages class from FingBugs report

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -193,6 +193,14 @@
           <excludePackageNames>org.kie.asm*,org.kie.objenesis.*,org.kie.commons.jci.*</excludePackageNames>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/drools-core/src/main/findbugs/findbugs-exclude.xml
+++ b/drools-core/src/main/findbugs/findbugs-exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <Class name="~org.drools.core.marshalling.impl.ProtobufMessages.*" />
+  </Match>
+</FindBugsFilter>
+


### PR DESCRIPTION
FindBugs is reporting around 100 warnings in `org.drools.core.marshalling.impl.ProrobufMessages` class , but since the class is generated it does not make sense to fix those. I think the best solution is to exclude the class from the FindBugs report. 

The exclude file is located in src/main/findbugs. I was also considering src/main/resources, but then the findbugs-exclude.xml file would end up in the resulting jar, which is not IMO desirable as it is just developer aid and its not needed at runtime.
