### PR TITLE
Pull request for kie module deployment builder

### DIFF
--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -71,6 +71,19 @@
       <artifactId>httpcore</artifactId>
     </dependency>
 
+    <!-- test --> 
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-compiler</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/FluentKieModuleDeploymentHelper.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/FluentKieModuleDeploymentHelper.java
@@ -1,0 +1,127 @@
+package org.kie.api.builder.helper;
+
+import java.util.List;
+
+import org.kie.api.KieBase;
+import org.kie.api.builder.KieModule;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.runtime.KieSession;
+
+/**
+ * A fluent interface to the {@link KieModuleDeploymentHelper} functionality. See
+ * the {@link KieModuleDeploymentHelper} for more info.
+ */
+public abstract class FluentKieModuleDeploymentHelper extends KieModuleDeploymentHelper {
+
+    /**
+     * Fluent API
+     */
+
+    /**
+     * Set the group id of the Kjar
+     * @param groupId The group id
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setGroupId(String groupId);
+
+    /**
+     * Set the artifact id of the Kjar
+     * @param artifactId The artifact id
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setArtifactId(String artifactId);
+
+    /**
+     * Set the (pom) version of the Kjar
+     * @param version The version
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setVersion(String version);
+
+    /**
+     * Set a {@link KieBase} name. </p> If you want to add multiple {@link KieBase}'s, use
+     * the {@link FluentKieModuleDeploymentHelper#getKieModuleModel()} method. 
+     * @param kbaseName The {@link KieBase} name
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setKBaseName(String kbaseName);
+   
+    /**
+     * Set the {@link KieSession} name. </p> If you want to add multiple {@link KieSession}'s, use
+     * the {@link FluentKieModuleDeploymentHelper#getKieModuleModel()} method. 
+     * @param ksessionName The {@link KieSession} name
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setKieSessionname(String ksessionName);
+
+    /**
+     * Set the list of paths containing resources. If the path refers to a directory, 
+     * all files in that directory will be added as resource files. 
+     * @param resourceFilePaths The list of resource file paths
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setResourceFilePaths(List<String> resourceFilePaths);
+
+    /**
+     * Add a path containing one or more resources. If the path is a directory,
+     * all files in the directory will be added as resource files. 
+     * @param resourceFilePath The resource file path
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper addResourceFilePath(String... resourceFilePath);
+
+    /**
+     * Set the list of classes to be added to the Kjar.
+     * @param classesForKjar The list of classes
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setClasses(List<Class<?>> classesForKjar);
+
+    /**
+     * Add a class that should be included in the Kjar.
+     * @param classForKjar The class
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper addClass(Class<?>... classForKjar);
+   
+    /**
+     * Set the list of dependencies that the Kjar should use. 
+     * @param dependencies The list of dependencies
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper setDependencies(List<String> dependencies);
+
+    /**
+     * Add one or more dependencies (specified by a "G:A:V" string) that the Kjar should use. 
+     * @param dependency One or more strings specifying a dependency
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper addDependencies(String... dependency);
+   
+    /**
+     * Get the {@link KieModuleModel}. Use the {@link KieModuleModel} instance to add
+     * more {@link KieBase} or {@link KieSession} instances as well as add or change the 
+     * default configuration of the {@link KieSession}'s.
+     * @return The {@link KieModuleModel} instance
+     */
+    public abstract KieModuleModel getKieModuleModel();
+
+    /**
+     * Reset the helper. This clears <i>ALL</i> configuration that has been done up to this point
+     * on the helper instance.
+     * @return The helper instance
+     */
+    public abstract FluentKieModuleDeploymentHelper resetHelper();
+   
+    /**
+     * Create the Kjar
+     * @return The {@link KieModule} that represents the Kjar
+     */
+    public abstract KieModule createKieJar();
+   
+    /**
+     * Create the Kjar and deploy (install) it to the local maven repository.
+     */
+    public abstract void createKieJarAndDeployToMaven();
+    
+}    

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentConfig.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentConfig.java
@@ -1,0 +1,132 @@
+package org.kie.api.builder.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.compiler.kie.builder.impl.KieRepositoryImpl;
+import org.drools.compiler.kie.builder.impl.KieServicesImpl;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieRepository;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.builder.model.KieBaseModel;
+import org.kie.api.builder.model.KieModuleModel;
+
+public class KieModuleDeploymentConfig {
+
+    // Getter/setter's only made when the code actually needs them
+    
+    private String groupId = null;
+    private String artifactId = null;
+    private String version = null;
+    private ReleaseId releaseId = null;
+    
+    private String kbaseName = null;
+    private String ksessionName = null;
+    
+    List<String> resourceFilePaths = new ArrayList<String>();
+    List<Class<?>> classes = new ArrayList<Class<?>>();
+    List<String> dependencies = new ArrayList<String>();
+    
+    private KieModuleModel kproj = null;
+    String pomText;
+
+    public KieModuleDeploymentConfig() { 
+        KieServices ks = new KieServicesImpl() {
+            public KieRepository getRepository() {
+                // override repository to not store the artifact on deploy to trigger load from maven repo
+                return new KieRepositoryImpl();
+            }
+        };
+        kieServicesLocal.set(ks);
+    }
+    
+    private final ThreadLocal<KieServices> kieServicesLocal = new ThreadLocal<KieServices>();
+    
+    KieServices getKieServicesInstance() { 
+        KieServices ks = kieServicesLocal.get();
+        if( ks == null ) { 
+            throw new IllegalStateException(KieModuleDeploymentHelper.class.getSimpleName() + " instances are not thread-safe!");
+        }
+        return ks;        
+    }
+    
+    
+    /**
+     * Getter/Setter's
+     */
+    
+    void setGroupId(String groupId) { 
+        this.groupId = groupId;
+    }
+    
+    void setArtifactId(String artifactId) { 
+        this.artifactId = artifactId;
+    }
+    
+    void setVersion(String version) { 
+        this.version = version;
+    }
+    
+    ReleaseId getReleaseId() {
+        if (releaseId == null) {
+            releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        }
+        return releaseId;
+    }
+
+    void setKbaseName(String kbaseName) {
+        this.kbaseName = kbaseName;
+    }
+    
+    String getKbaseName() {
+        if( kbaseName == null ) { 
+            this.kbaseName = "defaultKieBase";
+        }
+        return kbaseName;
+    }
+    
+    void setKsessionName(String ksessionName) {
+        this.ksessionName = ksessionName;
+    }
+    
+    String getKsessionName() {
+        if( ksessionName == null ) { 
+            this.ksessionName = "defaultKieSession";
+        }
+        return ksessionName;
+    }
+    
+    
+    /**
+     * Other methods
+     */
+    
+    void checkComplete() {
+        if ((groupId != null && artifactId != null && version != null) || releaseId != null) {
+            return;
+        } else if (releaseId == null) {
+            if (groupId == null) {
+                throw new IllegalStateException("No groupId has been set yet.");
+            } else if (artifactId == null) {
+                throw new IllegalStateException("No artifactId has been set yet.");
+            } else if (version == null) {
+                throw new IllegalStateException("No version has been set yet.");
+            } else if (groupId == artifactId && artifactId == version && version == null) {
+                throw new IllegalStateException("None of groupId, artifactId, version or releaseId have been set.");
+            }
+        }
+    }
+
+    KieModuleModel getKieProject() {
+        if (kproj != null) {
+            return kproj;
+        }
+        kproj = getKieServicesInstance().newKieModuleModel();
+
+        KieBaseModel kieBaseModel = kproj.newKieBaseModel(getKbaseName()).setDefault(true);
+        kieBaseModel.newKieSessionModel(getKsessionName()).setDefault(true);
+
+        return kproj;
+    }
+}

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelper.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelper.java
@@ -1,0 +1,18 @@
+package org.kie.api.builder.helper;
+
+/**
+ * This class provides users with the ability to programmatically create
+ * kjars and deploy them to the available maven repositories. 
+ * </p>
+ * Both a fluent and "single-method" interface are provided.
+ */
+public class KieModuleDeploymentHelper {
+
+    public static final FluentKieModuleDeploymentHelper newFluentInstance() { 
+        return new KieModuleDeploymentHelperImpl();
+    }
+    
+    public static final SingleKieModuleDeploymentHelper newSingleInstance() { 
+        return new KieModuleDeploymentHelperImpl();
+    }
+}

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelperImpl.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelperImpl.java
@@ -1,0 +1,601 @@
+package org.kie.api.builder.helper;
+
+import static org.kie.scanner.MavenRepository.getMavenRepository;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.kie.api.KieBase;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieModule;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.runtime.KieSession;
+import org.kie.scanner.MavenRepository;
+
+/**
+ * This is the main class where all interfaces and code comes together. 
+ */
+final class KieModuleDeploymentHelperImpl extends FluentKieModuleDeploymentHelper implements SingleKieModuleDeploymentHelper {
+    
+    /**
+     * package scope: Because users will do very unexpected things.
+     */
+
+    private KieModuleDeploymentConfig config;
+    
+    KieModuleDeploymentHelperImpl() { 
+        config = new KieModuleDeploymentConfig();
+    }
+
+    /**
+     * Fluent API
+     */
+    
+    @Override
+    public FluentKieModuleDeploymentHelper setGroupId(String groupId) { 
+        assertNotNull( groupId, "groupId");
+        this.config.setGroupId(groupId);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper setArtifactId(String artifactId) { 
+        assertNotNull( artifactId, "artifactId");
+        this.config.setArtifactId(artifactId);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper setVersion(String version) { 
+        assertNotNull( version, "version");
+        this.config.setVersion(version);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper setKBaseName(String kbaseName) {
+        assertNotNull(kbaseName, "kbase name");
+        this.config.setKbaseName(kbaseName);
+        return this;
+    }
+
+    @Override
+    public FluentKieModuleDeploymentHelper setKieSessionname(String ksessionName) {
+        assertNotNull(ksessionName, "ksession name");
+        this.config.setKsessionName(ksessionName);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper setResourceFilePaths(List<String> resourceFilePaths) {
+        assertNotNull( resourceFilePaths, "resourceFilePaths");
+        this.config.resourceFilePaths.addAll(resourceFilePaths);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper addResourceFilePath(String... resourceFilePath) {
+        assertNotNull( resourceFilePath, "resourceFilePath");
+        for( int i = 0; i < resourceFilePath.length; ++i ) { 
+            assertNotNull( resourceFilePath[i], "resourceFilePath[" + i + "]");
+            this.config.resourceFilePaths.add(resourceFilePath[i]);
+        }
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper setClasses(List<Class<?>> classesForKjar) { 
+        assertNotNull( classesForKjar, "classesForKjar");
+        this.config.classes.addAll(classesForKjar);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper addClass(Class<?>... classForKjar) { 
+        assertNotNull( classForKjar, "classForKjar");
+        for( int i = 0; i < classForKjar.length; ++i ) { 
+            assertNotNull( classForKjar[i], "classForKjar[" + i + "]");
+            this.config.classes.add(classForKjar[i]);
+        }
+        return this;
+    }
+
+    @Override
+    public FluentKieModuleDeploymentHelper setDependencies(List<String> dependencies) { 
+        assertNotNull( dependencies, "dependencies");
+        this.config.dependencies.addAll(dependencies);
+        return this;
+    }
+    
+    @Override
+    public FluentKieModuleDeploymentHelper addDependencies(String... dependency) { 
+        assertNotNull( dependency, "dependency");
+        for( int i = 0; i < dependency.length; ++i ) { 
+            assertNotNull( dependency[i], "dependency[" + i + "]");
+            this.config.dependencies.add(dependency[i]);
+        }
+        return this;
+    }
+    
+    @Override
+    public KieModuleModel getKieModuleModel() {
+        return config.getKieProject();
+    }
+
+    @Override
+    public FluentKieModuleDeploymentHelper resetHelper() {
+        this.config = new KieModuleDeploymentConfig();
+        return this;
+    }
+
+    @Override
+    public KieModule createKieJar() {
+        config.checkComplete();
+        return internalCreateKieJar(config.getReleaseId(), config.getKbaseName(), config.getKsessionName(), 
+                config.resourceFilePaths, config.classes, config.dependencies);
+    }
+
+    @Override
+    public void createKieJarAndDeployToMaven() {
+        config.checkComplete();
+        internalCreateAndDeployKjarToMaven(config.getReleaseId(), config.getKbaseName(), config.getKsessionName(), 
+                config.resourceFilePaths, config.classes, 
+                config.dependencies);
+    }
+    
+    private static void assertNotNull(Object obj, String name) { 
+        if( obj == null ) { 
+            throw new IllegalArgumentException("Null " + name + " arguments are not accepted!");
+        }
+    }
+    
+    /**
+     * General/Single API
+     */
+    
+    @Override
+    public KieModule createKieJar(String groupId, String artifactId, String version,
+            String kbaseName,
+            String ksessionName, 
+            List<String> resourceFilePaths ) { 
+        ReleaseId releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        return internalCreateKieJar(releaseId, kbaseName, ksessionName, resourceFilePaths, null, null);
+    }
+    
+    @Override
+    public KieModule createKieJar(String groupId, String artifactId, String version,
+            String kbaseName,
+            String ksessionName, 
+            List<String> bpmnFilePaths, 
+            List<Class<?>> classes) {
+        
+        ReleaseId releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        return internalCreateKieJar(releaseId, kbaseName, ksessionName, bpmnFilePaths, classes, null);
+    }
+    
+    @Override
+    public KieModule createKieJar(String groupId, String artifactId, String version,
+            String kbaseName,
+            String ksessionName, 
+            List<String> bpmnFilePaths, 
+            List<Class<?>> classes, 
+            List<String> dependencies) {
+        
+        ReleaseId releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        return internalCreateKieJar(releaseId, kbaseName, ksessionName, bpmnFilePaths, classes, dependencies);
+    }
+    
+    @Override
+    public void createKieJarAndDeployToMaven(String groupId, String artifactId, String version, String kbaseName,
+            String ksessionName, List<String> resourceFilePaths) {
+        ReleaseId releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        internalCreateAndDeployKjarToMaven(releaseId, kbaseName, ksessionName, resourceFilePaths, null, null);
+    }
+
+    @Override
+    public void createKieJarAndDeployToMaven(String groupId, String artifactId, String version, String kbaseName,
+            String ksessionName, List<String> resourceFilePaths, List<Class<?>> classesForKjar) {
+        ReleaseId releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        internalCreateAndDeployKjarToMaven(releaseId, kbaseName, ksessionName, resourceFilePaths, classesForKjar, null);
+    }
+
+    @Override
+    public void createKieJarAndDeployToMaven(String groupId, String artifactId, String version, String kbaseName,
+            String ksessionName, List<String> resourceFilePaths, List<Class<?>> classesForKjar, List<String> dependencies) {
+        ReleaseId releaseId = new ReleaseIdImpl(groupId, artifactId, version);
+        internalCreateAndDeployKjarToMaven(releaseId, kbaseName, ksessionName, resourceFilePaths, classesForKjar, dependencies);
+    }
+    
+    /**
+     * Internal methods
+     */
+
+    /**
+     * Create a KJar and deploy it to maven.
+     * 
+     * @param releaseId The {@link ReleaseId} of the jar.
+     * @param kbaseName The name to use for the (default) {@link KieBase} in the kmodule.xml.
+     * @param ksessionName The name to use for the (default) {@link KieSession} in the kmodule.xml.
+     * @param resourceFilePaths A (possibly null) list of files to be added to the kjar.
+     * @param classes
+     * @param dependencies
+     */
+    private synchronized void internalCreateAndDeployKjarToMaven(ReleaseId releaseId,
+            String kbaseName, 
+            String ksessionName,
+            List<String> resourceFilePaths,
+            List<Class<?>> classes, 
+            List<String> dependencies) {
+        
+        InternalKieModule kjar = (InternalKieModule) internalCreateKieJar(releaseId, 
+                kbaseName, ksessionName, 
+                resourceFilePaths, classes,
+                dependencies);
+        
+        String pomFileName = MavenRepository.toFileName(releaseId, null) + ".pom";
+        File pomFile = new File(System.getProperty("java.io.tmpdir"), pomFileName);
+        try {
+            FileOutputStream fos = new FileOutputStream(pomFile);
+            fos.write(config.pomText.getBytes());
+            fos.flush();
+            fos.close();
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unable to write pom.xml to temporary file : " + ioe.getMessage(), ioe);
+        }
+    
+        MavenRepository repository = getMavenRepository();
+        repository.deployArtifact(releaseId, kjar, pomFile);
+    }
+
+    /**
+     * Create a KJar for deployment;
+     * 
+     * @param releaseId Release (deployment) id.
+     * @param resourceFilePaths List of resource file paths
+     * @param kbaseName The name of the {@link KieBase}
+     * @param ksessionName The name of the {@link KieSession}.
+     * @param dependencies List of dependencies to add
+     * 
+     * @return The {@link InternalKieModule} which represents the KJar.
+     */
+    private synchronized KieModule internalCreateKieJar(ReleaseId releaseId, 
+            String kbaseName,
+            String ksessionName,
+            List<String> resourceFilePaths, 
+            List<Class<?>> classes, 
+            List<String> dependencies) {
+        
+        
+        ReleaseId [] releaseIds = { };
+        if( dependencies != null && dependencies.size() > 0 ) { 
+            List<ReleaseId> depReleaseIds = new ArrayList<ReleaseId>();
+            for( String dep : dependencies ) { 
+                String [] gav = dep.split(":");
+                if( gav.length != 3 ) { 
+                    throw new IllegalArgumentException("Dependendency id '" + dep  + "' does not conform to the format <groupId>:<artifactId>:<version> (Classifiers are not accepted).");
+                }
+                depReleaseIds.add(new ReleaseIdImpl(gav[0], gav[1], gav[2]));
+            }
+            releaseIds = depReleaseIds.toArray(new ReleaseId[depReleaseIds.size()]);
+        }
+        config.pomText = getPomText(releaseId, releaseIds);
+        
+        KieFileSystem kfs = createKieFileSystemWithKProject(kbaseName, ksessionName);
+        kfs.writePomXML(this.config.pomText);
+    
+        List<KJarResource> resourceFiles = loadResources(resourceFilePaths);
+        for (KJarResource resource : resourceFiles) {
+            kfs.write("src/main/resources/" + kbaseName + "/" + resource.name, resource.content);
+        }
+    
+        if( classes != null ) { 
+            for( Class<?> userClass : classes ) {
+                addClass(userClass, kfs);
+            }
+        }
+    
+        KieBuilder kieBuilder = config.getKieServicesInstance().newKieBuilder(kfs);
+        int buildMsgs = 0;
+        for( Message buildMsg : kieBuilder.buildAll().getResults().getMessages() ) { 
+           System.out.println( buildMsg.getPath() + " : " + buildMsg.getText() );
+           ++buildMsgs;
+        }
+        if( buildMsgs > 0 ) { 
+            throw new RuntimeException("Unable to build KieModule, see the " + buildMsgs + " messages above.");
+        }
+        
+        return (InternalKieModule) kieBuilder.getKieModule();
+    }
+
+    /**
+     * Create the {@link KieFileSystem} instance to store the content going into the KJar.
+     * 
+     * @param kbaseName
+     * @param ksessionName
+     * @return
+     */
+    private KieFileSystem createKieFileSystemWithKProject(String kbaseName, String ksessionName) {
+        KieModuleModel kproj = config.getKieProject();
+        KieFileSystem kfs = config.getKieServicesInstance().newKieFileSystem();
+        kfs.writeKModuleXML(kproj.toXML());
+        return kfs;
+    }
+
+    /**
+     * Create the pom that will be placed in the KJar.
+     * 
+     * @param releaseId The release (deployment) id.
+     * @param dependencies The list of dependendencies to be added to the pom
+     * @return A string representation of the pom.
+     */
+    private static String getPomText(ReleaseId releaseId, ReleaseId... dependencies) {
+        String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                + "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n" 
+                + "\n" 
+                + "  <groupId>" + releaseId.getGroupId() + "</groupId>\n"
+                + "  <artifactId>" + releaseId.getArtifactId() + "</artifactId>\n" 
+                + "  <version>" + releaseId.getVersion() + "</version>\n" + "\n";
+        
+        if (dependencies != null && dependencies.length > 0) {
+            pom += "<dependencies>\n";
+            for (ReleaseId dep : dependencies) {
+                pom += "<dependency>\n";
+                pom += "  <groupId>" + dep.getGroupId() + "</groupId>\n";
+                pom += "  <artifactId>" + dep.getArtifactId() + "</artifactId>\n";
+                pom += "  <version>" + dep.getVersion() + "</version>\n";
+                pom += "</dependency>\n";
+            }
+            pom += "</dependencies>\n";
+        }
+        
+        pom += "</project>";
+        
+        return pom;
+    }
+
+    /**
+     * Create a list of {@link KJarResource} instances with the process files to be included in the KJar.
+     * 
+     * @return The list of {@link KJarResource} instances.
+     * @throws Exception
+     */
+    static List<KJarResource> internalLoadResources(String path, boolean fromDir) throws Exception {
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        List<KJarResource> output = new ArrayList<KJarResource>();
+        URL url = KieModuleDeploymentHelperImpl.class.getResource(path);
+        if (fromDir) {
+            if (url == null) {
+                File folder = new File(path);
+                if (folder.exists()) {
+                    for (File folderFile : folder.listFiles()) {
+                        if (folderFile.isDirectory()) {
+                            continue;
+                        }
+                        String content = convertFileToString(new FileInputStream(folderFile));
+                        output.add(new KJarResource(folderFile.getName(), content));
+                    }
+                } else {
+                    throw new IllegalArgumentException("Directory + '" + path + "' does not exist.");
+                }
+            } else if ("file".equals(url.getProtocol())) {
+                File folder = new File(url.toURI());
+                if (folder.isDirectory()) {
+                    for (File folderFile : folder.listFiles()) {
+                        if (folderFile.getName().endsWith(".class")
+                                || folderFile.isDirectory() ) {
+                            continue;
+                        }
+                        String content = convertFileToString(new FileInputStream(folderFile));
+                        output.add(new KJarResource(folderFile.getName(), content));
+                    }
+                } else {
+                    throw new IllegalStateException("'" + path + "' is not an existing directory.");
+                }
+            } else if ("jar".equals(url.getProtocol())) {
+                String urlString = url.toExternalForm();
+                int jarPathIndex = urlString.lastIndexOf(".jar!") + 4;
+                String resourcePath = urlString.substring(jarPathIndex + 1);
+                if (resourcePath.startsWith("/")) {
+                    resourcePath = resourcePath.substring(1);
+                }
+                int depth = resourcePath.split(File.separator).length + 1;
+
+                String jarUrlString = urlString.substring("jar:".length(), jarPathIndex);
+                url = new URL(jarUrlString);
+                ZipInputStream zip = new ZipInputStream(url.openStream());
+
+                ZipEntry ze = zip.getNextEntry();
+                while (ze != null) {
+                    String name = ze.getName();
+                    if (name.startsWith(resourcePath) && !name.endsWith(File.separator)
+                            && (name.split(File.separator).length == depth)) {
+                        String shortName = name.substring(name.lastIndexOf("/") + 1);
+                        String content = convertFileToString(zip);
+                        output.add(new KJarResource(shortName, content));
+                    }
+                    ze = zip.getNextEntry();
+                }
+            } else {
+                throw new IllegalArgumentException("Unable to find resource directory '" + path + "'");
+            }
+        } else {
+            InputStream is = KieModuleDeploymentHelperImpl.class.getResourceAsStream(path);
+            if (is == null) {
+                is = new FileInputStream(new File(path));
+            }
+            String content = convertFileToString(is);
+            String name = path.substring(path.lastIndexOf("/") + 1);
+            output.add(new KJarResource(name, content));
+        }
+        return output;
+    }
+   
+    /**
+     * Find the resource files specified and create {@link KJarResource} instances from them.
+     * 
+     * @param resourceFilePaths A list of resource files or directories containing resource files
+     * @return A List of {@link KJarResource} instances representing the given list of resource files
+     */
+    private static List<KJarResource> loadResources(List<String> resourceFilePaths) { 
+        List<KJarResource> kjarResources = new ArrayList<KieModuleDeploymentHelperImpl.KJarResource>();
+        for( String filePath : resourceFilePaths ) { 
+            if( filePath.endsWith("/") ) {
+                try {
+                    kjarResources.addAll(internalLoadResources(filePath, true));
+                } catch (Exception e) {
+                    throw new RuntimeException("Unable to load resources from " + filePath + ": " + e.getMessage(), e);
+                }
+            } else { 
+                try {
+                    kjarResources.addAll(internalLoadResources(filePath, false));
+                } catch (FileNotFoundException fnfe) {
+                    throw new RuntimeException("No file found at '" + filePath + "' -- if it's a directory, please add a " + File.separator + " to the end of the path.");
+                } catch (Exception e) {
+                    throw new RuntimeException("Unable to load resource from '" + filePath + "'", e);
+                }
+            }
+        }
+        
+        return kjarResources;
+    }
+    
+    private static String convertFileToString(InputStream in) {
+        InputStreamReader input = new InputStreamReader(in);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputStreamWriter output = new OutputStreamWriter(baos);
+        char[] buffer = new char[4096];
+        int n = 0;
+        try {
+            while (-1 != (n = input.read(buffer))) {
+                output.write(buffer, 0, n);
+            }
+            output.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return baos.toString();
+    }
+
+    /**
+     * Add class to the {@link KieFileSystem}.
+     * 
+     * @param userClass The class to be added.
+     * @param kfs The {@link KieFileSystem}
+     */
+    private static void addClass(Class<?> userClass, KieFileSystem kfs) {
+        String classSimpleName = userClass.getSimpleName();
+        
+        URL classFileUrl = userClass.getResource(classSimpleName + ".class");
+        if( classFileUrl == null ) { 
+            throw new RuntimeException("Class " + userClass.getCanonicalName() + " can not be found on the classpath." );
+        }
+    
+        byte[] classByteCode = null;
+        if ("file".equalsIgnoreCase(classFileUrl.getProtocol())) {
+            File classFile = new File(classFileUrl.getPath());
+            if( ! classFile.exists() ) { 
+                throw new RuntimeException("Unable to find path for class " + userClass.getCanonicalName() 
+                        + " that should be here: " + classFileUrl.toExternalForm());
+            }
+    
+            try {
+                classByteCode = readStream(new FileInputStream(classFile));
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to read in " + classFile.getAbsolutePath(), e);
+            }
+            if( classByteCode.length == 0 ) { 
+                throw new RuntimeException("No bytes retrieved from " + classFile.getAbsolutePath() );
+            }
+        } else if ("jar".equalsIgnoreCase(classFileUrl.getProtocol())) {
+            // file:/opt/mavenRepository/org/kie/tests/kie-wb-tests-base/6.0.0-SNAPSHOT/kie-wb-tests-base-6.0.0-SNAPSHOT.jar!/org/kie/tests/wb/base/test/MyType.class
+            String path = classFileUrl.getPath();
+            int bangIndex = path.indexOf('!');
+            String jarPath = path.substring("file:".length(), bangIndex);
+            String classPath = path.substring(bangIndex+2); // no base /
+            
+            try { 
+                ZipFile zip = new ZipFile(new File(jarPath));
+                ZipEntry entry = zip.getEntry(classPath);
+                InputStream zipStream = zip.getInputStream(entry);
+                classByteCode = readStream(zipStream);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to read from " + jarPath, e);
+            }
+        }
+    
+        String pkgFolder = userClass.getPackage().toString();
+        
+        // @#$%ing Eclipe classloader!! The following 2 lines "normalize" the package name from what Eclipse (and other IDE's?) do with it
+        pkgFolder = pkgFolder.replace("package ", "");
+        pkgFolder = pkgFolder.replaceAll(",.+$", "");
+        
+        pkgFolder = pkgFolder.replaceAll("\\.", File.separator);
+        String classFilePath = pkgFolder + "/" + classSimpleName + ".class";
+        
+        if( classFilePath.contains(" " ) ) { 
+            throw new RuntimeException("Invalid class name ('" + classFilePath + "'), contact the developers.");
+        }
+    
+        kfs.write(classFilePath, classByteCode);
+    }
+
+    private static byte[] readStream(InputStream ios) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            byte[] buffer = new byte[4096];
+            int read = 0;
+            while ((read = ios.read(buffer)) != -1) {
+                baos.write(buffer, 0, read);
+            }
+        } finally {
+            try {
+                if (baos != null) {
+                    baos.close();
+                }
+                if (ios != null) {
+                    ios.close();
+                }
+            } catch (IOException e) {
+                // do nothing
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    static class KJarResource {
+        public String name;
+        public String content;
+    
+        public KJarResource(String name, String content) {
+            this.content = content;
+            this.name = name;
+        }
+    }
+
+
+
+
+
+}

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/SingleKieModuleDeploymentHelper.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/SingleKieModuleDeploymentHelper.java
@@ -1,0 +1,39 @@
+package org.kie.api.builder.helper;
+
+import java.util.List;
+
+import org.kie.api.builder.KieModule;
+
+public interface SingleKieModuleDeploymentHelper {
+
+    /**
+     * General API
+     */
+
+    public abstract KieModule createKieJar(String groupId, String artifactId, String version, 
+            String kbaseName, String ksessionName,
+            List<String> resourceFilePaths);
+
+    public abstract KieModule createKieJar(String groupId, String artifactId, String version, 
+            String kbaseName, String ksessionName,
+            List<String> resourceFilePaths, List<Class<?>> classesForKjar);
+
+    public abstract KieModule createKieJar(String groupId, String artifactId, String version, 
+            String kbaseName, String ksessionName,
+            List<String> resourceFilePaths, List<Class<?>> classesForKjar, 
+            List<String> dependencies);
+
+    public abstract void createKieJarAndDeployToMaven(String groupId, String artifactId, String version, 
+            String kbaseName, String ksessionName,
+            List<String> resourceFilePaths);
+
+    public abstract void createKieJarAndDeployToMaven(String groupId, String artifactId, String version, 
+            String kbaseName, String ksessionName,
+            List<String> resourceFilePaths, List<Class<?>> classesForKjar);
+
+    public abstract void createKieJarAndDeployToMaven(String groupId, String artifactId, String version, 
+            String kbaseName, String ksessionName, 
+            List<String> resourceFilePaths, List<Class<?>> classesForKjar, 
+            List<String> dependencies);
+
+}

--- a/kie-ci/src/test/java/org/kie/api/builder/helper/KieModuleDeploymentHelperTest.java
+++ b/kie-ci/src/test/java/org/kie/api/builder/helper/KieModuleDeploymentHelperTest.java
@@ -1,0 +1,200 @@
+package org.kie.api.builder.helper;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.drools.core.impl.EnvironmentImpl;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.builder.KieModule;
+import org.kie.api.builder.helper.FluentKieModuleDeploymentHelper;
+import org.kie.api.builder.helper.KieModuleDeploymentHelper;
+import org.kie.api.builder.helper.SingleKieModuleDeploymentHelper;
+import org.kie.api.builder.model.KieBaseModel;
+import org.kie.api.conf.EqualityBehaviorOption;
+import org.kie.api.conf.EventProcessingOption;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.scanner.MavenRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KieModuleDeploymentHelperTest {
+
+    protected static Logger logger = LoggerFactory.getLogger(KieModuleDeploymentHelperTest.class);
+    
+    private ZipInputStream zip;
+
+    @After
+    public void cleanUp() {
+        if (zip != null) {
+            try {
+                zip.close();
+            } catch (IOException e) {
+                // do nothing
+            }
+
+        }
+    }
+
+    @Test
+    public void testSingleDeploymentHelper() throws Exception {
+        int numFiles = 0;
+        int numDirs = 0;
+        SingleKieModuleDeploymentHelper deploymentHelper = KieModuleDeploymentHelper.newSingleInstance();
+
+        List<String> resourceFilePaths = new ArrayList<String>();
+        resourceFilePaths.add("builder/test/");
+        numFiles += 2;
+        resourceFilePaths.add("builder/simple_query_test.drl");
+        ++numFiles;
+
+        List<Class<?>> kjarClasses = new ArrayList<Class<?>>();
+        kjarClasses.add(KieModuleDeploymentHelper.class);
+        numDirs += 5; // org.kie.api.builder.helper
+        kjarClasses.add(EnvironmentImpl.class);
+        numDirs += 3; // (org.)drools.core.impl
+        kjarClasses.add(org.drools.compiler.Cheese.class);
+        numDirs += 1; // (org.drools.)compiler
+        numFiles += 3;
+
+        String groupId = "org.kie.api.builder";
+        String artifactId = "test-kjar";
+        String version = "0.1-SNAPSHOT";
+        deploymentHelper.createKieJarAndDeployToMaven(groupId, artifactId, version, 
+                "defaultKieBase", "defaultKieSession",
+                resourceFilePaths, kjarClasses);
+        // pom.xml, pom.properties
+        numFiles += 2;
+        // kmodule.xml, kmodule.info, kbase.cache
+        numFiles +=3;
+        
+        // META-INF/maven/org.kie.api.builder/test-kjar
+        numDirs += 4;
+        // defaultKiebase, META-INF/defaultKieBase
+        numDirs += 2;
+
+        File artifactFile = MavenRepository.getMavenRepository().resolveArtifact(groupId + ":" + artifactId + ":" + version).getFile();
+        zip = new ZipInputStream(new FileInputStream(artifactFile));
+
+        Set<String> jarFiles = new HashSet<String>();
+        Set<String> jarDirs = new HashSet<String>();
+        ZipEntry ze = zip.getNextEntry();
+        logger.debug("Getting files from deployed jar: " );
+        while( ze != null ) { 
+            String fileName = ze.getName();
+            if( fileName.endsWith("drl")
+                    || fileName.endsWith("class")
+                    || fileName.endsWith("xml")
+                    || fileName.endsWith("info")
+                    || fileName.endsWith("properties")
+                    || fileName.endsWith("cache") ) { 
+                jarFiles.add(fileName);
+                logger.debug("> " + fileName);
+            } else { 
+                jarDirs.add(fileName);
+                logger.debug("] " + fileName);
+            }
+            ze = zip.getNextEntry();
+        }
+        assertEquals("Num files in kjar", numFiles, jarFiles.size());
+        assertEquals("Num dirs in kjar", numDirs, jarDirs.size());
+        System.out.println( "------------------------------------");
+    }
+
+    @Test
+    public void testFluentDeploymentHelper() throws Exception {
+        int numFiles = 0;
+        int numDirs = 0;
+        String content = "test file created by " + this.getClass().getSimpleName();
+        File tempFile = File.createTempFile(UUID.randomUUID().toString(), ".tst");
+        tempFile.deleteOnExit();
+        FileOutputStream fos = new FileOutputStream(tempFile);
+        fos.write(content.getBytes());
+        fos.close();
+        
+        FluentKieModuleDeploymentHelper deploymentHelper = KieModuleDeploymentHelper.newFluentInstance();
+
+        String groupId = "org.kie.api.builder.fluent";
+        String artifactId = "test-kjar";
+        String version = "0.1-SNAPSHOT";
+        deploymentHelper = deploymentHelper.setGroupId(groupId)
+                .setArtifactId(artifactId)
+                .setVersion(version)
+                .addResourceFilePath("builder/test/", "builder/simple_query_test.drl")
+                .addResourceFilePath(tempFile.getAbsolutePath())
+                .addResourceFilePath("/META-INF/WorkDefinitions.conf") // from the drools-core jar
+                .addClass(KieModuleDeploymentHelperTest.class)
+                .addClass(KieModule.class)
+                .addClass(org.drools.compiler.Cheese.class);
+        // class dirs
+        numDirs += 5; // org.kie.api.builder.helper
+        numDirs += 2; // (org.)drools.compiler
+        
+        // pom.xml, pom.properties
+        numFiles += 3;
+        // kmodule.xml, kmodule.info
+        numFiles += 2;
+        // kbase.cache x 2
+        numFiles += 2;
+        // drl files
+        numFiles += 3;
+        // WorkDefinitions
+        ++numFiles;
+        // classes
+        numFiles += 3;
+        
+        // META-INF/maven/org.kie.api.builder/test-kjar
+        numDirs += 4;
+        // defaultKiebase, META-INF/defaultKieBase
+        numDirs += 2;
+        
+        KieBaseModel kbaseModel = deploymentHelper.getKieModuleModel().newKieBaseModel("otherKieBase");
+        kbaseModel.setEqualsBehavior(EqualityBehaviorOption.EQUALITY).setEventProcessingMode(EventProcessingOption.STREAM);
+        kbaseModel.newKieSessionModel("otherKieSession").setClockType(ClockTypeOption.get("realtime"));
+        // META-INF/otherKieBase
+        ++numDirs;
+
+        deploymentHelper.getKieModuleModel().getKieBaseModels().get("defaultKieBase").newKieSessionModel("secondKieSession");
+
+        deploymentHelper.createKieJarAndDeployToMaven();
+
+        File artifactFile = MavenRepository.getMavenRepository().resolveArtifact(groupId + ":" + artifactId + ":" + version).getFile();
+        zip = new ZipInputStream(new FileInputStream(artifactFile));
+
+        Set<String> jarFiles = new HashSet<String>();
+        Set<String> jarDirs = new HashSet<String>();
+        ZipEntry ze = zip.getNextEntry();
+        logger.debug("Getting files form deployed jar: ");
+        while( ze != null ) { 
+            String fileName = ze.getName();
+            if( fileName.endsWith("drl")
+                    || fileName.endsWith("class")
+                    || fileName.endsWith("tst")
+                    || fileName.endsWith("conf")
+                    || fileName.endsWith("xml")
+                    || fileName.endsWith("info")
+                    || fileName.endsWith("properties")
+                    || fileName.endsWith("cache") ) { 
+                jarFiles.add(fileName);
+                logger.debug("> " + fileName);
+            } else { 
+                jarDirs.add(fileName);
+                logger.debug("] " + fileName);
+            }
+            ze = zip.getNextEntry();
+        }
+        assertEquals("Num files in kjar", numFiles, jarFiles.size());
+        assertEquals("Num dirs in kjar", numDirs, jarDirs.size());
+    }
+}

--- a/kie-ci/src/test/resources/builder/simple_query_test.drl
+++ b/kie-ci/src/test/resources/builder/simple_query_test.drl
@@ -1,0 +1,7 @@
+package org.drools.compiler.test;
+
+import org.drools.compiler.Cheese;
+
+query "simple query"
+        Cheese(type == "stinky")
+end 

--- a/kie-ci/src/test/resources/builder/test/empty.drl
+++ b/kie-ci/src/test/resources/builder/test/empty.drl
@@ -1,0 +1,6 @@
+package com.sample
+
+rule "EmptyRule" 
+    when
+    then
+end 

--- a/kie-ci/src/test/resources/builder/test/literal_rule.drl
+++ b/kie-ci/src/test/resources/builder/test/literal_rule.drl
@@ -1,0 +1,10 @@
+package org.drools.compiler.test;
+
+import org.drools.compiler.Cheese;
+
+rule simple
+    when
+        Cheese( )
+    then
+
+end    

--- a/kie-ci/src/test/resources/logback-test.xml
+++ b/kie-ci/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie.api.builder" level="debug"/>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>
+


### PR DESCRIPTION
I developed this code for the `kie-remote` modules in the 6.0.x branch, because it was very helpful when unit testing: I could programmatically call the `KieModuleDeploymentHelper` instance to create a kjar and then use the REST/JMS services to deploy it. 

However, for obvious reasons, the code doesn't belong in the (`droolsjbpm-integration/kie-remote/kie-services-client`) but I'd like to keep it, since I think it would be useful. 

If the PR is approved, I'll add documentation as well (to `kie-docs`). 

The 6.0.x code (in `kie-services-client`) can be found [here](https://github.com/droolsjbpm/droolsjbpm-integration/tree/6.0.x/kie-remote/kie-services-client/src/main/java/org/kie/services/client/deployment).
