### PR TITLE
Updates to DrlDumper for positional args, timer, and duration.

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AttributeDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AttributeDescr.java
@@ -75,6 +75,11 @@ public class AttributeDescr extends BaseDescr {
             // needs escaping
             return "\""+this.value+"\"";
         }
+
+        if(this.name.equals("timer") || this.name.equals("duration")) {
+            return "("+this.value+")";
+        }
+
         return this.value;
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/PatternDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/PatternDescr.java
@@ -101,6 +101,35 @@ public class PatternDescr extends AnnotatedBaseDescr
         return this.constraint;
     }
 
+    public List< ? extends BaseDescr> getPositionalConstraints() {
+        return this.doGetConstraints(ExprConstraintDescr.Type.POSITIONAL);
+    }
+
+    public List< ? extends BaseDescr> getSlottedConstraints() {
+        return this.doGetConstraints(ExprConstraintDescr.Type.NAMED);
+    }
+
+    private List< ? extends BaseDescr> doGetConstraints(ExprConstraintDescr.Type type) {
+        List<BaseDescr> returnList = new ArrayList<BaseDescr>();
+        for(BaseDescr descr : this.constraint.getDescrs()) {
+
+            // if it is a ExprConstraintDescr - check the type
+            if(descr instanceof ExprConstraintDescr) {
+                ExprConstraintDescr desc = (ExprConstraintDescr) descr;
+                if(desc.getType().equals(type)) {
+                    returnList.add(desc);
+                }
+            } else {
+                // otherwise, assume 'NAMED'
+                if(type.equals(ExprConstraintDescr.Type.NAMED)) {
+                    returnList.add(descr);
+                }
+            }
+        }
+
+        return returnList;
+    }
+
     public boolean isInternalFact() {
         return this.getSource() != null && !(this.getSource() instanceof EntryPointDescr);
     }

--- a/drools-compiler/src/main/resources/org/drools/compiler/lang/drl.mvel
+++ b/drools-compiler/src/main/resources/org/drools/compiler/lang/drl.mvel
@@ -73,7 +73,7 @@ then
 }forall( @includeNamed{"cedchildren"; list=base.descrs; connect=""} )@elseif{ base instanceof EvalDescr }@comment{    
 }eval( @{base.content} )@elseif{ base instanceof NamedConsequenceDescr }@comment{
 }@if{base.breaking}break@else{}do@end{}[@{base.text}] @elseif{ base instanceof PatternDescr }@comment{
-}@if{base.identifier!=null}@{base.identifier} :@if{base.unification}=@end{} @end{}@code{topAcc=(base.source instanceof AccumulateDescr && "Object[]".equals(base.objectType))}@if{!topAcc}@{base.objectType}( @foreach{constr:base.descrs}@{constr}@end{", "} ) @foreach{b:base.behaviors}| @{b.type}:@{b.subType}(@foreach{p:b.params}@{p}@end{", "})@end{}@end{}@includeNamed{"psource";source=base.source;topLevelAcc=topAcc;constrs=base.descrs}@end{}@end{}
+}@if{base.identifier!=null}@{base.identifier} :@if{base.unification}=@end{} @end{}@code{topAcc=(base.source instanceof AccumulateDescr && "Object[]".equals(base.objectType))}@if{!topAcc}@{base.objectType}( @foreach{constr:base.positionalConstraints}@{constr}@end{", "}@if{base.positionalConstraints.size()>0}; @end{}@foreach{constr:base.slottedConstraints}@{constr}@end{", "} ) @foreach{b:base.behaviors}| @{b.type}:@{b.subType}(@foreach{p:b.params}@{p}@end{", "})@end{}@end{}@includeNamed{"psource";source=base.source;topLevelAcc=topAcc;constrs=base.descrs}@end{}@end{}
 
 @comment{***************************************************************
                        CONDITIONAL ELEMENT CHILD TEMPLATE


### PR DESCRIPTION
Updates to make the DrlDumper correctly print positional arguments as well as 'timer' and 'duration' rule attributes.
