### PR TITLE
Perform evaluation before launching a jit compilation request. This will...

### DIFF
--- a/drools-core/src/main/java/org/drools/rule/constraint/MvelConstraint.java
+++ b/drools-core/src/main/java/org/drools/rule/constraint/MvelConstraint.java
@@ -206,11 +206,14 @@ public class MvelConstraint extends MutableTypeConstraint implements IndexableCo
                 }
             }
 
+			boolean result = conditionEvaluator.evaluate(object, workingMemory, leftTuple);
             if (!isDynamic && invocationCounter.getAndIncrement() == JIT_THRESOLD) {
                 jitEvaluator(object, workingMemory, leftTuple);
             }
+            return result;
+        }else{
+			return conditionEvaluator.evaluate(object, workingMemory, leftTuple);
         }
-        return conditionEvaluator.evaluate(object, workingMemory, leftTuple);
     }
 
     protected void createMvelConditionEvaluator(InternalWorkingMemory workingMemory) {


### PR DESCRIPTION
... alleviate race conditions when jit compiling rules with Lazily initialized objects.
