### PR TITLE
Re-adding a call to setKnowledgeRuntime within StatefulKnowledgeSessionImpl constructor.

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -386,6 +386,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         if ( initInitFactHandle ) {
             initInitialFact(kBase, null);
         }
+        
+        setKnowledgeRuntime(this);
     }
 
     public EntryPoint getEntryPoint(String name) {


### PR DESCRIPTION
It seems as though this call was inadvertently removed
as part of commit 1f8dc327. The method makes a call that
results in the ksession's mbean being created and registered.

Without this call, no ksession mbeans are created.
