### PR TITLE
[Don't merge yet] Add dependency on jaxb-core

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -90,6 +90,11 @@
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -69,6 +69,11 @@
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/drools-pmml/pom.xml
+++ b/drools-pmml/pom.xml
@@ -64,6 +64,10 @@
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
- the jaxb-impl was split into two: jaxb-impl and jaxb-core
  so we need to depend on both to make the dependant modules
  work
- this needs to be merged after we upgrade to ip-bom 6.0.0.CR27, because the `jaxb-core` dep is not declared in CR26
