### PR TITLE
kie-test-util: ComparePair fix for collections

### DIFF
--- a/kie-test-util/src/test/java/org/kie/test/util/ComparePairTest.java
+++ b/kie-test-util/src/test/java/org/kie/test/util/ComparePairTest.java
@@ -1,0 +1,21 @@
+package org.kie.test.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.kie.test.util.compare.ComparePair;
+
+public class ComparePairTest {
+
+    @Test
+    public void collectionsTest() {
+        List<String> orig = new ArrayList<String>();
+        orig.add("asdfasdfasdfasdf");
+
+        List<String> copy = new ArrayList<String>();
+        copy.add(new String(orig.get(0)));
+
+        ComparePair.compareObjectsViaFields(orig, copy);
+    }
+}


### PR DESCRIPTION
@mswiderski This is the fix for the failing (JSON) test on kie-remote-services (`org.kie.services.client.serialization.JsonRemoteSerializationTest.deploymentDescriptorTest()`)
