### PR TITLE
Bug 1247559 - [GSS] (6.1.z) Guided Rule editor does not seem to reloa…

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -16,67 +16,25 @@
 
 package org.drools.workbench.models.commons.backend.rule;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.drools.compiler.lang.Expander;
 import org.drools.compiler.lang.dsl.DSLMappingFile;
 import org.drools.compiler.lang.dsl.DSLTokenizedMappingFile;
 import org.drools.compiler.lang.dsl.DefaultExpander;
-import org.drools.workbench.models.datamodel.oracle.DataType;
-import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
-import org.drools.workbench.models.datamodel.oracle.MethodInfo;
-import org.drools.workbench.models.datamodel.oracle.ModelField;
-import org.drools.workbench.models.datamodel.oracle.PackageDataModelOracle;
-import org.drools.workbench.models.datamodel.rule.ActionCallMethod;
-import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
-import org.drools.workbench.models.datamodel.rule.ActionGlobalCollectionAdd;
-import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
-import org.drools.workbench.models.datamodel.rule.ActionSetField;
-import org.drools.workbench.models.datamodel.rule.ActionUpdateField;
-import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
-import org.drools.workbench.models.datamodel.rule.CEPWindow;
-import org.drools.workbench.models.datamodel.rule.CompositeFactPattern;
-import org.drools.workbench.models.datamodel.rule.CompositeFieldConstraint;
-import org.drools.workbench.models.datamodel.rule.ConnectiveConstraint;
-import org.drools.workbench.models.datamodel.rule.DSLComplexVariableValue;
-import org.drools.workbench.models.datamodel.rule.DSLSentence;
-import org.drools.workbench.models.datamodel.rule.DSLVariableValue;
-import org.drools.workbench.models.datamodel.rule.ExpressionCollection;
-import org.drools.workbench.models.datamodel.rule.ExpressionField;
-import org.drools.workbench.models.datamodel.rule.ExpressionFormLine;
-import org.drools.workbench.models.datamodel.rule.ExpressionMethod;
-import org.drools.workbench.models.datamodel.rule.ExpressionPart;
-import org.drools.workbench.models.datamodel.rule.ExpressionText;
-import org.drools.workbench.models.datamodel.rule.ExpressionUnboundFact;
-import org.drools.workbench.models.datamodel.rule.ExpressionVariable;
-import org.drools.workbench.models.datamodel.rule.FactPattern;
-import org.drools.workbench.models.datamodel.rule.FieldConstraint;
-import org.drools.workbench.models.datamodel.rule.FieldNatureType;
-import org.drools.workbench.models.datamodel.rule.FreeFormLine;
-import org.drools.workbench.models.datamodel.rule.FromAccumulateCompositeFactPattern;
-import org.drools.workbench.models.datamodel.rule.FromCollectCompositeFactPattern;
-import org.drools.workbench.models.datamodel.rule.FromCompositeFactPattern;
-import org.drools.workbench.models.datamodel.rule.IAction;
-import org.drools.workbench.models.datamodel.rule.IPattern;
-import org.drools.workbench.models.datamodel.rule.RuleAttribute;
-import org.drools.workbench.models.datamodel.rule.RuleModel;
-import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
-import org.drools.workbench.models.datamodel.rule.SingleFieldConstraintEBLeftSide;
+import org.drools.workbench.models.datamodel.oracle.*;
+import org.drools.workbench.models.datamodel.rule.*;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.util.*;
+
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RuleModelDRLPersistenceUnmarshallingTest {
 
@@ -1039,6 +997,27 @@ public class RuleModelDRLPersistenceUnmarshallingTest {
         assertEquals( 1, m.lhs.length );
         assertTrue( m.lhs[ 0 ] instanceof FreeFormLine );
         assertEquals( "eval( true )", ( (FreeFormLine) m.lhs[ 0 ] ).getText() );
+    }
+
+    @Test
+    @Ignore("Bug 1247559 - [GSS] (6.1.z) Guided Rule editor does not seem to reload 'eval()' functions correctly while used inside the constraint of a fact")
+    public void testEval2() {
+        String drl = "rule rule1\n"
+                + "when\n"
+                + "Double( eval( functionTrue() && functionFalse()  ) )\n"
+                + "then\n"
+                + "end";
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                Collections.EMPTY_LIST,
+                dmo);
+
+        assertNotNull(m);
+        assertEquals(1, m.lhs.length);
+        assertTrue(m.lhs[0] instanceof FactPattern);
+        SingleFieldConstraint constraint = (SingleFieldConstraint) ((FactPattern) m.lhs[0]).getConstraint(0);
+        assertEquals("functionTrue() && functionFalse()", constraint.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_PREDICATE, constraint.getConstraintValueType());
     }
 
     @Test


### PR DESCRIPTION
…d "eval()" functions correctly while used inside the constraint of a fact

One more Guided Rule Editor bug. Here is the test for it.
