### PR TITLE
ClasspathKieProject should not deal ".jar" always like a file

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -211,7 +211,7 @@ public class ClasspathKieProject extends AbstractKieProject {
             rootPath = IoUtils.asSystemSpecificPath( rootPath, rootPath.lastIndexOf( ':' ) );
         }
 
-        if ( urlPathToAdd.endsWith( ".apk" ) || urlPathToAdd.endsWith( ".jar" ) || urlPathToAdd.endsWith( "/content" ) ) {
+        if ( urlPathToAdd.endsWith( ".apk" ) || isJarFile(urlPathToAdd, rootPath) || urlPathToAdd.endsWith( "/content" ) ) {
             pomProperties = getPomPropertiesFromZipFile(rootPath);
         } else {
             pomProperties = getPomPropertiesFromFileSystem(rootPath);
@@ -231,6 +231,17 @@ public class ClasspathKieProject extends AbstractKieProject {
             log.warn( "Unable to load pom.properties from" + urlPathToAdd );
         }
         return pomProperties;
+    }
+
+    private static boolean isJarFile(String urlPathToAdd, String rootPath) {
+        boolean result = false;
+        if (urlPathToAdd.endsWith( ".jar" )) {
+            File actualZipFile = new File( rootPath );
+            if (actualZipFile.exists() && actualZipFile.isFile()) {
+                result = true;
+            }
+        }
+        return result;
     }
 
     private static String getPomPropertiesFromZipFile(String rootPath) {

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/JarFileOrDirTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/JarFileOrDirTest.java
@@ -1,0 +1,85 @@
+package org.drools.compiler.kie.builder;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+
+import org.drools.compiler.kie.builder.impl.ClasspathKieProject;
+import org.drools.compiler.kproject.AbstractKnowledgeTest;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.builder.ReleaseId;
+
+/**
+ * Test for kModule in jar (file or directory).
+ */
+public class JarFileOrDirTest {
+
+    public static AbstractKnowledgeTest helper;
+
+    private static final String MODULE_JARFILE_NAME = "jar1";
+    private static final String MODULE_JARFILE_VERSION = "1.0";
+    private static final String MODULE_JARDIR_NAME = "jar2";
+    private static final String MODULE_JARDIR_VERSION = "2.0";
+
+    @BeforeClass
+    public static void beforeClass() {
+        helper = new AbstractKnowledgeTest();
+        try {
+            helper.setUp();
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+        try {
+            helper.createKieModule(MODULE_JARFILE_NAME, true, MODULE_JARFILE_VERSION);
+            helper.createKieModule(MODULE_JARDIR_NAME, false, MODULE_JARDIR_VERSION);
+            final File kModuleDir = helper.getFileManager().newFile(MODULE_JARDIR_NAME + "-" + MODULE_JARDIR_VERSION);
+            assertNotNull(kModuleDir);
+            assertTrue(kModuleDir.isDirectory());
+            kModuleDir.renameTo(new File(kModuleDir.getAbsolutePath() + ".jar"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Unable to build dynamic KieModules:\n" + e.toString());
+        }
+
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        try {
+            helper.tearDown();
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testkModuleJarFile() {
+        final File kModuleFile = helper.getFileManager()
+                .newFile(MODULE_JARFILE_NAME + "-" + MODULE_JARFILE_VERSION + ".jar");
+        final String pomProperties = ClasspathKieProject.getPomProperties(kModuleFile.getAbsolutePath());
+        checkPomProperties(pomProperties, MODULE_JARFILE_NAME, MODULE_JARFILE_VERSION);
+    }
+
+    @Test
+    public void testkModuleJarDir() {
+        final File kModuleFile = helper.getFileManager()
+                .newFile(MODULE_JARDIR_NAME + "-" + MODULE_JARDIR_VERSION + ".jar");
+        final String pomProperties = ClasspathKieProject.getPomProperties(kModuleFile.getAbsolutePath());
+        checkPomProperties(pomProperties, MODULE_JARDIR_NAME, MODULE_JARDIR_VERSION);
+    }
+
+    private void checkPomProperties(final String pomProperties, final String groupId, final String version) {
+        assertNotNull(pomProperties);
+        final ReleaseId release = ReleaseIdImpl.fromPropertiesString(pomProperties);
+        assertNotNull(release);
+        assertTrue(groupId.equals(release.getGroupId()));
+        assertTrue(version.equals(release.getVersion()));
+    }
+
+}


### PR DESCRIPTION
Some containers allow deployments of artifacts in "expanded" mode (instead of a unique jar/ear/war/... file, al artifacts are deployed full decompressed, so they are directories). This is default with last JBoss Tools and Wildfly (unless you use compressed option for deployments). In that case drools fails to load jar contents.

With this patch jar files are checked that they are actually files. In other case they are treated like directories.
