### PR TITLE
JaxbUnknownAdapter: return empty ArrayList when unmarshalling JaxbListWrapper without elements

### DIFF
--- a/drools-core/src/main/java/org/drools/core/xml/jaxb/util/JaxbUnknownAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/xml/jaxb/util/JaxbUnknownAdapter.java
@@ -67,7 +67,11 @@ public class JaxbUnknownAdapter extends XmlAdapter<Object, Object> {
     public Object unmarshal(Object o) throws Exception {
         if ( o instanceof JaxbListWrapper ) {
             JaxbListWrapper v = ( JaxbListWrapper ) o;
-            return Arrays.asList( v.getElements() );
+            Object[] vElements = v.getElements();
+            if (vElements == null) {
+                return new ArrayList<Object>();
+            }
+            return Arrays.asList( vElements );
         } else if (o instanceof JaxbObjectObjectPair[] ) {
             JaxbObjectObjectPair[] value = ( JaxbObjectObjectPair[] ) o;
             Map<Object, Object> r = new HashMap<Object, Object>();


### PR DESCRIPTION
In current implementation if there is unmarshalled JaxbListWrapper with null elements (happens when marshalling empty List) then Arrays.asList throws NPE, which upper layers process as null element. This fix assures that JaxbListWrapper is unmarshalled to List instance even with empty elements.
