### PR TITLE
Fixes for kie-ci tests

### DIFF
--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -169,4 +169,52 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+      <testResource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <systemProperties>
+              <kie.maven.settings.custom>${project.build.testOutputDirectory}/kie-ci-tests-custom-settings.xml</kie.maven.settings.custom>
+            </systemProperties>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <!-- The custom maven repo dir needs to exist before the test execution -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-custom-maven-repo-dir</id>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <tasks>
+                <mkdir dir="${project.build.directory}/testing-maven-repo"/>
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/kie-ci/src/main/java/org/kie/scanner/management/MBeanUtils.java
+++ b/kie-ci/src/main/java/org/kie/scanner/management/MBeanUtils.java
@@ -13,16 +13,20 @@ public class MBeanUtils {
 
     public static final String   MBEANS_PROPERTY = "kie.scanner.mbeans";
     private static final Logger  logger          = LoggerFactory.getLogger(MBeanUtils.class);
-    private static final boolean IS_MBEAN_ENABLED;
+    private static boolean       mbeanEnabled;
     private static MBeanServer   mbeanServer;
 
     static {
         String prop = System.getProperty(MBEANS_PROPERTY);
-        IS_MBEAN_ENABLED = prop != null && (prop.equalsIgnoreCase("enabled") || prop.equalsIgnoreCase("true"));
+        mbeanEnabled = prop != null && (prop.equalsIgnoreCase("enabled") || prop.equalsIgnoreCase("true"));
     }
 
     public static boolean isMBeanEnabled() {
-        return IS_MBEAN_ENABLED;
+        return mbeanEnabled;
+    }
+
+    public static void setMBeanEnabled(boolean mbeanEnabled) {
+        MBeanUtils.mbeanEnabled = mbeanEnabled;
     }
 
     public static synchronized <T> void registerMBean(T mbean,

--- a/kie-ci/src/test/filtered-resources/kie-ci-tests-custom-settings.xml
+++ b/kie-ci/src/test/filtered-resources/kie-ci-tests-custom-settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>${project.build.directory}/testing-maven-repo</localRepository>
+
+</settings>

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleIncrementalCompilationTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleIncrementalCompilationTest.java
@@ -14,7 +14,6 @@ import org.kie.internal.builder.InternalKieBuilder;
 
 import static org.junit.Assert.*;
 
-@Ignore
 public class KieModuleIncrementalCompilationTest extends AbstractKieCiTest {
 
     @Test

--- a/kie-ci/src/test/java/org/kie/scanner/KieScannerIncrementalCompilationTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieScannerIncrementalCompilationTest.java
@@ -21,7 +21,6 @@ import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
-@Ignore
 public class KieScannerIncrementalCompilationTest extends AbstractKieCiTest {
 
     private final int FIRST_VALUE = 5;

--- a/kie-ci/src/test/java/org/kie/scanner/management/KieScannerMBeanTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/management/KieScannerMBeanTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.kie.scanner.MavenRepository.getMavenRepository;
 
-
 public class KieScannerMBeanTest extends AbstractKieCiTest {
     
     private FileManager fileManager;
@@ -33,10 +32,11 @@ public class KieScannerMBeanTest extends AbstractKieCiTest {
 
     @Before
     public void setUp() throws Exception {
+        MBeanUtils.setMBeanEnabled(true);
         System.setProperty(MBeanUtils.MBEANS_PROPERTY, "enabled");
         this.fileManager = new FileManager();
         this.fileManager.setUp();
-        ReleaseId releaseId = KieServices.Factory.get().newReleaseId("org.kie", "scanner-test", "1.0-SNAPSHOT");
+        ReleaseId releaseId = KieServices.Factory.get().newReleaseId("org.kie", "scanner-mbean-test", "1.0-SNAPSHOT");
         kPom = createKPom(fileManager, releaseId);
     }
 
@@ -44,12 +44,13 @@ public class KieScannerMBeanTest extends AbstractKieCiTest {
     public void tearDown() throws Exception {
         this.fileManager.tearDown();
         System.setProperty(MBeanUtils.MBEANS_PROPERTY, "");
+        MBeanUtils.setMBeanEnabled(false);
     }
     
-    @Test @Ignore
+    @Test
     public void testKScannerMBean() throws Exception {
         KieServices ks = KieServices.Factory.get();
-        ReleaseId releaseId = ks.newReleaseId("org.kie", "scanner-test", "1.0-SNAPSHOT");
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "scanner-mbean-test", "1.0-SNAPSHOT");
 
         InternalKieModule kJar1 = createKieJar(ks, releaseId, "rule1", "rule2");
         KieContainer kieContainer = ks.newKieContainer(releaseId);


### PR DESCRIPTION
- fix failing test + un-ignore other KieScanner tests
- configure the tests to use custom maven repo to avoid using ~/.m2. This way the tests are more isolated and the result of the tests does not depend on the contents of local ~/.m2 repo on the particular machine.
