### PR TITLE
[6.3.x] Fix few intermittently failing tests

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -129,6 +129,11 @@
       <artifactId>glazedlists_java15</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -241,7 +241,7 @@ public class KieRepositoryImpl
     private static final Object PRESENT = new Object();
 
     /**
-     * The methods in this class are all synchronized becuase
+     * The methods in this class are all synchronized because
      * 1. performance is not particularly important here
      * 2. I wrote performant concurrent code and then realized it was not easily maintainable
      *    (and maintainability is more important here, AFAICT),

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -2007,7 +2007,7 @@ public class AccumulateTest extends CommonTestMethodBase {
                       results.get( 0 ) );
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void testInfiniteLoopAddingPkgAfterSession() throws Exception {
         // JBRULES-3488
         String rule = "package org.drools.compiler.test;\n" +

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieContainerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieContainerTest.java
@@ -15,6 +15,7 @@
 
 package org.drools.compiler.integrationtests;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;
@@ -190,9 +191,10 @@ public class KieContainerTest {
             kieSession.setGlobal("list", list);
             kieSession.fireAllRules();
             kieSession.dispose();
-            // There can be 2 items in the list if an updateToVersion is triggered during a fireAllRules
-            // in that case it may fire with both the old and the new rule
-            assertTrue( list.size() >= 1 && list.size() <= 2);
+            // There can be multiple items in the list if an updateToVersion is triggered during a fireAllRules
+            // (updateToVersion can be called multiple times during fireAllRules, especially on slower machines)
+            // in that case it may fire with the old rule and multiple new ones
+            Assertions.assertThat(list).isNotEmpty();
             if (list.get(0).equals("rule9")) {
                 break;
             }

--- a/drools-reteoo/src/test/java/org/drools/reteoo/integrationtests/AccumulateTest.java
+++ b/drools-reteoo/src/test/java/org/drools/reteoo/integrationtests/AccumulateTest.java
@@ -2023,7 +2023,7 @@ public class AccumulateTest extends CommonTestMethodBase {
                 results.get( 0 ) );
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void testInfiniteLoopAddingPkgAfterSession() throws Exception {
         // JBRULES-3488
         String rule = "package org.drools.compiler.test;\n" +

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
           <configuration>
             <forkCount>${surefire.forkCount}</forkCount>
             <reuseForks>true</reuseForks>
+            <runOrder>hourly</runOrder>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
- KieModuleRepoTest was influencing other tests,
  executed after
- specified runOrder for surefire. Hourly means
  that surefire will execute the tests
  in alphabetical order on even hours and in
  reverse alphabetical order on odd hours. This
  brings certain level of predictability as to
  in which order the tests are executed, but at the same
  time allows to detect at least some issues related
  to order of exeuction of the tests (which is
  bad as unit tests should not be dependent on
  each other). see http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder for more info
- increase test timeouts to accomodate slower machines

Same changes already applied to master. @etirelli since these are only test fixes, I believe it is save to apply them to 6.3.x as well.
