### PR TITLE
DROOLS-948 testEventWithShortExpiration() in CepEspTest and CepJavaTypeTest fails

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -5603,6 +5603,7 @@ public class CepEspTest extends CommonTestMethodBase {
 
         Thread.sleep(2L);
         ksession.fireAllRules();
-        assertEquals( 0, ksession.getObjects().size() );
+        Thread.sleep(100);
+        assertEquals(0, ksession.getObjects().size());
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
@@ -130,6 +130,7 @@ public class CepJavaTypeTest extends CommonTestMethodBase {
 
         Thread.sleep(2L);
         ksession.fireAllRules();
+        Thread.sleep(100);
         assertEquals( 0, ksession.getObjects().size() );
     }
 }


### PR DESCRIPTION
- Added sleep times.
