### PR TITLE
DROOLS-383, switch over String in function

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompilerSettings.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompilerSettings.java
@@ -54,6 +54,7 @@ public final class EclipseJavaCompilerSettings extends JavaCompilerSettings {
     public static final String CompilerOptions_OPTION_Encoding = "org.eclipse.jdt.core.encoding"; //$NON-NLS-1$
     public static final String CompilerOptions_OPTION_Source = "org.eclipse.jdt.core.compiler.source"; //$NON-NLS-1$
     public static final String CompilerOptions_OPTION_TargetPlatform = "org.eclipse.jdt.core.compiler.codegen.targetPlatform"; //$NON-NLS-1$
+    public static final String CompilerOptions_OPTION_Compliance = "org.eclipse.jdt.core.compiler.compliance"; //$NON-NLS-1$
     public static final String CompilerOptions_OPTION_ReportDeprecation = "org.eclipse.jdt.core.compiler.problem.deprecation"; //$NON-NLS-1$    
 
     final private Map defaultEclipseSettings = new HashMap();
@@ -107,6 +108,7 @@ public final class EclipseJavaCompilerSettings extends JavaCompilerSettings {
         map.put(CompilerOptions_OPTION_ReportDeprecation, isDeprecations()?CompilerOptions_GENERATE:CompilerOptions_DO_NOT_GENERATE);
         map.put(CompilerOptions_OPTION_TargetPlatform, toNativeVersion(getTargetVersion()));
         map.put(CompilerOptions_OPTION_Source, toNativeVersion(getSourceVersion()));
+        map.put(CompilerOptions_OPTION_Compliance, toNativeVersion(getSourceVersion()));
         map.put(CompilerOptions_OPTION_Encoding, getSourceEncoding());
 
         return map;


### PR DESCRIPTION
Eclipse compiler has a least known documented configuration property "org.eclipse.jdt.core.compiler.compliance"
which need to be set along with the 'org.eclipse.jdt.core.compiler.source' and 'org.eclipse.jdt.core.compiler.codegen.targetPlatform'
properties.
