### PR TITLE
Rename root POM from drools-multiproject to just drools

### DIFF
--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.drools</groupId>
-        <artifactId>drools-multiproject</artifactId>
+        <artifactId>drools</artifactId>
         <version>6.3.0-SNAPSHOT</version>
     </parent>
 

--- a/drools-examples-api/pom.xml
+++ b/drools-examples-api/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-examples-cdi/pom.xml
+++ b/drools-examples-cdi/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-jsr94/pom.xml
+++ b/drools-jsr94/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-persistence-jpa/pom.xml
+++ b/drools-persistence-jpa/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-pmml/pom.xml
+++ b/drools-pmml/pom.xml
@@ -21,7 +21,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-reteoo/pom.xml
+++ b/drools-reteoo/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-scorecards/pom.xml
+++ b/drools-scorecards/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-verifier/pom.xml
+++ b/drools-verifier/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/drools-workbench-models/pom.xml
+++ b/drools-workbench-models/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/kie-ci-osgi/pom.xml
+++ b/kie-ci-osgi/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>

--- a/kie-maven-plugin-example/pom.xml
+++ b/kie-maven-plugin-example/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/knowledge-api-legacy5-adapter/pom.xml
+++ b/knowledge-api-legacy5-adapter/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
-    <artifactId>drools-multiproject</artifactId>
+    <artifactId>drools</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,10 @@
   </parent>
 
   <groupId>org.drools</groupId>
-  <!-- TODO rename to drools once parent pom has been moved -->
-  <artifactId>drools-multiproject</artifactId>
+  <artifactId>drools</artifactId>
   <packaging>pom</packaging>
 
-  <name>Drools multiproject</name>
+  <name>Drools Multiproject</name>
   <description>
     Drools Expert is the rule engine and Drools Fusion does complex event processing (CEP).
   </description>


### PR DESCRIPTION
This should be quite safe change as only artifacts from this repo should depend on the root POM. 

@mbiarnes @ge0ffrey @etirelli could you please confirm that we want this change in? (I was following the comment in the pom, but it is a bit old, so things might have changed).
