### PR TITLE
deal with spurious wakeups of Object.wait()

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
@@ -1402,7 +1402,7 @@ public class DefaultAgenda
     }
 
     private void waitAndEnterExecutionState( ExecutionState newState ) {
-        if (currentState != ExecutionState.INACTIVE) {
+        while (currentState != ExecutionState.INACTIVE) {
             try {
                 stateMachineLock.wait();
             } catch (InterruptedException e) {


### PR DESCRIPTION
> As in the one argument version, interrupts and spurious wakeups are possible, and this method should always be used in a loop. [1]

[1] http://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#wait(long)
