### PR TITLE
DROOLS-868 Custom metadata declared at field-level is not available at runtime

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassDefinitionFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassDefinitionFactory.java
@@ -264,34 +264,34 @@ public class ClassDefinitionFactory {
                 fieldDef.addMetaData("key", null);
             }
 
-            if (typeResolver != null) {
-                for (AnnotationDescr annotationDescr : field.getAnnotations()) {
-                    if (annotationDescr.getFullyQualifiedName() == null) {
-                        if (annotationDescr.isStrict()) {
-                            kbuilder.addBuilderResult( new TypeDeclarationError( field,
-                                                                                 "Unknown annotation @" + annotationDescr.getName() + " on field " + field.getFieldName() ) );
-                        } else {
-                            continue;
-                        }
-                    }
-                    Annotation annotation = AnnotationFactory.buildAnnotation(typeResolver, annotationDescr);
-                    if (annotation != null) {
-                        try {
-                            AnnotationDefinition annotationDefinition = AnnotationDefinition.build( annotation.annotationType(),
-                                                                                                    field.getAnnotation(annotationDescr.getFullyQualifiedName()).getValueMap(),
-                                                                                                    typeResolver );
-                            fieldDef.addAnnotation( annotationDefinition );
-                        } catch ( Exception e ) {
-                            kbuilder.addBuilderResult( new TypeDeclarationError( field,
-                                                                                 "Annotated field " + field.getFieldName() +
-                                                                                 "  - undefined property in @annotation " +
-                                                                                 annotationDescr.getName() + ": " + e.getMessage() + ";" ) );
-                        }
+            for (AnnotationDescr annotationDescr : field.getAnnotations()) {
+                if (annotationDescr.getFullyQualifiedName() == null) {
+                    if (annotationDescr.isStrict()) {
+                        kbuilder.addBuilderResult( new TypeDeclarationError( field,
+                                                                             "Unknown annotation @" + annotationDescr.getName() + " on field " + field.getFieldName() ) );
                     } else {
-                        if (annotationDescr.isStrict()) {
-                            kbuilder.addBuilderResult(new TypeDeclarationError(field,
-                                                                               "Unknown annotation @" + annotationDescr.getName() + " on field " + field.getFieldName()));
-                        }
+                        // Annotation is custom metadata
+                        fieldDef.addMetaData(annotationDescr.getName(), annotationDescr.getSingleValue());
+                        continue;
+                    }
+                }
+                Annotation annotation = AnnotationFactory.buildAnnotation(typeResolver, annotationDescr);
+                if (annotation != null) {
+                    try {
+                        AnnotationDefinition annotationDefinition = AnnotationDefinition.build( annotation.annotationType(),
+                                                                                                field.getAnnotation(annotationDescr.getFullyQualifiedName()).getValueMap(),
+                                                                                                typeResolver );
+                        fieldDef.addAnnotation( annotationDefinition );
+                    } catch ( Exception e ) {
+                        kbuilder.addBuilderResult( new TypeDeclarationError( field,
+                                                                             "Annotated field " + field.getFieldName() +
+                                                                             "  - undefined property in @annotation " +
+                                                                             annotationDescr.getName() + ": " + e.getMessage() + ";" ) );
+                    }
+                } else {
+                    if (annotationDescr.isStrict()) {
+                        kbuilder.addBuilderResult(new TypeDeclarationError(field,
+                                                                           "Unknown annotation @" + annotationDescr.getName() + " on field " + field.getFieldName()));
                     }
                 }
             }

--- a/drools-compiler/src/test/java/org/drools/compiler/builder/impl/KnowledgeBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/builder/impl/KnowledgeBuilderTest.java
@@ -88,6 +88,7 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.definition.type.FactField;
+import org.kie.api.definition.type.FactType;
 import org.kie.api.definition.type.Role;
 import org.kie.api.definition.type.TypeSafe;
 import org.kie.api.runtime.KieSession;
@@ -1086,6 +1087,34 @@ public class KnowledgeBuilderTest extends DroolsTestCase {
 
         Class newBean = bp.getPackageClassLoader().loadClass( "org.drools.compiler.test.NewBean" );
         assertNotNull( newBean );
+    }
+
+    @Test
+    public void testTypeDeclarationWithFieldMetadata() throws Exception {
+        PackageDescr pkgDescr = new PackageDescr( "org.drools.compiler.test" );
+        TypeDeclarationDescr typeDescr = new TypeDeclarationDescr( "TypeWithFieldMeta" );
+
+        TypeFieldDescr f1 = new TypeFieldDescr( "field",
+                                                new PatternDescr( "String" ) );
+        f1.addAnnotation("custom", null);
+        typeDescr.addField( f1 );
+
+        pkgDescr.addTypeDeclaration( typeDescr );
+
+        KnowledgeBuilderImpl builder = new KnowledgeBuilderImpl();
+        builder.addPackage(pkgDescr);
+        assertFalse(builder.hasErrors());
+
+        InternalKnowledgePackage bp = builder.getPackage();
+
+        final FactType factType = bp.getFactType("org.drools.compiler.test.TypeWithFieldMeta");
+        assertNotNull( factType );
+        final FactField field = factType.getField( "field" );
+        assertNotNull( field );
+
+        final Map<String, Object> fieldMetaData = field.getMetaData();
+        assertNotNull("No field-level custom metadata got compiled", fieldMetaData);
+        assertTrue("Field metadata does not include expected value", fieldMetaData.containsKey("custom"));
     }
 
     @Test


### PR DESCRIPTION
In addition to adding the call to fieldDef.addMetaData(), I removed the not-null check on typeResolver since there are no test cases that define what the behaviour should be if typeResolver is null (i.e. it's never null for any of the tests).
