### PR TITLE
tests: use better names for non existing fields/classes + small typo …

### DIFF
--- a/drools-compiler/src/main/resources/org/drools/compiler/lang/DRL5Lexer.g
+++ b/drools-compiler/src/main/resources/org/drools/compiler/lang/DRL5Lexer.g
@@ -45,7 +45,7 @@ tokens {
         return errors;
     }
 
-    /** Overrided this method to not output mesages */
+    /** Overridden to not output messages */
     public void emitErrorMessage(String msg) {
     }
     

--- a/drools-compiler/src/main/resources/org/drools/compiler/lang/DRL6Lexer.g
+++ b/drools-compiler/src/main/resources/org/drools/compiler/lang/DRL6Lexer.g
@@ -45,7 +45,7 @@ tokens {
         return errors;
     }
 
-    /** Overrided this method to not output mesages */
+    /** Overridden to not output messages */
     public void emitErrorMessage(String msg) {
     }
     

--- a/drools-compiler/src/main/resources/org/drools/compiler/lang/dsl/DSLMap.g
+++ b/drools-compiler/src/main/resources/org/drools/compiler/lang/dsl/DSLMap.g
@@ -52,7 +52,7 @@ tokens {
         return errors;
     }
 
-    /** Override this method to not output mesages */
+    /** Overridden to not output messages */
     public void emitErrorMessage(String msg) {
     }
 }
@@ -68,7 +68,7 @@ tokens {
         return errors;
     }
 
-    /** Override this method to not output mesages */
+    /** Overridden to not output messages */
     public void emitErrorMessage(String msg) {
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
@@ -311,7 +311,7 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
         String drl2_2 = "package org.drools.compiler\n" +
                 "rule R2_2 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 
@@ -350,7 +350,7 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
         String drl2_1 = "package org.drools.compiler\n" +
                 "rule R2_1 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 
@@ -390,10 +390,10 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        //Field is unknown ("mesage" not "message")
+        //Field is unknown ("nonExistentField" not "message")
         String drl2_1 = "package org.drools.compiler\n" +
                 "rule R2_1 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 
@@ -429,17 +429,17 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
     @Test
     public void testIncrementalCompilationAddErrorThenRemoveIt() throws Exception {
-        //Fact Type is unknown ("Mesage" not "Message")
+        //Fact Type is unknown ("NonExistentClass" not "Message")
         String drl1 = "package org.drools.compiler\n" +
                 "rule R1 when\n" +
-                "   $m : Mesage()\n" +
+                "   $m : NonExistentClass()\n" +
                 "then\n" +
                 "end\n";
 
-        //Field is unknown ("mesage" not "message")
+        //Field is unknown ("nonExistentField" not "message")
         String drl2_1 = "package org.drools.compiler\n" +
                 "rule R2_1 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 
@@ -540,10 +540,10 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        //Field is unknown ("mesage" not "message")
+        //Field is unknown ("nonExistentField" not "message")
         String drl2_1 = "package org.drools.compiler\n" +
                 "rule R2_1 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 
@@ -1009,7 +1009,7 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
         String drl2_2 = "package org.drools.compiler\n" +
                 "rule R2_2 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 
@@ -1105,7 +1105,7 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
         String drl2_1 = "package org.drools.compiler\n" +
                 "rule R2\n" +
                 "when\n" +
-                "   $m : Mesage()\n" +
+                "   $m : NonExistentClass()\n" +
                 "then\n" +
                 "end\n";
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieHelloWorldTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieHelloWorldTest.java
@@ -36,6 +36,7 @@ import org.kie.api.runtime.conf.ClockTypeOption;
 import java.io.ByteArrayInputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -102,7 +103,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         String drl = "package org.drools.compiler.integrationtests\n" +
                 "import " + Message.class.getCanonicalName() + "\n" +
                 "rule R1 when\n" +
-                "   $m : Message( mesage == \"Hello World\" )\n" +
+                "   $m : Message( nonExistentField == \"Hello World\" )\n" +
                 "then\n" +
                 "end\n";
 


### PR DESCRIPTION
…fixes
- using names that are quite different from the expected ones
  makes it easier to spot them in the log. 'mesage' vs 'message'
  is very easy to overlook
