### PR TITLE
BZ1264321: Guided Rule Editor: replace or replaceAll condition parameters on a String missing on re-opening rule

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionMethod.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionMethod.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 public class ExpressionMethod extends ExpressionPart {
 
-    private Map<String, ExpressionFormLine> params = new LinkedHashMap<String, ExpressionFormLine>();
+    private Map<ExpressionMethodParameterDefinition, ExpressionFormLine> params = new LinkedHashMap<ExpressionMethodParameterDefinition, ExpressionFormLine>();
 
     public ExpressionMethod() {
     }
@@ -48,17 +48,18 @@ public class ExpressionMethod extends ExpressionPart {
                parametricType );
     }
 
-    public Map<String, ExpressionFormLine> getParams() {
+    public Map<ExpressionMethodParameterDefinition, ExpressionFormLine> getParams() {
         return params;
     }
 
-    public void setParams( Map<String, ExpressionFormLine> params ) {
+    public void setParams( Map<ExpressionMethodParameterDefinition, ExpressionFormLine> params ) {
         this.params.putAll( params );
     }
 
     public void putParam( String name,
                           ExpressionFormLine expression ) {
-        this.params.put( name,
+        this.params.put( new ExpressionMethodParameterDefinition( this.params.size(),
+                                                                  name ),
                          expression );
     }
 
@@ -77,9 +78,9 @@ public class ExpressionMethod extends ExpressionPart {
     }
 
     public String getParameterDataType( final ExpressionFormLine efl ) {
-        for ( Map.Entry<String, ExpressionFormLine> e : params.entrySet() ) {
+        for ( Map.Entry<ExpressionMethodParameterDefinition, ExpressionFormLine> e : params.entrySet() ) {
             if ( e.getValue().equals( efl ) ) {
-                return e.getKey();
+                return e.getKey().getDataType();
             }
         }
         return null;
@@ -91,13 +92,19 @@ public class ExpressionMethod extends ExpressionPart {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
 
         ExpressionMethod that = (ExpressionMethod) o;
 
-        if (params != null ? !params.equals(that.params) : that.params != null) return false;
+        if ( params != null ? !params.equals( that.params ) : that.params != null ) {
+            return false;
+        }
 
         return true;
     }
@@ -106,7 +113,7 @@ public class ExpressionMethod extends ExpressionPart {
     public int hashCode() {
         int result = super.hashCode();
         result = ~~result;
-        result = 31 * result + (params != null ? params.hashCode() : 0);
+        result = 31 * result + ( params != null ? params.hashCode() : 0 );
         result = ~~result;
         return result;
     }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionMethodParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ExpressionMethodParameterDefinition.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.datamodel.rule;
+
+import org.drools.workbench.models.datamodel.util.PortablePreconditions;
+
+/**
+ * Meta Data for a ExpressionMethod's parameter definitions.
+ */
+public class ExpressionMethodParameterDefinition {
+
+    private int index;
+    private String dataType;
+
+    public ExpressionMethodParameterDefinition() {
+        //Empty constructor for Errai marshalling. Cannot use @MapsTo since we don't want any Errai JAR dependencies here.
+    }
+
+    public ExpressionMethodParameterDefinition( final int index,
+                                                final String dataType ) {
+        this.index = index;
+        this.dataType = PortablePreconditions.checkNotNull( "dataType",
+                                                            dataType );
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( !( o instanceof ExpressionMethodParameterDefinition ) ) {
+            return false;
+        }
+
+        ExpressionMethodParameterDefinition that = (ExpressionMethodParameterDefinition) o;
+
+        if ( index != that.index ) {
+            return false;
+        }
+        return dataType.equals( that.dataType );
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = index;
+        result = 31 * result + dataType.hashCode();
+        result = ~~result;
+        return result;
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/CopyExpressionVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/CopyExpressionVisitor.java
@@ -26,6 +26,7 @@ import org.drools.workbench.models.datamodel.rule.ExpressionFormLine;
 import org.drools.workbench.models.datamodel.rule.ExpressionGlobalVariable;
 import org.drools.workbench.models.datamodel.rule.ExpressionMethod;
 import org.drools.workbench.models.datamodel.rule.ExpressionMethodParameter;
+import org.drools.workbench.models.datamodel.rule.ExpressionMethodParameterDefinition;
 import org.drools.workbench.models.datamodel.rule.ExpressionPart;
 import org.drools.workbench.models.datamodel.rule.ExpressionText;
 import org.drools.workbench.models.datamodel.rule.ExpressionUnboundFact;
@@ -133,9 +134,11 @@ public class CopyExpressionVisitor implements ExpressionVisitor {
 
     private void copyMethodParams( ExpressionMethod part,
                                    ExpressionMethod method ) {
-        Map<String, ExpressionFormLine> params = new HashMap<String, ExpressionFormLine>();
-        for ( Map.Entry<String, ExpressionFormLine> entry : part.getParams().entrySet() ) {
-            params.put( entry.getKey(), new ExpressionFormLine( entry.getValue() ) );
+        Map<ExpressionMethodParameterDefinition, ExpressionFormLine> params = new HashMap<ExpressionMethodParameterDefinition, ExpressionFormLine>();
+        for ( Map.Entry<ExpressionMethodParameterDefinition, ExpressionFormLine> entry : part.getParams().entrySet() ) {
+            params.put( new ExpressionMethodParameterDefinition( entry.getKey().getIndex(),
+                                                                 entry.getKey().getDataType() ),
+                        new ExpressionFormLine( entry.getValue() ) );
         }
         method.setParams( params );
     }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/resources/ErraiApp.properties
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/resources/ErraiApp.properties
@@ -62,6 +62,7 @@ errai.marshalling.serializableTypes=org.drools.workbench.models.datamodel.auditl
   org.drools.workbench.models.datamodel.rule.ActionFieldValue \
   org.drools.workbench.models.datamodel.rule.ExpressionMethod \
   org.drools.workbench.models.datamodel.rule.ExpressionMethodParameter \
+  org.drools.workbench.models.datamodel.rule.ExpressionMethodParameterDefinition \
   org.drools.workbench.models.datamodel.rule.ExpressionVariable \
   org.drools.workbench.models.datamodel.rule.FromCollectCompositeFactPattern \
   org.drools.workbench.models.datamodel.rule.FromEntryPointFactPattern \


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1264321

The issue was caused by a `ExpressionMethod`s parameters being stored as a Map keyed off the data-type; so `replace` has two parameters both of which are `String` so the first parameter was being overwritten by the second leading to the `replace` method invocation only having one parameter.

I changed this to be keyed off `ExpressionMethodParameterDefinition` which holds index and data-type information.
