### PR TITLE
[DROOLS-840] fix failing test when running on JDK8

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/conf/KnowledgeBaseConfigurationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/conf/KnowledgeBaseConfigurationTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.fail;
 
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.runtime.rule.impl.DefaultConsequenceExceptionHandler;
+import org.drools.core.util.MemoryUtil;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.KieBaseConfiguration;
@@ -299,6 +301,7 @@ public class KnowledgeBaseConfigurationTest {
 
     @Test
     public void testPermGenThresholdConfiguration() {
+        Assume.assumeTrue("JVM with perm gen", MemoryUtil.hasPermGen());
         // setting the option using the type safe method
         config.setOption( PermGenThresholdOption.get(85) );
 


### PR DESCRIPTION
- the perm gen option is not applicable when using JDK8+, so the test does not make sense there
