### PR TITLE
DROOLS-473: Drools spawning a lot of JIT threads

### DIFF
--- a/drools-core/src/main/java/org/drools/concurrent/ExecutorProviderImpl.java
+++ b/drools-core/src/main/java/org/drools/concurrent/ExecutorProviderImpl.java
@@ -1,8 +1,10 @@
 package org.drools.concurrent;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -22,8 +24,10 @@ public class ExecutorProviderImpl implements ExecutorProvider {
         // Don't saturate the CPUs with the JIT
         int poolSize = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
         poolSize = getExecutorParameter("drools.executor.poolSize", poolSize);
-        executor = new ThreadPoolExecutor(0, poolSize, 60L, TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(),
+        int queueSize = getExecutorParameter("drools.executor.queueSize", 1000);
+        BlockingQueue<Runnable> workQueue =
+                queueSize > 0 ? new LinkedBlockingQueue<Runnable>(queueSize) : new SynchronousQueue<Runnable>();
+        executor = new ThreadPoolExecutor(0, poolSize, 60L, TimeUnit.SECONDS, workQueue,
                 new ThreadFactory() {
                     public Thread newThread(Runnable r) {
                         Thread t = new Thread(r);

--- a/drools-core/src/main/java/org/drools/concurrent/ExecutorProviderImpl.java
+++ b/drools-core/src/main/java/org/drools/concurrent/ExecutorProviderImpl.java
@@ -7,6 +7,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 public class ExecutorProviderImpl implements ExecutorProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(ExecutorProviderImpl.class);
+    private static final AtomicInteger threadCount = new AtomicInteger();
     private static final java.util.concurrent.ExecutorService executor;
 
     static {
@@ -25,6 +27,7 @@ public class ExecutorProviderImpl implements ExecutorProvider {
                 new ThreadFactory() {
                     public Thread newThread(Runnable r) {
                         Thread t = new Thread(r);
+                        t.setName("drools-" + threadCount.incrementAndGet());
                         t.setDaemon(true);
                         return t;
                     }

--- a/drools-core/src/main/java/org/drools/concurrent/ExecutorProviderImpl.java
+++ b/drools-core/src/main/java/org/drools/concurrent/ExecutorProviderImpl.java
@@ -3,18 +3,45 @@ package org.drools.concurrent;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExecutorProviderImpl implements ExecutorProvider {
 
-    private static final java.util.concurrent.ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactory() {
-        public Thread newThread(Runnable r) {
-            Thread t = new Thread(r);
-            t.setDaemon(true);
-            return t;
+    private static final Logger logger = LoggerFactory.getLogger(ExecutorProviderImpl.class);
+    private static final java.util.concurrent.ExecutorService executor;
+
+    static {
+        // Don't saturate the CPUs with the JIT
+        int poolSize = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
+        poolSize = getExecutorParameter("drools.executor.poolSize", poolSize);
+        executor = new ThreadPoolExecutor(0, poolSize, 60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(),
+                new ThreadFactory() {
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r);
+                        t.setDaemon(true);
+                        return t;
+                    }
+                });
+    }
+
+    private static int getExecutorParameter(String key, int defaultValue) {
+        String property = System.getProperty(key);
+        if (property != null && property.length() > 0) {
+            try {
+                return Integer.parseInt(property);
+            } catch (NumberFormatException e) {
+                logger.error("The value of {} cannot be parsed as an integer", key, e);
+            }
         }
-    });;
+        return defaultValue;
+    }
 
     public Executor getExecutor() {
         return executor;


### PR DESCRIPTION
This pull request does 3 things:
- It replaces the unbounded thread pool by a bounded one (with a configurable bound)
- It adds a name to the threads in the pool
- It replaces the `SynchronizedQueue` used in the unbounded thread pool by a `LinkedBlockingQueue` (with a configurable bound as well) to retain an asynchronous behavior even when all the threads are already active

I'd add the documentation for the system properties configuring the bounds, but I'm not sure where it should go (beyond "somewhere in drools-expert-docs"), if you have any suggestions.
