### PR TITLE
RuleImpl implements new InternalRule interface which fixes DROOLS-995…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
@@ -387,7 +387,7 @@ public class RuleImpl implements Externalizable,
     /**
 	 * Returns <code>true</code> if the rule uses dynamic salience, <code>false</code> otherwise.
 	 * 
-	 * @return <code>true</code> if he rule uses dynamic salience, else <code>false</code>.
+	 * @return <code>true</code> if the rule uses dynamic salience, else <code>false</code>.
 	 */
     public boolean isSalienceDynamic() {
     	return getSalience().isDynamic();

--- a/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
@@ -16,6 +16,23 @@
 
 package org.drools.core.definitions.rule.impl;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.drools.core.WorkingMemory;
 import org.drools.core.base.EnabledBoolean;
 import org.drools.core.base.SalienceInteger;
@@ -42,31 +59,14 @@ import org.drools.core.spi.Wireable;
 import org.drools.core.time.impl.Timer;
 import org.drools.core.util.StringUtils;
 import org.kie.api.definition.rule.Query;
-import org.kie.api.definition.rule.Rule;
 import org.kie.api.io.Resource;
+import org.kie.internal.definition.rule.InternalRule;
 import org.kie.internal.security.KiePolicyHelper;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.io.Serializable;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 public class RuleImpl implements Externalizable,
                                  Wireable,
                                  Dialectable,
-                                 Rule,
+                                 InternalRule,
                                  Query {
 
     private static final int NO_LOOP_BIT =              1 << 0;
@@ -374,7 +374,25 @@ public class RuleImpl implements Externalizable,
     public Salience getSalience() {
         return this.salience;
     }
-
+    
+    /**
+     * Retrieve the <code>Rule</code> salience value.
+     * 
+     * @return The salience value.
+     */
+    public int getSalienceValue() {
+    	return getSalience().getValue();
+    }
+    
+    /**
+	 * Returns <code>true</code> if the rule uses dynamic salience, <code>false</code> otherwise.
+	 * 
+	 * @return <code>true</code> if he rule uses dynamic salience, else <code>false</code>.
+	 */
+    public boolean isSalienceDynamic() {
+    	return getSalience().isDynamic();
+    }
+    
     /**
      * Set the <code>Rule<code> salience.
      *

--- a/drools-core/src/test/java/org/drools/core/rule/RuleTest.java
+++ b/drools-core/src/test/java/org/drools/core/rule/RuleTest.java
@@ -16,21 +16,25 @@
 
 package org.drools.core.rule;
 
-import org.drools.core.ClockType;
-import org.drools.core.SessionConfiguration;
-import org.drools.core.WorkingMemory;
-import org.drools.core.base.EnabledBoolean;
-import org.drools.core.definitions.rule.impl.RuleImpl;
-import org.drools.core.impl.KnowledgeBaseImpl;
-import org.drools.core.reteoo.RuleTerminalNode;
-import org.drools.core.time.impl.PseudoClockScheduler;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.drools.core.ClockType;
+import org.drools.core.SessionConfiguration;
+import org.drools.core.WorkingMemory;
+import org.drools.core.base.EnabledBoolean;
+import org.drools.core.base.SalienceInteger;
+import org.drools.core.base.mvel.MVELSalienceExpression;
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.core.impl.KnowledgeBaseImpl;
+import org.drools.core.reteoo.RuleTerminalNode;
+import org.drools.core.spi.Salience;
+import org.drools.core.time.impl.PseudoClockScheduler;
+import org.junit.Test;
 
 public class RuleTest {
 
@@ -150,6 +154,28 @@ public class RuleTest {
         ((PseudoClockScheduler)wm.getSessionClock()).advanceTime( 1000000000000L, TimeUnit.MILLISECONDS );
         
         assertTrue(rule.isEffective(null, new RuleTerminalNode(), wm ));
+    }
+    
+    @Test
+    public void testGetSalienceValue() {
+    	final RuleImpl rule = new RuleImpl( "myrule" );
+    	final int salienceValue = 100;
+    	
+    	Salience salience = new SalienceInteger(salienceValue);
+    	rule.setSalience(salience);
+    	
+    	assertEquals(salienceValue, rule.getSalienceValue());
+    	assertFalse(rule.isSalienceDynamic());
+    }
+    
+    @Test
+    public void testIsSalienceDynamic() {
+    	final RuleImpl rule = new RuleImpl( "myrule" );
+    	
+    	Salience salience = new MVELSalienceExpression();
+    	rule.setSalience(salience);
+    	
+    	assertTrue(rule.isSalienceDynamic());
     }
 
 }


### PR DESCRIPTION
…. Exposes rule properties for runtime rule inspection.

Fixes DROOLS-995. RuleImpl now implements the new InternalRule interface, which allows us to do runtime rule inspection via the API instead of implementation class.

Note that this requires this PR to be merged first into kie-internal: https://github.com/droolsjbpm/droolsjbpm-knowledge/pull/110
