### PR TITLE
BZ-1096128: add reproducer for included and including KieModule change

### DIFF
--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -20,6 +20,7 @@ import org.kie.api.runtime.KieSession;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -232,7 +233,8 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
 
         assertEquals(results.length, list.size());
         for (Object result : results) {
-            assertTrue( list.contains( result ) );
+            assertTrue( String.format("Expected to contain: %s, got: %s", result, Arrays.toString(list.toArray())),
+                        list.contains( result ) );
         }
     }
 
@@ -370,5 +372,59 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
 
         KieSession ksession2 = kieContainer.newKieSession("KSession2");
         checkKSession(ksession2, "rule2");
+    }
+
+    @Test
+    public void testScanIncludedAndIncludingDependency() throws Exception {
+        MavenRepository repository = getMavenRepository();
+        KieServices ks = KieServices.Factory.get();
+
+        ReleaseId containerReleaseId = KieServices.Factory.get().newReleaseId( "org.kie", "test-container", "1.0.0-SNAPSHOT" );
+        ReleaseId includedReleaseId = KieServices.Factory.get().newReleaseId( "org.kie", "test-project", "1.0.0-SNAPSHOT" );
+
+        InternalKieModule kJar1 = createKieJar(ks, includedReleaseId, "rule1");
+        repository.deployArtifact(includedReleaseId, kJar1, createKPom(fileManager, includedReleaseId));
+
+        resetFileManager();
+
+        InternalKieModule containerKJar = createIncludingKJar(containerReleaseId, includedReleaseId, "ruleX");
+        repository.deployArtifact(containerReleaseId, containerKJar, createKPom(fileManager, containerReleaseId, includedReleaseId));
+
+        KieContainer kieContainer = ks.newKieContainer(containerReleaseId);
+        KieSession ksession = kieContainer.newKieSession("KSession2");
+        checkKSession(ksession, "rule1", "ruleX");
+
+        resetFileManager();
+
+        KieScanner scanner = ks.newKieScanner(kieContainer);
+
+        InternalKieModule kJar2 = createKieJar(ks, includedReleaseId, "rule2");
+        repository.deployArtifact(includedReleaseId, kJar2, createKPom(fileManager, includedReleaseId));
+        resetFileManager();
+
+        InternalKieModule containerKJar2 = createIncludingKJar(containerReleaseId, includedReleaseId, "ruleY");
+        repository.deployArtifact(containerReleaseId, containerKJar2, createKPom(fileManager, containerReleaseId, includedReleaseId));
+        resetFileManager();
+
+        scanner.scanNow();
+
+        KieSession ksession2 = kieContainer.newKieSession("KSession2");
+        checkKSession(ksession2, "rule2", "ruleY");
+    }
+
+    private InternalKieModule createIncludingKJar(ReleaseId containerReleaseId, ReleaseId includedReleaseId, String rule) {
+        KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem();
+        String file = "org/test/" + rule + ".drl";
+        kfs.write("src/main/resources/KBase1/" + file, createDRL(rule));
+
+        KieModuleModel kproj = ks.newKieModuleModel();
+        kproj.newKieBaseModel("KBase2").addInclude("KBase1").newKieSessionModel("KSession2");
+        kfs.writeKModuleXML(kproj.toXML());
+        kfs.writePomXML(getPom(containerReleaseId, includedReleaseId));
+
+        KieBuilder kieBuilder = ks.newKieBuilder(kfs);
+        assertTrue(kieBuilder.buildAll().getResults().getMessages().isEmpty());
+        return (InternalKieModule) kieBuilder.getKieModule();
     }
 }


### PR DESCRIPTION
Adding reproducer for problem with changes in a KieModule which includes KieBase from another KieModule not being picked up. 

I have experienced this behaviour also with workbench and KieScanner.
