### PR TITLE
[DROOLS-860] Retract the core object on the retraction of a trait.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
@@ -158,8 +158,8 @@ public class TraitTest extends CommonTestMethodBase {
 
     private KnowledgeBase getKieBaseFromString( String drl, RuleBaseConfiguration... conf ) {
         KnowledgeBuilder knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        knowledgeBuilder.add( ResourceFactory.newByteArrayResource( drl.getBytes() ),
-                              ResourceType.DRL );
+        knowledgeBuilder.add(ResourceFactory.newByteArrayResource(drl.getBytes()),
+                ResourceType.DRL);
         if (knowledgeBuilder.hasErrors()) {
             throw new RuntimeException( knowledgeBuilder.getErrors().toString() );
         }
@@ -171,6 +171,31 @@ public class TraitTest extends CommonTestMethodBase {
     }
 
 
+    @Test
+    public void testRetract( ) {
+        String drl = "package org.drools.compiler.trait.test; \n" +
+                "import org.drools.core.factmodel.traits.Traitable; \n" +
+                "" +
+                "declare Foo @Traitable end\n" +
+                "declare trait Bar end \n" +
+                "" +
+                "rule Init when then\n" +
+                "  Foo foo = new Foo(); \n" +
+                "  don( foo, Bar.class ); \n" +
+                "end\n" +
+                "rule Retract \n" +
+                "when\n" +
+                " $bar : Bar()\n" +
+                "then\n" +
+                "  retract( $bar ); \n" +
+                "end\n";
+
+        StatefulKnowledgeSession ks = getSessionFromString( drl );
+        TraitFactory.setMode(mode, ks.getKieBase());
+
+        assertEquals(2, ks.fireAllRules());
+        assertEquals(0, ks.getObjects().size());
+    }
 
 
     @Test(timeout=10000)

--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
@@ -187,13 +187,18 @@ public class TraitTest extends CommonTestMethodBase {
                 "when\n" +
                 " $bar : Bar()\n" +
                 "then\n" +
-                "  retract( $bar ); \n" +
+                "  delete( $bar ); \n" +
                 "end\n";
 
         StatefulKnowledgeSession ks = getSessionFromString( drl );
         TraitFactory.setMode(mode, ks.getKieBase());
 
         assertEquals(2, ks.fireAllRules());
+
+        for(Object o : ks.getObjects()) {
+            System.out.println(o);
+        }
+
         assertEquals(0, ks.getObjects().size());
     }
 

--- a/drools-core/src/main/java/org/drools/core/base/DefaultKnowledgeHelper.java
+++ b/drools-core/src/main/java/org/drools/core/base/DefaultKnowledgeHelper.java
@@ -443,6 +443,10 @@ public class DefaultKnowledgeHelper<T extends ModedAssertion<T>>
 
     public void delete(FactHandle handle) {
         Object o = ((InternalFactHandle) handle).getObject();
+        if ( ((InternalFactHandle) handle).isTraiting() ) {
+            delete( ((Thing) o).getCore() );
+            return;
+        }
         EqualityKey key = workingMemory.getTruthMaintenanceSystem().get( o );
 
         if ( key == null || key.getStatus() == EqualityKey.STATED ) {

--- a/drools-core/src/main/java/org/drools/core/base/TraitHelper.java
+++ b/drools-core/src/main/java/org/drools/core/base/TraitHelper.java
@@ -604,7 +604,6 @@ public class TraitHelper implements Externalizable {
     }
 
     public void delete( final FactHandle handle, Activation activation ) {
-        Object o = ((InternalFactHandle) handle).getObject();
         ((InternalWorkingMemoryEntryPoint) ((InternalFactHandle) handle).getEntryPoint()).delete( handle,
                                                                                                   activation.getRule(),
                                                                                                   activation );


### PR DESCRIPTION
Ensure that on the retraction of a traited object, the underlying core object is retracted as well.
