### PR TITLE
BZ1218308: [GSS](6.1.z) Non existing imports in rdrl files prevents the rule to be opened in Business Central

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-commons/pom.xml
@@ -38,6 +38,16 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/resources/log4j.xml
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/resources/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 JBoss Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+  <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%-5p %d{dd-MM HH:mm:ss,SSS} (%F:%M:%L) \t %m%n"/>
+    </layout>
+  </appender>
+  <logger name="org.drools">
+    <level value="INFO"/>
+  </logger>
+  <root>
+    <priority value="ERROR"/>
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
Additional test (and fix) for an edge-case reported by @yurloc 

Furthermore (all be it a hack for possible other bugs) if there's any Exception thrown during unmarshalling we fall-back to using a FreeFormLine to hold the DRL (so at least the user can open and edit the rule).
