### PR TITLE
set parent classloader for URLClassloader to allow use of classes from p...

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaDataImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaDataImpl.java
@@ -117,8 +117,7 @@ public class KieModuleMetaDataImpl implements KieModuleMetaData {
                 }
             }
 
-            classLoader = ProjectClassLoader.createProjectClassLoader(new URLClassLoader(urls));
-            classLoader.setDroolsClassLoader(getClass().getClassLoader());
+            classLoader = ProjectClassLoader.createProjectClassLoader(new URLClassLoader(urls, getClass().getClassLoader()));
 
             if (kieModule != null) {
                 Map<String, byte[]> classes = kieModule.getClassesMap(true);


### PR DESCRIPTION
...arent to avoid duplicates

this pull request makes sure that URLClassLoader will have parent set so classes defined in one of the jars of URLClassLoader can be created even if they reference/import classes that are already in class path like interfaces from kie-api and kie-internal
