### PR TITLE
adding some I18N test cases

### DIFF
--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/test_I18nPerson_utf8_forTestNewClassPathResource.drl
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/test_I18nPerson_utf8_forTestNewClassPathResource.drl
@@ -1,0 +1,12 @@
+package org.drools.compiler.i18ntest
+
+import org.drools.compiler.I18nPerson
+
+global java.util.List list
+
+rule "名称 is 山田花子"
+    when
+        p : I18nPerson( 名称 == "山田花子" )
+    then
+        list.add( "名称は山田花子です" );
+end

--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/UnicodeInCSVTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/UnicodeInCSVTest.java
@@ -1,0 +1,89 @@
+package org.drools.decisiontable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.compiler.compiler.DecisionTableFactory;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.DecisionTableConfiguration;
+import org.kie.internal.builder.DecisionTableInputType;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.api.command.Command;
+import org.kie.internal.command.CommandFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.io.ResourceType;
+
+public class UnicodeInCSVTest {
+
+	@Test
+    public void testUnicodeCSVDecisionTable() throws FileNotFoundException {
+
+        DecisionTableConfiguration dtconf = KnowledgeBuilderFactory.newDecisionTableConfiguration();
+        dtconf.setInputType(DecisionTableInputType.CSV);
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add(ResourceFactory.newClassPathResource("unicode.csv", getClass()), ResourceType.DTABLE, dtconf);
+        if (kbuilder.hasErrors()) {
+            System.out.println(kbuilder.getErrors().toString());
+            System.out.println(DecisionTableFactory.loadFromInputStream(getClass().getResourceAsStream("unicode.xls"), dtconf));
+            fail("Cannot build CSV decision table containing utf-8 characters\n" + kbuilder.getErrors().toString() );
+        }
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+        
+        StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+        
+        List<Command<?>> commands = new ArrayList<Command<?>>();
+        List<Člověk> dospělí = new ArrayList<Člověk>();
+        commands.add(CommandFactory.newSetGlobal("dospělí", dospělí));
+        Člověk Řehoř = new Člověk();
+        Řehoř.setVěk(30);
+        Řehoř.setJméno("Řehoř");
+        commands.add(CommandFactory.newInsert(Řehoř));
+        commands.add(CommandFactory.newFireAllRules());
+
+        ksession.execute(CommandFactory.newBatchExecution(commands));
+
+        // people with age greater than 18 should be added to list of adults
+        assertNotNull(kbase.getRule("org.drools.decisiontable", "přidej k dospělým"));
+        assertEquals(dospělí.size(), 5);
+        assertEquals(dospělí.iterator().next().getJméno(), "Řehoř");
+
+        assertNotNull(kbase.getRule("org.drools.decisiontable", "привет мир"));
+        assertNotNull(kbase.getRule("org.drools.decisiontable", "你好世界"));
+        assertNotNull(kbase.getRule("org.drools.decisiontable", "hallå världen"));
+        assertNotNull(kbase.getRule("org.drools.decisiontable", "مرحبا العالم"));
+
+        ksession.dispose();
+    }
+	
+    public static class Člověk {
+
+        private int věk;
+        private String jméno;
+
+        public void setVěk(int věk) {
+            this.věk = věk;
+        }
+
+        public int getVěk() {
+            return věk;
+        }
+
+        public void setJméno(String jméno) {
+            this.jméno = jméno;
+        }
+
+        public String getJméno() {
+            return jméno;
+        }
+    }
+}

--- a/drools-decisiontables/src/test/resources/org/drools/decisiontable/unicode.csv
+++ b/drools-decisiontables/src/test/resources/org/drools/decisiontable/unicode.csv
@@ -1,0 +1,14 @@
+"RuleSet","org.drools.decisiontable",
+"Import","org.drools.decisiontable.UnicodeInCSVTest.Člověk",
+"Variables","java.util.List dospělí",
+,,
+"RuleTable Test použití češtiny",,
+"NAME","CONDITION","ACTION"
+,"$člověk : Člověk",
+,"$param > 18","dospělí.add($člověk);"
+"název pravidla","starší než 18 let","přidat do seznamu dospělých"
+"přidej k dospělým","věk","X"
+"привет мир","věk","X"
+"你好世界","věk","X"
+"hallå världen","věk","X"
+"مرحبا العالم","věk","X"


### PR DESCRIPTION
All of these test cases run successfully with UTF-8 environment (hence in daily build).

But some of these test cases fail with -Dfile.encoding=MS932.
