### PR TITLE
DROOLS-951: add missing @Test annotation

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
@@ -2082,6 +2082,7 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
         }
     }
 
+    @Test
     public void testRetractLogicalAssertedObjectOnRuleRemoval() throws Exception {
         // DROOLS-951
         String drl1 =


### PR DESCRIPTION
Added missing @Test annotation. When run locally, the test passed.
