### PR TITLE
Handle bundle resource naming convention used by Karaf Equinox framework

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -135,7 +135,7 @@ public class ClasspathKieProject extends AbstractKieProject {
     }
 
     public static InternalKieModule fetchKModule(URL url) {
-        if (url.toString().startsWith("bundle:")) {
+        if (url.toString().startsWith("bundle:") || url.toString().startsWith("bundleresource:")) {
             return fetchOsgiKModule(url);
         }
         return fetchKModule(url, fixURLFromKProjectPath(url));


### PR DESCRIPTION
Apache Karaf supports 2 OSGi frameworks - Felix and Equinox. I am able to use Drools under Felix framework. But when I use with Equinox, it gives the below exception. It appears that when Drools tries to search for META-INF/kmodule.xml file, Felix returns URL in format "bundle://..." whereas under Equinoix it is of format "bundleresource://...". Submitting this patch to handle the format returned by Equinox classloader as well

2015-08-31 18:54:09,414 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature simple-rule 6.2.0.Final
2015-08-31 18:54:09,416 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature drools-module 6.2.0.Final
2015-08-31 18:54:09,417 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature lib 1.0.0-SNAPSHOT
2015-08-31 18:54:09,541 | INFO  | h for user karaf | ClasspathKieProject              | 332 - org.drools.compiler - 6.2.0.201503042125 | Found kmodule: bundleresource://341.fwk52277164/META-INF/kmodule.xml
2015-08-31 18:54:09,544 | WARN  | h for user karaf | ClasspathKieProject              | 332 - org.drools.compiler - 6.2.0.201503042125 | Unable to find pom.properties in
2015-08-31 18:54:09,544 | WARN  | h for user karaf | ClasspathKieProject              | 332 - org.drools.compiler - 6.2.0.201503042125 | As folder project tried to fall back to pom.xml, but could not find one for null
2015-08-31 18:54:09,544 | WARN  | h for user karaf | ClasspathKieProject              | 332 - org.drools.compiler - 6.2.0.201503042125 | Unable to load pom.properties from
2015-08-31 18:54:09,544 | WARN  | h for user karaf | ClasspathKieProject              | 332 - org.drools.compiler - 6.2.0.201503042125 | Cannot find maven pom properties for this project. Using the container's default ReleaseId
2015-08-31 18:54:09,544 | ERROR | h for user karaf | ClasspathKieProject              | 332 - org.drools.compiler - 6.2.0.201503042125 | Unable to build index of kmodule.xml url=bundleresource://341.fwk52277164/META-INF/kmodule.xml
Unable to get all ZipFile entries:
2015-08-31 18:54:09,564 | ERROR | h for user karaf | ShellUtil                        | 25 - org.apache.karaf.shell.console - 3.0.3 | Exception caught while executing command
java.lang.IllegalStateException: Can't install feature simple-rule/0.0.0:
Could not start bundle mvn:org.drools.example/simple/1.0.0-SNAPSHOT in feature(s) simple-rule-6.2.0.Final: Exception in org.drools.example.osgi.CanDrinkRuleOsgiActivator.start() of bundle simple.
        at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeature(FeaturesServiceImpl.java:388)
        at Proxy7de22fa8_6395_44d0_a975_c4567777c7be.installFeature(Unknown Source)
        at org.apache.karaf.features.command.InstallFeatureCommand.doExecute(InstallFeatureCommand.java:67)
        at org.apache.karaf.features.command.FeaturesCommandSupport.doExecute(FeaturesCommandSupport.java:38)
        at org.apache.karaf.shell.console.AbstractAction.execute(AbstractAction.java:33)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.karaf.shell.console.OsgiCommandSupport.execute(OsgiCommandSupport.java:39)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.karaf.shell.commands.basic.AbstractCommand.execute(AbstractCommand.java:33)[25:org.apache.karaf.shell.console:3.0.3]
        at Proxy8a5dc04e_6185_423a_80c7_fea10956e5db.execute(Unknown Source)[:]
        at Proxy8a5dc04e_6185_423a_80c7_fea10956e5db.execute(Unknown Source)[:]
        at org.apache.felix.gogo.runtime.CommandProxy.execute(CommandProxy.java:78)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:477)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:403)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Pipe.run(Pipe.java:108)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:183)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:120)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.CommandSessionImpl.execute(CommandSessionImpl.java:92)
        at org.apache.karaf.shell.console.impl.jline.ConsoleImpl.run(ConsoleImpl.java:208)
        at org.apache.karaf.shell.ssh.ShellFactoryImpl$ShellImpl$1.runConsole(ShellFactoryImpl.java:158)[308:org.apache.karaf.shell.ssh:3.0.3]
        at org.apache.karaf.shell.ssh.ShellFactoryImpl$ShellImpl$1$1.run(ShellFactoryImpl.java:133)
        at java.security.AccessController.doPrivileged(Native Method)[:1.7.0_79]
        at org.apache.karaf.jaas.modules.JaasHelper.doAs(JaasHelper.java:57)[26:org.apache.karaf.jaas.modules:3.0.3]
        at org.apache.karaf.shell.ssh.ShellFactoryImpl$ShellImpl$1.run(ShellFactoryImpl.java:129)[308:org.apache.karaf.shell.ssh:3.0.3]
