### PR TITLE
DROOLS-696 - default constructor added to KnowledgeBaseAdapter

### DIFF
--- a/knowledge-api-legacy5-adapter/src/main/java/org/drools/impl/adapters/KnowledgeBaseAdapter.java
+++ b/knowledge-api-legacy5-adapter/src/main/java/org/drools/impl/adapters/KnowledgeBaseAdapter.java
@@ -33,6 +33,8 @@ public class KnowledgeBaseAdapter implements org.drools.KnowledgeBase, Externali
 
     private final Map<KnowledgeBaseEventListener, KieBaseEventListener> listeners = new HashMap<KnowledgeBaseEventListener, KieBaseEventListener>();
 
+    public KnowledgeBaseAdapter() {}
+
     public KnowledgeBaseAdapter(KnowledgeBase delegate) {
         this.delegate = delegate;
     }


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/DROOLS-696
