### PR TITLE
DROOLS-759 GuidedDecisionTreeModelUnmarshallingVisitor doesn't support unmarshalling rules that contain line with only spaces in LHS

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -1951,7 +1951,7 @@ public class RuleModelDRLPersistenceImpl
         int lhsParenthesisBalance = 0;
 
         for ( String line : lines ) {
-            if (line.trim().length() == 0) {
+            if ( line.trim().length() == 0 ) {
                 continue;
             }
             if ( ruleSection == RuleSection.HEADER ) {

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -1951,6 +1951,9 @@ public class RuleModelDRLPersistenceImpl
         int lhsParenthesisBalance = 0;
 
         for ( String line : lines ) {
+            if (line.trim().length() == 0) {
+                continue;
+            }
             if ( ruleSection == RuleSection.HEADER ) {
                 drl.append( line ).append( "\n" );
                 if ( isLHSStartMarker( line ) ) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtree/src/test/java/org/drools/workbench/models/guided/dtree/backend/GuidedDecisionTreeDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtree/src/test/java/org/drools/workbench/models/guided/dtree/backend/GuidedDecisionTreeDRLPersistenceUnmarshallingTest.java
@@ -100,8 +100,8 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
             existingModelFields.add( modelFields[ 0 ] );
             modelFields = existingModelFields.toArray( modelFields );
         }
-        packageModelFields.put( factName,
-                                modelFields );
+        packageModelFields.put(factName,
+                modelFields);
     }
 
     private void addJavaEnumDefinition( final String factName,
@@ -189,24 +189,24 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
         assertEquals( expected.getTreeName(),
                       model.getTreeName() );
 
-        assertNotNull( model.getRoot() );
-        assertEquals( type.getClassName(),
-                      model.getRoot().getClassName() );
-        assertFalse( model.getRoot().isBound() );
+        assertNotNull(model.getRoot());
+        assertEquals(type.getClassName(),
+                model.getRoot().getClassName());
+        assertFalse(model.getRoot().isBound());
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ConstraintNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ConstraintNode);
 
         final ConstraintNode _c1 = (ConstraintNode) model.getRoot().getChildren().get( 0 );
 
-        assertEquals( c1.getClassName(),
-                      _c1.getClassName() );
+        assertEquals(c1.getClassName(),
+                _c1.getClassName());
         assertEquals( c1.getFieldName(),
                       _c1.getFieldName() );
-        assertEquals( c1.getOperator(),
-                      _c1.getOperator() );
+        assertEquals(c1.getOperator(),
+                _c1.getOperator());
         assertEquals( c1.getValue().getValue().toString(),
                       _c1.getValue().getValue().toString() );
     }
@@ -385,8 +385,8 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       _c1.getClassName() );
         assertEquals( c1.getFieldName(),
                       _c1.getFieldName() );
-        assertNull( _c1.getOperator() );
-        assertNull( _c1.getValue() );
+        assertNull(_c1.getOperator());
+        assertNull(_c1.getValue());
     }
 
     @Test
@@ -504,9 +504,9 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                                                           "age",
                                                           "==",
                                                           new IntegerValue( 41 ) );
-        expected.setRoot( type );
+        expected.setRoot(type);
         type.addChild( c1 );
-        type.addChild( c2 );
+        type.addChild(c2);
 
         addModelField( "Person",
                        "this",
@@ -516,32 +516,32 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                        "name",
                        String.class.getName(),
                        DataType.TYPE_STRING );
-        addModelField( "Person",
-                       "age",
-                       Integer.class.getName(),
-                       DataType.TYPE_NUMERIC_INTEGER );
+        addModelField("Person",
+                "age",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         final TypeNode _t1 = model.getRoot();
 
-        assertEquals( type.getClassName(),
-                      _t1.getClassName() );
-        assertFalse( _t1.isBound() );
+        assertEquals(type.getClassName(),
+                _t1.getClassName());
+        assertFalse(_t1.isBound());
 
-        assertEquals( 2,
-                      _t1.getChildren().size() );
-        assertNotNull( _t1.getChildren().get( 0 ) );
-        assertTrue( _t1.getChildren().get( 0 ) instanceof ConstraintNode );
+        assertEquals(2,
+                _t1.getChildren().size());
+        assertNotNull(_t1.getChildren().get(0));
+        assertTrue(_t1.getChildren().get(0) instanceof ConstraintNode);
 
         final ConstraintNode _c1 = (ConstraintNode) _t1.getChildren().get( 0 );
 
@@ -728,10 +728,10 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                                                           "age",
                                                           "==",
                                                           new IntegerValue( 41 ) );
-        expected.setRoot( type );
+        expected.setRoot(type);
         type.addChild( c1 );
         type.addChild( c2 );
-        c2.addChild( c3 );
+        c2.addChild(c3);
 
         addModelField( "Person",
                        "this",
@@ -793,13 +793,13 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
         assertEquals( c2.getValue().getValue().toString(),
                       _c2.getValue().getValue().toString() );
 
-        assertEquals( 0,
-                      _c1.getChildren().size() );
+        assertEquals(0,
+                _c1.getChildren().size());
 
-        assertEquals( 1,
-                      _c2.getChildren().size() );
-        assertNotNull( _c2.getChildren().get( 0 ) );
-        assertTrue( _c2.getChildren().get( 0 ) instanceof ConstraintNode );
+        assertEquals(1,
+                _c2.getChildren().size());
+        assertNotNull(_c2.getChildren().get(0));
+        assertTrue(_c2.getChildren().get(0) instanceof ConstraintNode);
 
         final ConstraintNode _c3 = (ConstraintNode) _c2.getChildren().get( 0 );
 
@@ -838,10 +838,10 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                                                           "country",
                                                           "==",
                                                           new StringValue( "England" ) );
-        expected.setRoot( type1 );
+        expected.setRoot(type1);
         type1.addChild( c1 );
         c1.addChild( type2 );
-        type2.addChild( c2 );
+        type2.addChild(c2);
 
         addModelField( "Person",
                        "this",
@@ -851,36 +851,36 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                        "name",
                        String.class.getName(),
                        DataType.TYPE_STRING );
-        addModelField( "Address",
-                       "this",
-                       "Address",
-                       DataType.TYPE_THIS );
-        addModelField( "Address",
-                       "country",
-                       String.class.getName(),
-                       DataType.TYPE_STRING );
+        addModelField("Address",
+                "this",
+                "Address",
+                DataType.TYPE_THIS);
+        addModelField("Address",
+                "country",
+                String.class.getName(),
+                DataType.TYPE_STRING);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
-        assertEquals( 0,
-                      model.getParserErrors().size() );
+        assertNotNull(model);
+        assertEquals(0,
+                model.getParserErrors().size());
         assertEquals( expected.getTreeName(),
                       model.getTreeName() );
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         final TypeNode _t1 = model.getRoot();
 
         assertEquals( type1.getClassName(),
                       _t1.getClassName() );
-        assertFalse( _t1.isBound() );
+        assertFalse(_t1.isBound());
 
-        assertEquals( 1,
-                      _t1.getChildren().size() );
-        assertNotNull( _t1.getChildren().get( 0 ) );
-        assertTrue( _t1.getChildren().get( 0 ) instanceof ConstraintNode );
+        assertEquals(1,
+                _t1.getChildren().size());
+        assertNotNull(_t1.getChildren().get(0));
+        assertTrue(_t1.getChildren().get(0) instanceof ConstraintNode);
 
         final ConstraintNode _c1 = (ConstraintNode) _t1.getChildren().get( 0 );
 
@@ -888,21 +888,21 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       _c1.getClassName() );
         assertEquals( c1.getFieldName(),
                       _c1.getFieldName() );
-        assertEquals( c1.getOperator(),
-                      _c1.getOperator() );
-        assertEquals( c1.getValue().getValue().toString(),
-                      _c1.getValue().getValue().toString() );
+        assertEquals(c1.getOperator(),
+                _c1.getOperator());
+        assertEquals(c1.getValue().getValue().toString(),
+                _c1.getValue().getValue().toString());
 
         assertEquals( 1,
                       _c1.getChildren().size() );
-        assertNotNull( _c1.getChildren().get( 0 ) );
-        assertTrue( _c1.getChildren().get( 0 ) instanceof TypeNode );
+        assertNotNull(_c1.getChildren().get(0));
+        assertTrue(_c1.getChildren().get(0) instanceof TypeNode);
 
         final TypeNode _t2 = (TypeNode) _c1.getChildren().get( 0 );
 
         assertEquals( type2.getClassName(),
                       _t2.getClassName() );
-        assertFalse( _t2.isBound() );
+        assertFalse(_t2.isBound());
 
         assertEquals( 1,
                       _t2.getChildren().size() );
@@ -1752,31 +1752,31 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        type.setBinding( "$p" );
-        expected.setRoot( type );
+        type.setBinding("$p");
+        expected.setRoot(type);
 
-        addModelField( "Person",
-                       "this",
-                       "Person",
-                       DataType.TYPE_THIS );
+        addModelField("Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         assertEquals( type.getClassName(),
                       model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
+        assertTrue(model.getRoot().isBound());
         assertEquals( type.getBinding(),
                       model.getRoot().getBinding() );
 
@@ -1860,21 +1860,21 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                                                           "name",
                                                           "==",
                                                           new EnumValue( "Names.FRED" ) );
-        expected.setRoot( type );
-        type.addChild( c1 );
+        expected.setRoot(type);
+        type.addChild(c1);
 
-        addModelField( "Person",
-                       "this",
-                       "Person",
-                       DataType.TYPE_THIS );
+        addModelField("Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS);
         addModelField( "Person",
                        "name",
                        String.class.getName(),
                        DataType.TYPE_COMPARABLE );
 
-        addJavaEnumDefinition( "Person",
-                               "name",
-                               new String[]{ "Names.FRED=Names.FRED" } );
+        addJavaEnumDefinition("Person",
+                "name",
+                new String[]{"Names.FRED=Names.FRED"});
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
@@ -1902,9 +1902,9 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       _c1.getClassName() );
         assertEquals( c1.getFieldName(),
                       _c1.getFieldName() );
-        assertEquals( c1.getOperator(),
-                      _c1.getOperator() );
-        assertNotNull( _c1.getValue() );
+        assertEquals(c1.getOperator(),
+                _c1.getOperator());
+        assertNotNull(_c1.getValue());
         assertTrue( _c1.getValue() instanceof EnumValue );
         assertEquals( c1.getValue().getValue().toString(),
                       _c1.getValue().getValue().toString() );
@@ -1926,47 +1926,47 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                                                           "name",
                                                           "!= null",
                                                           null );
-        expected.setRoot( type );
-        type.addChild( c1 );
+        expected.setRoot(type);
+        type.addChild(c1);
 
-        addModelField( "Person",
-                       "this",
-                       "Person",
-                       DataType.TYPE_THIS );
-        addModelField( "Person",
-                       "name",
-                       String.class.getName(),
-                       DataType.TYPE_STRING );
+        addModelField("Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS);
+        addModelField("Person",
+                "name",
+                String.class.getName(),
+                DataType.TYPE_STRING);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
-        assertEquals( 0,
-                      model.getParserErrors().size() );
+        assertNotNull(model);
+        assertEquals(0,
+                model.getParserErrors().size());
         assertEquals( expected.getTreeName(),
                       model.getTreeName() );
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         assertEquals( type.getClassName(),
                       model.getRoot().getClassName() );
-        assertFalse( model.getRoot().isBound() );
+        assertFalse(model.getRoot().isBound());
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ConstraintNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ConstraintNode);
 
         final ConstraintNode _c1 = (ConstraintNode) model.getRoot().getChildren().get( 0 );
 
         assertEquals( c1.getClassName(),
                       _c1.getClassName() );
-        assertEquals( c1.getFieldName(),
-                      _c1.getFieldName() );
-        assertEquals( c1.getOperator(),
-                      _c1.getOperator() );
-        assertNull( _c1.getValue() );
+        assertEquals(c1.getFieldName(),
+                _c1.getFieldName());
+        assertEquals(c1.getOperator(),
+                _c1.getOperator());
+        assertNull(_c1.getValue());
     }
 
     @Test
@@ -2038,50 +2038,50 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        type.setBinding( "$p" );
-        expected.setRoot( type );
+        type.setBinding("$p");
+        expected.setRoot(type);
 
         final ActionRetractNode action = new ActionRetractNodeImpl( type );
         type.addChild( action );
 
-        addModelField( "Person",
-                       "this",
-                       "Person",
-                       DataType.TYPE_THIS );
-        addModelField( "Person",
-                       "name",
-                       String.class.getName(),
-                       DataType.TYPE_STRING );
+        addModelField("Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS);
+        addModelField("Person",
+                "name",
+                String.class.getName(),
+                DataType.TYPE_STRING);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
-        assertEquals( 0,
-                      model.getParserErrors().size() );
+        assertNotNull(model);
+        assertEquals(0,
+                model.getParserErrors().size());
         assertEquals( expected.getTreeName(),
                       model.getTreeName() );
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         assertEquals( type.getClassName(),
                       model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
-        assertEquals( type.getBinding(),
-                      model.getRoot().getBinding() );
+        assertTrue(model.getRoot().isBound());
+        assertEquals(type.getBinding(),
+                model.getRoot().getBinding());
 
         assertEquals( 1,
                       model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ActionRetractNode );
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ActionRetractNode);
 
         final ActionRetractNode _a1 = (ActionRetractNode) model.getRoot().getChildren().get( 0 );
 
-        assertEquals( action.getBoundNode().getBinding(),
-                      _a1.getBoundNode().getBinding() );
+        assertEquals(action.getBoundNode().getBinding(),
+                _a1.getBoundNode().getBinding());
     }
 
     @Test
@@ -2171,48 +2171,48 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        type.setBinding( "$p" );
-        expected.setRoot( type );
+        type.setBinding("$p");
+        expected.setRoot(type);
 
         final ActionUpdateNode action = new ActionUpdateNodeImpl( type );
         action.setModify( true );
-        action.getFieldValues().add( new ActionFieldValueImpl( "age",
-                                                               new IntegerValue( 25 ) ) );
-        type.addChild( action );
+        action.getFieldValues().add(new ActionFieldValueImpl("age",
+                new IntegerValue(25)));
+        type.addChild(action);
 
         addModelField( "Person",
                        "this",
                        "Person",
                        DataType.TYPE_THIS );
-        addModelField( "Person",
-                       "age",
-                       Integer.class.getName(),
-                       DataType.TYPE_NUMERIC_INTEGER );
+        addModelField("Person",
+                "age",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
-        assertEquals( type.getClassName(),
-                      model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
+        assertNotNull(model.getRoot());
+        assertEquals(type.getClassName(),
+                model.getRoot().getClassName());
+        assertTrue(model.getRoot().isBound());
         assertEquals( type.getBinding(),
                       model.getRoot().getBinding() );
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ActionUpdateNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ActionUpdateNode);
 
         final ActionUpdateNode _action = (ActionUpdateNode) model.getRoot().getChildren().get( 0 );
 
@@ -2220,14 +2220,14 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       _action.getBoundNode().getBinding() );
         assertEquals( action.isModify(),
                       _action.isModify() );
-        assertEquals( action.getFieldValues().size(),
-                      _action.getFieldValues().size() );
+        assertEquals(action.getFieldValues().size(),
+                _action.getFieldValues().size());
         assertEquals( 1,
                       _action.getFieldValues().size() );
-        assertEquals( action.getFieldValues().get( 0 ).getFieldName(),
-                      _action.getFieldValues().get( 0 ).getFieldName() );
-        assertEquals( action.getFieldValues().get( 0 ).getValue().getValue().toString(),
-                      _action.getFieldValues().get( 0 ).getValue().getValue().toString() );
+        assertEquals(action.getFieldValues().get(0).getFieldName(),
+                _action.getFieldValues().get(0).getFieldName());
+        assertEquals(action.getFieldValues().get(0).getValue().getValue().toString(),
+                _action.getFieldValues().get(0).getValue().getValue().toString());
 
         assertEquals( 0,
                       _action.getChildren().size() );
@@ -2345,60 +2345,60 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        type.setBinding( "$p" );
-        expected.setRoot( type );
+        type.setBinding("$p");
+        expected.setRoot(type);
 
         final ActionUpdateNode action1 = new ActionUpdateNodeImpl( type );
-        action1.setModify( true );
-        action1.getFieldValues().add( new ActionFieldValueImpl( "age",
-                                                                new IntegerValue( 25 ) ) );
-        type.addChild( action1 );
+        action1.setModify(true);
+        action1.getFieldValues().add(new ActionFieldValueImpl("age",
+                new IntegerValue(25)));
+        type.addChild(action1);
 
         final ActionRetractNode action2 = new ActionRetractNodeImpl( type );
-        action1.addChild( action2 );
+        action1.addChild(action2);
 
-        addModelField( "Person",
-                       "this",
-                       "Person",
-                       DataType.TYPE_THIS );
-        addModelField( "Person",
-                       "age",
-                       Integer.class.getName(),
-                       DataType.TYPE_NUMERIC_INTEGER );
+        addModelField("Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS);
+        addModelField("Person",
+                "age",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         assertEquals( type.getClassName(),
                       model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
-        assertEquals( type.getBinding(),
-                      model.getRoot().getBinding() );
+        assertTrue(model.getRoot().isBound());
+        assertEquals(type.getBinding(),
+                model.getRoot().getBinding());
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ActionUpdateNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ActionUpdateNode);
 
         final ActionUpdateNode _action1 = (ActionUpdateNode) model.getRoot().getChildren().get( 0 );
 
         assertEquals( action1.getBoundNode().getBinding(),
                       _action1.getBoundNode().getBinding() );
-        assertEquals( action1.isModify(),
-                      _action1.isModify() );
-        assertEquals( action1.getFieldValues().size(),
-                      _action1.getFieldValues().size() );
+        assertEquals(action1.isModify(),
+                _action1.isModify());
+        assertEquals(action1.getFieldValues().size(),
+                _action1.getFieldValues().size());
         assertEquals( 1,
                       _action1.getFieldValues().size() );
         assertEquals( action1.getFieldValues().get( 0 ).getFieldName(),
@@ -2408,8 +2408,8 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
 
         assertEquals( 1,
                       _action1.getChildren().size() );
-        assertNotNull( _action1.getChildren().get( 0 ) );
-        assertTrue( _action1.getChildren().get( 0 ) instanceof ActionRetractNode );
+        assertNotNull(_action1.getChildren().get(0));
+        assertTrue(_action1.getChildren().get(0) instanceof ActionRetractNode);
 
         final ActionRetractNode _action2 = (ActionRetractNode) _action1.getChildren().get( 0 );
 
@@ -2440,8 +2440,8 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
         action.setModify( true );
         action.getFieldValues().add( new ActionFieldValueImpl( "age",
                                                                new IntegerValue( 25 ) ) );
-        action.getFieldValues().add( new ActionFieldValueImpl( "name",
-                                                               new StringValue( "Michael" ) ) );
+        action.getFieldValues().add(new ActionFieldValueImpl("name",
+                new StringValue("Michael")));
         type.addChild( action );
 
         addModelField( "Person",
@@ -2452,32 +2452,32 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                        "name",
                        String.class.getName(),
                        DataType.TYPE_STRING );
-        addModelField( "Person",
-                       "age",
-                       Integer.class.getName(),
-                       DataType.TYPE_NUMERIC_INTEGER );
+        addModelField("Person",
+                "age",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
-        assertEquals( type.getClassName(),
-                      model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
+        assertNotNull(model.getRoot());
+        assertEquals(type.getClassName(),
+                model.getRoot().getClassName());
+        assertTrue(model.getRoot().isBound());
         assertEquals( type.getBinding(),
                       model.getRoot().getBinding() );
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ActionUpdateNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ActionUpdateNode);
 
         final ActionUpdateNode _action = (ActionUpdateNode) model.getRoot().getChildren().get( 0 );
 
@@ -2489,14 +2489,14 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       _action.getFieldValues().size() );
         assertEquals( 2,
                       _action.getFieldValues().size() );
-        assertEquals( action.getFieldValues().get( 0 ).getFieldName(),
-                      _action.getFieldValues().get( 0 ).getFieldName() );
+        assertEquals( action.getFieldValues().get(0).getFieldName(),
+                      _action.getFieldValues().get(0).getFieldName() );
         assertEquals( action.getFieldValues().get( 0 ).getValue().getValue().toString(),
                       _action.getFieldValues().get( 0 ).getValue().getValue().toString() );
-        assertEquals( action.getFieldValues().get( 1 ).getFieldName(),
-                      _action.getFieldValues().get( 1 ).getFieldName() );
-        assertEquals( action.getFieldValues().get( 1 ).getValue().getValue().toString(),
-                      _action.getFieldValues().get( 1 ).getValue().getValue().toString() );
+        assertEquals(action.getFieldValues().get(1).getFieldName(),
+                _action.getFieldValues().get(1).getFieldName());
+        assertEquals(action.getFieldValues().get(1).getValue().getValue().toString(),
+                _action.getFieldValues().get(1).getValue().getValue().toString());
 
         assertEquals( 0,
                       _action.getChildren().size() );
@@ -2645,14 +2645,14 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        type.setBinding( "$p" );
-        expected.setRoot( type );
+        type.setBinding("$p");
+        expected.setRoot(type);
 
         final ActionUpdateNode action = new ActionUpdateNodeImpl( type );
-        action.setModify( false );
+        action.setModify(false);
         action.getFieldValues().add( new ActionFieldValueImpl( "age",
                                                                new IntegerValue( 25 ) ) );
         type.addChild( action );
@@ -2815,60 +2815,60 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        type.setBinding( "$p" );
-        expected.setRoot( type );
+        type.setBinding("$p");
+        expected.setRoot(type);
 
         final ActionUpdateNode action1 = new ActionUpdateNodeImpl( type );
-        action1.setModify( false );
-        action1.getFieldValues().add( new ActionFieldValueImpl( "age",
-                                                                new IntegerValue( 25 ) ) );
-        type.addChild( action1 );
+        action1.setModify(false);
+        action1.getFieldValues().add(new ActionFieldValueImpl("age",
+                new IntegerValue(25)));
+        type.addChild(action1);
 
         final ActionRetractNode action2 = new ActionRetractNodeImpl( type );
-        action1.addChild( action2 );
+        action1.addChild(action2);
 
-        addModelField( "Person",
-                       "this",
-                       "Person",
-                       DataType.TYPE_THIS );
-        addModelField( "Person",
-                       "age",
-                       Integer.class.getName(),
-                       DataType.TYPE_NUMERIC_INTEGER );
+        addModelField("Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS);
+        addModelField("Person",
+                "age",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
+        assertNotNull(model.getRoot());
         assertEquals( type.getClassName(),
                       model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
-        assertEquals( type.getBinding(),
-                      model.getRoot().getBinding() );
+        assertTrue(model.getRoot().isBound());
+        assertEquals(type.getBinding(),
+                model.getRoot().getBinding());
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ActionUpdateNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ActionUpdateNode);
 
         final ActionUpdateNode _action1 = (ActionUpdateNode) model.getRoot().getChildren().get( 0 );
 
         assertEquals( action1.getBoundNode().getBinding(),
                       _action1.getBoundNode().getBinding() );
-        assertEquals( action1.isModify(),
-                      _action1.isModify() );
-        assertEquals( action1.getFieldValues().size(),
-                      _action1.getFieldValues().size() );
+        assertEquals(action1.isModify(),
+                _action1.isModify());
+        assertEquals(action1.getFieldValues().size(),
+                _action1.getFieldValues().size());
         assertEquals( 1,
                       _action1.getFieldValues().size() );
         assertEquals( action1.getFieldValues().get( 0 ).getFieldName(),
@@ -2878,8 +2878,8 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
 
         assertEquals( 1,
                       _action1.getChildren().size() );
-        assertNotNull( _action1.getChildren().get( 0 ) );
-        assertTrue( _action1.getChildren().get( 0 ) instanceof ActionRetractNode );
+        assertNotNull(_action1.getChildren().get(0));
+        assertTrue(_action1.getChildren().get(0) instanceof ActionRetractNode);
 
         final ActionRetractNode _action2 = (ActionRetractNode) _action1.getChildren().get( 0 );
 
@@ -2908,8 +2908,8 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
         action.setModify( false );
         action.getFieldValues().add( new ActionFieldValueImpl( "age",
                                                                new IntegerValue( 25 ) ) );
-        action.getFieldValues().add( new ActionFieldValueImpl( "name",
-                                                               new StringValue( "Michael" ) ) );
+        action.getFieldValues().add(new ActionFieldValueImpl("name",
+                new StringValue("Michael")));
         type.addChild( action );
 
         addModelField( "Person",
@@ -2920,32 +2920,32 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                        "name",
                        String.class.getName(),
                        DataType.TYPE_STRING );
-        addModelField( "Person",
-                       "age",
-                       Integer.class.getName(),
-                       DataType.TYPE_NUMERIC_INTEGER );
+        addModelField("Person",
+                "age",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
-        assertEquals( type.getClassName(),
-                      model.getRoot().getClassName() );
-        assertTrue( model.getRoot().isBound() );
+        assertNotNull(model.getRoot());
+        assertEquals(type.getClassName(),
+                model.getRoot().getClassName());
+        assertTrue(model.getRoot().isBound());
         assertEquals( type.getBinding(),
                       model.getRoot().getBinding() );
 
-        assertEquals( 1,
-                      model.getRoot().getChildren().size() );
-        assertNotNull( model.getRoot().getChildren().get( 0 ) );
-        assertTrue( model.getRoot().getChildren().get( 0 ) instanceof ActionUpdateNode );
+        assertEquals(1,
+                model.getRoot().getChildren().size());
+        assertNotNull(model.getRoot().getChildren().get(0));
+        assertTrue(model.getRoot().getChildren().get(0) instanceof ActionUpdateNode);
 
         final ActionUpdateNode _action = (ActionUpdateNode) model.getRoot().getChildren().get( 0 );
 
@@ -2957,14 +2957,14 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       _action.getFieldValues().size() );
         assertEquals( 2,
                       _action.getFieldValues().size() );
-        assertEquals( action.getFieldValues().get( 0 ).getFieldName(),
-                      _action.getFieldValues().get( 0 ).getFieldName() );
+        assertEquals( action.getFieldValues().get(0).getFieldName(),
+                      _action.getFieldValues().get(0).getFieldName() );
         assertEquals( action.getFieldValues().get( 0 ).getValue().getValue().toString(),
                       _action.getFieldValues().get( 0 ).getValue().getValue().toString() );
-        assertEquals( action.getFieldValues().get( 1 ).getFieldName(),
-                      _action.getFieldValues().get( 1 ).getFieldName() );
-        assertEquals( action.getFieldValues().get( 1 ).getValue().getValue().toString(),
-                      _action.getFieldValues().get( 1 ).getValue().getValue().toString() );
+        assertEquals(action.getFieldValues().get(1).getFieldName(),
+                _action.getFieldValues().get(1).getFieldName());
+        assertEquals(action.getFieldValues().get(1).getValue().getValue().toString(),
+                _action.getFieldValues().get(1).getValue().getValue().toString());
 
         assertEquals( 0,
                       _action.getChildren().size() );
@@ -3114,13 +3114,13 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                 "end";
 
         final GuidedDecisionTree expected = new GuidedDecisionTree();
-        expected.setTreeName( "test" );
+        expected.setTreeName("test");
 
         final TypeNode type = new TypeNodeImpl( "Person" );
-        expected.setRoot( type );
+        expected.setRoot(type);
 
         final ActionInsertNode action = new ActionInsertNodeImpl( "Person" );
-        action.setLogicalInsertion( false );
+        action.setLogicalInsertion(false);
         action.getFieldValues().add( new ActionFieldValueImpl( "age",
                                                                new IntegerValue( 25 ) ) );
         type.addChild( action );
@@ -3147,7 +3147,7 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
         assertNotNull( model.getRoot() );
         assertEquals( type.getClassName(),
                       model.getRoot().getClassName() );
-        assertFalse( model.getRoot().isBound() );
+        assertFalse(model.getRoot().isBound());
         assertEquals( type.getBinding(),
                       model.getRoot().getBinding() );
 
@@ -3273,41 +3273,41 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                  1985 );
         dob.set( Calendar.MONTH,
                  6 );
-        dob.set( Calendar.DATE,
-                 15 );
-        dob.set( Calendar.HOUR_OF_DAY,
-                 0 );
-        dob.set( Calendar.MINUTE,
-                 0 );
-        dob.set( Calendar.SECOND,
-                 0 );
-        action.getFieldValues().add( new ActionFieldValueImpl( "dateOfBirth",
-                                                               new DateValue( dob.getTime() ) ) );
-        type.addChild( action );
+        dob.set(Calendar.DATE,
+                15);
+        dob.set(Calendar.HOUR_OF_DAY,
+                0);
+        dob.set(Calendar.MINUTE,
+                0);
+        dob.set(Calendar.SECOND,
+                0);
+        action.getFieldValues().add(new ActionFieldValueImpl("dateOfBirth",
+                new DateValue(dob.getTime())));
+        type.addChild(action);
 
         addModelField( "Person",
                        "this",
                        "Person",
                        DataType.TYPE_THIS );
-        addModelField( "Person",
-                       "dateOfBirth",
-                       Date.class.getName(),
-                       DataType.TYPE_DATE );
+        addModelField("Person",
+                "dateOfBirth",
+                Date.class.getName(),
+                DataType.TYPE_DATE);
 
         final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
                                                                                                    "test",
                                                                                                    dmo );
 
-        assertNotNull( model );
+        assertNotNull(model);
         assertEquals( 0,
                       model.getParserErrors().size() );
-        assertEquals( expected.getTreeName(),
-                      model.getTreeName() );
+        assertEquals(expected.getTreeName(),
+                model.getTreeName());
 
-        assertNotNull( model.getRoot() );
-        assertEquals( type.getClassName(),
-                      model.getRoot().getClassName() );
-        assertFalse( model.getRoot().isBound() );
+        assertNotNull(model.getRoot());
+        assertEquals(type.getClassName(),
+                model.getRoot().getClassName());
+        assertFalse(model.getRoot().isBound());
 
         assertEquals( 1,
                       model.getRoot().getChildren().size() );
@@ -3544,4 +3544,31 @@ public class GuidedDecisionTreeDRLPersistenceUnmarshallingTest {
                       model.getParserErrors().size() );
     }
 
+    @Test
+    public void testRuleWithLinesWithSpaces() throws Exception {
+        final String drl = "rule \"test1\" \n" +
+                "when \n" +
+                " \n" +
+                " \n" +
+                " Person( integerField == 10 ) \n" +
+                "then \n" +
+                "end \n";
+
+        addModelField( "Person",
+                "this",
+                "Person",
+                DataType.TYPE_THIS );
+        addModelField( "Person",
+                "integerField",
+                Integer.class.getName(),
+                DataType.TYPE_NUMERIC_INTEGER );
+
+        final GuidedDecisionTree model = GuidedDecisionTreeDRLPersistence.getInstance().unmarshal( drl,
+                "test",
+                dmo );
+
+        assertNotNull( model );
+        assertEquals( 0,
+                model.getParserErrors().size() );
+    }
 }


### PR DESCRIPTION
See JIRA: https://issues.jboss.org/browse/DROOLS-759

Contains reproducer of the issue and possible fix. 
