### PR TITLE
[DROOLS-923] make KieRepository thread safe

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -151,8 +151,92 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>
-    </dependency>     
+    </dependency>
+         
+   <!-- test: byteman -->
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-submit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-install</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-bmunit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.drools.compiler</Bundle-SymbolicName>
+            <Import-Package>
+              com.sun.tools.xjc.*;resolution:=optional,
+              com.sun.codemodel;resolution:=optional,
+              javax.enterprise.*;resolution:=optional,
+              org.antlr.*;resolution:=optional,
+              org.codehaus.janino.*;resolution:=optional,
+              org.eclipse.jdt.*;resolution:=optional,
+              org.osgi.*;resolution:=optional,
+              =org.kie.spring;resolution:=optional,
+              =org.kie.scanner.*;resolution:=optional,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.drools.compiler.*
+            </Export-Package>
+            <Bundle-Activator>org.drools.compiler.osgi.Activator</Bundle-Activator>
+            <Provide-Capability>
+              org.ops4j.pax.cdi.extension; extension=kie-cdi
+            </Provide-Capability>
+            <_removeheaders>Private-Package</_removeheaders>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${project.basedir}/src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.jboss.byteman</groupId>
+        <artifactId>byteman-rulecheck-maven-plugin</artifactId>
+        <version>${version.org.jboss.byteman}</version>
+        <executions>
+          <execution>
+            <id>rulecheck-test</id>
+            <goals>
+              <goal>rulecheck</goal>
+            </goals>
+            <phase>test-compile</phase>
+            <configuration>
+              <includes>
+                <include>**/*.btm</include>
+              </includes>
+              <verbose>true</verbose>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   
   <profiles>
     <profile>
@@ -252,44 +336,5 @@
       </build>
     </profile>
   </profiles>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>org.drools.compiler</Bundle-SymbolicName>
-            <Import-Package>
-              com.sun.tools.xjc.*;resolution:=optional,
-              com.sun.codemodel;resolution:=optional,
-              javax.enterprise.*;resolution:=optional,
-              org.antlr.*;resolution:=optional,
-              org.codehaus.janino.*;resolution:=optional,
-              org.eclipse.jdt.*;resolution:=optional,
-              org.osgi.*;resolution:=optional,
-              =org.kie.spring;resolution:=optional,
-              =org.kie.scanner.*;resolution:=optional,
-              *
-            </Import-Package>
-            <Export-Package>
-              org.drools.compiler.*
-            </Export-Package>
-            <Bundle-Activator>org.drools.compiler.osgi.Activator</Bundle-Activator>
-            <Provide-Capability>
-              org.ops4j.pax.cdi.extension; extension=kie-cdi
-            </Provide-Capability>
-            <_removeheaders>Private-Package</_removeheaders>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${project.basedir}/src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  
 </project>

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -214,7 +214,8 @@
           <excludeFilterFile>${project.basedir}/src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
         </configuration>
       </plugin>
-      
+     
+      <!--  Re-enable once https://issues.jboss.org/browse/BYTEMAN-296 is solved
       <plugin>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-rulecheck-maven-plugin</artifactId>
@@ -235,6 +236,7 @@
           </execution>
         </executions>
       </plugin>
+       --> 
     </plugins>
   </build>
   

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -149,7 +149,7 @@ public class KieRepositoryImpl
         public void start(long pollingInterval) { }
 
         public void stop() { }
-        
+
         public void shutdown() { }
 
         public void scanNow() { }
@@ -237,13 +237,14 @@ public class KieRepositoryImpl
         }
     }
 
-    private static class KieModuleRepo {
+    // package scope so that we can test it
+    static class KieModuleRepo {
 
         private final InternalKieScanner kieScanner;
         private final Map<String, TreeMap<ComparableVersion, KieModule>> kieModules = new ConcurrentHashMap<String, TreeMap<ComparableVersion, KieModule>>();
         private final Map<ReleaseId, KieModule> oldKieModules = new ConcurrentHashMap<ReleaseId, KieModule>();
 
-        private KieModuleRepo(InternalKieScanner kieScanner) {
+        KieModuleRepo(InternalKieScanner kieScanner) {
             this.kieScanner = kieScanner;
         }
 
@@ -272,7 +273,9 @@ public class KieRepositoryImpl
                 kieModules.put(ga, artifactMap);
             }
             ComparableVersion comparableVersion = new ComparableVersion(releaseId.getVersion());
-            if (oldKieModules.get(releaseId) == null) {
+            KieModule oldReleaseIdKieModule = oldKieModules.get(releaseId);
+            // variable used in order to test race condition
+            if (oldReleaseIdKieModule == null) {
                 KieModule oldKieModule = artifactMap.get( comparableVersion);
                 if (oldKieModule != null) {
                     oldKieModules.put( releaseId, oldKieModule );
@@ -281,7 +284,7 @@ public class KieRepositoryImpl
             artifactMap.put(comparableVersion, kieModule);
         }
 
-        private KieModule loadOldAndRemove(ReleaseId releaseId) {
+        KieModule loadOldAndRemove(ReleaseId releaseId) {
             return oldKieModules.remove(releaseId);
         }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -37,15 +37,20 @@ import java.math.BigInteger;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
 import java.util.Properties;
 import java.util.Stack;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
@@ -241,8 +246,94 @@ public class KieRepositoryImpl
     static class KieModuleRepo {
 
         private final InternalKieScanner kieScanner;
-        private final Map<String, TreeMap<ComparableVersion, KieModule>> kieModules = new ConcurrentHashMap<String, TreeMap<ComparableVersion, KieModule>>();
-        private final Map<ReleaseId, KieModule> oldKieModules = new ConcurrentHashMap<ReleaseId, KieModule>();
+
+        private final ConcurrentHashMap<String, ConcurrentSkipListMap<ComparableVersion, KieModule>> kieModules
+            = new ConcurrentHashMap<String, ConcurrentSkipListMap<ComparableVersion, KieModule>>();
+        private final ConcurrentHashMap<ReleaseId, KieModule> oldKieModules
+            = new ConcurrentHashMap<ReleaseId, KieModule>();
+
+        /**
+         * The gaLocks map:
+         * - A LRU cache (based on *access* order, not insertion order) for locks per GA
+         *
+         * We lock on the basis of these objects (instead of on the artifactMap) because
+         * the artifactMap can be removed and then readded,
+         * whereas these lock objects will only be removed
+         * when there MAX_UNIQUE_GAs objects that have been more recently accessed than the lock to be removed
+         *
+         * These objects are used to safeguard:
+         * - modifications to and reads of a GA artifactMap,
+         *   especially when the logic depends on multiple reads
+         * - modifications to the oldKieModules map
+         */
+        private static final String UNIQUE_PROJECT_GA_MAX_PROPERTY = "org.kie.repository.project.ga.unique.max";
+        private static final int MAX_UNIQUE_GAs
+            = Integer.parseInt(System.getProperty(UNIQUE_PROJECT_GA_MAX_PROPERTY, "100"));
+        private final HashMap<String,Object> gaLocks = new LinkedHashMap<String, Object>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry( Entry<String, Object> eldest ) {
+                return size() > MAX_UNIQUE_GAs;
+            }
+        };
+
+        // This value *must* always be smaller than MAX_UNIQUE_GAs
+        public static final String GA_ARTIFACT_MAP_REPLACEMENT_MAX_PROPERTY = "org.kie.repository.project.ga.replacement.max";
+        private static final int EMPTY_ARTIFACT_MAP_REMOVAL_QUEUE_SIZE
+            = Integer.parseInt(System.getProperty(GA_ARTIFACT_MAP_REPLACEMENT_MAX_PROPERTY, "20"));
+
+        static {
+            if( EMPTY_ARTIFACT_MAP_REMOVAL_QUEUE_SIZE > MAX_UNIQUE_GAs + 1 ) {
+               throw new IllegalStateException("The " + GA_ARTIFACT_MAP_REPLACEMENT_MAX_PROPERTY + " property [" +
+                       EMPTY_ARTIFACT_MAP_REMOVAL_QUEUE_SIZE + "] may not be larger than the  "
+                       + UNIQUE_PROJECT_GA_MAX_PROPERTY + " [" + MAX_UNIQUE_GAs + "] property!");
+            }
+        }
+
+        /**
+         * The removeArtifactMapQueue:
+         * - A LRU cache based on insertion order that triggers artifactMap removal when the object is discarded
+         *
+         * When the max size[1] for the removeArtifactMapQueue map has been reached,
+         * the removeEldestEntry logic below checks to see if the artifactMap (value) from the last (inserted) entry is still empty.
+         * If the artifactMap entry is empty, the empty artifactMap s removed from the kieModules map.
+         * Regardless of whether the artifactMap is empty, the entry is then removed from the removeArtifactMapQueue map,
+         * so that it's not checked twice.
+         *
+         * [1] The max size her is the KIE_MODULES_REMOVE_EMPTY_ARTIFACT_MAP_QUEUE_SIZE constant
+         *
+         * The idea here is that we need a mechanism that
+         *   1. removes the artifactMap from the kieModules map field
+         *   2. but delays it,
+         * this is in order to avoid a race condition for situations in which operations with ga-single version deployments
+         * (i.e. one thread removes while the next thread stores) would cause different threads to use different artifactMap instances
+         * for the same GA
+         *
+         * Of couse, if the user is doing this for enough[2] ga-single versions modules, then there will be a race condition.
+         * However, that situation is unlikely.
+         *
+         * [2] where "enough" > the max-size of the cache or KIE_MODULES_REMOVE_EMPTY_ARTIFACT_MAP_QUEUE_SIZE
+         */
+        private final Map<String, NavigableMap<ComparableVersion, KieModule>> removeArtifactMapQueue = new LinkedHashMap<String, NavigableMap<ComparableVersion, KieModule>>() {
+            @Override
+            protected boolean removeEldestEntry( Entry<String, NavigableMap<ComparableVersion, KieModule>> eldest ) {
+                boolean remove = size() > EMPTY_ARTIFACT_MAP_REMOVAL_QUEUE_SIZE;
+                if( remove ) {
+                    String ga = eldest.getKey();
+                    NavigableMap<ComparableVersion, KieModule> artifactMap = eldest.getValue();
+                    Object gaLock = getGALockObject(ga);
+                    synchronized(gaLock) {
+                        // if the artifact map is empty (and it's the one still in the kieModules map!), then remove it
+                        if( artifactMap.isEmpty() ) {
+                            kieModules.remove(ga, artifactMap);
+                            // the remove above can fail if the artifactMap value was somehow replaced,
+                            // but that's what we want for that case
+                        }
+                    }
+                }
+                return remove;
+            }
+        };
+
 
         KieModuleRepo(InternalKieScanner kieScanner) {
             this.kieScanner = kieScanner;
@@ -251,15 +342,25 @@ public class KieRepositoryImpl
         KieModule remove(ReleaseId releaseId) {
             KieModule removedKieModule = null;
             String ga = releaseId.getGroupId() + ":" + releaseId.getArtifactId();
-            TreeMap<ComparableVersion, KieModule> artifactMap = kieModules.get(ga);
-            if (artifactMap != null) {
-                ComparableVersion comparableVersion = new ComparableVersion(releaseId.getVersion());
-                removedKieModule = artifactMap.remove(comparableVersion);
-                if (artifactMap.isEmpty()) {
-                    kieModules.remove(ga);
+            NavigableMap<ComparableVersion, KieModule> artifactMap = kieModules.get(ga);
+            ComparableVersion comparableVersion = new ComparableVersion(releaseId.getVersion());
+
+            // synchronize on the GA, otherwise we might be removing what another thread is adding
+            Object gaLock = getGALockObject(ga);
+            synchronized(gaLock) {
+                if (artifactMap != null) {
+                    removedKieModule = artifactMap.remove(comparableVersion);
+                    if (artifactMap.isEmpty()) {
+                        // add the KieModule artifactMap to the queue to be deleted
+                        // (otherwise, if we remove it immediately, there's a possible race condition
+                        //  for users that remove and add ga-single version (as opposed to ga-multiple versions)
+                        //  kie modules)
+                        removeArtifactMapQueue.put(ga, artifactMap);
+                    }
                 }
+                oldKieModules.remove(releaseId);
             }
-            oldKieModules.remove(releaseId);
+
             return removedKieModule;
         }
 
@@ -267,25 +368,53 @@ public class KieRepositoryImpl
             ReleaseId releaseId = kieModule.getReleaseId();
             String ga = releaseId.getGroupId() + ":" + releaseId.getArtifactId();
 
-            TreeMap<ComparableVersion, KieModule> artifactMap = kieModules.get(ga);
-            if (artifactMap == null) {
-                artifactMap = new TreeMap<ComparableVersion, KieModule>();
-                kieModules.put(ga, artifactMap);
-            }
-            ComparableVersion comparableVersion = new ComparableVersion(releaseId.getVersion());
-            KieModule oldReleaseIdKieModule = oldKieModules.get(releaseId);
-            // variable used in order to test race condition
-            if (oldReleaseIdKieModule == null) {
-                KieModule oldKieModule = artifactMap.get( comparableVersion);
-                if (oldKieModule != null) {
-                    oldKieModules.put( releaseId, oldKieModule );
+            // doing a kieModules.get(ga) first is more performant than always creating a possibly new map for the putIfAbsent operation
+            ConcurrentSkipListMap<ComparableVersion, KieModule> artifactMap = kieModules.get(ga);
+            if( artifactMap == null ) {
+                artifactMap = new ConcurrentSkipListMap<ComparableVersion, KieModule>();
+                ConcurrentSkipListMap<ComparableVersion, KieModule> existingArtifactMap = kieModules.putIfAbsent(ga, artifactMap);
+                if( existingArtifactMap != null ) {
+                    artifactMap = existingArtifactMap;
                 }
             }
-            artifactMap.put(comparableVersion, kieModule);
+
+            ComparableVersion comparableVersion = new ComparableVersion(releaseId.getVersion());
+
+            // synchronize on the GA, otherwise we might be adding what another thread is removing
+            // Also, without a synchronize, Thread A's oldKieModule value can be Thread B's kieModule value
+            Object gaLock = getGALockObject(ga);
+            synchronized(gaLock) {
+                KieModule oldReleaseIdKieModule = oldKieModules.get(releaseId);
+                // variable used in order to test race condition
+                if (oldReleaseIdKieModule == null) {
+                    KieModule oldKieModule = artifactMap.get(comparableVersion);
+                    if (oldKieModule != null) {
+                        oldKieModules.put( releaseId, oldKieModule );
+                    }
+                }
+                artifactMap.put(comparableVersion, kieModule);
+            }
+        }
+
+        private Object getGALockObject(String ga) {
+            Object lock = new Object();
+            synchronized(gaLocks) {
+                Object existingLock = gaLocks.get(ga);
+                if( existingLock == null ) {
+                    gaLocks.put(ga, lock);
+                } else {
+                    lock = existingLock;
+                }
+            }
+            return lock;
         }
 
         KieModule loadOldAndRemove(ReleaseId releaseId) {
-            return oldKieModules.remove(releaseId);
+            String ga = releaseId.getGroupId() + ":" + releaseId.getArtifactId();
+            Object gaLock = getGALockObject(ga);
+            synchronized(gaLock) {
+                return oldKieModules.remove(releaseId);
+            }
         }
 
         KieModule load(ReleaseId releaseId) {
@@ -294,13 +423,19 @@ public class KieRepositoryImpl
 
         KieModule load(ReleaseId releaseId, VersionRange versionRange) {
             String ga = releaseId.getGroupId() + ":" + releaseId.getArtifactId();
-            TreeMap<ComparableVersion, KieModule> artifactMap = kieModules.get(ga);
-            if ( artifactMap == null ) {
-                return null;
+            Object gaLock = getGALockObject(ga);
+
+            KieModule kieModule = null;
+            NavigableMap<ComparableVersion, KieModule> artifactMap;
+            synchronized(gaLock) {
+                artifactMap = kieModules.get(ga);
+                if ( artifactMap == null || artifactMap.isEmpty() ) {
+                    return null;
+                }
+                kieModule = artifactMap.get(new ComparableVersion(releaseId.getVersion()));
             }
 
             if (versionRange.fixed) {
-                KieModule kieModule = artifactMap.get(new ComparableVersion(releaseId.getVersion()));
                 if ( kieModule != null && releaseId.isSnapshot() ) {
                     String oldSnapshotVersion = ((ReleaseIdImpl)kieModule.getReleaseId()).getSnapshotVersion();
                     if ( oldSnapshotVersion != null ) {
@@ -316,6 +451,7 @@ public class KieRepositoryImpl
                 return kieModule;
             }
 
+            // no need for a ga lock here, since this is one-time read
             Map.Entry<ComparableVersion, KieModule> entry =
                     versionRange.upperBound == null ?
                     artifactMap.lastEntry() :

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieModuleRepoTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieModuleRepoTest.java
@@ -1,0 +1,337 @@
+package org.drools.compiler.kie.builder.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.compiler.kie.builder.impl.KieRepositoryImpl.ComparableVersion;
+import org.drools.compiler.kie.builder.impl.KieRepositoryImpl.KieModuleRepo;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.drools.core.common.ResourceProvider;
+import org.jboss.byteman.contrib.bmunit.BMScript;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.builder.KieModule;
+import org.kie.api.builder.KieRepository;
+import org.kie.api.builder.ReleaseId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(org.jboss.byteman.contrib.bmunit.BMUnitRunner.class)
+@BMUnitConfig(loadDirectory="target/test-classes") // set "debug=true to see debug output
+@SuppressWarnings("unchecked")
+public class KieModuleRepoTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(KnowledgeBuilderConfigurationImpl.class);
+
+    private KieModuleRepo kieModuleRepo;
+
+    @Before
+    public void before() {
+
+        InternalKieScanner mockKieScanner = mock(InternalKieScanner.class);
+        kieModuleRepo = new KieModuleRepo(mockKieScanner);
+    }
+
+    /**
+     * HELPER METHODS -------------------------------------------------------------------------------------------------------------
+     */
+
+    protected static void waitFor(CyclicBarrier barrier) {
+        String threadName = Thread.currentThread().getName();
+        try {
+            barrier.await();
+        } catch( InterruptedException e ) {
+            fail( "Thread '" + threadName + "' was interrupted while waiting for the other threads!");
+        } catch( BrokenBarrierException e ) {
+            fail( "Thread '" + threadName + "' barrier was broken while waiting for the other threads!");
+        }
+    }
+
+    protected static void waitFor(CountDownLatch countDownLatch) {
+        String threadName = Thread.currentThread().getName();
+        try {
+            countDownLatch.await();
+        } catch( InterruptedException e ) {
+            fail( "Thread '" + threadName + "' was interrupted while waiting for the count down!");
+        }
+    }
+
+    private static Map<ComparableVersion, KieModule> getArtifactMapFromKieModuleRepoInstance(KieModuleRepo kieModuleRepo, String ga)
+                throws Exception {
+        Field kieModulesField = KieModuleRepo.class.getDeclaredField("kieModules");
+        kieModulesField.setAccessible(true);
+        Object kieModulesObj = kieModulesField.get(kieModuleRepo);
+
+        Map<ComparableVersion, KieModule> artifactMap = (Map<ComparableVersion, KieModule>) ((Map) kieModulesObj).get(ga);
+        return artifactMap;
+    }
+
+    private static Map<ReleaseId, KieModule> getOldKieModulesMapFromKieModuleRepoInstance(KieModuleRepo kieModuleRepo)
+            throws Exception {
+        Field oldKieModulesField = KieModuleRepo.class.getDeclaredField("oldKieModules");
+        oldKieModulesField.setAccessible(true);
+        Object kieModulesObj = oldKieModulesField.get(kieModuleRepo);
+
+        return (Map<ReleaseId, KieModule>) kieModulesObj;
+    }
+
+    private static KieContainerImpl createMockKieContainer(ReleaseId projectReleaseId, KieModuleRepo kieModuleRepo) throws Exception {
+
+        // kie module
+        InternalKieModule mockKieProjectKieModule = mock(InternalKieModule.class);
+        ResourceProvider mockKieProjectKieModuleResourceProvider = mock(ResourceProvider.class);
+        when(mockKieProjectKieModule.createResourceProvider()).thenReturn(mockKieProjectKieModuleResourceProvider);
+
+        // kie project
+        KieModuleKieProject kieProject = new KieModuleKieProject(mockKieProjectKieModule);
+        KieModuleKieProject mockKieProject = spy(kieProject);
+        doNothing().when(mockKieProject).init();
+        doReturn(projectReleaseId).when(mockKieProject).getGAV();
+        doNothing().when(mockKieProject).updateToModule(any(InternalKieModule.class));
+
+        // kie repository
+        KieRepository kieRepository = new KieRepositoryImpl();
+        Field kieModuleRepoField = KieRepositoryImpl.class.getDeclaredField("kieModuleRepo");
+        kieModuleRepoField.setAccessible(true);
+        kieModuleRepoField.set(kieRepository, kieModuleRepo);
+        kieModuleRepoField.setAccessible(false);
+
+        // kie container
+        KieContainerImpl kieContainerImpl = new KieContainerImpl(mockKieProject, kieRepository);
+        return kieContainerImpl;
+    }
+
+    private void continueTest() {
+       // placeholder for byteman rule to signal other threads
+    }
+
+    private static void checkRules() {
+       // placeholder for byteman rule to check test
+    }
+
+    /**
+     * TESTS ----------------------------------------------------------------------------------------------------------------------
+     */
+
+    // simultaneous requests to deploy two new deployments (different versions)
+    // for an empty/new GA artifactMap
+    @Test(timeout=5000)
+    @BMScript(value="byteman/setArtifactMapTest.btm")
+    public void setArtifactMapTest() throws Exception {
+        Thread.currentThread().setName("test");
+
+        final String groupId = "org";
+        final String artifactId = "one";
+        final String firstVersion = "1.0";
+        final String secondVersion = "1.0-NEW-FEATURE";
+
+        final CyclicBarrier threadsFinishedBarrier = new CyclicBarrier(3);
+
+        Thread firstThread = new Thread(new Runnable() {
+
+            private final KieModuleRepo kieModuleRepo = KieModuleRepoTest.this.kieModuleRepo;
+
+            @Override
+            public void run() {
+                ReleaseIdImpl firstReleaseId = new ReleaseIdImpl(groupId, artifactId, firstVersion);
+                KieModule firstKieModule = mock(KieModule.class);
+                when(firstKieModule.getReleaseId()).thenReturn(firstReleaseId);
+                kieModuleRepo.store(firstKieModule);
+
+                waitFor(threadsFinishedBarrier);
+            }
+        });
+
+        Thread secondThread = new Thread(new Runnable() {
+
+            private final KieModuleRepo kieModuleRepo = KieModuleRepoTest.this.kieModuleRepo;
+
+            @Override
+            public void run() {
+                ReleaseIdImpl secondReleaseId = new ReleaseIdImpl(groupId, artifactId, secondVersion);
+                KieModule secondKieModule = mock(KieModule.class);
+                when(secondKieModule.getReleaseId()).thenReturn(secondReleaseId);
+                kieModuleRepo.store(secondKieModule);
+
+                waitFor(threadsFinishedBarrier);
+            }
+        });
+
+        firstThread.setName("normal");
+        firstThread.start();
+        secondThread.setName("newFeature");
+        secondThread.start();
+
+        waitFor(threadsFinishedBarrier);
+        checkRules();
+
+        String ga = groupId + ":" + artifactId;
+        Map<ComparableVersion, KieModule> artifactMap = getArtifactMapFromKieModuleRepoInstance(kieModuleRepo, ga);
+
+        ComparableVersion normalVersion = new ComparableVersion(firstVersion);
+        KieModule normalKieModule = artifactMap.get(normalVersion);
+        ComparableVersion newFeatureVersion = new ComparableVersion(secondVersion);
+        KieModule newFeatureKieModule = artifactMap.get(newFeatureVersion);
+
+        assertNotNull( "Race condition occurred: normal KieModule disappeared from KieModuleRepo!", normalKieModule);
+        assertNotNull( "Race condition occurred: new feature KieModule disappeared from KieModuleRepo!", newFeatureKieModule);
+    }
+
+    // remove request followed by a store request on a high load system
+    // * remove does not completely finish before store starts
+    @Test(timeout=5000)
+    @BMScript(value="byteman/removeStoreArtifactMapTest.btm")
+    public void removeStoreArtifactMapTest() throws Exception {
+        Thread.currentThread().setName("test");
+
+        final ReleaseIdImpl releaseId = new ReleaseIdImpl("org", "redeploy", "2.0");
+        final KieModule redeployKieModule = mock(KieModule.class);
+        when(redeployKieModule.getReleaseId()).thenReturn(releaseId);
+
+        final CountDownLatch initialDeploy = new CountDownLatch(1);
+
+        // 1. initial deploy ("long ago")
+        kieModuleRepo.store(redeployKieModule);
+        initialDeploy.countDown();
+
+        final CyclicBarrier storeAndRemoveThreadsToFinish = new CyclicBarrier(3);
+
+        Thread removeThread = new Thread(new Runnable() {
+
+            private final KieModuleRepo kieModuleRepo = KieModuleRepoTest.this.kieModuleRepo;
+
+            @Override
+            public void run() {
+                waitFor(initialDeploy);
+
+                kieModuleRepo.remove(releaseId);
+
+                waitFor(storeAndRemoveThreadsToFinish);
+            }
+        });
+
+        Thread redeployThread = new Thread(new Runnable() {
+
+            private final KieModuleRepo kieModuleRepo = KieModuleRepoTest.this.kieModuleRepo;
+
+            @Override
+            public void run() {
+                waitFor(initialDeploy);
+
+                kieModuleRepo.store(redeployKieModule);
+
+                waitFor(storeAndRemoveThreadsToFinish);
+            }
+        });
+
+        // 2. remove and redploy
+        removeThread.setName("remove");
+        removeThread.start();
+
+//        continueTest(); // test development, because there are race conditions in the *test* :/
+
+        redeployThread.setName("store");
+        redeployThread.start();
+
+        waitFor(storeAndRemoveThreadsToFinish);
+        checkRules();
+
+        String ga = releaseId.getGroupId() + ":" + releaseId.getArtifactId();
+        Map<ComparableVersion, KieModule> artifactMap = getArtifactMapFromKieModuleRepoInstance(kieModuleRepo, ga);
+
+        assertNotNull( "Artifact Map for GA '" + ga + "' not in KieModuleRepo!", artifactMap);
+
+        // never gets this far, but this is a good check
+        KieModule redployedKieModule = artifactMap.get(new ComparableVersion(releaseId.getVersion()));
+        assertNotNull( "Redeployed module has disappeared from KieModuleRepo!", redployedKieModule);
+    }
+
+    // 2. duplicate deploy request
+    // - multitenant UI
+    // - duplicate REST requests
+    @Test(timeout=5000)
+    @BMScript(value="byteman/newerVersionDeployOverwritesTest.btm")
+    public void newerVersionDeployOverwritesTest() throws Exception {
+        Thread.currentThread().setName("test");
+
+        // setup
+        ReleaseIdImpl releaseId = new ReleaseIdImpl("org", "deployTwiceAfterUpdateDependency", "1.0-SNAPSHOT");
+        InternalKieModule originalOldKieModule = mock(InternalKieModule.class);
+        when(originalOldKieModule.getReleaseId()).thenReturn(releaseId);
+        when(originalOldKieModule.getCreationTimestamp()).thenReturn(0l);
+
+        ReleaseId dependentReleaseid = new ReleaseIdImpl("org", "deployTwiceAfterUpdate", "1.0-SNAPSHOT");
+        KieContainerImpl kieContainer = createMockKieContainer(dependentReleaseid, kieModuleRepo);
+
+        // test
+        final CountDownLatch initialDeployAndUpdateDependencyToFinish = new CountDownLatch(1);
+
+        // 1. deploy
+        kieModuleRepo.store(originalOldKieModule);
+
+        // 2. another project is dependent on this project
+        kieContainer.updateDependencyToVersion(releaseId, releaseId);
+
+        // once above is done, let the threads below proceed
+        initialDeployAndUpdateDependencyToFinish.countDown();
+
+        final CyclicBarrier bothStoreThreadsToFinish = new CyclicBarrier(3);
+
+        final InternalKieModule newKieModule = mock(InternalKieModule.class);
+        when(newKieModule.getReleaseId()).thenReturn(releaseId);
+        when(newKieModule.getCreationTimestamp()).thenReturn(10l);
+
+        Runnable deployRunnable = new Runnable() {
+
+            private final KieModuleRepo kieModuleRepo = KieModuleRepoTest.this.kieModuleRepo;
+
+            @Override
+            public void run() {
+                waitFor(initialDeployAndUpdateDependencyToFinish);
+
+                kieModuleRepo.store(newKieModule);
+
+                waitFor(bothStoreThreadsToFinish);
+            }
+        };
+
+        Thread deployThread = new Thread(deployRunnable);
+        Thread secondDeployThread = new Thread(deployRunnable);
+
+        // 2. remove and redploy
+        deployThread.setName("one");
+        deployThread.start();
+
+        secondDeployThread.setName("two");
+        secondDeployThread.start();
+
+        waitFor(bothStoreThreadsToFinish);
+        checkRules();
+
+        Map<ReleaseId, KieModule> oldKieModules = getOldKieModulesMapFromKieModuleRepoInstance(kieModuleRepo);
+
+        // never gets this far, but this is a good check
+        KieModule oldKieModule = oldKieModules.get(releaseId);
+        long oldKieModuleTimeStamp = ((InternalKieModule) oldKieModule).getCreationTimestamp();
+        long originalKieModuleTimestamp = ((InternalKieModule) originalOldKieModule).getCreationTimestamp();
+        assertEquals( "The old kie module in the repo is not the originally deployed module!",
+                      originalKieModuleTimestamp, oldKieModuleTimeStamp);
+    }
+
+}

--- a/drools-compiler/src/test/resources/byteman/newerVersionDeployOverwritesTest.btm
+++ b/drools-compiler/src/test/resources/byteman/newerVersionDeployOverwritesTest.btm
@@ -25,7 +25,7 @@ ENDRULE
 RULE store: first thread before get oldKieModule
 CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
 METHOD store
-AFTER WRITE $oldReleaseIdKieModule
+AT SYNCHRONIZE
 BIND threadName = Thread.currentThread().getName();
 IF threadName.equals("one")
 DO 
@@ -37,7 +37,7 @@ ENDRULE
 RULE store: second thread before get oldKieModule
 CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
 METHOD store
-AFTER WRITE $oldReleaseIdKieModule
+AT SYNCHRONIZE
 BIND threadName = Thread.currentThread().getName();
 IF threadName.equals("two")
 DO 
@@ -51,7 +51,7 @@ ENDRULE
 RULE store: first thread after put oldKieModule
 CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
 METHOD store
-AFTER READ $artifactMap 3
+AT EXIT
 BIND threadName = Thread.currentThread().getName();
 IF threadName.equals("one")
 DO 

--- a/drools-compiler/src/test/resources/byteman/newerVersionDeployOverwritesTest.btm
+++ b/drools-compiler/src/test/resources/byteman/newerVersionDeployOverwritesTest.btm
@@ -1,0 +1,79 @@
+# Byteman Rule for 
+# org.drools.compiler.kie.builder.KieModuleRepoTest.artifactMapTest
+
+RULE test setup ( after initial store and updateDependencyToVersion)
+CLASS org.drools.compiler.kie.builder.impl.KieModuleRepoTest
+METHOD newerVersionDeployOverwritesTest
+AFTER WRITE $deployRunnable
+BIND threadName = Thread.currentThread().getName();
+IF TRUE
+DO 
+# traceln(">>>> " + threadName + ": create rendezvous's");
+createRendezvous("before get oldKieModule", 2);
+createRendezvous("after 1st put new kieModule", 2);
+flag("0")
+ENDRULE
+
+# ----
+# Basically, the first thread does the normal store, 
+# except that the second thread
+# *also* thinks that it needs to store an 'oldKieModule'
+# and because of the timing, grabs the *first thread*'s *new* kieModule,
+# thereby incorrectly replacing the original/"real" oldKieModule instance!
+# ----
+
+RULE store: first thread before get oldKieModule
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AFTER WRITE $oldReleaseIdKieModule
+BIND threadName = Thread.currentThread().getName();
+IF threadName.equals("one")
+DO 
+# traceln(">>>> " + threadName + " [1rst]: rendezvous [before get oldKieModule]");
+rendezvous("before get oldKieModule");
+flag("1a")
+ENDRULE
+
+RULE store: second thread before get oldKieModule
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AFTER WRITE $oldReleaseIdKieModule
+BIND threadName = Thread.currentThread().getName();
+IF threadName.equals("two")
+DO 
+# traceln(">>>> " + threadName + " [2nd]: rendezvous [before get oldKieModule]");
+rendezvous("before get oldKieModule");
+# traceln(">>>> " + threadName + " [2nd]: rendezvous [after 1rst put new kieModule]");
+rendezvous("after 1st put new kieModule");
+flag("2")
+ENDRULE
+
+RULE store: first thread after put oldKieModule
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AFTER READ $artifactMap 3
+BIND threadName = Thread.currentThread().getName();
+IF threadName.equals("one")
+DO 
+# traceln(">>>> " + threadName + " [1rst]: rendezvous [after 1rst put new kieModule]");
+rendezvous("after 1st put new kieModule");
+flag("1b")
+ENDRULE
+
+# --
+# Check rules
+# --
+ 
+RULE check thread actions
+CLASS org.drools.compiler.kie.builder.impl.KieModuleRepoTest
+METHOD checkRules
+AT ENTRY
+BIND threadName = Thread.currentThread().getName();
+IF NOT ( flagged("0") || flagged("2") || flagged("1a") || flagged("1b") )
+DO 
+throw new IllegalStateException("Not all rules were activated: " 
++ flagged("0") + ", "
++ flagged("2") + ", "
++ flagged("1a") + ", " 
++ flagged("1b") );
+ENDRULE

--- a/drools-compiler/src/test/resources/byteman/removeStoreArtifactMapTest.btm
+++ b/drools-compiler/src/test/resources/byteman/removeStoreArtifactMapTest.btm
@@ -1,0 +1,98 @@
+# Byteman Rule for 
+# org.drools.compiler.kie.builder.KieModuleRepoTest.artifactMapTest
+
+RULE test setup
+CLASS org.drools.compiler.kie.builder.impl.KieModuleRepoTest
+METHOD removeStoreArtifactMapTest
+AT READ org.drools.compiler.kie.builder.impl.KieModuleRepoTest.kieModuleRepo
+BIND threadName = Thread.currentThread().getName();
+IF TRUE
+DO 
+# traceln(">>>> " + threadName + ": create rendezvous's");
+createRendezvous("get artifactMap", 2);
+createRendezvous("remove artifactMap", 2);
+createRendezvous("continue test", 2);
+flag("0");
+ENDRULE
+
+# RULE test dev
+# CLASS org.drools.compiler.kie.builder.impl.KieModuleRepoTest
+# METHOD continueTest
+# AT ENTRY
+# BIND threadName = Thread.currentThread().getName();
+# IF TRUE
+# DO 
+# traceln(">>>> " + threadName + ": rendezvous [continue test]");
+# rendezvous("continue test");
+# ENDRULE
+
+RULE store: after [artifactMap = kieModules.get(ga)]
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AFTER WRITE $artifactMap
+BIND threadName = Thread.currentThread().getName();
+IF threadName.equals("store")
+DO 
+# traceln(">>>> " + threadName + ": rendezvous [get artifactMap]");
+rendezvous("get artifactMap");
+# traceln(">>>> " + threadName + ": rendezvous [remove artifactMap]");
+rendezvous("remove artifactMap");
+flag("2");
+ENDRULE
+
+# If this rule FIRES, then your test is BROKEN!
+RULE store: 2nd kieModule read
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AT READ org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo.kieModules 2
+BIND threadName = Thread.currentThread().getName();
+IF threadName.equals("store")
+DO 
+throw new IllegalStateException("A new artifactMap was added to the KieModuleRepo.kieModules field! That action invalidates this test.");
+ENDRULE
+
+RULE remove: after [artifactMap = kieModules.get(ga)]
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD remove
+AFTER WRITE $artifactMap 
+BIND threadName = Thread.currentThread().getName();
+IF TRUE
+DO 
+# traceln(">>>> " + threadName + ": rendezvous [continue test]");
+# rendezvous("continue test");
+# traceln(">>>> " + threadName + ": rendezvous [get artifactMap]");
+rendezvous("get artifactMap");
+flag("1");
+ENDRULE
+
+# we do AT READ oldKieModules 
+# because AFTER READ kieModules 
+# does *not* guarantee that kieModules.remove(ga) has been called!
+RULE remove: after [kieModules.remove(ga)]
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD remove
+AT READ org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo.oldKieModules 1
+BIND threadName = Thread.currentThread().getName();
+IF TRUE
+DO 
+# traceln(">>>> " + threadName + ": rendezvous [remove artifactMap]");
+rendezvous("remove artifactMap");
+flag("2");
+ENDRULE
+
+# --
+# Check rules
+# --
+ 
+RULE check thread actions
+CLASS org.drools.compiler.kie.builder.impl.KieModuleRepoTest
+METHOD checkRules
+AT ENTRY
+BIND threadName = Thread.currentThread().getName();
+IF NOT ( flagged("0") || flagged("1") || flagged("2") )
+DO 
+throw new IllegalStateException("Not all rules were activated: " 
++ flagged("0") + ", "
++ flagged("1") + ", " 
++ flagged("2") );
+ENDRULE

--- a/drools-compiler/src/test/resources/byteman/removeStoreArtifactMapTest.btm
+++ b/drools-compiler/src/test/resources/byteman/removeStoreArtifactMapTest.btm
@@ -71,7 +71,7 @@ ENDRULE
 RULE remove: after [kieModules.remove(ga)]
 CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
 METHOD remove
-AT READ org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo.oldKieModules 1
+AT EXIT
 BIND threadName = Thread.currentThread().getName();
 IF TRUE
 DO 

--- a/drools-compiler/src/test/resources/byteman/setArtifactMapTest.btm
+++ b/drools-compiler/src/test/resources/byteman/setArtifactMapTest.btm
@@ -1,0 +1,42 @@
+# Byteman Rule for 
+# org.drools.compiler.kie.builder.KieModuleRepoTest.artifactMapTest
+
+RULE store: 1rst thread set artifactMap wait
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AT WRITE $artifactMap 1
+BIND threadName = Thread.currentThread().getName();
+IF flag("first artifactMap check")
+DO 
+# traceln(">>>> " + threadName + ": wait [after set artifactMap]");
+waitFor("after set artifactMap");
+flag("1");
+ENDRULE
+
+RULE store: 2nd thread set ArtifactMap signal
+CLASS org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo
+METHOD store
+AFTER READ org.drools.compiler.kie.builder.impl.KieRepositoryImpl$KieModuleRepo.kieModules 2
+BIND threadName = Thread.currentThread().getName();
+IF flag("first kieModules.put")
+DO 
+# traceln(">>>> " + threadName + ": signal [after set artifactMap]");
+signalWake("after set artifactMap");
+flag("2");
+ENDRULE
+
+# --
+# Check rules
+# --
+ 
+RULE check thread actions
+CLASS org.drools.compiler.kie.builder.impl.KieModuleRepoTest
+METHOD checkRules
+AT ENTRY
+BIND threadName = Thread.currentThread().getName();
+IF NOT ( flagged("0") || flagged("1") || flagged("2") )
+DO 
+throw new IllegalStateException("Not all rules were activated: " 
++ flagged("1") + ", " 
++ flagged("2") );
+ENDRULE


### PR DESCRIPTION
@mariofusco You have a better idea of the concurrency problems that this code might deal with, but I saw a couple of use cases that I think should be fixed regardless (in particular, there are some places where `putIfAbsent` or other `ConcurrentMap` variants could be used instead of the normal `Map` methods).  

Let me know if you have questions, there are a lot of different race conditions that this code deals with: I tried to add good explanations in the comments, but that's not always enough (or, of course, I might have made a mistake.. :) ). 
