### PR TITLE
DROOLS-899: KIE-CI sends MavenRequest without considering the repositories defined in user settings file

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/MavenRepository.java
+++ b/kie-ci/src/main/java/org/kie/scanner/MavenRepository.java
@@ -15,20 +15,19 @@
 
 package org.kie.scanner;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.settings.Mirror;
-import org.apache.maven.settings.Profile;
-import org.apache.maven.settings.Repository;
-import org.apache.maven.settings.RepositoryPolicy;
-import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
-import org.eclipse.aether.util.repository.AuthenticationBuilder;
-import org.kie.api.builder.ReleaseId;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
-import org.kie.scanner.embedder.MavenSettings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.collection.DependencyCollectionException;
@@ -44,23 +43,18 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.util.artifact.SubArtifact;
 import org.eclipse.aether.version.Version;
+import org.kie.api.builder.ReleaseId;
+import org.kie.scanner.embedder.MavenSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-
-import static org.kie.scanner.DependencyDescriptor.isRangedVersion;
+import static org.kie.scanner.DependencyDescriptor.*;
 
 public class MavenRepository {
 
-    private static final Logger log = LoggerFactory.getLogger(MavenRepository.class);
+    private static final Logger log = LoggerFactory.getLogger( MavenRepository.class );
 
     private static MavenRepository defaultMavenRepository;
 
@@ -68,11 +62,11 @@ public class MavenRepository {
     private final Collection<RemoteRepository> extraRepositories;
     private final Collection<RemoteRepository> remoteRepositoriesForRequest;
 
-    protected MavenRepository(Aether aether) {
+    protected MavenRepository( Aether aether ) {
         this.aether = aether;
         Settings settings = getSettings();
-        extraRepositories = initExtraRepositories(settings);
-        remoteRepositoriesForRequest = initRemoteRepositoriesForRequest(settings);
+        extraRepositories = initExtraRepositories( settings );
+        remoteRepositoriesForRequest = initRemoteRepositoriesForRequest( settings );
     }
 
     protected Settings getSettings() {
@@ -84,220 +78,164 @@ public class MavenRepository {
     }
 
     public static synchronized MavenRepository getMavenRepository() {
-        if (defaultMavenRepository == null) {
+        if ( defaultMavenRepository == null ) {
             Aether defaultAether = Aether.getAether();
-            defaultMavenRepository = new MavenRepository(defaultAether);
+            defaultMavenRepository = new MavenRepository( defaultAether );
         }
         return defaultMavenRepository;
     }
 
-    private Collection<RemoteRepository> initExtraRepositories(Settings settings) {
+    private Collection<RemoteRepository> initExtraRepositories( Settings settings ) {
+        final MavenRepositoryUtils repositoryUtils = new MavenRepositoryUtils( settings );
         Collection<RemoteRepository> extraRepositories = new HashSet<RemoteRepository>();
-        for (Profile profile : settings.getProfiles()) {
-            if (isProfileActive(settings, profile)) {
-                for (Repository repository : profile.getRepositories()) {
-                    extraRepositories.add( toRemoteRepositoryBuilder(settings, repository).build() );
-                }
-                for (Repository repository : profile.getPluginRepositories()) {
-                    extraRepositories.add( toRemoteRepositoryBuilder(settings, repository).build() );
-                }
-            }
-        }
+        extraRepositories.addAll( repositoryUtils.getExtraRepositories() );
         return extraRepositories;
     }
 
-    private Collection<RemoteRepository> initRemoteRepositoriesForRequest(Settings settings) {
+    private Collection<RemoteRepository> initRemoteRepositoriesForRequest( Settings settings ) {
+        final MavenRepositoryUtils repositoryUtils = new MavenRepositoryUtils( settings );
         Collection<RemoteRepository> remoteRepos = new HashSet<RemoteRepository>();
-        for (RemoteRepository repo : extraRepositories) {
-            remoteRepos.add( resolveMirroredRepo(settings, repo) );
-        }
-        for (RemoteRepository repo : aether.getRepositories()) {
-            remoteRepos.add( resolveMirroredRepo(settings, repo) );
+        remoteRepos.addAll( repositoryUtils.getRemoteRepositoriesForRequest() );
+
+        for ( RemoteRepository repo : aether.getRepositories() ) {
+            remoteRepos.add( repositoryUtils.resolveMirroredRepo( repo ) );
         }
         return remoteRepos;
     }
 
-    private RemoteRepository resolveMirroredRepo(Settings settings, RemoteRepository repo) {
-        for (Mirror mirror : settings.getMirrors()) {
-            if (isMirror(repo, mirror.getMirrorOf())) {
-                return toRemoteRepositoryBuilder(settings, mirror.getId(), mirror.getLayout(), mirror.getUrl()).build();
-            }
-        }
-        return repo;
+    public static MavenRepository getMavenRepository( MavenProject mavenProject ) {
+        return new MavenRepository( new Aether( mavenProject ) );
     }
 
-    private boolean isMirror(RemoteRepository repo, String mirrorOf)  {
-        return mirrorOf.equals("*") ||
-               ( mirrorOf.equals("external:*") && !repo.getUrl().startsWith("file:") ) ||
-               ( mirrorOf.contains("external:*") && !repo.getUrl().startsWith("file:") && !mirrorOf.contains("!" + repo.getId()) ) ||
-               ( mirrorOf.startsWith("*") && !mirrorOf.contains("!" + repo.getId()) ) ||
-               ( !mirrorOf.startsWith("*") && !mirrorOf.contains("external:*") && mirrorOf.contains(repo.getId()) );
-    }
-
-    private boolean isProfileActive(Settings settings, Profile profile) {
-        return settings.getActiveProfiles().contains(profile.getId()) ||
-               (profile.getActivation() != null && profile.getActivation().isActiveByDefault());
-    }
-
-    private static RemoteRepository.Builder toRemoteRepositoryBuilder(Settings settings, Repository repository) {
-        RemoteRepository.Builder remoteBuilder = toRemoteRepositoryBuilder( settings, repository.getId(), repository.getLayout(), repository.getUrl() );
-        setPolicy(remoteBuilder, repository.getSnapshots(), true);
-        setPolicy(remoteBuilder, repository.getReleases(), false);
-        return remoteBuilder;
-    }
-
-    private static RemoteRepository.Builder toRemoteRepositoryBuilder(Settings settings, String id, String layout, String url) {
-        RemoteRepository.Builder remoteBuilder = new RemoteRepository.Builder( id, layout, url );
-        Server server = settings.getServer( id );
-        if (server != null) {
-            remoteBuilder.setAuthentication( new AuthenticationBuilder().addUsername(server.getUsername())
-                                                                        .addPassword(server.getPassword())
-                                                                        .build() );
-        }
-        return remoteBuilder;
-
-    }
-
-    private static void setPolicy(RemoteRepository.Builder builder, RepositoryPolicy policy, boolean snapshot) {
-        if (policy != null) {
-            org.eclipse.aether.repository.RepositoryPolicy repoPolicy =
-                    new org.eclipse.aether.repository.RepositoryPolicy(policy.isEnabled(),
-                                                                       policy.getUpdatePolicy(),
-                                                                       policy.getChecksumPolicy());
-            if (snapshot) {
-                builder.setSnapshotPolicy(repoPolicy);
-            } else {
-                builder.setReleasePolicy(repoPolicy);
-            }
-        }
-    }
-
-    public static MavenRepository getMavenRepository(MavenProject mavenProject) {
-        return new MavenRepository(new Aether(mavenProject));
-    }
-
-    public List<DependencyDescriptor> getArtifactDependecies(String artifactName) {
+    public List<DependencyDescriptor> getArtifactDependecies( String artifactName ) {
         Artifact artifact = new DefaultArtifact( artifactName );
         CollectRequest collectRequest = new CollectRequest();
         Dependency root = new Dependency( artifact, "" );
         collectRequest.setRoot( root );
-        for (RemoteRepository repo : remoteRepositoriesForRequest) {
-            collectRequest.addRepository(repo);
+        for ( RemoteRepository repo : remoteRepositoriesForRequest ) {
+            collectRequest.addRepository( repo );
         }
         CollectResult collectResult;
         try {
-            collectResult = aether.getSystem().collectDependencies(aether.getSession(), collectRequest);
-        } catch (DependencyCollectionException e) {
-            throw new RuntimeException(e);
+            collectResult = aether.getSystem().collectDependencies( aether.getSession(), collectRequest );
+        } catch ( DependencyCollectionException e ) {
+            throw new RuntimeException( e );
         }
         CollectDependencyVisitor visitor = new CollectDependencyVisitor();
         collectResult.getRoot().accept( visitor );
 
         List<DependencyDescriptor> descriptors = new ArrayList<DependencyDescriptor>();
-        for (DependencyNode node : visitor.getDependencies()) {
+        for ( DependencyNode node : visitor.getDependencies() ) {
             // skip root to not add artifact as dependency
-            if (node.getDependency().equals(root)) {
+            if ( node.getDependency().equals( root ) ) {
                 continue;
             }
-            descriptors.add(new DependencyDescriptor(node.getDependency().getArtifact()));
+            descriptors.add( new DependencyDescriptor( node.getDependency().getArtifact() ) );
         }
         return descriptors;
     }
 
-    public Artifact resolveArtifact(ReleaseId releaseId) {
+    public Artifact resolveArtifact( ReleaseId releaseId ) {
         String artifactName = releaseId.toString();
-        if (isRangedVersion(releaseId.getVersion())) {
-            Version v = resolveVersion(artifactName);
-            if (v == null) {
+        if ( isRangedVersion( releaseId.getVersion() ) ) {
+            Version v = resolveVersion( artifactName );
+            if ( v == null ) {
                 return null;
             }
             artifactName = releaseId.getGroupId() + ":" + releaseId.getArtifactId() + ":" + v;
         }
-        return resolveArtifact(artifactName);
+        return resolveArtifact( artifactName );
     }
 
-    public Artifact resolveArtifact(String artifactName) {
-        return resolveArtifact(artifactName, true);
+    public Artifact resolveArtifact( String artifactName ) {
+        return resolveArtifact( artifactName, true );
     }
 
-    public Artifact resolveArtifact(String artifactName, boolean logUnresolvedArtifact) {
+    public Artifact resolveArtifact( String artifactName,
+                                     boolean logUnresolvedArtifact ) {
         Artifact artifact = new DefaultArtifact( artifactName );
         ArtifactRequest artifactRequest = new ArtifactRequest();
         artifactRequest.setArtifact( artifact );
-        for (RemoteRepository repo : remoteRepositoriesForRequest) {
-            artifactRequest.addRepository(repo);
+        for ( RemoteRepository repo : remoteRepositoriesForRequest ) {
+            artifactRequest.addRepository( repo );
         }
         try {
-            ArtifactResult artifactResult = aether.getSystem().resolveArtifact(aether.getSession(), artifactRequest);
+            ArtifactResult artifactResult = aether.getSystem().resolveArtifact( aether.getSession(), artifactRequest );
             return artifactResult.getArtifact();
-        } catch (ArtifactResolutionException e) {
-            if (logUnresolvedArtifact) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Unable to resolve artifact: " + artifactName, e);
+        } catch ( ArtifactResolutionException e ) {
+            if ( logUnresolvedArtifact ) {
+                if ( log.isDebugEnabled() ) {
+                    log.debug( "Unable to resolve artifact: " + artifactName, e );
                 } else {
-                    log.warn("Unable to resolve artifact: " + artifactName);
+                    log.warn( "Unable to resolve artifact: " + artifactName );
                 }
             }
             return null;
         }
     }
 
-    public Version resolveVersion(String artifactName) {
+    public Version resolveVersion( String artifactName ) {
         Artifact artifact = new DefaultArtifact( artifactName );
         VersionRangeRequest versionRequest = new VersionRangeRequest();
-        versionRequest.setArtifact(artifact);
-        for (RemoteRepository repo : remoteRepositoriesForRequest) {
-            versionRequest.addRepository(repo);
+        versionRequest.setArtifact( artifact );
+        for ( RemoteRepository repo : remoteRepositoriesForRequest ) {
+            versionRequest.addRepository( repo );
         }
         try {
-            VersionRangeResult versionRangeResult = aether.getSystem().resolveVersionRange(aether.getSession(), versionRequest);
+            VersionRangeResult versionRangeResult = aether.getSystem().resolveVersionRange( aether.getSession(), versionRequest );
             return versionRangeResult.getHighestVersion();
-        } catch (VersionRangeResolutionException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Unable to resolve version range for artifact: " + artifactName, e);
+        } catch ( VersionRangeResolutionException e ) {
+            if ( log.isDebugEnabled() ) {
+                log.debug( "Unable to resolve version range for artifact: " + artifactName, e );
             } else {
-                log.warn("Unable to resolve version range for artifact: " + artifactName);
+                log.warn( "Unable to resolve version range for artifact: " + artifactName );
             }
             return null;
         }
     }
 
-    public void deployArtifact(ReleaseId releaseId, InternalKieModule kieModule, File pomfile) {
-        File jarFile = new File( System.getProperty( "java.io.tmpdir" ), toFileName(releaseId, null) + ".jar");
+    public void deployArtifact( ReleaseId releaseId,
+                                InternalKieModule kieModule,
+                                File pomfile ) {
+        File jarFile = new File( System.getProperty( "java.io.tmpdir" ), toFileName( releaseId, null ) + ".jar" );
         try {
-            FileOutputStream fos = new FileOutputStream(jarFile);
-            fos.write(kieModule.getBytes());
+            FileOutputStream fos = new FileOutputStream( jarFile );
+            fos.write( kieModule.getBytes() );
             fos.flush();
             fos.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        } catch ( IOException e ) {
+            throw new RuntimeException( e );
         }
-        deployArtifact(releaseId, jarFile, pomfile);
+        deployArtifact( releaseId, jarFile, pomfile );
     }
 
-    public void deployArtifact(ReleaseId releaseId, byte[] jarContent, byte[] pomContent ) {
-        File jarFile = new File( System.getProperty( "java.io.tmpdir" ), toFileName(releaseId, null) + ".jar");
+    public void deployArtifact( ReleaseId releaseId,
+                                byte[] jarContent,
+                                byte[] pomContent ) {
+        File jarFile = new File( System.getProperty( "java.io.tmpdir" ), toFileName( releaseId, null ) + ".jar" );
         try {
-            FileOutputStream fos = new FileOutputStream(jarFile);
-            fos.write(jarContent);
+            FileOutputStream fos = new FileOutputStream( jarFile );
+            fos.write( jarContent );
             fos.flush();
             fos.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        } catch ( IOException e ) {
+            throw new RuntimeException( e );
         }
-        File pomFile = new File( System.getProperty( "java.io.tmpdir" ), toFileName(releaseId, null) + ".pom");
+        File pomFile = new File( System.getProperty( "java.io.tmpdir" ), toFileName( releaseId, null ) + ".pom" );
         try {
-            FileOutputStream fos = new FileOutputStream(pomFile);
-            fos.write(pomContent);
+            FileOutputStream fos = new FileOutputStream( pomFile );
+            fos.write( pomContent );
             fos.flush();
             fos.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        } catch ( IOException e ) {
+            throw new RuntimeException( e );
         }
-        deployArtifact(releaseId, jarFile, pomFile);
+        deployArtifact( releaseId, jarFile, pomFile );
     }
 
-    public void deployArtifact(ReleaseId releaseId, File jar, File pomfile) {
+    public void deployArtifact( ReleaseId releaseId,
+                                File jar,
+                                File pomfile ) {
         Artifact jarArtifact = new DefaultArtifact( releaseId.getGroupId(), releaseId.getArtifactId(), "jar", releaseId.getVersion() );
         jarArtifact = jarArtifact.setFile( jar );
 
@@ -308,28 +246,31 @@ public class MavenRepository {
         deployRequest
                 .addArtifact( jarArtifact )
                 .addArtifact( pomArtifact )
-                .setRepository(aether.getLocalRepository());
+                .setRepository( aether.getLocalRepository() );
 
         try {
-            aether.getSystem().deploy(aether.getSession(), deployRequest);
-        } catch (DeploymentException e) {
-            throw new RuntimeException(e);
+            aether.getSystem().deploy( aether.getSession(), deployRequest );
+        } catch ( DeploymentException e ) {
+            throw new RuntimeException( e );
         }
     }
 
-    public void deployPomArtifact(String groupId, String artifactId, String version, File pomfile) {
+    public void deployPomArtifact( String groupId,
+                                   String artifactId,
+                                   String version,
+                                   File pomfile ) {
         Artifact pomArtifact = new DefaultArtifact( groupId, artifactId, "pom", version );
         pomArtifact = pomArtifact.setFile( pomfile );
 
         DeployRequest deployRequest = new DeployRequest();
         deployRequest
-                .addArtifact(pomArtifact)
-                .setRepository(aether.getLocalRepository());
+                .addArtifact( pomArtifact )
+                .setRepository( aether.getLocalRepository() );
 
         try {
-            aether.getSystem().deploy(aether.getSession(), deployRequest);
-        } catch (DeploymentException e) {
-            throw new RuntimeException(e);
+            aether.getSystem().deploy( aether.getSession(), deployRequest );
+        } catch ( DeploymentException e ) {
+            throw new RuntimeException( e );
         }
     }
 
@@ -337,12 +278,12 @@ public class MavenRepository {
 
         private final List<DependencyNode> dependencies = new ArrayList<DependencyNode>();
 
-        public boolean visitEnter(DependencyNode node) {
-            dependencies.add(node);
+        public boolean visitEnter( DependencyNode node ) {
+            dependencies.add( node );
             return true;
         }
 
-        public boolean visitLeave(DependencyNode node) {
+        public boolean visitLeave( DependencyNode node ) {
             return true;
         }
 
@@ -350,9 +291,10 @@ public class MavenRepository {
             return dependencies;
         }
     }
-    
-    public static String toFileName(ReleaseId releaseId, String classifier) {
-        if (classifier != null) {
+
+    public static String toFileName( ReleaseId releaseId,
+                                     String classifier ) {
+        if ( classifier != null ) {
             return releaseId.getArtifactId() + "-" + releaseId.getVersion() + "-" + classifier;
         }
 

--- a/kie-ci/src/main/java/org/kie/scanner/MavenRepositoryUtils.java
+++ b/kie-ci/src/main/java/org/kie/scanner/MavenRepositoryUtils.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.scanner;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.apache.maven.settings.Mirror;
+import org.apache.maven.settings.Profile;
+import org.apache.maven.settings.Repository;
+import org.apache.maven.settings.RepositoryPolicy;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+
+public class MavenRepositoryUtils {
+
+    private final Settings settings;
+    private final Collection<RemoteRepository> extraRepositories;
+    private final Collection<RemoteRepository> remoteRepositoriesForRequest;
+
+    public MavenRepositoryUtils( Settings settings ) {
+        this.settings = settings;
+        this.extraRepositories = initExtraRepositories();
+        this.remoteRepositoriesForRequest = initRemoteRepositoriesForRequest();
+    }
+
+    public Collection<RemoteRepository> getExtraRepositories() {
+        return extraRepositories;
+    }
+
+    public Collection<RemoteRepository> getRemoteRepositoriesForRequest() {
+        return remoteRepositoriesForRequest;
+    }
+
+    private Collection<RemoteRepository> initExtraRepositories() {
+        Collection<RemoteRepository> extraRepositories = new HashSet<RemoteRepository>();
+        for ( Profile profile : settings.getProfiles() ) {
+            if ( isProfileActive( profile ) ) {
+                for ( Repository repository : profile.getRepositories() ) {
+                    extraRepositories.add( toRemoteRepositoryBuilder( settings,
+                                                                      repository ).build() );
+                }
+                for ( Repository repository : profile.getPluginRepositories() ) {
+                    extraRepositories.add( toRemoteRepositoryBuilder( settings,
+                                                                      repository ).build() );
+                }
+            }
+        }
+        return extraRepositories;
+    }
+
+    private Collection<RemoteRepository> initRemoteRepositoriesForRequest() {
+        Collection<RemoteRepository> remoteRepos = new HashSet<RemoteRepository>();
+        for ( RemoteRepository repo : extraRepositories ) {
+            remoteRepos.add( resolveMirroredRepo( repo ) );
+        }
+        return remoteRepos;
+    }
+
+    public RemoteRepository resolveMirroredRepo( RemoteRepository repo ) {
+        for ( Mirror mirror : settings.getMirrors() ) {
+            if ( isMirror( repo, mirror.getMirrorOf() ) ) {
+                return toRemoteRepositoryBuilder( settings,
+                                                  mirror.getId(),
+                                                  mirror.getLayout(),
+                                                  mirror.getUrl() ).build();
+            }
+        }
+        return repo;
+    }
+
+    private boolean isMirror( RemoteRepository repo,
+                              String mirrorOf ) {
+        return mirrorOf.equals( "*" ) ||
+                ( mirrorOf.equals( "external:*" ) && !repo.getUrl().startsWith( "file:" ) ) ||
+                ( mirrorOf.contains( "external:*" ) && !repo.getUrl().startsWith( "file:" ) && !mirrorOf.contains( "!" + repo.getId() ) ) ||
+                ( mirrorOf.startsWith( "*" ) && !mirrorOf.contains( "!" + repo.getId() ) ) ||
+                ( !mirrorOf.startsWith( "*" ) && !mirrorOf.contains( "external:*" ) && mirrorOf.contains( repo.getId() ) );
+    }
+
+    private boolean isProfileActive( Profile profile ) {
+        return settings.getActiveProfiles().contains( profile.getId() ) ||
+                ( profile.getActivation() != null && profile.getActivation().isActiveByDefault() );
+    }
+
+    private static RemoteRepository.Builder toRemoteRepositoryBuilder( Settings settings,
+                                                                       Repository repository ) {
+        RemoteRepository.Builder remoteBuilder = toRemoteRepositoryBuilder( settings,
+                                                                            repository.getId(),
+                                                                            repository.getLayout(),
+                                                                            repository.getUrl() );
+        setPolicy( remoteBuilder, repository.getSnapshots(),
+                   true );
+        setPolicy( remoteBuilder, repository.getReleases(),
+                   false );
+        return remoteBuilder;
+    }
+
+    private static RemoteRepository.Builder toRemoteRepositoryBuilder( Settings settings,
+                                                                       String id,
+                                                                       String layout,
+                                                                       String url ) {
+        RemoteRepository.Builder remoteBuilder = new RemoteRepository.Builder( id,
+                                                                               layout,
+                                                                               url );
+        Server server = settings.getServer( id );
+        if ( server != null ) {
+            remoteBuilder.setAuthentication( new AuthenticationBuilder().addUsername( server.getUsername() )
+                                                     .addPassword( server.getPassword() )
+                                                     .build() );
+        }
+        return remoteBuilder;
+
+    }
+
+    private static void setPolicy( RemoteRepository.Builder builder,
+                                   RepositoryPolicy policy,
+                                   boolean snapshot ) {
+        if ( policy != null ) {
+            org.eclipse.aether.repository.RepositoryPolicy repoPolicy =
+                    new org.eclipse.aether.repository.RepositoryPolicy( policy.isEnabled(),
+                                                                        policy.getUpdatePolicy(),
+                                                                        policy.getChecksumPolicy() );
+            if ( snapshot ) {
+                builder.setSnapshotPolicy( repoPolicy );
+            } else {
+                builder.setReleasePolicy( repoPolicy );
+            }
+        }
+    }
+
+}

--- a/kie-ci/src/test/java/org/kie/scanner/embedder/MavenEmbedderTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/embedder/MavenEmbedderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.scanner.embedder;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuilder;
+import org.apache.maven.settings.building.SettingsBuildingException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MavenEmbedderTest {
+
+    @Test
+    public void testExternalRepositories() {
+        try {
+            final MavenRequest mavenRequest = createMavenRequest();
+            final MavenEmbedder embedder = new MavenEmbedderMock( mavenRequest );
+            final MavenExecutionRequest request = embedder.buildMavenExecutionRequest( mavenRequest );
+
+            assertNotNull( request );
+
+            final List<ArtifactRepository> remoteRepositories = request.getRemoteRepositories();
+            assertEquals( 2,
+                          remoteRepositories.size() );
+            for ( ArtifactRepository remoteRepository : remoteRepositories ) {
+                assertTrue( remoteRepository.getId().equals( "central" )
+                                    || remoteRepository.getId().equals( "kie-wb-m2-repo" ) );
+            }
+
+        } catch ( MavenEmbedderException mee ) {
+            fail( mee.getMessage() );
+
+        } catch ( ComponentLookupException cle ) {
+            fail( cle.getMessage() );
+        }
+    }
+
+    public static class MavenEmbedderMock extends MavenEmbedder {
+
+        public MavenEmbedderMock( final MavenRequest mavenRequest ) throws MavenEmbedderException {
+            super( mavenRequest );
+        }
+
+        @Override
+        protected Settings getMavenSettings() {
+            String path = getClass().getResource( "." ).toString().substring( "file:".length() );
+            File testSettingsFile = new File( path + "settings_with_repositories.xml" );
+            assertTrue( testSettingsFile.exists() );
+
+            SettingsBuilder settingsBuilder = new DefaultSettingsBuilderFactory().newInstance();
+            DefaultSettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+            request.setUserSettingsFile( testSettingsFile );
+
+            try {
+                return settingsBuilder.build( request ).getEffectiveSettings();
+            } catch ( SettingsBuildingException e ) {
+                throw new RuntimeException( e );
+            }
+        }
+    }
+
+    private static MavenRequest createMavenRequest() {
+        MavenRequest mavenRequest = new MavenRequest();
+        mavenRequest.setLocalRepositoryPath( MavenSettings.getSettings().getLocalRepository() );
+        mavenRequest.setUserSettingsFile( MavenSettings.getUserSettingsFile().getAbsolutePath() );
+        mavenRequest.setResolveDependencies( true );
+        mavenRequest.setOffline( true );
+        return mavenRequest;
+    }
+
+}

--- a/kie-ci/src/test/resources/org/kie/scanner/embedder/settings_with_repositories.xml
+++ b/kie-ci/src/test/resources/org/kie/scanner/embedder/settings_with_repositories.xml
@@ -1,0 +1,38 @@
+<settings>
+
+  <servers>
+    <server>
+      <id>kie-wb-m2-repo</id>
+      <username>testadmin</username>
+      <password>admin1234;</password>
+      <configuration>
+        <wagonProvider>httpclient</wagonProvider>
+        <httpConfiguration>
+          <all>
+            <usePreemptive>true</usePreemptive>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>kie-wb-m2-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>kie-wb-m2-repo</id>
+          <name>KIE-WB M2 Repo</name>
+          <url>http://localhost:8080/business-central/maven2</url>
+          <snapshots>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  
+</settings>


### PR DESCRIPTION
I moved resolution of additional repositories from MavenRepository to a new class MavenRepositoryUtils that is then used by MavenEmebedder. I could not reference MavenRepository from MavenEmbedder as the former instantiates a MavenEmbedder when constructing Aether and a circular loop develops. MavenRepository makes use of the MavenRepositoryUtils class but also appends repositories defined in the Aether class.

I really need to test this with the clr.mortgages example and execution server before this is merged... but that'll require either temporaribly backporting to 6.2.x or running Execution Server in 6.3.x.... that'll teach me to bail out of Edson's presentation last week :(
