### PR TITLE
Fixed compareTo method to adhere to equals contract

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/OrderedTransactionSynchronization.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/OrderedTransactionSynchronization.java
@@ -21,6 +21,10 @@ public abstract class OrderedTransactionSynchronization implements TransactionSy
         if (this.getClass() != o.getClass()) {
             return this.getOrder().compareTo(o.getOrder()+1);
         }
-        return this.getOrder().compareTo(o.getOrder());
+        int result = this.getOrder().compareTo(o.getOrder());
+        if (result == 0 && !this.equals(o)) {
+        	return 1;
+        }
+        return result;
     }
 }


### PR DESCRIPTION
There is an issue with creating multiple runtime engines in one transaction. When the DisposeSessionTransactionSynchronization is registered for the second runtime engine, it never gets added to the TransactionSynchronizationContainer. This is because the container uses a TreeSet, and _all_ instances of DisposeSessionTransactionSynchronization are equals (via the compareTo method) from the TreeSet perspective[1].

This fix alter the compareTo method to fallback to .equals if the order is the same on the objects. This way we can register multiple DisposeSessionTransactionSynchronizations in one TransactionSynchronizationContainer.

[1]From the TreeSet Javadocs: ... a TreeSet instance performs all element comparisons using its compareTo (or compare) method, so two elements that are deemed equal by this method are, from the standpoint of the set, equal.
