### PR TITLE
BPMSPL-151 - Change Impact prediction (preparation work on fully resolving imports in rules files)

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
@@ -34,6 +34,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 
 import java.io.ByteArrayOutputStream;
@@ -148,7 +149,6 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
             final JavaCompilerSettings pSettings
             ) {
 
-        final Map settingsMap = new EclipseJavaCompilerSettings(pSettings).toNativeSettings();
 
         final Collection problems = new ArrayList();
 
@@ -409,7 +409,11 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
             }
         };
 
-        final Compiler compiler = new Compiler(nameEnvironment, policy, settingsMap, compilerRequestor, problemFactory, false);
+        final Map settingsMap = new EclipseJavaCompilerSettings(pSettings).toNativeSettings();
+        CompilerOptions compilerOptions = new CompilerOptions(settingsMap);
+        compilerOptions.parseLiteralExpressionsAsConstants = false;
+        
+        final Compiler compiler = new Compiler(nameEnvironment, policy, compilerOptions, compilerRequestor, problemFactory);
 
         compiler.compile(compilationUnits);
 


### PR DESCRIPTION
This PR updates the `EclipseJavaCompiler` class to use the newer ECJ `Compiler`
constructor instead of the deprecated one. 

The change is very simple and easy enough to figure out if you look at the deprecated
methods that were being used: 
1. How to use `CompilerOptions`: 
   https://github.com/eclipse/eclipse.jdt.core/blob/R4_3_maintenance/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/Compiler.java#L161
2. How/why to set the `CompilerOptions.parseLiteralExpressionsAsConstants` field: 
   https://github.com/eclipse/eclipse.jdt.core/blob/R4_3_maintenance/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java#L495-498

I also included a small change to use the `JavaCompilerFactory` constructor (in the `KieBuilder` class), 
since the `JavaCompilerFactory.getInstance()` method has also been deprecated. 
