### PR TITLE
[DROOLS-483] fix the repeated look-up of absent services

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilderFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ProcessBuilderFactory.java
@@ -8,6 +8,7 @@ public class ProcessBuilderFactory {
 
     private static final String PROVIDER_CLASS = "org.jbpm.process.builder.ProcessBuilderFactoryServiceImpl";
 
+    private static IllegalArgumentException initializationException;
     private static ProcessBuilderFactoryService provider;
 
     public static ProcessBuilder newProcessBuilder(KnowledgeBuilder kBuilder) {
@@ -19,8 +20,16 @@ public class ProcessBuilderFactory {
     }
 
     public static synchronized ProcessBuilderFactoryService getProcessBuilderFactoryService() {
-        if (provider == null) {
-            loadProvider();
+        if (provider == null && initializationException == null) {
+            try {
+                loadProvider();
+            } catch (IllegalArgumentException e) {
+                initializationException = e;
+            }
+        }
+        if (initializationException != null) {
+            // KnowledgeBuilderImpl expects an exception to report the origin of the failure
+            throw initializationException;
         }
         return provider;
     }

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -747,11 +747,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     }
 
     private InternalProcessRuntime createProcessRuntime() {
-        try {
-            return ProcessRuntimeFactory.newProcessRuntime(this);
-        } catch ( IllegalArgumentException e ) {
-            return null;
-        }
+        return ProcessRuntimeFactory.newProcessRuntime(this);
     }
 
     public String getEntryPointId() {

--- a/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactory.java
@@ -6,10 +6,15 @@ import org.kie.internal.utils.ServiceRegistryImpl;
 
 public class ProcessRuntimeFactory {
 
+    private static boolean initialized;
     private static ProcessRuntimeFactoryService provider;
 
     public static InternalProcessRuntime newProcessRuntime(StatefulKnowledgeSessionImpl workingMemory) {
-        return getProcessRuntimeFactoryService().newProcessRuntime(workingMemory);
+        ProcessRuntimeFactoryService provider = getProcessRuntimeFactoryService();
+        if (provider == null) {
+            return null;
+        }
+        return provider.newProcessRuntime(workingMemory);
     }
 
     public static synchronized void setProcessRuntimeFactoryService(ProcessRuntimeFactoryService provider) {
@@ -17,8 +22,11 @@ public class ProcessRuntimeFactory {
     }
 
     public static synchronized ProcessRuntimeFactoryService getProcessRuntimeFactoryService() {
-        if (provider == null) {
-            loadProvider();
+        if (!initialized) {
+            initialized = true;
+            try {
+                loadProvider();
+            } catch (IllegalArgumentException e) { }
         }
         return provider;
     }


### PR DESCRIPTION
Some services accessed through the `ServiceRegistry` are not provided by
Drools modules but by jBPM, and have a higher probability of not
actually being in the classpath. `ProcessBuilderFactory` and
`ProcessRuntimeFactory` (try to) load such services when respectively
called during the construction of `KnowledgeBuilderImpl` and
`StatefulKnowledgeSessionImpl`. Trying to load a class is an expensive
operation, especially in the context of a web application where the
classloader will scan all the jars. With Tomcat for example, this
operation is moreover synchronized and can lead to lock contention.

There's also the issue of using exceptions for the regular control flow,
because filling an exception's stacktrace is also quite expensive.

`ProcessBuilderFactory` is modified to only try to load the service once,
and then either stores the service or the exception. The exception can
then be rethrown on subsequent accesses, to keep reporting on the failure
to load the service in `KnowledgeBuilderImpl`.

`ProcessRuntimeFactory` is simply modified to try to load the service once
and return null is the service cannot be loaded, simplifying the control
flow in `StatefulKnowledgeSessionImpl`.
