### PR TITLE
kie-ci: fix wired component provider after upgrading to maven 3.2.5

### DIFF
--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -49,12 +49,12 @@ import static org.kie.scanner.MavenRepository.getMavenRepository;
 @RunWith(Parameterized.class)
 public class KieRepositoryScannerTest extends AbstractKieCiTest {
 
-    private final boolean uesWiredComponentProvider;
+    private final boolean useWiredComponentProvider;
 
     private FileManager fileManager;
     private File kPom;
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "Manually wired component provider={0}")
     public static Collection modes() {
         Object[][] locking = new Object[][] {
                 { true },
@@ -63,13 +63,13 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         return Arrays.asList(locking);
     }
 
-    public KieRepositoryScannerTest( boolean uesWiredComponentProvider ) {
-        this.uesWiredComponentProvider = uesWiredComponentProvider;
+    public KieRepositoryScannerTest( boolean useWiredComponentProvider) {
+        this.useWiredComponentProvider = useWiredComponentProvider;
     }
 
     @Before
     public void setUp() throws Exception {
-        MavenEmbedderUtils.enforceWiredComponentProvider = uesWiredComponentProvider;
+        MavenEmbedderUtils.enforceWiredComponentProvider = useWiredComponentProvider;
         this.fileManager = new FileManager();
         this.fileManager.setUp();
         ReleaseId releaseId = KieServices.Factory.get().newReleaseId("org.kie", "scanner-test", "1.0-SNAPSHOT");


### PR DESCRIPTION
This wired thing will require lot of tweaking each time we upgrade Maven. I know it's there so that the Maven works in OSGi, but this really seems like maintenance nightmare.
