### PR TITLE
[DROOLS-729] Android support

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -196,7 +196,7 @@ public class ClasspathKieProject extends AbstractKieProject {
             rootPath = IoUtils.asSystemSpecificPath( rootPath, rootPath.lastIndexOf( ':' ) );
         }
 
-        if ( urlPathToAdd.endsWith( ".jar" ) || urlPathToAdd.endsWith( "/content" ) ) {
+        if ( urlPathToAdd.endsWith( ".apk" ) || urlPathToAdd.endsWith( ".jar" ) || urlPathToAdd.endsWith( "/content" ) ) {
             pomProperties = getPomPropertiesFromZipFile(rootPath);
         } else {
             pomProperties = getPomPropertiesFromFileSystem(rootPath);

--- a/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorCache.java
+++ b/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorCache.java
@@ -16,6 +16,8 @@
 
 package org.drools.core.base;
 
+import org.drools.core.util.ByteArrayClassLoader;
+import org.drools.core.util.ClassUtils;
 import org.drools.core.util.asm.ClassFieldInspector;
 
 import java.security.ProtectionDomain;
@@ -152,7 +154,10 @@ public class ClassFieldAccessorCache {
             if ( parentClassLoader == null ) {
                 throw new RuntimeException( "ClassFieldAccessorFactory cannot have a null parent ClassLoader" );
             }
-            this.byteArrayClassLoader = new ByteArrayClassLoader( parentClassLoader );
+            this.byteArrayClassLoader = ClassUtils.isAndroid() ?
+                    (ByteArrayClassLoader) ClassUtils.instantiateObject(
+                            "org.drools.android.MultiDexClassLoader", null, parentClassLoader) :
+                    new DefaultByteArrayClassLoader( parentClassLoader );
         }
 
         public ByteArrayClassLoader getByteArrayClassLoader() {
@@ -223,8 +228,8 @@ public class ClassFieldAccessorCache {
 
     }
 
-    public static class ByteArrayClassLoader extends ClassLoader {
-        public ByteArrayClassLoader(final ClassLoader parent) {
+    public static class DefaultByteArrayClassLoader extends ClassLoader implements ByteArrayClassLoader {
+        public DefaultByteArrayClassLoader(final ClassLoader parent) {
             super( parent );
         }
 

--- a/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorFactory.java
+++ b/drools-core/src/main/java/org/drools/core/base/ClassFieldAccessorFactory.java
@@ -16,7 +16,6 @@
 
 package org.drools.core.base;
 
-import org.drools.core.base.ClassFieldAccessorCache.ByteArrayClassLoader;
 import org.drools.core.base.ClassFieldAccessorCache.CacheEntry;
 import org.drools.core.base.extractors.BaseBooleanClassFieldReader;
 import org.drools.core.base.extractors.BaseBooleanClassFieldWriter;
@@ -41,6 +40,7 @@ import org.drools.core.base.extractors.BaseShortClassFieldWriter;
 import org.drools.core.base.extractors.SelfReferenceClassFieldReader;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.util.asm.ClassFieldInspector;
+import org.drools.core.util.ByteArrayClassLoader;
 import org.mvel2.asm.ClassWriter;
 import org.mvel2.asm.Label;
 import org.mvel2.asm.MethodVisitor;

--- a/drools-core/src/main/java/org/drools/core/util/ByteArrayClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/util/ByteArrayClassLoader.java
@@ -1,0 +1,9 @@
+package org.drools.core.util;
+
+import java.security.ProtectionDomain;
+
+public interface ByteArrayClassLoader {
+    Class< ? > defineClass(final String name,
+                           final byte[] bytes,
+                           final ProtectionDomain domain);
+}

--- a/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -55,6 +56,8 @@ import static org.drools.core.util.StringUtils.ucFirst;
 public final class ClassUtils {
     private static final ProtectionDomain  PROTECTION_DOMAIN;
 
+    public static final boolean IS_ANDROID;
+
     static {
         PROTECTION_DOMAIN = (ProtectionDomain) AccessController.doPrivileged( new PrivilegedAction() {
 
@@ -62,9 +65,22 @@ public final class ClassUtils {
                 return ClassLoaderUtil.class.getProtectionDomain();
             }
         } );
+
+        // determine if we are running on Android
+        boolean isAndroid;
+        try {
+            isAndroid = loadClass("org.drools.android.DroolsAndroidContext", null) != null &&
+                    loadClass("android.os.Build", null) != null &&
+                    loadClass("dalvik.system.DexPathList", null) != null;
+        } catch (Exception e) {
+            isAndroid = false;
+        }
+        IS_ANDROID = isAndroid;
     }
     
     private static Map<String, Class<?>> classes = Collections.synchronizedMap( new HashMap() );
+
+    private static Map<String, Constructor<?>> constructors = Collections.synchronizedMap( new HashMap() );
 
     private static final String STAR    = "*";
 
@@ -112,8 +128,8 @@ public final class ClassUtils {
                                    final File file) {
         final int rootLength = base.getAbsolutePath().length();
         final String absFileName = file.getAbsolutePath();
-        final int p = absFileName.lastIndexOf( '.' );
-        final String relFileName = absFileName.substring( rootLength + 1, p );
+        final int p = absFileName.lastIndexOf('.');
+        final String relFileName = absFileName.substring(rootLength + 1, p);
         return relFileName.replace(File.separatorChar, '.');
     }
 
@@ -121,7 +137,7 @@ public final class ClassUtils {
                                   final File file) {
         final int rootLength = base.getAbsolutePath().length();
         final String absFileName = file.getAbsolutePath();
-        return absFileName.substring( rootLength + 1 );
+        return absFileName.substring(rootLength + 1);
     }
 
     public static String canonicalName(Class clazz) {
@@ -141,19 +157,14 @@ public final class ClassUtils {
         return name.toString();
     }
 
-    public static Object instantiateObject(String className) {
-        return instantiateObject( className,
-                                  null );
-    }
-
     /**
-     * This method will attempt to create an instance of the specified Class. It uses
+     * This method will attempt to load the specified Class. It uses
      * a syncrhonized HashMap to cache the reflection Class lookup.
      * @param className
      * @return
      */
-    public static Object instantiateObject(String className,
-                                           ClassLoader classLoader) {
+    public static Class<?> loadClass(String className,
+                                     ClassLoader classLoader) {
         Class cls = (Class) classes.get( className );
         if ( cls == null ) {
             try {
@@ -201,15 +212,68 @@ public final class ClassUtils {
                 throw new RuntimeException( "Unable to load class '" + className + "'" );
             }
         }
+        return cls;
+    }
 
+    public static Object instantiateObject(String className) {
+        return instantiateObject(className,
+                (ClassLoader)null);
+    }
+
+    /**
+     * This method will attempt to create an instance of the specified Class. It uses
+     * a syncrhonized HashMap to cache the reflection Class lookup.
+     * @param className
+     * @return
+     */
+    public static Object instantiateObject(String className,
+                                           ClassLoader classLoader) {
         Object object;
         try {
-            object = cls.newInstance();
+            object = loadClass(className, classLoader).newInstance();
         } catch ( Throwable e ) {
             throw new RuntimeException( "Unable to instantiate object for class '" + className + "'",
                                         e );
         }
         return object;
+    }
+
+    /**
+     * This method will attempt to create an instance of the specified Class. It uses
+     * a synchronized HashMap to cache the reflection Class lookup.  It will execute the default
+     * constructor with the passed in arguments
+     * @param className
+     * @param args  arguments to default constructor
+     * @return
+     */
+    public static Object instantiateObject(String className,
+                                           ClassLoader classLoader, Object...args) {
+        Constructor c = (Constructor) constructors.get( className );
+        if ( c == null ) {
+            c = loadClass(className, classLoader).getConstructors()[0];
+            constructors.put(className, c);
+        }
+
+        Object object;
+        try {
+            object = c.newInstance(args);
+        } catch ( Throwable e ) {
+            throw new RuntimeException( "Unable to instantiate object for class '" + className +
+                    "' with constructor " + c, e );
+        }
+        return object;
+    }
+
+    /**
+     * This method will attempt to create an instance of the specified Class. It uses
+     * a synchronized HashMap to cache the reflection Class lookup.  It will execute the default
+     * constructor with the passed in arguments
+     * @param className
+     * @param args  arguments to default constructor
+     * @return
+     */
+    public static Object instantiateObject(String className, Object...args) {
+        return instantiateObject(className, null, args);
     }
 
     /**
@@ -620,6 +684,13 @@ public final class ClassUtils {
     public static boolean isOSX() {
         String os =  System.getProperty("os.name");
         return os.toUpperCase().contains( "MAC OS X" );
+    }
+
+    /**
+     * Checks if running on Android operating system
+     */
+    public static boolean isAndroid() {
+        return IS_ANDROID;
     }
     
     /**

--- a/drools-core/src/main/java/org/drools/core/util/Drools.java
+++ b/drools-core/src/main/java/org/drools/core/util/Drools.java
@@ -18,7 +18,7 @@ public class Drools {
 
     static {
         droolsFullVersion = Drools.class.getPackage().getImplementationVersion();
-        if (droolsFullVersion == null) {
+        if (droolsFullVersion == null || droolsFullVersion.equals("0.0")) {
             InputStream is = null;
             try {
                 is = Drools.class.getClassLoader().getResourceAsStream("drools.versions.properties");

--- a/drools-core/src/main/java/org/drools/core/util/IoUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/IoUtils.java
@@ -125,6 +125,9 @@ public class IoUtils {
             Enumeration< ? extends ZipEntry> entries = zipFile.entries();
             while ( entries.hasMoreElements() ) {
                 ZipEntry entry = entries.nextElement();
+                if (entry.getName().endsWith(".dex")) {
+                    continue; //avoid out of memory error, it is useless anyway
+                }                
                 byte[] bytes = readBytesFromInputStream( zipFile.getInputStream( entry ) );
                 files.put( entry.getName(),
                            bytes );

--- a/drools-core/src/main/java/org/drools/core/util/MemoryUtil.java
+++ b/drools-core/src/main/java/org/drools/core/util/MemoryUtil.java
@@ -11,26 +11,38 @@ public class MemoryUtil {
     private MemoryUtil() { }
 
     static {
-        MemoryPoolMXBean permGenBean = null;
-        for (MemoryPoolMXBean mx : ManagementFactory.getMemoryPoolMXBeans()) {
-            if (mx.getName() != null && mx.getName().contains("Perm")) {
-                permGenBean = mx;
-                break;
+        if(!ClassUtils.isAndroid()) {
+            MemoryPoolMXBean permGenBean = null;
+            for (MemoryPoolMXBean mx : ManagementFactory.getMemoryPoolMXBeans()) {
+                if (mx.getName() != null && mx.getName().contains("Perm")) {
+                    permGenBean = mx;
+                    break;
+                }
             }
+            permGenStats = new MemoryStats(permGenBean);
+        } else {
+            permGenStats = new MemoryStats();
         }
-        permGenStats = new MemoryStats(permGenBean);
     }
 
     public static class MemoryStats {
         private final MemoryPoolMXBean memoryBean;
+
+        public MemoryStats() {
+            memoryBean = null;
+        }
 
         public MemoryStats(MemoryPoolMXBean memoryBean) {
             this.memoryBean = memoryBean;
         }
 
         public boolean isUsageThresholdExceeded(int threshold) {
-            MemoryUsage memoryUsage = getMemoryUsage();
-            return memoryUsage != null && memoryUsage.getUsed() * 100 / memoryUsage.getMax() >= threshold;
+            if (!ClassUtils.isAndroid()) {
+                MemoryUsage memoryUsage = getMemoryUsage();
+                return memoryUsage != null && memoryUsage.getUsed() * 100 / memoryUsage.getMax() >= threshold;
+            } else {
+                return false;
+            }
         }
 
         public MemoryUsage getMemoryUsage() {

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -22,9 +22,89 @@
         <configuration>
           <goalPrefix>kie</goalPrefix>
         </configuration>
+        <executions>
+          <execution>
+            <id>generated-helpmojo</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>generate-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-metadata</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-metadata</goal>
+              <goal>generate-test-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.takari.maven.plugins</groupId>
+        <artifactId>takari-lifecycle-plugin</artifactId>
+        <version>1.10.2</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>testProperties</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testProperties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=1024m</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <dependencyManagement>
+    <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+      <version>1.5.5</version>
+    </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-container-default</artifactId>
+        <version>1.5.5</version>
+      </dependency>
+      <dependency>
+        <groupId>io.takari.maven.plugins</groupId>
+        <artifactId>takari-plugin-testing</artifactId>
+        <version>2.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.takari.maven.plugins</groupId>
+        <artifactId>takari-plugin-integration-testing</artifactId>
+        <version>2.1.0</version>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -43,6 +123,23 @@
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-classworlds</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-container-default</artifactId>
     </dependency>
 
     <dependency>
@@ -63,6 +160,28 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-internal</artifactId>
+    </dependency>
 
+    <!-- Testing deps -->
+    <dependency>
+      <groupId>io.takari.maven.plugins</groupId>
+      <artifactId>takari-plugin-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.takari.maven.plugins</groupId>
+      <artifactId>takari-plugin-integration-testing</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/IncludeProjectDependenciesComponentConfigurator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/IncludeProjectDependenciesComponentConfigurator.java
@@ -1,0 +1,82 @@
+package org.kie.maven.plugin;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.configurator.AbstractComponentConfigurator;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.composite.ObjectWithFieldsConverter;
+import org.codehaus.plexus.component.configurator.converters.special.ClassRealmConverter;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A custom ComponentConfigurator which adds the project's runtime classpath elements
+ * to the
+ */
+@Component(role=ComponentConfigurator.class, hint="include-project-dependencies")
+public class IncludeProjectDependenciesComponentConfigurator extends AbstractComponentConfigurator {
+
+   private static final Logger LOGGER = new ConsoleLogger(Logger.LEVEL_DEBUG, "Configurator");
+
+   public void configureComponent( Object component, PlexusConfiguration configuration,
+                                   ExpressionEvaluator expressionEvaluator, ClassRealm containerRealm,
+                                   ConfigurationListener listener )
+         throws ComponentConfigurationException {
+
+      addProjectDependenciesToClassRealm(expressionEvaluator, containerRealm);
+
+      converterLookup.registerConverter( new ClassRealmConverter( containerRealm ) );
+
+      ObjectWithFieldsConverter converter = new ObjectWithFieldsConverter();
+
+      converter.processConfiguration( converterLookup, component, containerRealm.getClassLoader(), configuration,
+            expressionEvaluator, listener );
+   }
+
+   private void addProjectDependenciesToClassRealm(ExpressionEvaluator expressionEvaluator, ClassRealm containerRealm) throws ComponentConfigurationException {
+      List<String> runtimeClasspathElements;
+      try {
+         //noinspection unchecked
+         runtimeClasspathElements = (List<String>) expressionEvaluator.evaluate("${project.runtimeClasspathElements}");
+      } catch (ExpressionEvaluationException e) {
+         throw new ComponentConfigurationException("There was a problem evaluating: ${project.runtimeClasspathElements}", e);
+      }
+
+      // Add the project dependencies to the ClassRealm
+      final URL[] urls = buildURLs(runtimeClasspathElements);
+      for (URL url : urls) {
+         containerRealm.addConstituent(url);
+      }
+   }
+
+   private URL[] buildURLs(List<String> runtimeClasspathElements) throws ComponentConfigurationException {
+      // Add the projects classes and dependencies
+      List<URL> urls = new ArrayList<URL>(runtimeClasspathElements.size());
+      for (String element : runtimeClasspathElements) {
+         try {
+            final URL url = new File(element).toURI().toURL();
+            urls.add(url);
+            if (LOGGER.isDebugEnabled()) {
+               LOGGER.debug("Added to project class loader: " + url);
+            }
+         } catch (MalformedURLException e) {
+            throw new ComponentConfigurationException("Unable to access project dependency: " + element, e);
+         }
+      }
+
+      // Add the plugin's dependencies (so Trove stuff works if Trove isn't on
+      return urls.toArray(new URL[urls.size()]);
+   }
+
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/SerializeMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/SerializeMojo.java
@@ -1,0 +1,78 @@
+package org.kie.maven.plugin;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.drools.core.util.DroolsStreamUtils;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.Results;
+import org.kie.api.runtime.KieContainer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.List;
+
+/**
+ * Compiles and serializes knowledge packages.
+ */
+@Mojo(name = "serialize",
+      requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+      requiresProject = true,
+      defaultPhase = LifecyclePhase.COMPILE,
+      configurator = "include-project-dependencies")
+public class SerializeMojo extends AbstractMojo {
+
+    /**
+     * KnowledgeBases to serialize
+     */
+    @Parameter(property = "kie.kiebases",required = true)
+    private List<String> kiebases;
+
+    /**
+     * Output folder
+     */
+    @Parameter(property = "kie.resDirectory", defaultValue = "${project.basedir}/src/main/res/raw" )
+    private String resDirectory;
+
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            File outputFolder = new File(resDirectory);
+            outputFolder.mkdirs();
+
+            KieServices ks = KieServices.Factory.get();
+            KieContainer kc = ks.newKieClasspathContainer();
+            Results messages = kc.verify();
+
+            List<Message> warnings = messages.getMessages(Message.Level.WARNING);
+            for (Message warning : warnings) {
+                getLog().warn(warnings.toString());
+            }
+            List<Message> errors = messages.getMessages(Message.Level.ERROR);
+            if (!errors.isEmpty()) {
+                for (Message error : errors) {
+                    getLog().error(error.toString());
+                }
+                throw new MojoFailureException("Build failed!");
+            }
+
+            for(String kbase : kiebases) {
+                KieBase kb = kc.getKieBase(kbase);
+                getLog().info("Writing KBase: " + kbase);
+                File file = new File(outputFolder, kbase.replace('.', '_').toLowerCase());
+                FileOutputStream out = new FileOutputStream(file);
+                DroolsStreamUtils.streamOut(out, kb.getKiePackages());
+                out.close();
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("error", e);
+        }
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/TouchResourcesMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/TouchResourcesMojo.java
@@ -1,0 +1,77 @@
+package org.kie.maven.plugin;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.drools.core.util.DroolsStreamUtils;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.Results;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieContainer;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderConfiguration;
+import org.kie.internal.builder.KnowledgeBuilderError;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.definition.KnowledgePackage;
+import org.kie.internal.io.ResourceFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Compiles and serializes knowledge packages.
+ * @author kedzie
+ *
+ */
+@Mojo(name = "touch",
+      requiresProject = true,
+      defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public class TouchResourcesMojo extends AbstractMojo {
+
+    /**
+     * DRL rule package
+     */
+    @Parameter(property = "kie.ruleFiles",required = true)
+    private List<String> ruleFiles;
+
+    /**
+     * KnowledgeBases to serialize
+     */
+    @Parameter(property = "kie.kiebases",required = true)
+    private List<String> kiebases;
+
+    /**
+     * Output folder
+     */
+    @Parameter(property = "kie.resDirectory", defaultValue = "${project.basedir}/res/raw" )
+    private String resDirectory;
+
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            File outputFolder = new File(resDirectory);
+            outputFolder.mkdirs();
+
+            for(String kbase : kiebases) {
+                getLog().info("Touching KBase: " + kbase);
+                File file = new File(outputFolder, kbase.replace('.', '_').toLowerCase());
+                file.createNewFile();
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("error", e);
+        }
+    }
+}

--- a/kie-maven-plugin/src/test/java/org/kie/maven/plugin/BuildMojoIntegrationTest.java
+++ b/kie-maven-plugin/src/test/java/org/kie/maven/plugin/BuildMojoIntegrationTest.java
@@ -1,0 +1,41 @@
+package org.kie.maven.plugin;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenExecutionResult;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+/**
+ * Integration test for kjar
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.2.3"})
+public class BuildMojoIntegrationTest {
+
+    @Rule
+    public final TestResources resources = new TestResources();
+
+    public final MavenRuntime mavenRuntime;
+
+    public BuildMojoIntegrationTest(MavenRuntime.MavenRuntimeBuilder builder) throws Exception {
+        this.mavenRuntime = builder.withCliOptions( "-X" ).build();
+    }
+
+    @Test
+    public void buildDeployAndRun() throws Exception {
+        File basedir = resources.getBasedir("kjar-1");
+        MavenExecutionResult result = mavenRuntime
+                .forProject(basedir)
+                .execute("clean",
+                        "install");
+
+        result.assertErrorFreeLog();
+    }
+}
+

--- a/kie-maven-plugin/src/test/projects/kjar-1/pom.xml
+++ b/kie-maven-plugin/src/test/projects/kjar-1/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.drools</groupId>
+    <artifactId>drools-multiproject</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.kie</groupId>
+  <artifactId>kie-maven-plugin-example</artifactId>
+
+  <packaging>kjar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-compiler</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>serialize</id>
+            <goals>
+              <goal>serialize</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <kiebases>
+                <kiebase>KBase1</kiebase>
+              </kiebases>
+              <resDirectory>${project.build.outputDirectory}</resDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/java/org/kie/sample/model/Fire.java
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/java/org/kie/sample/model/Fire.java
@@ -1,0 +1,20 @@
+package org.kie.sample.model;
+
+public class Fire {
+
+    private Room room;
+
+    public Fire() { }
+
+    public Fire(Room room) {
+        this.room = room;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+}

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/java/org/kie/sample/model/Room.java
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/java/org/kie/sample/model/Room.java
@@ -1,0 +1,36 @@
+package org.kie.sample.model;
+
+public class Room {
+
+    private String name;
+
+    public Room() { }
+
+    public Room(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Room)) { return false; }
+        return name.equals(((Room) obj).getName());
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/java/org/kie/sample/model/Sprinkler.java
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/java/org/kie/sample/model/Sprinkler.java
@@ -1,0 +1,45 @@
+package org.kie.sample.model;
+
+public class Sprinkler {
+
+    private Room room;
+    private boolean on = false;
+
+    public Sprinkler() { }
+
+    public Sprinkler(Room room) {
+        this.room = room;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
+    public boolean isOn() {
+        return on;
+    }
+
+    public void setOn(boolean on) {
+        this.on = on;
+    }
+
+    @Override
+    public int hashCode() {
+        return room.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Sprinkler)) { return false; }
+        return room.equals(((Sprinkler) obj).getRoom());
+    }
+
+    @Override
+    public String toString() {
+        return "Sprinkler for " + room;
+    }
+}

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/FireAlarmKBase/alarm.drl
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/FireAlarmKBase/alarm.drl
@@ -1,0 +1,3 @@
+package org.kie.sample.model
+declare Alarm
+end

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/FireAlarmKBase/rules.drl
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/FireAlarmKBase/rules.drl
@@ -1,0 +1,23 @@
+package org.kie.sample
+
+import java.util.*
+import org.kie.sample.model.*
+
+rule "When there is a fire turn on the sprinkler"
+when
+    $fire: Fire($room : room)
+    $sprinkler : Sprinkler( room == $room, !on )
+then
+    modify( $sprinkler ) { setOn( true ) };
+    System.out.println( "Turn on the sprinkler for room " + $room.getName() );
+end
+
+rule "When the fire is gone turn off the sprinkler"
+when
+    $room : Room( )
+    $sprinkler : Sprinkler( room == $room, on )
+    not Fire( room == $room )
+then
+    modify( $sprinkler ) { setOn( false ) };
+    System.out.println( "Turn off the sprinkler for room " + $room.getName() );
+end

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/FireAlarmKBase/rules2.drl
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/FireAlarmKBase/rules2.drl
@@ -1,0 +1,29 @@
+package org.kie.sample
+
+import java.util.*
+import org.kie.sample.model.*
+
+rule "Raise the alarm when we have one or more fires"
+when
+    exists Fire()
+then
+    insert( new Alarm() );
+    System.out.println( "Raise the alarm" );
+end
+
+rule "Cancel the alarm when all the fires have gone"
+when
+    not Fire()
+    $alarm : Alarm()
+then
+    retract( $alarm );
+    System.out.println( "Cancel the alarm" );
+end
+
+rule "Status output when things are ok"
+when
+    not Alarm()
+    not Sprinkler( on == true )
+then
+    System.out.println( "Everything is ok" );
+end

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/KBase1/decA.drl
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/KBase1/decA.drl
@@ -1,0 +1,4 @@
+package org.kie.test
+declare FactA
+    fieldB: FactB
+end

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/KBase1/decB.drl
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/KBase1/decB.drl
@@ -1,0 +1,4 @@
+package org.kie.test
+declare FactB
+    fieldA: FactA
+end

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/KBase1/rule.drl
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/KBase1/rule.drl
@@ -1,0 +1,6 @@
+package org.kie.test
+rule R1 when
+   $fieldA : FactA( $fieldB : fieldB )
+   FactB( this == $fieldB, fieldA == $fieldA )
+then
+end

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/META-INF/kmodule.xml
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+    <kbase name="KBase1" packages="KBase1">
+        <ksession name="KBase1.session" type="stateful"/>
+    </kbase>
+    <kbase name="FireAlarmKBase" packages="FireAlarmKBase">
+        <ksession name="FireAlarmKBase.session" type="stateful"/>
+    </kbase>
+</kmodule>

--- a/kie-maven-plugin/src/test/projects/kjar-1/src/test/java/org/kie/kproject/KProjectTest.java
+++ b/kie-maven-plugin/src/test/projects/kjar-1/src/test/java/org/kie/kproject/KProjectTest.java
@@ -1,0 +1,37 @@
+package org.kie.kproject;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.sample.model.Fire;
+import org.kie.sample.model.Room;
+import org.kie.sample.model.Sprinkler;
+
+import static org.junit.Assert.assertEquals;
+
+public class KProjectTest {
+
+    @Test
+    public void testKJar() throws Exception {
+        KieServices ks = KieServices.Factory.get();
+        KieContainer kContainer = ks.getKieClasspathContainer();
+        KieSession kSession = kContainer.newKieSession("FireAlarmKBase.session");
+
+        Room room = new Room("101");
+        kSession.insert(room);
+        Sprinkler sprinkler = new Sprinkler(room);
+        kSession.insert(sprinkler);
+        Fire fire = new Fire(room);
+        FactHandle fireFH = kSession.insert(fire);
+
+        int rules = kSession.fireAllRules();
+        assertEquals(2, rules);
+
+        kSession.delete(fireFH);
+        rules = kSession.fireAllRules();
+        assertEquals(3, rules);
+    }
+}


### PR DESCRIPTION
-drools-android module added
-dex classloaders for generated classes
-maven plugin for pre-serializing knowledge packages during buildtime
-roboguice extension for injecting kiebases from pre serialized packages
-Kie classpath container works.  loads compilation cache from maven build
-added drools-android-examples. one with preserialized kbases and one with classpath container

At this point the only advantage of using the preserialized kbases is that it requires lot less dependencies.  With the drools-compiler dependency I needed to use multidex to package all the classes.  Which some users might not want.. to limit the size of the apk.

-This change also depends on a change to the maven-android-plugin, to which I have already submitted a pull request.  
-Finally android 5.0 support depends on a change to mvel2, namely it's handling of the java.version system property, which cannot be overridden in android 5.0.  I am also submitting a pull request for that.

Looking forward to feedback!
