### PR TITLE
Fixed wrong quotes in documentation

### DIFF
--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/LanguageReference/DSL.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/LanguageReference/DSL.xml
@@ -106,7 +106,7 @@
       <title>Example with quotes</title>
 
       <programlisting>[when]something is "{colour}"=Something(colour=="{colour}")
-[when]another {state} thing=OtherThing(state=="{state}"</programlisting>
+[when]another {state} thing=OtherThing(state=="{state}")</programlisting>
     </example>
 
     <para>It is a good idea to avoid punctuation (other than quotes or

--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
@@ -444,7 +444,7 @@ end</programlisting>
 when 
     Alarm()
 then
-    send( "priority high - we have an alarm” );
+    send( "priority high - we have an alarm" );
 end 
 
 rule "weekend are low priority"
@@ -453,7 +453,7 @@ rule "weekend are low priority"
 when 
     Alarm()
 then
-    send( "priority low - we have an alarm” );
+    send( "priority low - we have an alarm" );
 end</programlisting>
     </example>
   </section>


### PR DESCRIPTION
It was the wrong quote character that will be removed when converted to html, with will fix it.
