### PR TITLE
DROOLS-748 - Unreliable Thread.sleep(1) replacement.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MultithreadTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MultithreadTest.java
@@ -202,12 +202,16 @@ public class MultithreadTest extends CommonTestMethodBase {
                         final String s = Thread.currentThread().getName();
                         long endTS = System.currentTimeMillis() + RUN_TIME;
                         int j = 0;
-                        while( System.currentTimeMillis() < endTS) {
-                            ep.insert( new StockTick( j++, s, 0.0, 0 ) );
-                            Thread.sleep(1);
+                        long lastTimeInserted = -1;
+                        while( System.currentTimeMillis() < endTS ) {
+                            final long currentTimeInMillis = System.currentTimeMillis();
+                            if ( currentTimeInMillis > lastTimeInserted ) {
+                                lastTimeInserted = currentTimeInMillis;
+                                ep.insert( new StockTick( j++, s, 0.0, 0 ) );
+                            }
                         }
                         return true;
-                    } catch (Exception e) {
+                    } catch ( Exception e ) {
                         errors.add( e );
                         e.printStackTrace();
                         return false;
@@ -237,7 +241,7 @@ public class MultithreadTest extends CommonTestMethodBase {
         assertTrue( errors.isEmpty() );
         assertTrue( success );
 
-        assertTrue( ! list.isEmpty() && ( (Number) list.get( list.size() - 1 ) ).intValue() > 200 );
+        assertTrue( ! list.isEmpty() && ( (Number) list.get( list.size() - 1 ) ).intValue() > 400 );
         ksession.dispose();
     }
 

--- a/drools-reteoo/src/test/java/org/drools/reteoo/integrationtests/MultithreadTest.java
+++ b/drools-reteoo/src/test/java/org/drools/reteoo/integrationtests/MultithreadTest.java
@@ -201,12 +201,16 @@ public class MultithreadTest extends CommonTestMethodBase {
                         final String s = Thread.currentThread().getName();
                         long endTS = System.currentTimeMillis() + RUN_TIME;
                         int j = 0;
-                        while( System.currentTimeMillis() < endTS) {
-                            ep.insert( new StockTick( j++, s, 0.0, 0 ) );
-                            Thread.sleep(1);
+                        long lastTimeInserted = -1;
+                        while( System.currentTimeMillis() < endTS ) {
+                            final long currentTimeInMillis = System.currentTimeMillis();
+                            if ( currentTimeInMillis > lastTimeInserted ) {
+                                lastTimeInserted = currentTimeInMillis;
+                                ep.insert( new StockTick( j++, s, 0.0, 0 ) );
+                            }
                         }
                         return true;
-                    } catch (Exception e) {
+                    } catch ( Exception e ) {
                         errors.add( e );
                         e.printStackTrace();
                         return false;
@@ -236,7 +240,7 @@ public class MultithreadTest extends CommonTestMethodBase {
         assertTrue( errors.isEmpty() );
         assertTrue( success );
 
-        assertTrue( ! list.isEmpty() && ( (Number) list.get( list.size() - 1 ) ).intValue() > 200 );
+        assertTrue( ! list.isEmpty() && ( (Number) list.get( list.size() - 1 ) ).intValue() > 400 );
         ksession.dispose();
     }
 


### PR DESCRIPTION
See JIRA: https://issues.jboss.org/browse/DROOLS-748
