### PR TITLE
fix javadoc about lnglevel

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/JavaDialectConfiguration.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/JavaDialectConfiguration.java
@@ -40,7 +40,7 @@ import static org.mvel2.asm.Opcodes.V1_8;
  * The valid values are "ECLIPSE" and "JANINO" only. 
  * 
  * drools.dialect.java.compiler = <ECLIPSE|JANINO>
- * drools.dialect.java.lngLevel = <1.5|1.6>
+ * drools.dialect.java.compiler.lnglevel = <1.5|1.6>
  * 
  * The default compiler is Eclipse and the default lngLevel is 1.5.
  * The lngLevel will attempt to autodiscover your system using the 

--- a/knowledge-api-legacy5-adapter/src/main/java/org/drools/builder/KnowledgeBuilderConfiguration.java
+++ b/knowledge-api-legacy5-adapter/src/main/java/org/drools/builder/KnowledgeBuilderConfiguration.java
@@ -58,7 +58,7 @@ import org.drools.builder.conf.KnowledgeBuilderOptionsConfiguration;
  * The Java dialect supports the following configurations:
  * <ul>
  * <li>drools.dialect.java.compiler = &lt;ECLIPSE|JANINO&gt;</li>
- * <li>drools.dialect.java.lngLevel = &lt;1.5|1.6&gt;</li>
+ * <li>drools.dialect.java.compiler.lnglevel = &lt;1.5|1.6&gt;</li>
  * </ul>
  * 
  * And MVEL supports the following configurations:


### PR DESCRIPTION
drools.dialect.java.compiler.lnglevel is the correct system property name.

https://github.com/tkobayas/drools/blob/master/drools-core/src/main/java/org/drools/core/rule/builder/dialect/asm/ClassLevel.java#L26
