### PR TITLE
Bugfix for DROOLS-354 and DROOLS-540

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -221,6 +221,7 @@ public class ClasspathKieProject extends AbstractKieProject {
         File actualZipFile = new File( rootPath );
         if ( !actualZipFile.exists() ) {
             log.error( "Unable to load pom.properties from" + rootPath + " as jarPath cannot be found\n" + rootPath );
+            return null;
         }
 
         ZipFile zipFile = null;

--- a/drools-core/src/main/java/org/drools/core/util/IoUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/IoUtils.java
@@ -326,6 +326,8 @@ public class IoUtils {
         String ic = urlPath.substring( Math.max( 0, colonIndex - 2 ), colonIndex + 1 );
         if  ( ic.matches( "\\/[A-Z]:" ) ) {
             return urlPath.substring( colonIndex - 2 );
+        } else if  ( ic.matches( "[A-Z]:" ) ) {
+            return urlPath.substring( colonIndex - 1 );
         } else {
             return urlPath.substring( colonIndex + 1 );
         }


### PR DESCRIPTION
This pull request includes a bugfix for Drools issues DROOLS-354 and DROOLS-540 on Windows using WildFly application server.

Essentially, the problem is, that the path obtained via WildFly VFS is a path (so there is no leading "/"), but the code in IoUtils checks for the leading "/", otherwise the drive letter gets stripped creating a drive-relative path. This works well when WildFly's working directory and the VFS target file is on the same drive, but fails if two different drives are involved.
