### PR TITLE
Automating version number in protobuf marshalling

### DIFF
--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -193,13 +193,51 @@
           <excludePackageNames>org.kie.asm*,org.kie.objenesis.*,org.kie.commons.jci.*</excludePackageNames>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <configuration>
           <excludeFilterFile>src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
         </configuration>
+      </plugin>
+      
+      <!-- Version information for marshalling -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <executions>
+          <execution>
+            <id>put-version-in-persister-helper</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+            <configuration>
+              <basedir>${basedir}/src/main/java</basedir>
+              <includes>
+                <include>org/drools/core/marshalling/impl/PersisterHelper.java</include>
+              </includes>
+              <replacements>
+                <replacement>
+                  <token>final static String PROJECT_VERSION = ".*</token>
+                  <value>final static String PROJECT_VERSION = "${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}";</value>
+                </replacement>
+              </replacements>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/PersisterHelper.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/PersisterHelper.java
@@ -46,6 +46,12 @@ import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 
 public class PersisterHelper {
+    
+    // This field is automatically updated by the replacer-plugin, 
+    //  which relies on the following line starting exactly the way
+    // the following line starts
+    final static String PROJECT_VERSION = "6.1.0";
+    
     public static WorkingMemoryAction readWorkingMemoryAction(MarshallerReaderContext context) throws IOException,
                                                                                               ClassNotFoundException {
         int type = context.readShort();
@@ -189,11 +195,12 @@ public class PersisterHelper {
     public static void writeToStreamWithHeader( MarshallerWriteContext context,
                                                 Message payload ) throws IOException {
         ProtobufMessages.Header.Builder _header = ProtobufMessages.Header.newBuilder();
-        // need to automate this version numbering somehow
+        
+        int [] version = getVersion(PROJECT_VERSION);
         _header.setVersion( ProtobufMessages.Version.newBuilder()
-                            .setVersionMajor( 5 )
-                            .setVersionMinor( 4 )
-                            .setVersionRevision( 0 )
+                            .setVersionMajor( version[0] )
+                            .setVersionMinor( version[1] )
+                            .setVersionRevision( version[2] )
                             .build() );
         
         writeStrategiesIndex( context, _header );
@@ -381,5 +388,16 @@ public class PersisterHelper {
                + (((long)b[7]) & 0xFF);
     }    
 
+    static int [] getVersion(String versionString) { 
+       int [] version = new int [3];
+       
+       String [] versionParts = versionString.split("\\.");
+       versionParts[2] = versionParts[2].replaceAll("(\\d+)-.*", "$1");
 
+       for( int i = 0; i < 3; ++i ) { 
+          version[i] = Integer.parseInt(versionParts[i]);
+       }
+       
+       return version;
+    }
 }

--- a/drools-core/src/test/java/org/drools/core/marshalling/impl/VersionTest.java
+++ b/drools-core/src/test/java/org/drools/core/marshalling/impl/VersionTest.java
@@ -1,0 +1,29 @@
+package org.drools.core.marshalling.impl;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class VersionTest {
+
+    @Test
+    public void versionParsingTest() { 
+       int [] version = PersisterHelper.getVersion("6.1.0");
+       assertEquals( "Incorrect major version", 6, version[0]);
+       assertEquals( "Incorrect minor version", 1, version[1]);
+       assertEquals( "Incorrect patch version", 0, version[2]);
+       
+       version = PersisterHelper.getVersion("6.1.0-SNAPSHOT");
+       assertEquals( "Incorrect major version", 6, version[0]);
+       assertEquals( "Incorrect minor version", 1, version[1]);
+       assertEquals( "Incorrect patch version", 0, version[2]);
+
+       version = PersisterHelper.getVersion("6.1.0.Final");
+       assertEquals( "Incorrect major version", 6, version[0]);
+       assertEquals( "Incorrect minor version", 1, version[1]);
+       assertEquals( "Incorrect patch version", 0, version[2]);
+
+       // this should not throw an exception
+       version = PersisterHelper.getVersion(PersisterHelper.PROJECT_VERSION);
+    }
+    
+}


### PR DESCRIPTION
(I had this laying around and figured I should submit it before I forgot about it.. ;) )

The downside of the code is that the replacer-plugin will automatically modify the code after a release. However, that's also kind of the upside. 

Because the `-SNAPSHOT` of the version isn't used (parse-version), the code replacement won't happen until _after_ a release. 
