### PR TITLE
Remove org.drools:drools-decisiontables dep from API jar avoids optio…

### DIFF
--- a/knowledge-api-legacy5-adapter/pom.xml
+++ b/knowledge-api-legacy5-adapter/pom.xml
@@ -29,10 +29,6 @@
       <artifactId>drools-reteoo</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-decisiontables</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
     </dependency>


### PR DESCRIPTION
…nal dependencies

The org.drools:knowledge-api jar currently depends on org.drools:drools-decisiontables. It seems incorrect for an API jar to pull in all the optional dependencies due to dependence on org.drools:drools-decisiontables jar. 

Here's the dep tree:

```
org.drools:knowledge-api:jar:6.1.0.Final:compile
+- org.drools:drools-core:jar:6.1.0.Final:compile
|  +- org.mvel:mvel2:jar:2.2.1.Final:compile
|  +- org.kie:kie-api:jar:6.1.0.Final:compile
|  \- org.kie:kie-internal:jar:6.1.0.Final:compile
+- org.drools:drools-compiler:jar:6.1.0.Final:compile
|  +- org.antlr:antlr-runtime:jar:3.5:compile
|  +- org.eclipse.jdt.core.compiler:ecj:jar:4.3.1:compile
|  +- com.thoughtworks.xstream:xstream:jar:1.4.7:compile
|  |  +- xmlpull:xmlpull:jar:1.1.3.1:compile
|  |  \- xpp3:xpp3_min:jar:1.1.4c:compile
|  \- com.google.protobuf:protobuf-java:jar:2.5.0:compile
+- org.drools:drools-reteoo:jar:6.1.0.Final:compile
+- org.drools:drools-decisiontables:jar:6.1.0.Final:compile
|  +- org.drools:drools-templates:jar:6.1.0.Final:compile
|  \- org.apache.poi:poi-ooxml:jar:3.10-FINAL:compile
|     +- org.apache.poi:poi:jar:3.10-FINAL:compile
|     |  \- commons-codec:commons-codec:jar:1.5:compile
|     +- org.apache.poi:poi-ooxml-schemas:jar:3.10-FINAL:compile
|     |  \- org.apache.xmlbeans:xmlbeans:jar:2.3.0:compile
|     |     \- stax:stax-api:jar:1.0.1:compile
|     \- dom4j:dom4j:jar:1.6.1:compile
|        \- xml-apis:xml-apis:jar:1.0.b2:compile
\- org.slf4j:slf4j-api:jar:1.7.2:compile
```

Not at all tested, but wanted to at least report the problem.
