### PR TITLE
fix drools parserhelper.reportError's outofindexexception

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/ParserHelper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/ParserHelper.java
@@ -336,8 +336,13 @@ public class ParserHelper {
     }
 
     public void reportError( Exception e ) {
-        errors.add( errorMessageFactory.createDroolsException( e,
-                                                               input.LT( 1 ) ) );
+        if (input.index()-input.range()<2) {
+            errors.add( errorMessageFactory.createDroolsException( e,
+                                                                   input.LT( -1 ) ) );
+        }else{
+            errors.add( errorMessageFactory.createDroolsException( e,
+                                                                   input.LT( 1 ) ) );
+        }
     }
 
     /** return the raw DroolsParserException errors */

--- a/drools-compiler/src/test/java/org/drools/compiler/lang/DRLParserHelperTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/lang/DRLParserHelperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.lang;
+
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+
+public class DRLParserHelperTest {
+
+    /**
+     * this test will throw a {@link RuntimeException} caused 
+     * by an {@link IndexOutOfBoundsException}<br>
+     * 
+     */
+    @Test
+    public void test() throws Exception {
+        byte[] content=new byte[]{0x04,0x44,0x00,0x00,0x60,0x00,0x00,0x00};
+        //"content" may come from any .DS_Store file of Mac,
+        //i just use this 8-Byte instead to reproduce the case
+        
+        KnowledgeBuilder knowledgeBuilder = KnowledgeBuilderFactory
+                .newKnowledgeBuilder();
+        try {
+            knowledgeBuilder.add(ResourceFactory.newByteArrayResource(content), 
+                    ResourceType.DRL);
+        } catch (Exception e) {
+            assertTrue(e instanceof RuntimeException);
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
On my mac, this code may result in a exception

```
@BeforeClass
    public static void setup() throws IOException, RuleException {
        executor = new PostExecutor();
        String ruleFileDircetory = "src/test/resources/rule-post/";
        File ruleDirectory = new File(ruleFileDircetory);
        String apath = ruleDirectory.getAbsolutePath();
        File[] rules = ruleDirectory.listFiles();
        for (File ruleFile : rules) {
            StringBuilder sb = new StringBuilder();
            TestUtils.readFile(new FileInputStream(ruleFile), sb);
            String ruleStr = sb.toString();
            Statement st = new Statement();
            st.setRuleId(ruleFile.getName());
            st.setVersion(1);
            st.setContent(ruleStr);
                executor.updateKnowledge(st);
        }
    }
```

the out put will be:

```
java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
    at java.util.ArrayList.rangeCheck(ArrayList.java:653)
    at java.util.ArrayList.get(ArrayList.java:429)
    at org.antlr.runtime.CommonTokenStream.LT(CommonTokenStream.java:106)
    at org.drools.compiler.lang.ParserHelper.reportError(ParserHelper.java:388)
    at org.drools.compiler.lang.DRL6Parser.compilationUnit(DRL6Parser.java:134)
    at org.drools.compiler.lang.AbstractDRLParser.compilationUnit(AbstractDRLParser.java:86)
    at org.drools.compiler.compiler.DrlParser.compile(DrlParser.java:238)
    at org.drools.compiler.compiler.DrlParser.parse(DrlParser.java:155)
    at org.drools.compiler.compiler.DrlParser.parse(DrlParser.java:144)
    at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.drlToPackageDescr(KnowledgeBuilderImpl.java:445)
    at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.addPackageFromDrl(KnowledgeBuilderImpl.java:433)
    at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.addKnowledgeResource(KnowledgeBuilderImpl.java:653)
    at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.add(KnowledgeBuilderImpl.java:2164)
    at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.add(KnowledgeBuilderImpl.java:2153)
    at org.thomas.drools.BasicExecutor.updateKnowledge(BasicExecutor.java:84)
    at org.thomas.drools.PostExecutorTest.setup(PostExecutorTest.java:35)
    at org.thomas.drools.PostExecutorTest.main(PostExecutorTest.java:44)
java.lang.RuntimeException: org.drools.compiler.compiler.DroolsParserException: Unexpected exception raised while parsing. This is a bug. Please contact the Development team :
Index: 1, Size: 1
```

i think  this is because AntLR use code below to parse the .DS_Store file, but not so correctlly:

```
@Override
    public Token LT(int k) {
        //System.out.println("enter LT("+k+")");
        if ( p == -1 ) setup();
        if ( k == 0 ) return null;
        if ( k < 0 ) return LB(-k);
        int i = p;
        int n = 1; // we know tokens[p] is a good one
        // find k good tokens
        while ( n<k ) {
            // skip off-channel tokens
            i = skipOffTokenChannels(i+1);
            n++;
        }
        if ( i>range ) range = i;
        return tokens.get(i);
    }
```

the code assumed that EOF should be last token, but in this case it won't. so i think ParserHelper.reportError need to check it .

tks.
