### PR TITLE
StaticImports are copied into new package instance

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -1062,6 +1062,11 @@ public class KnowledgeBaseImpl
         // Merge imports
         final Map<String, ImportDeclaration> imports = pkg.getImports();
         imports.putAll(newPkg.getImports());
+        
+        // Merge static imports
+        for (String staticImport : newPkg.getStaticImports()) {
+            pkg.addStaticImport(staticImport);
+        }
 
         String lastIdent = null;
         String lastType = null;

--- a/drools-core/src/test/java/org/drools/core/impl/KnowledgeBaseImplTest.java
+++ b/drools-core/src/test/java/org/drools/core/impl/KnowledgeBaseImplTest.java
@@ -1,0 +1,34 @@
+package org.drools.core.impl;
+
+import org.drools.core.definitions.InternalKnowledgePackage;
+import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KnowledgeBaseImplTest {
+
+    @Test
+    public void testStaticImports() {
+
+        KnowledgeBaseImpl base = new KnowledgeBaseImpl( "default", null);
+
+        // assume empty knowledge base
+        assertTrue( base.getPackages().length == 0 );
+
+        // add package with function static import into knowledge base
+        InternalKnowledgePackage pkg = new KnowledgePackageImpl( "org.drools.test" );
+        pkg.addStaticImport( "org.drools.function.myFunction" );
+        base.addPackage( pkg );
+
+        // verify package has been added
+        assertTrue( base.getPackages().length == 1 );
+
+        // retrieve copied and merged package from the base
+        InternalKnowledgePackage copy = base.getPackage( "org.drools.test" );
+        assertEquals( Collections.singleton( "org.drools.function.myFunction" ), copy.getStaticImports() );
+    }
+}


### PR DESCRIPTION
During the knowledge base process, constructed KnowledgePackages are cloned and then also manually copied into new instances. During that merge some information losts, e.g. record of static imports of function.

This pull request fixes the merge function by copying also the static imports. The functionality is required for developers (as me) programatically dealing with knowledge packages inside of knowledge base.

If the pull request will be approved I will publish another to merge it into upcoming version of 6.2.x
