### PR TITLE
Build drools-core before drools-beliefs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
   </scm>
 
   <modules>
-      <module>drools-beliefs</module>
     <module>drools-core</module>
+    <module>drools-beliefs</module>
     <module>drools-reteoo</module>
     <module>drools-compiler</module>
     <module>drools-jsr94</module>


### PR DESCRIPTION
Without this change, a compilation error can occur, because
drools-beliefs depends on drools-core.
