### PR TITLE
BZ1075293  KnowledgeAgent doesn't update kbase in Windows

### DIFF
--- a/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/io/impl/UrlResource.java
@@ -203,7 +203,18 @@ public class UrlResource extends BaseResource
             in.close();
 
             File cacheFile = getCacheFile();
-            fi.renameTo(cacheFile);
+            boolean result = fi.renameTo(cacheFile);
+            if (!result) {
+                // BZ1075293 Windows fails to rename when a target file exists
+                if (cacheFile.exists()) {
+                    cacheFile.delete();
+                }
+                boolean result2 = fi.renameTo(cacheFile);
+                if (!result2) {
+                    throw new RuntimeException("Failed to rename a tmp file to a cache file. " +
+                            "Possible cause is missing stream close: cacheFile = " + cacheFile.getAbsolutePath());
+                }
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
KnowledgeAgentTest
- Added testModifyPackageUrlWithCache() for "drools.resource.urlcache" option.

UrlResourceTest
- Changed this.server = new Server(0); because it uses different ports every time start/stop. This affects all tests in this file but I guess it is the expected test.
- Fixed missing stream close in testWithCache(). If you miss to close the stream from the cache file, it will not be updated in Windows environment.
- Added  testWithCacheForSameInstance(). This is a variant of testWithCache(). But this test is a more realistic use case and can detect the issue in BZ1075293

Urlresource
- Windows fails on File.renameTo() when a target file exists.
