### PR TITLE
Improve logging format

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
@@ -67,7 +67,7 @@ public class FileKieModule extends AbstractKieModule implements InternalKieModul
     }
 
     public String toString() {
-        return "FileKieModule[ ReleaseId=" + getReleaseId() + "file=" + file + "]";
+        return "FileKieModule[releaseId=" + getReleaseId() + ",file=" + file + "]";
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -69,7 +69,7 @@ public class KieRepositoryImpl
 
     public void addKieModule(KieModule kieModule) {
         kieModuleRepo.store(kieModule);
-        log.info("KieModule was added:" + kieModule);
+        log.info("KieModule was added: " + kieModule);
     }
 
     public KieModule getKieModule(ReleaseId releaseId) {
@@ -170,13 +170,13 @@ public class KieRepositoryImpl
     }
 
     public KieModule addKieModule(Resource resource, Resource... dependencies) {
-        log.info("Adding KieModule from resource :" + resource);
+        log.info("Adding KieModule from resource: " + resource);
         KieModule kModule = getKieModule(resource);
         if (dependencies != null && dependencies.length > 0) {
             for (Resource depRes : dependencies) {
                 InternalKieModule depKModule = (InternalKieModule) getKieModule(depRes);
                 ((InternalKieModule) kModule).addKieDependency(depKModule);
-                log.info("Adding KieModule dependency from resource :" + resource);
+                log.info("Adding KieModule dependency from resource: " + resource);
             }
         }
 
@@ -201,7 +201,7 @@ public class KieRepositoryImpl
                     urlPath = "jar:" + urlPath + "!/" + KieModuleModelImpl.KMODULE_JAR_PATH;
                 }
                 kModule = ClasspathKieProject.fetchKModule(new URL(urlPath));
-                log.debug("fetched KieModule from resource :" + resource);
+                log.debug("Fetched KieModule from resource: " + resource);
             } else {
                 // might be a byte[] resource
                 MemoryFileSystem mfs = MemoryFileSystem.readFromJar(res.getInputStream());
@@ -215,7 +215,7 @@ public class KieRepositoryImpl
             }
             return kModule;
         } catch (Exception e) {
-            throw new RuntimeException("Unable to fetch module from resource :" + res, e);
+            throw new RuntimeException("Unable to fetch module from resource: " + res, e);
         }
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/MemoryKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/MemoryKieModule.java
@@ -70,7 +70,7 @@ public class MemoryKieModule extends AbstractKieModule
     }
 
     public String toString() {
-        return "MemoryKieModule[ ReleaseId=" + getReleaseId() + "]";
+        return "MemoryKieModule[releaseId=" + getReleaseId() + "]";
     }
 
     MemoryKieModule cloneForIncrementalCompilation(ReleaseId releaseId, KieModuleModel kModuleModel, MemoryFileSystem newFs) {

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
@@ -50,6 +50,6 @@ public class ZipKieModule extends AbstractKieModule implements InternalKieModule
     }
 
     public String toString() {
-        return "ZipKieModule[ ReleaseId=" + getReleaseId() + "file=" + file + "]";
+        return "ZipKieModule[releaseId=" + getReleaseId() + ",file=" + file + "]";
     }
 }

--- a/drools-core/src/main/java/org/drools/core/io/impl/ByteArrayResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/ByteArrayResource.java
@@ -125,7 +125,7 @@ public class ByteArrayResource extends BaseResource
     }
     
     public String toString() {
-        return "[ByteArrayResource resource=" + Arrays.toString(this.bytes) + "]";
+        return "ByteArrayResource[resource=" + Arrays.toString(this.bytes) + "]";
     }
 
 

--- a/drools-core/src/main/java/org/drools/core/io/impl/ClassPathResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/ClassPathResource.java
@@ -307,7 +307,7 @@ public class ClassPathResource extends BaseResource
     }
 
     public String toString() {
-        return "[ClassPathResource path='" + this.path + "']";
+        return "ClassPathResource[path=" + this.path + "]";
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/io/impl/DescrResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/DescrResource.java
@@ -100,7 +100,7 @@ public class DescrResource extends BaseResource implements InternalResource, Ext
     }
     
     public String toString() {
-        return "[DescrResource resource=" + this.descr + "']";
+        return "DescrResource[resource=" + this.descr + "]";
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/io/impl/EncodedResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/EncodedResource.java
@@ -135,7 +135,7 @@ public class EncodedResource  extends BaseResource implements InternalResource, 
     }
     
     public String toString() {
-        return "[EncodedResource resource=" + this.resource + " encoding='" + this.encoding + "']";
+        return "EncodedResource[resource=" + this.resource + ",encoding=" + this.encoding + "]";
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/io/impl/FileSystemResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/FileSystemResource.java
@@ -172,7 +172,7 @@ public class FileSystemResource  extends BaseResource implements InternalResourc
     }
     
     public String toString() {
-        return "[FileResource file='" + this.file.toString() + "']";
+        return "FileResource[file=" + this.file.toString() + "]";
     }
     
     public boolean equals(Object object) {

--- a/drools-core/src/main/java/org/drools/core/io/impl/ReaderResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/ReaderResource.java
@@ -115,6 +115,6 @@ public class ReaderResource  extends BaseResource implements InternalResource {
     }
     
     public String toString() {
-        return "[ReaderResource resource=" + this.reader + " encoding='" + this.encoding + "']";
+        return "ReaderResource[resource=" + this.reader + ",encoding=" + this.encoding + "]";
     }
 }

--- a/drools-core/src/main/java/org/drools/core/io/impl/UrlResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/UrlResource.java
@@ -226,9 +226,9 @@ public class UrlResource extends BaseResource
             fout.flush();
             fout.close();
             in.close();
-
+            
             File cacheFile = getCacheFile();
-            fi.renameTo(cacheFile);
+            fi.renameTo(cacheFile);            
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -410,7 +410,7 @@ public class UrlResource extends BaseResource
     }
 
     public String toString() {
-        return "[UrlResource path='" + this.url.toString() + "']";
+        return "UrlResource[path=" + this.url.toString() + "]";
     }
 
     private static File getCacheDir() {


### PR DESCRIPTION
- space _after_ colon
- using commons-lang ToStringBuilder to produce consistent object
  descriptions in the form of ClassName[attr1=val1,attr2=val2].

This commit will turn the old ouput that looks like:

> ```
> [main] INFO  Adding KieModule from resource :[ByteArrayResource resource=[0, 8]]
> [main] INFO  KieModule was added:MemoryKieModule[ ReleaseId=org.kie:test-upgrade:1.1.0]
> ```

into:

> ```
> [main] INFO  Adding KieModule from resource: ByteArrayResource[resource={0,8}]
> [main] INFO  KieModule was added: MemoryKieModule[releaseId=org.kie:test-upgrade:1.1.0]
> ```
