### PR TITLE
Documentation typo fix.

### DIFF
--- a/drools-docs/drools-expert-docs/src/main/docbook/en-US/ApiReference/KieBuilding.xml
+++ b/drools-docs/drools-expert-docs/src/main/docbook/en-US/ApiReference/KieBuilding.xml
@@ -131,10 +131,10 @@ KieContainer kContainer = kieServices.getKieClasspathContainer();</programlistin
         xmlns="http://jboss.org/kie/6.0.0/kmodule"&gt;
   &lt;kbase name="KBase1" default="true" eventProcessingMode="cloud" equalsBehavior="equality" declarativeAgenda="enabled" packages="org.domain.pkg1"&gt;
     &lt;ksession name="KSession2_1" type="stateful" default="true/"&gt;
-    &lt;ksession name="KSession2_1" type="stateless" default="false/"&gt;
+    &lt;ksession name="KSession2_2" type="stateless" default="false/"&gt;
   &lt;/kbase&gt;
   &lt;kbase name="KBase2" default="false" eventProcessingMode="stream" equalsBehavior="equality" declarativeAgenda="enabled" packages="org.domain.pkg2, org.domain.pkg3" includes="KBase1"&gt;
-    &lt;ksession name="KSession2_1" type="stateful" default="false" clockType="realtime"&gt;
+    &lt;ksession name="KSession3_1" type="stateful" default="false" clockType="realtime"&gt;
       &lt;fileLogger file="drools.log" threaded="true" interval="10"/&gt;
       &lt;workItemHandlers&gt;
         &lt;workItemHandler name="name" type="org.domain.WorkItemHandler"/&gt;


### PR DESCRIPTION
KieSession names must be unique. Also session with name KSession2_2 is mentioned later in documentation, so this was a copy-paste mistake I think. 
