### PR TITLE
[DROOLS-495] maven-plugin now executes also process-test-resources phase

### DIFF
--- a/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -9,9 +9,8 @@
             <configuration>
                 <phases>
                     <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
-                    <compile>
-                        org.apache.maven.plugins:maven-compiler-plugin:compile,org.kie:kie-maven-plugin:build
-                    </compile>
+                    <compile>org.apache.maven.plugins:maven-compiler-plugin:compile,org.kie:kie-maven-plugin:build</compile>
+                    <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
                     <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
                     <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
                     <package>org.apache.maven.plugins:maven-jar-plugin:jar</package>


### PR DESCRIPTION
- this phase is needed in order to copy the test resources into target/,
  so they can be actually used for testing.
