### PR TITLE
Fix: Invalid slash on Windows platform

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -389,9 +389,9 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
     private void dumpDrlGeneratedFromDTable(File dumpDir, String generatedDrl, String srcPath) {
         File dumpFile;
         if (srcPath != null) {
-            dumpFile = new File(dumpDir, srcPath.replaceAll(File.separator, "_") + ".drl");
+            dumpFile = createDumpDrlFile(dumpDir, srcPath, ".drl");
         } else {
-            dumpFile = new File(dumpDir, "decision-table-" + UUID.randomUUID() + ".drl");
+            dumpFile = createDumpDrlFile(dumpDir, "decision-table-" + UUID.randomUUID(), ".drl");
         }
         try {
             IoUtils.write(dumpFile, generatedDrl.getBytes(IoUtils.UTF8_CHARSET));
@@ -400,6 +400,10 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
             logger.warn("Can't write the DRL generated from decision table to file " + dumpFile.getAbsolutePath() + "!\n" +
                     Arrays.toString(ex.getStackTrace()));
         }
+    }
+
+    protected static File createDumpDrlFile(File dumpDir, String fileName, String extension) {
+        return new File(dumpDir, fileName.replaceAll("[^a-zA-Z0-9\\.\\-_]+", "_") + extension);
     }
 
     public void addPackageFromScoreCard(Resource resource,

--- a/drools-compiler/src/test/java/org/drools/compiler/builder/impl/KnowledgeBuilderImplTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/builder/impl/KnowledgeBuilderImplTest.java
@@ -1,0 +1,60 @@
+package org.drools.compiler.builder.impl;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+
+public class KnowledgeBuilderImplTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testCreateDumpDrlGeneratedFileRemovingInvalidCharacters() throws Exception {
+        final File dumpDir = temporaryFolder.getRoot();
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "xxx", ".drl"), fileEndsWith(File.separator + "xxx.drl"));
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x?x?", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x/x/", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x\\x\\", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "x*x*", ".drl"), fileEndsWith(File.separator + "x_x_.drl"));
+        assertThat(KnowledgeBuilderImpl.createDumpDrlFile(dumpDir, "aa.AA01-_", ".drl"), fileEndsWith(File.separator + "aa.AA01-_.drl"));
+    }
+
+    private static FileEndsWithMatcher fileEndsWith(String endsWithString) {
+        return new FileEndsWithMatcher(endsWithString);
+    }
+
+    private static class FileEndsWithMatcher extends BaseMatcher<File> {
+
+        private final String endsWithString;
+
+        private FileEndsWithMatcher(String endsWithString) {
+            this.endsWithString = endsWithString;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            if (item instanceof File) {
+                try {
+                    return ((File) item).getCanonicalPath().endsWith(endsWithString);
+                } catch (IOException e) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendValue(endsWithString);
+        }
+    }
+}

--- a/drools-pmml/src/test/java/org/drools/pmml/pmml_4_2/global/AdapterTest.java
+++ b/drools-pmml/src/test/java/org/drools/pmml/pmml_4_2/global/AdapterTest.java
@@ -40,7 +40,7 @@ public class AdapterTest extends DroolsAbstractPMMLTest {
 
     @Test
     public void testCustomInputAdapter() {
-        String source = PMML4Helper.pmmlDefaultPackageName().replace( ".", File.separator ) + File.separator + "mock_cold_adapter.xml";
+        String source = PMML4Helper.pmmlDefaultPackageName().replace( ".", "/" ) + "/" + "mock_cold_adapter.xml";
 
         KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem();


### PR DESCRIPTION
Hi,
I am experiencing errors when configuration.dumpDir is set on Windows platform. I found that it is because of invalid slash usage in file name. I have created createDumpDrlFile method and test for it. I think that allowed characters in regexp are good enough.
Also when I have run test I found that AdapterTest has same issue. 
If you like the patch you can merge it. 
Thx Ivos
