### PR TITLE
DROOLS-927 Persistence tests don't support Postgres Plus

### DIFF
--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/util/PersistenceUtil.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/util/PersistenceUtil.java
@@ -223,7 +223,7 @@ public class PersistenceUtil {
                 }
                 pds.getDriverProperties().put("REQUEST_HA_SESSION", "false");
                 pds.getDriverProperties().put("networkProtocol", "Tds");
-            } else if (driverClass.startsWith("org.postgresql")) {
+            } else if (driverClass.startsWith("org.postgresql") || driverClass.startsWith("com.edb")) {
                 for (String propertyName : new String[] { "databaseName", "portNumber", "serverName" }) {
                     pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));
                 }


### PR DESCRIPTION
Added support for PostgresPlus driver.

Please merge also to 6.3.x branch. 
