### PR TITLE
Propagation queue halt problem reproducer. 

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -131,7 +131,7 @@ public class CepFireUntilHaltTimerTest {
             // give time to fireUntilHalt to process the insertions
             Thread.sleep(1000);
 
-            Thread.sleep(60000);
+            Thread.sleep(30000);
 //            clock.advanceTime(30, TimeUnit.SECONDS);
             Thread.sleep(1000);
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -41,7 +41,6 @@ import org.kie.api.time.SessionClock;
 public class CepFireUntilHaltTimerTest {
 
     private KieContainer container;
-    private int runCounter = 0;
 
     @Before
     public void init() {
@@ -93,11 +92,10 @@ public class CepFireUntilHaltTimerTest {
 
     @Test
     public void testTimerAccumulateFireUntilHalt() throws Exception {
-        System.out.println("Run number: " + (++runCounter));
-        testInternal();
-
-        System.out.println("Run number: " + (++runCounter));
-        testInternal();
+        for (int i = 0; i < 2; i++) {
+            System.out.println("Run number: " + (i + 1));
+            testInternal();
+        }
     }
 
     private void testInternal() throws InterruptedException, TimeoutException, ExecutionException {
@@ -121,9 +119,11 @@ public class CepFireUntilHaltTimerTest {
         try {
 
             final Date eventTime = new Date(clock.getCurrentTime());
+            System.out.println("INSERTING EVENTS!!!!");
             for (int i = 0; i < 205; i++) {
                 ksession.insert(new MetadataEvent(eventTime, 0L));
             }
+            System.out.println("INSERTING EVENTS - DONE!!!!");
 
             // this triggers the rule on after all events had been inserted
             ksession.insert("events_inserted");
@@ -147,10 +147,10 @@ public class CepFireUntilHaltTimerTest {
 
             thread.shutdown();
             if (thread.awaitTermination(60, TimeUnit.SECONDS)) {
-              System.out.println("FireUntilHalt thread stopped. ");
+                System.out.println("FireUntilHalt thread stopped. ");
             } else {
-              System.out.println("Forcing shutdown...");
-              thread.shutdownNow();
+                System.out.println("Forcing shutdown...");
+                thread.shutdownNow();
             }
         }
     }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -111,7 +111,7 @@ public class CepFireUntilHaltTimerTest {
         ksession.insert(clock);
 
         final ExecutorService thread = Executors.newSingleThreadExecutor();
-        final Future fireUntilHaltResult = thread.submit(new Runnable() {
+        thread.submit(new Runnable() {
             @Override
             public void run() {
                 ksession.fireUntilHalt();
@@ -144,10 +144,13 @@ public class CepFireUntilHaltTimerTest {
 //            ksession.destroy();
             // wait for the engine to finish and throw exception if any was thrown
             // in engine's thread
-            fireUntilHaltResult.get(60000, TimeUnit.SECONDS);
-            thread.shutdown();
-            // Wait for everything to properly shutdown.
-            Thread.sleep(10000);
+
+            if (thread.awaitTermination(60, TimeUnit.SECONDS)) {
+              System.out.println("task completed");
+            } else {
+              System.out.println("Forcing shutdown...");
+              thread.shutdownNow();
+            }
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -4,26 +4,34 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.drools.core.time.SessionPseudoClock;
 import org.junit.After;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.io.Resource;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.api.time.SessionClock;
 
 /**
  * Tests proper timer firing using accumulate and fireUntilHalt() mode.
@@ -32,80 +40,83 @@ import org.kie.api.runtime.conf.ClockTypeOption;
 @Ignore
 public class CepFireUntilHaltTimerTest {
 
-    private KieSession ksession;
-    private List<Long> result;
-    private SessionPseudoClock clock;
+    private KieContainer container;
+    private int runCounter = 0;
 
     @Before
     public void init() {
         String drl = "package org.drools.compiler.integrationtests\n" +
-                     "\n" +
-                     "import org.drools.compiler.integrationtests.CepFireUntilHaltTimerTest.MetadataEvent;\n" +
-                     "import java.util.List;\n" +
-                     "\n" +
-                     "global List countResult;\n" +
-                     "\n" +
-                     "declare MetadataEvent\n" +
-                     "    @role( event )\n" +
-                     "    @timestamp( metadataTimestamp )\n" +
-                     "    @duration( metadataDuration )\n" +
-                     "    @expires (24h)\n" +
-                     "end\n" +
-                     "\n" +
-                     "rule \"Number of metadata events in the last 10 seconds\"\n" +
-                     "timer (int: 1s 10s)\n" +
-                     "//timer (int: 0s 10s) // this works\n" +
-                     "when\n" +
-                     "    String( this == \"events_inserted\" )\n" +
-                     "    $count: Number() from accumulate( $event: MetadataEvent() over window:time(10s),  count( $event ) )\n" +
-                     "then\n" +
-                     "    System.out.println(\"Events count: \" + $count);\n" +
-                     "    countResult.add($count);\n" +
-                     "end\n";
+                "\n" +
+                "import org.drools.compiler.integrationtests.CepFireUntilHaltTimerTest.MetadataEvent;\n" +
+                "import java.util.List;\n" +
+                "\n" +
+                "global List countResult;\n" +
+                "\n" +
+                "declare MetadataEvent\n" +
+                "    @role( event )\n" +
+                "    @timestamp( metadataTimestamp )\n" +
+                "    @duration( metadataDuration )\n" +
+                "    @expires (24h)\n" +
+                "end\n" +
+                "\n" +
+                "rule \"Number of metadata events in the last 10 seconds\"\n" +
+                "timer (int: 1s 10s)\n" +
+                "//timer (int: 0s 10s) // this works\n" +
+                "when\n" +
+                "    String( this == \"events_inserted\" )\n" +
+                "    $count: Number() from accumulate( $event: MetadataEvent() over window:time(10s),  count( $event " +
+                ") )\n" +
+                "then\n" +
+                "    System.out.println(\"Events count: \" + $count);\n" +
+                "    countResult.add($count);\n" +
+                "end\n";
 
         KieServices ks = KieServices.Factory.get();
 
         KieModuleModel module = ks.newKieModuleModel();
 
         KieBaseModel defaultBase = module.newKieBaseModel("defaultKBase")
-                                         .setDefault(true)
-                                         .addPackage("*")
-                                         .setEventProcessingMode(EventProcessingOption.STREAM);
+                .setDefault(true)
+                .addPackage("*")
+                .setEventProcessingMode(EventProcessingOption.STREAM);
         defaultBase.newKieSessionModel("defaultKSession")
-                   .setDefault(true)
-                   .setClockType(ClockTypeOption.get("pseudo"));
+                .setDefault(true);
+//                .setClockType(ClockTypeOption.get("pseudo"));
 
         KieFileSystem kfs = ks.newKieFileSystem()
-                              .write("src/main/resources/r1.drl", drl);
+                .write("src/main/resources/r1.drl", drl);
         kfs.writeKModuleXML(module.toXML());
         ks.newKieBuilder(kfs).buildAll();
 
-        ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId())
-                     .newKieSession();
-
-        result = new ArrayList<Long>();
-        ksession.setGlobal("countResult", result);
-
-        clock = ksession.getSessionClock();
-        ksession.insert(clock);
-    }
-
-    @After
-    public void cleanup() {
-        ksession.dispose();
+        container = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
     }
 
     @Test
     public void testTimerAccumulateFireUntilHalt() throws Exception {
+        System.out.println("Run number: " + (++runCounter));
+        testInternal();
 
-        ExecutorService thread = Executors.newSingleThreadExecutor();
+        System.out.println("Run number: " + (++runCounter));
+        testInternal();
+    }
+
+    private void testInternal() throws InterruptedException, TimeoutException, ExecutionException {
+
+        final KieSession ksession = container.newKieSession((Environment) null, null);
+        final List<Long> result = new ArrayList<Long>();
+        ksession.setGlobal("countResult", result);
+
+        //    final SessionPseudoClock clock = ksession.getSessionClock();
+        final SessionClock clock = ksession.getSessionClock();
+        ksession.insert(clock);
+
+        final ExecutorService thread = Executors.newSingleThreadExecutor();
         final Future fireUntilHaltResult = thread.submit(new Runnable() {
             @Override
             public void run() {
                 ksession.fireUntilHalt();
             }
         });
-
 
         try {
 
@@ -120,7 +131,8 @@ public class CepFireUntilHaltTimerTest {
             // give time to fireUntilHalt to process the insertions
             Thread.sleep(1000);
 
-            clock.advanceTime(30, TimeUnit.SECONDS);
+            Thread.sleep(60000);
+//            clock.advanceTime(30, TimeUnit.SECONDS);
             Thread.sleep(1000);
 
             assertFalse("The result is unexpectedly empty", result.isEmpty());
@@ -128,10 +140,14 @@ public class CepFireUntilHaltTimerTest {
             assertEquals(0, (long) result.get(1));
         } finally {
             ksession.halt();
-            // wait for the engine to finish and throw exception if any was thrown 
+            ksession.dispose();
+//            ksession.destroy();
+            // wait for the engine to finish and throw exception if any was thrown
             // in engine's thread
             fireUntilHaltResult.get(60000, TimeUnit.SECONDS);
             thread.shutdown();
+            // Wait for everything to properly shutdown.
+            Thread.sleep(10000);
         }
     }
 
@@ -162,7 +178,7 @@ public class CepFireUntilHaltTimerTest {
 
         public void setMetadataTimestamp(Date metadataTimestamp) {
             this.metadataTimestamp = metadataTimestamp != null
-                                     ? (Date) metadataTimestamp.clone() : null;
+                    ? (Date) metadataTimestamp.clone() : null;
         }
 
         public Long getMetadataDuration() {
@@ -183,7 +199,8 @@ public class CepFireUntilHaltTimerTest {
 
         @Override
         public String toString() {
-            return String.format("MetadataEvent[name='%s' timestamp='%s', duration='%s']", name, metadataTimestamp, metadataDuration);
+            return String.format("MetadataEvent[name='%s' timestamp='%s', duration='%s']", name, metadataTimestamp,
+                    metadataDuration);
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -145,8 +145,9 @@ public class CepFireUntilHaltTimerTest {
             // wait for the engine to finish and throw exception if any was thrown
             // in engine's thread
 
+            thread.shutdown();
             if (thread.awaitTermination(60, TimeUnit.SECONDS)) {
-              System.out.println("task completed");
+              System.out.println("FireUntilHalt thread stopped. ");
             } else {
               System.out.println("Forcing shutdown...");
               thread.shutdownNow();


### PR DESCRIPTION
Reproducer for problem mentioned in BZ [1]. Tested in latest 6.2.x branch. 

It looks like that there's some bad race condition when Timers are involved. The test sometimes fails on second test iteration. From what I examined, the iteration calls SynchronizedPropagationList.halt() method and there's no call to notifyAll later, so the queue processing is halted till the end of the test. However, it fails not in deterministic way, so sometimes the test passes.   

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1218291
