### PR TITLE
Add test cases for extending POJO classes

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -261,15 +261,7 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
         this.pkgRegistryMap = new LinkedHashMap<String, PackageRegistry>();
         this.results = new ArrayList<KnowledgeBuilderResult>();
 
-        PackageRegistry pkgRegistry = new PackageRegistry(rootClassLoader, this.configuration, pkg);
-        pkgRegistry.setDialect(this.defaultDialect);
-        this.pkgRegistryMap.put(pkg.getName(),
-                                pkgRegistry);
-
-        // add imports to pkg registry
-        for (final ImportDeclaration implDecl : pkg.getImports().values()) {
-            pkgRegistry.addImport(new ImportDescr(implDecl.getTarget()));
-        }
+		addInternalKnowledgePackage(pkg);
 
         processBuilder = createProcessBuilder();
         typeBuilder = new TypeDeclarationBuilder(this);
@@ -298,9 +290,26 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
 
         this.kBase = kBase;
 
+		if (kBase != null) {
+			for (InternalKnowledgePackage pkg : kBase.getPackagesMap().values()) {
+				addInternalKnowledgePackage(pkg);
+			}
+		}
+
         processBuilder = createProcessBuilder();
         typeBuilder = new TypeDeclarationBuilder(this);
     }
+
+	private void addInternalKnowledgePackage(InternalKnowledgePackage pkg) {
+        PackageRegistry pkgRegistry = new PackageRegistry(this.rootClassLoader, this.configuration, pkg);
+        pkgRegistry.setDialect(this.defaultDialect);
+        this.pkgRegistryMap.put(pkg.getName(), pkgRegistry);
+
+        // add imports to pkg registry
+        for (final ImportDeclaration implDecl : pkg.getImports().values()) {
+            pkgRegistry.addImport(new ImportDescr(implDecl.getTarget()));
+        }
+	}
 
     private ProcessBuilder createProcessBuilder() {
         try {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
@@ -2426,41 +2426,6 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
                "end";
     }
 
-	/*
-	@Test
-    public void testDeclarationWithPojoExtensionMultiplePackages() throws Exception {
-        String drlDeclare = "package org.drools.compiler.integrationtests\n" +
-                     "declare Drools_applications extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
-                     "    drools_app_name: String\n" +
-                     "end";
-        String drlRule = "package org.drools.compiler.test\n" +
-                     "rule R1 when\n" +
-                     "   $fact : org.drools.compiler.integrationtests.Drools_applications( drools_app_name == \"appName\" )\n" +
-                     "then\n" +
-                     "end";
-
-        org.drools.builder.KnowledgeBuilder kbuilder = org.drools.builder.KnowledgeBuilderFactory.newKnowledgeBuilder();
-		kbuilder.add(org.drools.io.ResourceFactory.newReaderResource(new StringReader(drlDeclare)), org.drools.builder.ResourceType.DRL);
-        org.drools.KnowledgeBase kbase = org.drools.KnowledgeBaseFactory.newKnowledgeBase();
-		kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
-
-        org.drools.builder.KnowledgeBuilder kbuilder2 = org.drools.builder.KnowledgeBuilderFactory.newKnowledgeBuilder(kbase);
-		kbuilder2.add(org.drools.io.ResourceFactory.newReaderResource(new StringReader(drlRule)), org.drools.builder.ResourceType.DRL);
-		// This line may not be necessary
-		// kbase.addKnowledgePackages(kbuilder2.getKnowledgePackages());
-
-		org.drools.runtime.StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
-
-        org.drools.definition.type.FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Drools_applications" );
-        Object fact = factType.newInstance();
-        factType.set( fact, "drools_app_name", "appName" );
-        ksession.insert( fact );
-
-        int rules = ksession.fireAllRules();
-        assertEquals( 1, rules );
-    }
-	*/
-
 	public static class BaseClass {
 		String baseField;
 		public String getBaseField() {
@@ -2497,8 +2462,13 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
         kieBuilder.buildAll();
 
+        KieModule kieModule = kieBuilder.getKieModule();
+        assertEquals( releaseId1, kieModule.getReleaseId() );
+
         KieContainer kc = ks.newKieContainer( releaseId1 );
 
+        ReleaseId releaseId2 = ks.newReleaseId( "org.kie", "test-upgrade", "1.1.0" );
+        kfs.generateAndWritePomXML( releaseId2 );
         kfs.write( ks.getResources()
                            .newReaderResource( new StringReader( drlRule ) )
                            .setResourceType( ResourceType.DRL )
@@ -2508,7 +2478,9 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
         System.out.println( results.getAddedMessages() );
         assertEquals( 0, results.getAddedMessages().size() );
 
-        ReleaseId releaseId2 = ks.newReleaseId( "org.kie", "test-upgrade", "1.1.0" );
+        kieModule = kieBuilder.getKieModule();
+        assertEquals( releaseId2, kieModule.getReleaseId() );
+
         Results updateResults = kc.updateToVersion( releaseId2 );
         assertEquals( 0, updateResults.getMessages().size() );
 
@@ -2547,8 +2519,13 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
         kieBuilder.buildAll();
 
+        KieModule kieModule = kieBuilder.getKieModule();
+        assertEquals( releaseId1, kieModule.getReleaseId() );
+
         KieContainer kc = ks.newKieContainer( releaseId1 );
 
+        ReleaseId releaseId2 = ks.newReleaseId( "org.kie", "test-upgrade", "1.1.0" );
+        kfs.generateAndWritePomXML( releaseId2 );
         kfs.write( ks.getResources()
                            .newReaderResource( new StringReader( drlRule ) )
                            .setResourceType( ResourceType.DRL )
@@ -2558,7 +2535,9 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
         System.out.println( results.getAddedMessages() );
         assertEquals( 0, results.getAddedMessages().size() );
 
-        ReleaseId releaseId2 = ks.newReleaseId( "org.kie", "test-upgrade", "1.1.0" );
+        kieModule = kieBuilder.getKieModule();
+        assertEquals( releaseId2, kieModule.getReleaseId() );
+
         Results updateResults = kc.updateToVersion( releaseId2 );
         assertEquals( 0, updateResults.getMessages().size() );
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KnowledgeBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KnowledgeBuilderTest.java
@@ -538,4 +538,69 @@ public class KnowledgeBuilderTest {
 
         }
     }
+
+	@Test
+    public void testDeclarationWithPojoExtension() throws Exception {
+        String drlDeclare = "package org.drools.compiler.integrationtests\n" +
+                     "declare Drools_applications extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
+                     "    drools_app_name: String\n" +
+                     "end";
+        String drlRule = "package org.drools.compiler.integrationtests\n" +
+                     "rule R1 when\n" +
+                     "   $fact : org.drools.compiler.integrationtests.Drools_applications( drools_app_name == \"appName\" )\n" +
+                     "then\n" +
+                     "end";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( drlDeclare.getBytes() ), ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+		kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+
+        KnowledgeBuilder kbuilder2 = KnowledgeBuilderFactory.newKnowledgeBuilder(kbase);
+        kbuilder2.add( ResourceFactory.newByteArrayResource( drlRule.getBytes() ), ResourceType.DRL );
+		// This line may not be necessary
+		// kbase.addKnowledgePackages(kbuilder2.getKnowledgePackages());
+
+		StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+        FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Drools_applications" );
+        Object fact = factType.newInstance();
+        factType.set( fact, "drools_app_name", "appName" );
+        ksession.insert( fact );
+
+        int rules = ksession.fireAllRules();
+        assertEquals( 1, rules );
+    }
+	@Test
+    public void testDeclarationWithPojoExtensionMultiplePackages() throws Exception {
+        String drlDeclare = "package org.drools.compiler.integrationtests\n" +
+                     "declare Drools_applications extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
+                     "    drools_app_name: String\n" +
+                     "end";
+        String drlRule = "package org.drools.compiler.test\n" +
+                     "rule R1 when\n" +
+                     "   $fact : org.drools.compiler.integrationtests.Drools_applications( drools_app_name == \"appName\" )\n" +
+                     "then\n" +
+                     "end";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( drlDeclare.getBytes() ), ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+		kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+
+        KnowledgeBuilder kbuilder2 = KnowledgeBuilderFactory.newKnowledgeBuilder(kbase);
+        kbuilder2.add( ResourceFactory.newByteArrayResource( drlRule.getBytes() ), ResourceType.DRL );
+		// This line may not be necessary
+		// kbase.addKnowledgePackages(kbuilder2.getKnowledgePackages());
+
+		StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+        FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Drools_applications" );
+        Object fact = factType.newInstance();
+        factType.set( fact, "drools_app_name", "appName" );
+        ksession.insert( fact );
+
+        int rules = ksession.fireAllRules();
+        assertEquals( 1, rules );
+    }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TypeDeclarationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TypeDeclarationTest.java
@@ -116,4 +116,86 @@ public class TypeDeclarationTest {
         int rules = ksession.fireAllRules();
         assertEquals( 1, rules );
     }
+
+	public static class BaseClass {
+		String baseField;
+		public String getBaseField() {
+			return baseField;
+		}
+		public void setBaseField(String baseField) {
+			this.baseField = baseField;
+		}
+	}
+
+    @Test
+    public void testDeclarationWithPojoExtension() throws Exception {
+        String drl = "package org.drools.compiler.integrationtests\n" +
+                     "declare Fact extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
+                     "    field: String\n" +
+                     "end\n" +
+                     "rule R1 when\n" +
+                     "   $fact : Fact( field == baseField )\n" +
+                     "then\n" +
+                     "end";
+
+        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build();
+        KieSession ksession = kbase.newKieSession();
+
+        FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Fact" );
+        Object fact = factType.newInstance();
+        factType.set( fact, "baseField", "foo" );
+        factType.set( fact, "field", "foo" );
+        ksession.insert( fact );
+
+        int rules = ksession.fireAllRules();
+        assertEquals( 1, rules );
+    }
+
+    @Test
+    public void testDeclarationWithPojoExtensionDifferentPackage() throws Exception {
+        String drl = "package org.drools.compiler.test\n" +
+                     "declare Fact extends org.drools.compiler.test.TypeDeclarationTest.BaseClass\n" +
+                     "    field: String\n" +
+                     "end\n" +
+                     "rule R1 when\n" +
+                     "   $fact : Fact( field == baseField )\n" +
+                     "then\n" +
+                     "end";
+
+        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build();
+        KieSession ksession = kbase.newKieSession();
+
+        FactType factType = kbase.getFactType( "org.drools.compiler.test", "Fact" );
+        Object fact = factType.newInstance();
+        factType.set( fact, "baseField", "foo" );
+        factType.set( fact, "field", "foo" );
+        ksession.insert( fact );
+
+        int rules = ksession.fireAllRules();
+        assertEquals( 1, rules );
+    }
+
+	@Test
+    public void testDeclarationWithPojoExtensionMultiplePackages() throws Exception {
+        String drlDeclare = "package org.drools.compiler.integrationtests\n" +
+                     "declare Drools_applications extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
+                     "    drools_app_name: String\n" +
+                     "end\n";
+        String drlRule = "package org.drools.compiler.test\n" +
+                     "rule R1 when\n" +
+                     "   $fact : org.drools.compiler.integrationtests.Drools_applications( drools_app_name == \"appName\" )\n" +
+                     "then\n" +
+                     "end";
+
+        KieBase kbase = new KieHelper().addContent(drlDeclare, ResourceType.DRL).addContent(drlRule, ResourceType.DRL).build();
+        KieSession ksession = kbase.newKieSession();
+
+        FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Drools_applications" );
+        Object fact = factType.newInstance();
+        factType.set( fact, "drools_app_name", "appName" );
+        ksession.insert( fact );
+
+        int rules = ksession.fireAllRules();
+        assertEquals( 1, rules );
+    }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TypeDeclarationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TypeDeclarationTest.java
@@ -23,6 +23,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TypeDeclarationTest {
 
@@ -143,8 +144,9 @@ public class TypeDeclarationTest {
 
         FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Fact" );
         Object fact = factType.newInstance();
-        factType.set( fact, "baseField", "foo" );
         factType.set( fact, "field", "foo" );
+        //factType.set( fact, "baseField", "foo" ); // This doesn't work, so case it to the base type
+		((TypeDeclarationTest.BaseClass) fact).setBaseField("foo");
         ksession.insert( fact );
 
         int rules = ksession.fireAllRules();
@@ -153,8 +155,9 @@ public class TypeDeclarationTest {
 
     @Test
     public void testDeclarationWithPojoExtensionDifferentPackage() throws Exception {
+        String drlBase = "package org.drools.compiler.integrationtests\n";
         String drl = "package org.drools.compiler.test\n" +
-                     "declare Fact extends org.drools.compiler.test.TypeDeclarationTest.BaseClass\n" +
+                     "declare Fact extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
                      "    field: String\n" +
                      "end\n" +
                      "rule R1 when\n" +
@@ -162,40 +165,18 @@ public class TypeDeclarationTest {
                      "then\n" +
                      "end";
 
-        KieBase kbase = new KieHelper().addContent(drl, ResourceType.DRL).build();
+        KieBase kbase = new KieHelper().addContent(drlBase, ResourceType.DRL).addContent(drl, ResourceType.DRL).build();
         KieSession ksession = kbase.newKieSession();
 
         FactType factType = kbase.getFactType( "org.drools.compiler.test", "Fact" );
         Object fact = factType.newInstance();
-        factType.set( fact, "baseField", "foo" );
         factType.set( fact, "field", "foo" );
+        //factType.set( fact, "baseField", "foo" ); // This doesn't work, so case it to the base type
+		((TypeDeclarationTest.BaseClass) fact).setBaseField("foo");
         ksession.insert( fact );
 
         int rules = ksession.fireAllRules();
         assertEquals( 1, rules );
     }
 
-	@Test
-    public void testDeclarationWithPojoExtensionMultiplePackages() throws Exception {
-        String drlDeclare = "package org.drools.compiler.integrationtests\n" +
-                     "declare Drools_applications extends org.drools.compiler.integrationtests.TypeDeclarationTest.BaseClass\n" +
-                     "    drools_app_name: String\n" +
-                     "end\n";
-        String drlRule = "package org.drools.compiler.test\n" +
-                     "rule R1 when\n" +
-                     "   $fact : org.drools.compiler.integrationtests.Drools_applications( drools_app_name == \"appName\" )\n" +
-                     "then\n" +
-                     "end";
-
-        KieBase kbase = new KieHelper().addContent(drlDeclare, ResourceType.DRL).addContent(drlRule, ResourceType.DRL).build();
-        KieSession ksession = kbase.newKieSession();
-
-        FactType factType = kbase.getFactType( "org.drools.compiler.integrationtests", "Drools_applications" );
-        Object fact = factType.newInstance();
-        factType.set( fact, "drools_app_name", "appName" );
-        ksession.insert( fact );
-
-        int rules = ksession.fireAllRules();
-        assertEquals( 1, rules );
-    }
 }


### PR DESCRIPTION
This adds test cases for extending POJO classes in DRL. testDeclarationWithPojoExtensionDifferentPackage currently fails, but I don't see that it should.

testDeclarationWithPojoExtensionMultiplePackages is a working version of a case that fails for me when I load rules incrementally, I am working on a test case that fails now. I can currently only cause it to fail using thr Drools 5 API
