### PR TITLE
[6.3.x] [BZ-1266076] add support for guided rule templates with DSL

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/GuidedDecisionTableProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/GuidedDecisionTableProvider.java
@@ -22,24 +22,6 @@ import java.io.InputStream;
 
 public interface GuidedDecisionTableProvider extends Service {
 
-    ConversionResult loadFromInputStream(InputStream is) throws IOException;
-
-    class ConversionResult {
-        private final String drl;
-        private final boolean containsDsl;
-
-        public ConversionResult(String drl, boolean containsDsl) {
-            this.drl = drl;
-            this.containsDsl = containsDsl;
-        }
-
-        public String getDrl() {
-            return drl;
-        }
-
-        public boolean containsDsl() {
-            return containsDsl;
-        }
-    }
+    ResourceConversionResult loadFromInputStream(InputStream is) throws IOException;
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/GuidedRuleTemplateProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/GuidedRuleTemplateProvider.java
@@ -23,5 +23,6 @@ import java.io.InputStream;
 
 public interface GuidedRuleTemplateProvider extends Service {
 
-    String loadFromInputStream(InputStream is) throws IOException;
+    ResourceConversionResult loadFromInputStream(InputStream is) throws IOException;
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ResourceConversionResult.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ResourceConversionResult.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.compiler;
+
+import org.kie.api.io.ResourceType;
+
+/**
+ * Result of conversion from custom resource (like guided dtable or guided template) into DRL or DSLR.
+ */
+public class ResourceConversionResult {
+    private final String content;
+    private final ResourceType type;
+
+    public ResourceConversionResult(String content, ResourceType type) {
+        this.content = content;
+        this.type = type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public ResourceType getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceConversionResult{" +
+                "content='" + content + '\'' +
+                ", type=" + type +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ResourceConversionResult that = (ResourceConversionResult) o;
+
+        if (content != null ? !content.equals(that.content) : that.content != null) return false;
+        return !(type != null ? !type.equals(that.type) : that.type != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = content != null ? content.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
+    }
+
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/pom.xml
@@ -18,6 +18,10 @@
 
     <!-- Internal dependencies -->
     <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
     </dependency>

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDecisionTableProviderImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDecisionTableProviderImpl.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.backend;
 
 import org.drools.compiler.compiler.GuidedDecisionTableProvider;
+import org.drools.compiler.compiler.ResourceConversionResult;
 import org.drools.core.util.IoUtils;
 import org.drools.workbench.models.datamodel.rule.DSLSentence;
 import org.drools.workbench.models.datamodel.rule.IAction;
@@ -26,6 +27,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.kie.api.io.ResourceType;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,12 +35,15 @@ import java.io.InputStream;
 public class GuidedDecisionTableProviderImpl implements GuidedDecisionTableProvider {
 
     @Override
-    public ConversionResult loadFromInputStream(InputStream is) throws IOException {
+    public ResourceConversionResult loadFromInputStream(InputStream is) throws IOException {
         String xml = new String(IoUtils.readBytesFromInputStream(is), IoUtils.UTF8_CHARSET);
         GuidedDecisionTable52 model = GuidedDTXMLPersistence.getInstance().unmarshal(xml);
-        boolean containsDsl = hasDSLSentences(model);
-        String drl = GuidedDTDRLPersistence.getInstance().marshal(model);
-        return new ConversionResult(drl, containsDsl);
+        String content = GuidedDTDRLPersistence.getInstance().marshal(model);
+        if (hasDSLSentences(model)) {
+            return new ResourceConversionResult(content, ResourceType.DSLR);
+        } else {
+            return new ResourceConversionResult(content, ResourceType.DRL);
+        }
     }
 
     // Check if the model uses DSLSentences and hence requires expansion. This code is copied from GuidedDecisionTableUtils.

--- a/drools-workbench-models/drools-workbench-models-guided-template/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-template/pom.xml
@@ -19,6 +19,10 @@
 
     <!-- Internal dependencies -->
     <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
     </dependency>
@@ -57,6 +61,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/GuidedRuleTemplateProviderImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/GuidedRuleTemplateProviderImpl.java
@@ -17,8 +17,10 @@
 package org.drools.workbench.models.guided.template.backend;
 
 import org.drools.compiler.compiler.GuidedRuleTemplateProvider;
+import org.drools.compiler.compiler.ResourceConversionResult;
 import org.drools.core.util.IoUtils;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
+import org.kie.api.io.ResourceType;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,10 +28,15 @@ import java.io.InputStream;
 public class GuidedRuleTemplateProviderImpl implements GuidedRuleTemplateProvider {
 
     @Override
-    public String loadFromInputStream(InputStream is) throws IOException {
+    public ResourceConversionResult loadFromInputStream(InputStream is) throws IOException {
         String xml = new String(IoUtils.readBytesFromInputStream(is), IoUtils.UTF8_CHARSET);
         TemplateModel model = RuleTemplateModelXMLPersistenceImpl.getInstance().unmarshal(xml);
-        return RuleTemplateModelDRLPersistenceImpl.getInstance().marshal(model);
+        String content = RuleTemplateModelDRLPersistenceImpl.getInstance().marshal(model);
+        if (model.hasDSLSentences()) {
+            return new ResourceConversionResult(content, ResourceType.DSLR);
+        } else {
+            return new ResourceConversionResult(content, ResourceType.DRL);
+        }
     }
 
 }

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/TemplateWithDSLIntegrationTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/TemplateWithDSLIntegrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.workbench.models.guided.template.backend;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.Results;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.utils.KieHelper;
+
+import java.util.Collections;
+
+public class TemplateWithDSLIntegrationTest {
+
+    @Test
+    public void testCompileTemplateWithDSL() {
+        String template = "<rule>\n" +
+                "  <name>guided-template-with-dsl</name>\n" +
+                "  <modelVersion>1.0</modelVersion>\n" +
+                "  <attributes/>\n" +
+                "  <metadataList/>\n" +
+                "  <lhs>\n" +
+                "    <dslSentence>\n" +
+                "      <drl>applicant:" + Applicant.class.getCanonicalName() + "(approved=={bool})</drl>\n" +
+                "      <definition>When the applicant approval is {bool:BOOLEAN:checked}</definition>\n" +
+                "      <values>\n" +
+                "        <org.drools.workbench.models.datamodel.rule.DSLVariableValue>\n" +
+                "          <value>false</value>\n" +
+                "        </org.drools.workbench.models.datamodel.rule.DSLVariableValue>\n" +
+                "        <org.drools.workbench.models.datamodel.rule.DSLComplexVariableValue>\n" +
+                "          <value>bool</value>\n" +
+                "          <id>BOOLEAN:checked</id>\n" +
+                "        </org.drools.workbench.models.datamodel.rule.DSLComplexVariableValue>\n" +
+                "      </values>\n" +
+                "    </dslSentence>\n" +
+                "  </lhs>\n" +
+                "  <rhs>\n" +
+                "    <dslSentence>\n" +
+                "      <drl>applicant.setApproved(true)</drl>\n" +
+                "      <definition>Approve the loan</definition>\n" +
+                "      <values/>\n" +
+                "    </dslSentence>\n" +
+                "  </rhs>\n" +
+                "  <imports>\n" +
+                "    <imports/>\n" +
+                "  </imports>\n" +
+                "  <packageName>org.mortgages</packageName>\n" +
+                "  <isNegated>false</isNegated>\n" +
+                "  <table>\n" +
+                "    <entry>\n" +
+                "      <string>__ID_KOL_NAME__</string>\n" +
+                "      <list>\n" +
+                "        <string>1</string>\n" +
+                "      </list>\n" +
+                "    </entry>\n" +
+                "  </table>\n" +
+                "  <idCol>1</idCol>\n" +
+                "  <rowsCount>1</rowsCount>\n" +
+                "</rule>";
+
+        String dsl = "[when]When the applicant approval is {bool:BOOLEAN:checked} = applicant:" + Applicant.class.getCanonicalName() + "(approved=={bool})\n" +
+                "[then]Approve the loan = applicant.setApproved(true)";
+
+        KieHelper kieHelper = new KieHelper();
+        KieSession kieSession = kieHelper
+                .addContent(template, ResourceType.TEMPLATE)
+                .addContent(dsl, ResourceType.DSL)
+                .build()
+                .newKieSession();
+
+        Applicant applicant = new Applicant();
+        applicant.setApproved(false);
+        kieSession.insert(applicant);
+        int rulesFired = kieSession.fireAllRules();
+        Assert.assertEquals("Incorrect number of rules fired!", 1, rulesFired);
+        Assert.assertEquals("Rule RHS wasn't triggered!", true, applicant.isApproved());
+    }
+
+    public static class Applicant {
+        private boolean approved;
+
+        public boolean isApproved() {
+            return approved;
+        }
+
+        public void setApproved(boolean approved) {
+            this.approved = approved;
+        }
+    }
+
+}


### PR DESCRIPTION
- guided templates use the same mechanism as guided dtables. If it
  contains DSL sentences, the generated string is treated as DSLR,
  otherwise as standard DRL
