### PR TITLE
BZ-1274696: add reproducer

### DIFF
--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/test_CEP_DeleteExpiredEvent.drl
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/test_CEP_DeleteExpiredEvent.drl
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler
+
+import org.drools.compiler.StockTick;
+
+dialect "mvel"
+
+declare StockTick
+    @role( event )
+end
+
+rule "TestEventReceived"
+no-loop
+when
+	$st1 : StockTick( company == "ACME" ) from entry-point "Event Stream"
+	not (
+            StockTick(
+            	this != $st1,
+                this after[0ms, 1100ms] $st1
+            )
+        )
+then
+	delete($st1)
+end


### PR DESCRIPTION
Added a reproducer for a possible bug, or a change in behavior since 6.2.x. It is very likely that failing fast when attempting to delete an expired event is expected, in that case, please feel free to close this PR.

On the other hand, if this behavior is expected, is there a way how to delete the event "safely"? For instance, a method callable from the rule RHS, such as:

```
boolean deleteSafely(FactHandle handle) {
  if (kieSession.getFactHandles().contains(handle)) {
    delete(handle);
    return true;
  } else {
    return false;
  }
}
```
