### PR TITLE
DROOLS-924: add test assertions for EventFactHandle

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -5574,8 +5574,8 @@ public class CepEspTest extends CommonTestMethodBase {
 
         FactHandle key = DefaultFactHandle.createFromExternalFormat( helloHandle.toExternalForm() );
         assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
-        assertEquals("hello",
-                ksession.getObject(key));
+        assertEquals( "hello",
+                      ksession.getObject(key));
 
         key = DefaultFactHandle.createFromExternalFormat( goodbyeHandle.toExternalForm() );
         assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -5575,7 +5575,7 @@ public class CepEspTest extends CommonTestMethodBase {
         FactHandle key = DefaultFactHandle.createFromExternalFormat( helloHandle.toExternalForm() );
         assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
         assertEquals( "hello",
-                      ksession.getObject(key));
+                      ksession.getObject( key ) );
 
         key = DefaultFactHandle.createFromExternalFormat( goodbyeHandle.toExternalForm() );
         assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -5573,10 +5573,12 @@ public class CepEspTest extends CommonTestMethodBase {
         DefaultFactHandle goodbyeHandle = (DefaultFactHandle) ksession.insert( "goodbye" );
 
         FactHandle key = DefaultFactHandle.createFromExternalFormat( helloHandle.toExternalForm() );
-        assertEquals( "hello",
-                      ksession.getObject( key ) );
+        assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
+        assertEquals("hello",
+                ksession.getObject(key));
 
         key = DefaultFactHandle.createFromExternalFormat( goodbyeHandle.toExternalForm() );
+        assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
         assertEquals( "goodbye",
                       ksession.getObject( key ) );
     }


### PR DESCRIPTION
Added assertion verifying that the deserialized FactHandle is in fact an EventFactHandle.
