### PR TITLE
Infinite loop on fireAllRules after a fact modification

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/LeftTupleSetsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/LeftTupleSetsImpl.java
@@ -189,7 +189,7 @@ public class LeftTupleSetsImpl implements LeftTupleSets {
             } else {
                 LeftTuple current = insertFirst;
                 LeftTuple last = null;
-                while ( current != null ) {
+                while ( current != null && current != last ) {
                     last = current;
                     current = current.getStagedNext();
                 }
@@ -212,7 +212,7 @@ public class LeftTupleSetsImpl implements LeftTupleSets {
             } else {
                 LeftTuple current = deleteFirst;
                 LeftTuple last = null;
-                while ( current != null ) {
+                while ( current != null && current != last ) {
                     last = current;
                     current = current.getStagedNext();
                 }
@@ -235,7 +235,7 @@ public class LeftTupleSetsImpl implements LeftTupleSets {
             } else {
                 LeftTuple current = updateFirst;
                 LeftTuple last = null;
-                while ( current != null ) {
+                while ( current != null && current != last ) {
                     last = current;
                     current = current.getStagedNext();
                 }

--- a/drools-core/src/main/java/org/drools/core/common/RightTupleSetsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/RightTupleSetsImpl.java
@@ -185,7 +185,7 @@ public class RightTupleSetsImpl implements RightTupleSets {
         } else {
             RightTuple current = insertFirst;
             RightTuple last = null;
-            while ( current != null ) {
+            while ( current != null && current != last ) {
                 last = current;
                 current = current.getStagedNext();
             }
@@ -204,7 +204,7 @@ public class RightTupleSetsImpl implements RightTupleSets {
         } else {
             RightTuple current = deleteFirst;
             RightTuple last = null;
-            while ( current != null ) {
+            while ( current != null && current != last ) {
                 last = current;
                 current = current.getStagedNext();
             }
@@ -223,7 +223,7 @@ public class RightTupleSetsImpl implements RightTupleSets {
         } else {
             RightTuple current = updateFirst;
             RightTuple last = null;
-            while ( current != null ) {
+            while ( current != null && current != last ) {
                 last = current;
                 current = current.getStagedNext();
             }


### PR DESCRIPTION
When I run drools with a rather huge knowledge base (> 10.000 rules) then - from time to time - I end up with drools running in an infinite loop in class LeftTupleSetsImpl. The scenario is as follows:
// Create a StateFulKnowledgeSession kSession
// Insert some facts into kSession
// kSession.fireAllRules()
// Retrieve some facts from the kSession
// Update values of the facts
// Notify drools about the updated facts  (using kSession.update() and the appropriate FactHandles)
// kSession.fireAllRules() again <-- despite of identical input values, sometimes fireAllRules() succeeds - but somtimes this ends up in an infinite loop in the class LeftTupleSetsImpl
I have not much ideas about the internals of Drools but checked in the debugger where this infinite loop happens. I always end up in the while loop (which I modified in the commit). Drools never exits this loop, because current.getStagedNext() returns a reference to current, or in other words: "current == current.getStagedNext()" is true and current will never become null.
When I modify the loop like in the commit I have a drools version that does exit the loop and that does then work as expected. I am really not sure if this modification of the while loop is ok or if this should rather be an illegal state and the root error is caused elsewhere?
Unfortunately I can not reproduce this error in a smaller scenario but only with production data that I can't provide to you.
Thank you for evaluating this (possible) fix!
