### PR TITLE
[DROOLS-512] Re-adding call to setKnowledgeRuntime in StatefulKnowledgeS...

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -398,7 +398,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         //runtimeServices = new HashMap<ResourceType, KieRuntimeManager>();
 		
-        setKnowledgeRuntime(this);
+        initManagementBeans();
     }
 
     public <T> T getKieRuntime(Class<T> cls) {

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -397,6 +397,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         }
 
         //runtimeServices = new HashMap<ResourceType, KieRuntimeManager>();
+		
+        setKnowledgeRuntime(this);
     }
 
     public <T> T getKieRuntime(Class<T> cls) {


### PR DESCRIPTION
...essionImpl constructor.

It seems as though this call was inadvertently removed
as part of commit 1f8dc32. The method makes a call that
results in the ksession's mbean being created and registered.

Without this call, no ksession mbeans are created.
