### PR TITLE
Fix two rule model issues related to FormLineExpression

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionPart.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionPart.java
@@ -104,10 +104,8 @@ public abstract class ExpressionPart
         if (classType != null ? !classType.equals(that.classType) : that.classType != null) return false;
         if (genericType != null ? !genericType.equals(that.genericType) : that.genericType != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
-        if (next != null ? !next.equals(that.next) : that.next != null) return false;
         if (parametricType != null ? !parametricType.equals(that.parametricType) : that.parametricType != null)
             return false;
-        if (prev != null ? !prev.equals(that.prev) : that.prev != null) return false;
 
         return true;
     }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionVisitor.java
@@ -32,6 +32,8 @@ public interface ExpressionVisitor {
 
     void visit( ExpressionCollectionIndex part );
 
+    void visit( ExpressionFieldVariable part );
+
     void visit( ExpressionText part );
 
     void visit( ExpressionMethodParameter part );

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/CopyExpressionVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/CopyExpressionVisitor.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.drools.workbench.models.datamodel.rule.ExpressionCollection;
 import org.drools.workbench.models.datamodel.rule.ExpressionCollectionIndex;
 import org.drools.workbench.models.datamodel.rule.ExpressionField;
+import org.drools.workbench.models.datamodel.rule.ExpressionFieldVariable;
 import org.drools.workbench.models.datamodel.rule.ExpressionFormLine;
 import org.drools.workbench.models.datamodel.rule.ExpressionGlobalVariable;
 import org.drools.workbench.models.datamodel.rule.ExpressionMethod;
@@ -73,6 +74,12 @@ public class CopyExpressionVisitor implements ExpressionVisitor {
     public void visit( ExpressionVariable part ) {
         add( new ExpressionVariable( part.getName(),
                                      part.getFactType() ) );
+        moveNext( part );
+    }
+
+    public void visit( ExpressionFieldVariable part ) {
+        add( new ExpressionFieldVariable( part.getName(),
+                                          part.getClassType() ) );
         moveNext( part );
     }
 

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/ToStringExpressionVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/ToStringExpressionVisitor.java
@@ -21,6 +21,7 @@ import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.ExpressionCollection;
 import org.drools.workbench.models.datamodel.rule.ExpressionCollectionIndex;
 import org.drools.workbench.models.datamodel.rule.ExpressionField;
+import org.drools.workbench.models.datamodel.rule.ExpressionFieldVariable;
 import org.drools.workbench.models.datamodel.rule.ExpressionFormLine;
 import org.drools.workbench.models.datamodel.rule.ExpressionGlobalVariable;
 import org.drools.workbench.models.datamodel.rule.ExpressionMethod;
@@ -109,6 +110,14 @@ public class ToStringExpressionVisitor implements
 
     public void visit( ExpressionCollectionIndex part ) {
         sb.append( '[' ).append( paramsToString( part.getOrderedParams() ) ).append( ']' );
+        moveNext( part );
+    }
+
+    public void visit( ExpressionFieldVariable part ) {
+        if ( !first ) {
+            sb.append( '.' );
+        }
+        sb.append( part.getName() );
         moveNext( part );
     }
 

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/visitors/CopyExpressionVisitorTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/visitors/CopyExpressionVisitorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.models.datamodel.rule.visitors;
+
+import org.drools.workbench.models.datamodel.rule.ExpressionCollection;
+import org.drools.workbench.models.datamodel.rule.ExpressionCollectionIndex;
+import org.drools.workbench.models.datamodel.rule.ExpressionField;
+import org.drools.workbench.models.datamodel.rule.ExpressionFieldVariable;
+import org.drools.workbench.models.datamodel.rule.ExpressionFormLine;
+import org.drools.workbench.models.datamodel.rule.ExpressionGlobalVariable;
+import org.drools.workbench.models.datamodel.rule.ExpressionMethod;
+import org.drools.workbench.models.datamodel.rule.ExpressionMethodParameter;
+import org.drools.workbench.models.datamodel.rule.ExpressionText;
+import org.drools.workbench.models.datamodel.rule.ExpressionUnboundFact;
+import org.drools.workbench.models.datamodel.rule.ExpressionVariable;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CopyExpressionVisitorTest {
+
+    @Test
+    public void testExpressionFormLineCopy() {
+        ExpressionFormLine efl = new ExpressionFormLine();
+        efl.appendPart( new ExpressionCollection( "collection", "CT", "GT", "PT" ) );
+        efl.appendPart( new ExpressionCollectionIndex( "collectionIndex", "CT", "GT" ) );
+        efl.appendPart( new ExpressionField( "field", "CT", "FT", "PT" ) );
+        efl.appendPart( new ExpressionFieldVariable( "fieldVariable", "Type" ) );
+        efl.appendPart( new ExpressionGlobalVariable( "globalVariable", "CT", "GT", "PT" ) );
+        efl.appendPart( new ExpressionMethod( "method", "CT", "GT" ) );
+        efl.appendPart( new ExpressionMethodParameter( "methodParam", "CT", "GT" ) );
+        efl.appendPart( new ExpressionText( "text" ) );
+        efl.appendPart( new ExpressionUnboundFact( "FactType" ) );
+        efl.appendPart( new ExpressionVariable( "binding", "FactType" ) );
+        // verify that the new instance created with copy constructor is equal to original
+        assertEquals( efl, new ExpressionFormLine( efl ) );
+    }
+}


### PR DESCRIPTION
- Avoid StackOverflowError caused by a loop in ExpressionPart#equals().
- Extend ExpressionVisitor to handle ExpressionFieldVariable classes.

Not ready to merge yet. Help with implementing `ToStringExpressionVisitor#visit(ExpressionFieldVariable)` needed.
