### PR TITLE
DO NOT MERGE YET - [DROOLS-653] avoid wrapping the LeftTuple created by a subnetwork into a RightTuple

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -817,7 +817,7 @@ public class AccumulateTest extends CommonTestMethodBase {
         execTestAccumulateMax( "test_AccumulateMaxMVEL.drl" );
     }
 
-    @Test(timeout = 10000)
+    @Test//(timeout = 10000)
     public void testAccumulateMultiPatternJava() throws Exception {
         execTestAccumulateReverseModifyMultiPattern( "test_AccumulateMultiPattern.drl" );
     }
@@ -1421,13 +1421,13 @@ public class AccumulateTest extends CommonTestMethodBase {
         wm.setGlobal( "results",
                       results );
 
-        final Cheese[] cheese = new Cheese[]{new Cheese( "stilton",
-                                                         10 ), new Cheese( "stilton",
-                                                                           2 ), new Cheese( "stilton",
-                                                                                            5 ), new Cheese( "brie",
-                                                                                                             15 ), new Cheese( "brie",
-                                                                                                                               16 ), new Cheese( "provolone",
-                                                                                                                                                 8 )};
+        final Cheese[] cheese = new Cheese[]{ new Cheese( "stilton", 10 ),
+                                              new Cheese( "stilton", 2 ),
+                                              new Cheese( "stilton", 5 ),
+                                              new Cheese( "brie", 15 ),
+                                              new Cheese( "brie", 16 ),
+                                              new Cheese( "provolone", 8 ) };
+
         final Person bob = new Person( "Bob",
                                        "stilton" );
         final Person mark = new Person( "Mark",

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
@@ -3274,7 +3274,7 @@ public class BackwardChainingTest extends CommonTestMethodBase {
                 "   Integer( this == 10 ) " +
                 "then " +
                 "   System.out.println(\"10 \" + $i);" +
-                //"   list.add( $i );\n" +
+                "   list.add( 10 );\n" +
                 "end\n" +
                 "\n" +
 
@@ -3283,6 +3283,7 @@ public class BackwardChainingTest extends CommonTestMethodBase {
                 "   Integer( this == 20 ) " +
                 "then " +
                 "   System.out.println(\"20 \" + $i);" +
+                "   list.add( 20 );\n" +
                 "end\n" +
 
                 "rule r3 when " +
@@ -3304,5 +3305,8 @@ public class BackwardChainingTest extends CommonTestMethodBase {
         kieSession.insert( 20 );
 
         kieSession.fireAllRules();
+
+        assertEquals( 1, list.size() );
+        assertEquals( 20, (int)list.get(0) );
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
@@ -37,6 +37,7 @@ import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.RightInputAdapterNode;
 import org.junit.Test;
 import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.LiveQuery;
 import org.kie.api.runtime.rule.QueryResults;
@@ -52,6 +53,7 @@ import org.kie.internal.builder.conf.RuleEngineOption;
 import org.kie.internal.definition.KnowledgePackage;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.internal.utils.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2131,7 +2133,7 @@ public class BackwardChainingTest extends CommonTestMethodBase {
         KnowledgeBase kbase = SerializationHelper.serializeObject( loadKnowledgeBaseFromString( drl ) );
     }
 
-    @Test (timeout = 10000)
+    @Test(timeout = 10000)
     public void testInsertionOrderTwo() throws Exception {
         String str = "" +
                 "package org.drools.compiler.test \n" +
@@ -3258,5 +3260,49 @@ public class BackwardChainingTest extends CommonTestMethodBase {
 
     }
 
+    @Test
+    public void testNpeOnQuery() {
+        String drl =
+                "global java.util.List list; " +
+                "query foo( Integer $i ) " +
+                "   $i := Integer( this < 10 ) " +
+                "end\n" +
+                "\n" +
 
+                "rule r1 when " +
+                "   foo( $i ; ) " +
+                "   Integer( this == 10 ) " +
+                "then " +
+                "   System.out.println(\"10 \" + $i);" +
+                //"   list.add( $i );\n" +
+                "end\n" +
+                "\n" +
+
+                "rule r2 when " +
+                "   foo( $i; ) " +
+                "   Integer( this == 20 ) " +
+                "then " +
+                "   System.out.println(\"20 \" + $i);" +
+                "end\n" +
+
+                "rule r3 when " +
+                "   $i : Integer( this == 1 ) " +
+                "then " +
+                "   System.out.println($i);" +
+                "   update( kcontext.getKieRuntime().getFactHandle( $i ), $i + 1 );" +
+                "end\n" +
+                "\n";
+
+        KieHelper helper = new KieHelper();
+        helper.addContent( drl, ResourceType.DRL );
+        KieSession kieSession = helper.build().newKieSession();
+
+        List<Integer> list = new ArrayList<Integer>();
+        kieSession.setGlobal( "list", list );
+
+        kieSession.insert( 1 );
+        kieSession.insert( 20 );
+
+        kieSession.fireAllRules();
+    }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IncrementalCompilationTest.java
@@ -2456,4 +2456,87 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
 
         ksession.fireAllRules();
     }
+
+    @Test
+    public void testSplitAfterQuery() throws Exception {
+        String drl1 =
+                "global java.util.List list; " +
+                "query foo( Integer $i ) " +
+                "   $i := Integer( this < 10 ) " +
+                "end\n" +
+                "\n" +
+
+                "rule r2 when " +
+                "   foo( $i; ) " +
+                "   Integer( this == 20 ) " +
+                "then " +
+                "   System.out.println(\"20 \" + $i);" +
+                "   list.add( 20 + $i );\n" +
+                "end\n" +
+
+                "rule r3 when " +
+                "   $i : Integer( this == 1 ) " +
+                "then " +
+                "   System.out.println($i);" +
+                "   update( kcontext.getKieRuntime().getFactHandle( $i ), $i + 1 );" +
+                "end\n" +
+                "\n";
+
+        String drl2 =
+                "global java.util.List list; " +
+                "query foo( Integer $i ) " +
+                "   $i := Integer( this < 10 ) " +
+                "end\n" +
+                "\n" +
+
+                "rule r1 when " +
+                "   foo( $i ; ) " +
+                "   Integer( this == 10 ) " +
+                "then " +
+                "   System.out.println(\"10 \" + $i);" +
+                "   list.add( 10 + $i );\n" +
+                "end\n" +
+
+                "rule r2 when " +
+                "   foo( $i; ) " +
+                "   Integer( this == 20 ) " +
+                "then " +
+                "   System.out.println(\"20 \" + $i);" +
+                "   list.add( 20 + $i );\n" +
+                "end\n" +
+
+                "rule r3 when " +
+                "   $i : Integer( this == 1 ) " +
+                "then " +
+                "   System.out.println($i);" +
+                "   update( kcontext.getKieRuntime().getFactHandle( $i ), $i + 1 );" +
+                "end\n" +
+                "\n";
+
+        KieServices ks = KieServices.Factory.get();
+
+        ReleaseId releaseId1 = ks.newReleaseId( "org.kie", "test-upgrade", "1.1.1" );
+        KieModule km = createAndDeployJar( ks, releaseId1, drl1 );
+
+        KieContainer kc = ks.newKieContainer(km.getReleaseId());
+        KieSession ksession = kc.newKieSession();
+
+        List<Integer> list = new ArrayList<Integer>();
+        ksession.setGlobal( "list", list );
+
+        ksession.insert( 1 );
+        ksession.insert( 20 );
+
+        ksession.fireAllRules();
+
+        ReleaseId releaseId2 = ks.newReleaseId("org.kie", "test-upgrade", "1.1.2");
+        km = createAndDeployJar( ks, releaseId2, drl2 );
+        kc.updateToVersion(releaseId2);
+
+        ksession.fireAllRules();
+
+        assertEquals( 2, list.size() );
+        assertEquals( 21, (int)list.get(0) );
+        assertEquals( 22, (int)list.get(1) );
+    }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
@@ -881,11 +881,11 @@ public class Misc2Test extends CommonTestMethodBase {
         ksession.insert( new A( 2, 2, 2, 2 ) );
 
         LeftTuple leftTuple = ( (DefaultFactHandle) fh ).getFirstLeftTuple();
-        ObjectTypeNode.Id letTupleOtnId = leftTuple.getTupleSink().getLeftInputOtnId();
+        ObjectTypeNode.Id letTupleOtnId = leftTuple.getInputOtnId();
         leftTuple = leftTuple.getHandleNext();
         while ( leftTuple != null ) {
-            assertTrue( letTupleOtnId.before( leftTuple.getTupleSink().getLeftInputOtnId() ) );
-            letTupleOtnId = leftTuple.getTupleSink().getLeftInputOtnId();
+            assertTrue( letTupleOtnId.before( leftTuple.getInputOtnId() ) );
+            letTupleOtnId = leftTuple.getInputOtnId();
             leftTuple = leftTuple.getHandleNext();
         }
     }
@@ -6741,11 +6741,11 @@ public class Misc2Test extends CommonTestMethodBase {
         ksession.insert( "1" );
         FactHandle iFH = ksession.insert( 1 );
         FactHandle lFH = ksession.insert( 1L );
-        ksession.fireAllRules();
+        assertEquals( 0, ksession.fireAllRules() );
 
         ksession.delete( iFH );
         ksession.delete( lFH );
-        ksession.fireAllRules();
+        assertEquals( 1, ksession.fireAllRules() );
 
         assertEquals( 0, ksession.getFactCount() );
     }

--- a/drools-core/src/main/java/org/drools/core/base/DroolsQuery.java
+++ b/drools-core/src/main/java/org/drools/core/base/DroolsQuery.java
@@ -44,7 +44,7 @@ public final class DroolsQuery extends ArrayElements {
 
     private WorkingMemoryAction action;
 
-    private TupleSets<LeftTuple> resultLeftTuples;
+    private final TupleSets<LeftTuple> resultLeftTuples;
 
     private QueryElementNodeMemory qmem;
 
@@ -53,24 +53,6 @@ public final class DroolsQuery extends ArrayElements {
     private StackEntry stackEntry;
 
     private LeftTupleSink sink;
-
-    //    public DroolsQuery(DroolsQuery droolsQuery) {
-    //        super( new Object[droolsQuery.getElements().length] );
-    //
-    //        this.name = droolsQuery.getName();
-    //        this.resultsCollector = droolsQuery.getQueryResultCollector();
-    //        this.open = droolsQuery.isOpen();
-    //        final Object[] params = getElements();
-    //        System.arraycopy( droolsQuery.getElements(), 0, params, 0, params.length );
-    //        originalDroolsQuery = droolsQuery;
-    //    }
-
-    public DroolsQuery(final String name,
-                       final Object[] params,
-                       final InternalViewChangedEventListener resultsCollector,
-                       final boolean open) {
-        this(name, params, resultsCollector, open, null, null, null, null, null);
-    }
 
     public DroolsQuery(final String name,
                        final Object[] params,
@@ -207,7 +189,4 @@ public final class DroolsQuery extends ArrayElements {
                     ", args=" + Arrays.toString( getElements() ) +
                     ", vars=" + Arrays.toString( vars ) + "]";
     }
-    
-
-
 }

--- a/drools-core/src/main/java/org/drools/core/common/TupleSets.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleSets.java
@@ -39,6 +39,8 @@ public interface TupleSets<T extends Tuple> {
 
     void addAll(TupleSets<T> source);
 
+    void addTo(TupleSets<T> target);
+
     TupleSets<T> takeAll();
 
     boolean isEmpty();

--- a/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
@@ -16,7 +16,6 @@
 
 package org.drools.core.common;
 
-import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.spi.Tuple;
 
 public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
@@ -39,44 +38,60 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
         return this.insertFirst;
     }
 
+    protected void setInsertFirst( T insertFirst ) {
+        this.insertFirst = insertFirst;
+    }
+
     public T getDeleteFirst() {
         return this.deleteFirst;
+    }
+
+    protected void setDeleteFirst( T deleteFirst ) {
+        this.deleteFirst = deleteFirst;
     }
 
     public T getUpdateFirst() {
         return this.updateFirst;
     }
 
+    protected void setUpdateFirst( T updateFirst ) {
+        this.updateFirst = updateFirst;
+    }
+
     public T getNormalizedDeleteFirst() {
         return normalizedDeleteFirst;
     }
 
+    protected void setNormalizedDeleteFirst( T normalizedDeleteFirst ) {
+        this.normalizedDeleteFirst = normalizedDeleteFirst;
+    }
+
     public void resetAll() {
-        insertFirst = null;
-        deleteFirst = null;
-        updateFirst = null;
-        normalizedDeleteFirst = null;
+        setInsertFirst( null );
+        setDeleteFirst( null );
+        setUpdateFirst( null );
+        setNormalizedDeleteFirst( null );
     }
 
     public boolean addInsert(T tuple) {
-        if (tuple.getStagedType() == Tuple.UPDATE) {
+        if ( getStagedType( tuple ) == Tuple.UPDATE) {
             // do nothing, it's already staged as an update, which means it's already scheduled for eval too.
             return false;
         }
 
-        tuple.setStagedType( Tuple.INSERT );
+        setStagedType( tuple, Tuple.INSERT );
         if ( insertFirst == null ) {
             insertFirst = tuple;
             return true;
         }
-        tuple.setStagedNext( insertFirst );
-        insertFirst.setStagedPrevious( tuple );
+        setStagedNext( tuple, insertFirst );
+        setStagedPrevious( insertFirst, tuple );
         insertFirst = tuple;
         return false;
     }
 
     public boolean addDelete(T tuple) {
-        switch ( tuple.getStagedType() ) {
+        switch ( getStagedType( tuple ) ) {
             // handle clash with already staged entries
             case Tuple.INSERT:
                 removeInsert( tuple );
@@ -86,100 +101,100 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
                 break;
         }
 
-        tuple.setStagedType( Tuple.DELETE );
+        setStagedType( tuple, Tuple.DELETE );
         if ( deleteFirst == null ) {
             deleteFirst = tuple;
             return true;
         }
-        tuple.setStagedNext( deleteFirst );
-        deleteFirst.setStagedPrevious( tuple );
+        setStagedNext( tuple, deleteFirst );
+        setStagedPrevious( deleteFirst, tuple );
         deleteFirst = tuple;
         return false;
     }
 
     public boolean addNormalizedDelete(T tuple) {
-        tuple.setStagedType( Tuple.NORMALIZED_DELETE );
+        setStagedType( tuple, Tuple.NORMALIZED_DELETE );
         if ( normalizedDeleteFirst == null ) {
             normalizedDeleteFirst = tuple;
             return true;
         }
-        tuple.setStagedNext( normalizedDeleteFirst );
-        normalizedDeleteFirst.setStagedPrevious( tuple );
+        setStagedNext( tuple, normalizedDeleteFirst );
+        setStagedPrevious( normalizedDeleteFirst, tuple );
         normalizedDeleteFirst = tuple;
         return false;
     }
 
     public boolean addUpdate(T tuple) {
-        if (tuple.getStagedType() != LeftTuple.NONE) {
+        if ( getStagedType( tuple ) != Tuple.NONE) {
             // do nothing, it's already staged as insert, which means it's already scheduled for eval too.
             return false;
         }
 
-        tuple.setStagedType( Tuple.UPDATE );
+        setStagedType( tuple, Tuple.UPDATE );
         if ( updateFirst == null ) {
             updateFirst = tuple;
             return true;
         }
-        tuple.setStagedNext( updateFirst );
-        updateFirst.setStagedPrevious( tuple );
+        setStagedNext( tuple, updateFirst );
+        setStagedPrevious( updateFirst, tuple );
         updateFirst = tuple;
         return false;
     }
 
     public void removeInsert(T tuple) {
-        tuple.setStagedType( Tuple.NONE );
+        setStagedType( tuple, Tuple.NONE );
         if ( tuple == insertFirst ) {
-            Tuple next = tuple.getStagedNext();
+            T next = getStagedNext( tuple );
             if ( next != null ) {
-                next.setStagedPrevious( null );
+                setStagedPrevious( next, null );
             }
-            insertFirst = (T)next;
+            setInsertFirst( next );
         } else {
-            Tuple next = tuple.getStagedNext();
-            Tuple previous = tuple.getStagedPrevious();
+            T next = getStagedNext( tuple );
+            T previous = getStagedPrevious( tuple );
             if ( next != null ) {
-                next.setStagedPrevious( previous );
+                setStagedPrevious( next, previous );
             }
-            previous.setStagedNext( next );
+            setStagedNext( previous, next );
         }
         tuple.clearStaged();
     }
 
     public void removeDelete(T tuple) {
-        tuple.setStagedType( Tuple.NONE );
+        setStagedType( tuple, Tuple.NONE );
         if ( tuple == deleteFirst ) {
-            Tuple next = tuple.getStagedNext();
+            T next = getStagedNext( tuple );
             if ( next != null ) {
-                next.setStagedPrevious( null );
+                setStagedPrevious( next, null );
             }
             deleteFirst = (T) next;
         } else {
-            Tuple next = tuple.getStagedNext();
-            Tuple previous = tuple.getStagedPrevious();
+            T next = getStagedNext( tuple );
+            T previous = getStagedPrevious( tuple );
             if ( next != null ) {
-                next.setStagedPrevious( previous );
+                setStagedPrevious( next, previous );
             }
-            previous.setStagedNext( next );
+            setStagedNext( previous, next );
 
         }
         tuple.clearStaged();
     }
 
     public void removeUpdate(Tuple tuple) {
-        tuple.setStagedType( Tuple.NONE );
+        setStagedType( (T) tuple, Tuple.NONE );
         if ( tuple == updateFirst ) {
-            Tuple next = tuple.getStagedNext();
+            T next = getStagedNext( (T) tuple );
             if ( next != null ) {
-                next.setStagedPrevious( null );
+                setStagedPrevious( next, null );
             }
-            updateFirst = (T)next;
+            updateFirst = next;
         } else {
-            Tuple next = tuple.getStagedNext();
-            Tuple previous = tuple.getStagedPrevious();
+            T next = getStagedNext( (T) tuple );
+            T previous = getStagedPrevious( (T) tuple );
             if ( next != null ) {
-                next.setStagedPrevious( previous );
+                setStagedPrevious( next, previous );
             }
-            previous.setStagedNext( next );
+            setStagedNext( previous, next );
         }
         tuple.clearStaged();
     }
@@ -187,57 +202,57 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
     public void addAllInserts(TupleSets<T> tupleSets) {
         if ( tupleSets.getInsertFirst() != null ) {
             if ( insertFirst == null ) {
-                insertFirst = tupleSets.getInsertFirst();
+                setInsertFirst( tupleSets.getInsertFirst() );
             } else {
-                Tuple current = insertFirst;
-                Tuple last = null;
+                T current = insertFirst;
+                T last = null;
                 while ( current != null ) {
                     last = current;
-                    current = current.getStagedNext();
+                    current = getStagedNext( current );
                 }
-                Tuple tuple = tupleSets.getInsertFirst();
-                last.setStagedNext( tuple );
-                tuple.setStagedPrevious( last );
+                T tuple = tupleSets.getInsertFirst();
+                setStagedNext( last, tuple );
+                setStagedPrevious( tuple, last );
             }
-            ( (TupleSetsImpl) tupleSets ).insertFirst = null;
+            ( (TupleSetsImpl) tupleSets ).setInsertFirst( null );
         }
     }
 
     public void addAllDeletes(TupleSets<T> tupleSets) {
         if ( tupleSets.getDeleteFirst() != null ) {
             if ( deleteFirst == null ) {
-                deleteFirst = tupleSets.getDeleteFirst();
+                setDeleteFirst( tupleSets.getDeleteFirst() );
             } else {
-                Tuple current = deleteFirst;
-                Tuple last = null;
+                T current = deleteFirst;
+                T last = null;
                 while ( current != null ) {
                     last = current;
-                    current = current.getStagedNext();
+                    current = getStagedNext( current );
                 }
-                Tuple tuple = tupleSets.getDeleteFirst();
-                last.setStagedNext( tuple );
-                tuple.setStagedPrevious( last );
+                T tuple = tupleSets.getDeleteFirst();
+                setStagedNext( last, tuple );
+                setStagedPrevious( tuple, last );
             }
-            ((TupleSetsImpl) tupleSets).deleteFirst = null;
+            ((TupleSetsImpl) tupleSets).setDeleteFirst( null );
         }
     }
 
     public void addAllUpdates(TupleSets<T> tupleSets) {
         if ( tupleSets.getUpdateFirst() != null ) {
             if ( updateFirst == null ) {
-                updateFirst = tupleSets.getUpdateFirst();
+                setUpdateFirst( tupleSets.getUpdateFirst() );
             } else {
-                Tuple current = updateFirst;
-                Tuple last = null;
+                T current = updateFirst;
+                T last = null;
                 while ( current != null ) {
                     last = current;
-                    current = current.getStagedNext();
+                    current = getStagedNext( current );
                 }
-                Tuple tuple = tupleSets.getUpdateFirst();
-                last.setStagedNext( tuple );
-                tuple.setStagedPrevious( last );
+                T tuple = tupleSets.getUpdateFirst();
+                setStagedNext( last, tuple );
+                setStagedPrevious( tuple, last );
             }
-            ( (TupleSetsImpl) tupleSets ).updateFirst = null;
+            ( (TupleSetsImpl) tupleSets ).setUpdateFirst( null );
         }
     }
 
@@ -266,9 +281,9 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
         resetAll();
     }
 
-    private void clear( Tuple tuple ) {
+    private void clear( T tuple ) {
         while ( tuple != null ) {
-            Tuple next =  tuple.getStagedNext();
+            T next = getStagedNext( tuple );
             tuple.clearStaged();
             tuple = next;
         }
@@ -303,8 +318,32 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
     }
 
     private void appendSet( StringBuilder sbuilder, Tuple tuple ) {
-        for ( ; tuple != null; tuple = tuple.getStagedNext() ) {
+        for ( ; tuple != null; tuple = getStagedNext( (T) tuple ) ) {
             sbuilder.append( " " ).append( tuple ).append( "\n" );
         }
+    }
+
+    protected T getStagedPrevious( T tuple ) {
+        return (T) tuple.getStagedPrevious();
+    }
+
+    protected void setStagedPrevious( T tuple, T stagedPrevious ) {
+        tuple.setStagedPrevious( stagedPrevious );
+    }
+
+    protected T getStagedNext( T tuple ) {
+        return tuple.getStagedNext();
+    }
+
+    protected void setStagedNext( T tuple, T stagedNext ) {
+        tuple.setStagedNext( stagedNext );
+    }
+
+    protected void setStagedType( T tuple, short type ) {
+        tuple.setStagedType( type );
+    }
+
+    protected short getStagedType( T tuple ) {
+        return tuple.getStagedType();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/TupleSetsImpl.java
@@ -262,6 +262,10 @@ public class TupleSetsImpl<T extends Tuple> implements TupleSets<T> {
         addAllUpdates( source );
     }
 
+    public void addTo(TupleSets<T> target) {
+        target.addAll( this );
+    }
+
     @Override
     public TupleSets<T> takeAll() {
         TupleSets<T> clone = new TupleSetsImpl(insertFirst, updateFirst, deleteFirst, normalizedDeleteFirst);

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -908,7 +908,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
             this.kBase.readLock();
             this.lock.lock();
 
-            LeftInputAdapterNode lian = ( LeftInputAdapterNode ) factHandle.getFirstLeftTuple().getTupleSink().getLeftTupleSource();
+            LeftInputAdapterNode lian = factHandle.getFirstLeftTuple().getTupleSource();
             LeftInputAdapterNode.LiaNodeMemory lmem = getNodeMemory(lian);
             SegmentMemory lsmem = lmem.getSegmentMemory();
 

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufOutputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufOutputMarshaller.java
@@ -455,8 +455,8 @@ public class ProtobufOutputMarshaller {
 
             // iterates over all propagated handles and assert them to the new sink
             for ( RightTuple entry = (RightTuple) it.next(); entry != null; entry = (RightTuple) it.next() ) {
-                LeftTuple leftTuple = (LeftTuple) entry.getFactHandle().getObject();
-                InternalFactHandle handle = (InternalFactHandle) leftTuple.getContextObject();
+                LeftTuple leftTuple = (LeftTuple) entry;
+                InternalFactHandle handle = (InternalFactHandle) leftTuple.getFactHandle();
                 FactHandle _handle = ProtobufMessages.FactHandle.newBuilder()
                         .setId( handle.getId() )
                         .setRecency( handle.getRecency() )

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufOutputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufOutputMarshaller.java
@@ -455,7 +455,9 @@ public class ProtobufOutputMarshaller {
 
             // iterates over all propagated handles and assert them to the new sink
             for ( RightTuple entry = (RightTuple) it.next(); entry != null; entry = (RightTuple) it.next() ) {
-                LeftTuple leftTuple = (LeftTuple) entry;
+                LeftTuple leftTuple = entry instanceof LeftTuple ?
+                                      (LeftTuple) entry : // with phreak the entry is always both a right and a left tuple
+                                      (LeftTuple) entry.getFactHandle().getObject(); // this is necessary only for reteoo
                 InternalFactHandle handle = (InternalFactHandle) leftTuple.getFactHandle();
                 FactHandle _handle = ProtobufMessages.FactHandle.newBuilder()
                         .setId( handle.getId() )

--- a/drools-core/src/main/java/org/drools/core/phreak/AddRemoveRule.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/AddRemoveRule.java
@@ -44,6 +44,7 @@ import org.drools.core.reteoo.ObjectSource;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ObjectTypeNode.ObjectTypeNodeMemory;
 import org.drools.core.reteoo.PathMemory;
+import org.drools.core.reteoo.QueryElementNode;
 import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.RightInputAdapterNode.RiaNodeMemory;
 import org.drools.core.reteoo.RightTuple;
@@ -127,6 +128,7 @@ public class AddRemoveRule {
                 insertLiaFacts( splitStartLeftTupleSource, wm );
             }
 
+            correctMemoryOnSplitsChanged( splitStartLeftTupleSource, wm );
             insertFacts( splitStartLeftTupleSource.getSinkPropagator().getLastLeftTupleSink(), wm);
         }
     }
@@ -229,6 +231,8 @@ public class AddRemoveRule {
              if ( removedPmem.getRuleAgendaItem() != null && removedPmem.getRuleAgendaItem().isQueued() ) {
                  removedPmem.getRuleAgendaItem().dequeue();
              }
+
+             correctMemoryOnSplitsChanged( splitStartNode, wm );
          }
      }
 
@@ -432,7 +436,13 @@ public class AddRemoveRule {
          processLeftTuples(lts, peerLts, newSmem, wm, true);
      }
 
-     private static void correctSegmentOnSplitOnRemove(InternalWorkingMemory wm, SegmentMemory sm1,SegmentMemory sm2,  PathMemory pmem, PathMemory removedPmem, int p) {
+    private static void correctMemoryOnSplitsChanged( LeftTupleSource splitStart, InternalWorkingMemory wm ) {
+        if ( splitStart.getType() == NodeTypeEnums.UnificationNode) {
+            ((QueryElementNode.QueryElementNodeMemory) wm.getNodeMemory( (MemoryFactory) splitStart )).correctMemoryOnSinksChanged();
+        }
+    }
+
+    private static void correctSegmentOnSplitOnRemove(InternalWorkingMemory wm, SegmentMemory sm1,SegmentMemory sm2,  PathMemory pmem, PathMemory removedPmem, int p) {
          if ( p == 0 ) {
              mergeSegment(sm1, sm2);
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -169,9 +169,8 @@ public class PhreakAccumulateNode {
                                                                     rightIt); rightTuple != null; ) {
                 RightTuple nextRightTuple = (RightTuple) rightIt.next(rightTuple);
 
-                InternalFactHandle handle = rightTuple.getFactHandle();
                 if (constraints.isAllowedCachedLeft(contextEntry,
-                                                    handle)) {
+                                                    rightTuple.getFactHandleForEvaluation())) {
                     // add a match
                     addMatch(accNode,
                              accumulate,
@@ -223,7 +222,7 @@ public class PhreakAccumulateNode {
             if ( ltm != null && ltm.size() > 0 ) {
                 constraints.updateFromFactHandle( contextEntry,
                                                   wm,
-                                                  rightTuple.getFactHandle() );
+                                                  rightTuple.getFactHandleForEvaluation() );
 
                 FastIterator leftIt = accNode.getLeftIterator( ltm );
 
@@ -336,9 +335,8 @@ public class PhreakAccumulateNode {
             // either we are indexed and changed buckets or
             // we had no children before, but there is a bucket to potentially match, so try as normal assert
             for (; rightTuple != null; rightTuple = (RightTuple) rightIt.next(rightTuple)) {
-                final InternalFactHandle handle = rightTuple.getFactHandle();
                 if (constraints.isAllowedCachedLeft(bm.getContext(),
-                                                    handle)) {
+                                                    rightTuple.getFactHandleForEvaluation())) {
                     // add a new match
                     addMatch(accNode,
                              accumulate,
@@ -356,10 +354,8 @@ public class PhreakAccumulateNode {
             boolean isDirty = false;
             // in the same bucket, so iterate and compare
             for (; rightTuple != null; rightTuple = (RightTuple) rightIt.next(rightTuple)) {
-                final InternalFactHandle handle = rightTuple.getFactHandle();
-
                 if (constraints.isAllowedCachedLeft(bm.getContext(),
-                                                    handle)) {
+                                                    rightTuple.getFactHandleForEvaluation())) {
                     if (childLeftTuple == null || childLeftTuple.getRightParent() != rightTuple) {
                         // add a new match
                         addMatch(accNode,
@@ -432,7 +428,7 @@ public class PhreakAccumulateNode {
 
                 constraints.updateFromFactHandle( contextEntry,
                                                   wm,
-                                                  rightTuple.getFactHandle() );
+                                                  rightTuple.getFactHandleForEvaluation() );
 
                 // first check our index (for indexed nodes only) hasn't changed and we are returning the same bucket
                 // We assume a bucket change if leftTuple == null
@@ -680,9 +676,9 @@ public class PhreakAccumulateNode {
         AlphaNodeFieldConstraint[] resultConstraints = accNode.getResultConstraints();
         BetaConstraints resultBinder = accNode.getResultBinder();
         boolean isAllowed = true;
-        for (int i = 0, length = resultConstraints.length; i < length; i++) {
-            if (!resultConstraints[i].isAllowed(accctx.resultFactHandle,
-                                                workingMemory)) {
+        for ( AlphaNodeFieldConstraint resultConstraint : resultConstraints ) {
+            if ( !resultConstraint.isAllowed( accctx.resultFactHandle,
+                                              workingMemory ) ) {
                 isAllowed = false;
                 break;
             }
@@ -748,7 +744,8 @@ public class PhreakAccumulateNode {
         InternalFactHandle handle = rightTuple.getFactHandle();
         if (accNode.isUnwrapRightObject()) {
             // if there is a subnetwork, handle must be unwrapped
-            tuple = (LeftTuple) handle.getObject();
+            tuple = (LeftTuple) rightTuple;
+            handle = rightTuple.getFactHandleForEvaluation();
         }
 
         accctx.setPropagationContext(rightTuple.getPropagationContext());
@@ -793,7 +790,8 @@ public class PhreakAccumulateNode {
         InternalFactHandle handle = rightTuple.getFactHandle();
         LeftTuple tuple = leftTuple;
         if (accNode.isUnwrapRightObject()) {
-            tuple = (LeftTuple) handle.getObject();
+            tuple = (LeftTuple) rightTuple;
+            handle = rightTuple.getFactHandleForEvaluation();
         }
 
         if (accumulate.supportsReverse()) {
@@ -829,11 +827,13 @@ public class PhreakAccumulateNode {
                         leftTuple,
                         wm);
         for (LeftTuple childMatch = leftTuple.getFirstChild(); childMatch != null; childMatch = childMatch.getHandleNext()) {
-            InternalFactHandle childHandle = childMatch.getRightParent().getFactHandle();
+            RightTuple rightTuple = childMatch.getRightParent();
+            InternalFactHandle childHandle = rightTuple.getFactHandle();
             LeftTuple tuple = leftTuple;
             if (accNode.isUnwrapRightObject()) {
                 // if there is a subnetwork, handle must be unwrapped
-                tuple = (LeftTuple) childHandle.getObject();
+                tuple = (LeftTuple) rightTuple;
+                childHandle = rightTuple.getFactHandleForEvaluation();
             }
             accumulate.accumulate(am.workingMemoryContext,
                                   accctx.context,

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakExistsNode.java
@@ -108,8 +108,6 @@ public class PhreakExistsNode {
         for (LeftTuple leftTuple = srcLeftTuples.getInsertFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
 
-            FastIterator it = existsNode.getRightIterator(rtm);
-
             boolean useLeftMemory = RuleNetworkEvaluator.useLeftMemory(existsNode, leftTuple);
 
             constraints.updateFromTuple( contextEntry,
@@ -117,7 +115,7 @@ public class PhreakExistsNode {
                                          leftTuple );
 
             // This method will also remove rightTuples that are from subnetwork where no leftmemory use used
-            RuleNetworkEvaluator.findLeftTupleBlocker( existsNode, rtm, contextEntry, constraints, leftTuple, it, useLeftMemory );
+            RuleNetworkEvaluator.findLeftTupleBlocker( existsNode, rtm, contextEntry, constraints, leftTuple, useLeftMemory );
 
             if (leftTuple.getBlocker() != null) {
                 // tuple is not blocked to propagate
@@ -154,7 +152,7 @@ public class PhreakExistsNode {
 
                 constraints.updateFromFactHandle( contextEntry,
                                                   wm,
-                                                  rightTuple.getFactHandle() );
+                                                  rightTuple.getFactHandleForEvaluation() );
 
                 for ( LeftTuple leftTuple = existsNode.getFirstLeftTuple( rightTuple, ltm, it ); leftTuple != null; ) {
                     // preserve next now, in case we remove this leftTuple
@@ -237,7 +235,7 @@ public class PhreakExistsNode {
 
             // if we where not blocked before (or changed buckets), or the previous blocker no longer blocks, then find the next blocker
             if (blocker == null || !constraints.isAllowedCachedLeft(contextEntry,
-                                                                    blocker.getFactHandle())) {
+                                                                    blocker.getFactHandleForEvaluation())) {
 
                 if (blocker != null) {
                     // remove previous blocker if it exists, as we know it doesn't block any more
@@ -247,7 +245,7 @@ public class PhreakExistsNode {
                 // find first blocker, because it's a modify, we need to start from the beginning again
                 for (RightTuple newBlocker = firstRightTuple; newBlocker != null; newBlocker = (RightTuple) rightIt.next(newBlocker)) {
                     if (constraints.isAllowedCachedLeft( contextEntry,
-                                                         newBlocker.getFactHandle() )) {
+                                                         newBlocker.getFactHandleForEvaluation() )) {
                         leftTuple.setBlocker( newBlocker );
                         newBlocker.addBlocked( leftTuple );
 
@@ -385,7 +383,7 @@ public class PhreakExistsNode {
                         // cannot select a RightTuple queued in the delete list
                         // There may be UPDATE RightTuples too, but that's ok. They've already been re-added to the correct bucket, safe to be reprocessed.
                         if ( leftTuple.getStagedType() != LeftTuple.DELETE && newBlocker.getStagedType() != LeftTuple.DELETE &&
-                             constraints.isAllowedCachedLeft( contextEntry, newBlocker.getFactHandle() ) ) {
+                             constraints.isAllowedCachedLeft( contextEntry, newBlocker.getFactHandleForEvaluation() ) ) {
                             leftTuple.setBlocker( newBlocker );
                             newBlocker.addBlocked( leftTuple );
 
@@ -490,7 +488,7 @@ public class PhreakExistsNode {
                     // we know that older tuples have been checked so continue previously
                     for (RightTuple newBlocker = rootBlocker; newBlocker != null; newBlocker = (RightTuple) it.next(newBlocker)) {
                         if (constraints.isAllowedCachedLeft(contextEntry,
-                                                            newBlocker.getFactHandle())) {
+                                                            newBlocker.getFactHandleForEvaluation())) {
                             leftTuple.setBlocker(newBlocker);
                             newBlocker.addBlocked(leftTuple);
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
@@ -314,7 +314,7 @@ public class PhreakFromNode {
                                   boolean useLeftMemory,
                                   TupleSets<LeftTuple> trgLeftTuples,
                                   TupleSets<LeftTuple> stagedLeftTuples ) {
-        if (betaConstraints.isAllowedCachedLeft(context, rightTuple.getFactHandle())) {
+        if (betaConstraints.isAllowedCachedLeft(context, rightTuple.getFactHandleForEvaluation())) {
 
             if (rightTuple.getFirstChild() == null) {
                 // this is a new match, so propagate as assert

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
@@ -146,7 +146,7 @@ public class PhreakJoinNode {
 
                 constraints.updateFromFactHandle( contextEntry,
                                                   wm,
-                                                  rightTuple.getFactHandle() );
+                                                  rightTuple.getFactHandleForEvaluation() );
 
                 for ( LeftTuple leftTuple = joinNode.getFirstLeftTuple( rightTuple, ltm, it ); leftTuple != null; leftTuple = (LeftTuple) it.next( leftTuple ) ) {
                     if ( leftTuple.getStagedType() == LeftTuple.UPDATE ) {
@@ -296,7 +296,7 @@ public class PhreakJoinNode {
 
                 constraints.updateFromFactHandle( contextEntry,
                                                   wm,
-                                                  rightTuple.getFactHandle() );
+                                                  rightTuple.getFactHandleForEvaluation() );
 
                 // first check our index (for indexed nodes only) hasn't changed and we are returning the same bucket
                 // We assume a bucket change if leftTuple == null

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakNotNode.java
@@ -104,8 +104,6 @@ public class PhreakNotNode {
         for (LeftTuple leftTuple = srcLeftTuples.getInsertFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
 
-            FastIterator it = notNode.getRightIterator(rtm);
-
             boolean useLeftMemory = RuleNetworkEvaluator.useLeftMemory(notNode, leftTuple);
 
             constraints.updateFromTuple( contextEntry,
@@ -113,7 +111,7 @@ public class PhreakNotNode {
                                          leftTuple );
 
             // This method will also remove rightTuples that are from subnetwork where no leftmemory use used
-            RuleNetworkEvaluator.findLeftTupleBlocker( notNode, rtm, contextEntry, constraints, leftTuple, it, useLeftMemory );
+            RuleNetworkEvaluator.findLeftTupleBlocker( notNode, rtm, contextEntry, constraints, leftTuple, useLeftMemory );
 
             if (leftTuple.getBlocker() == null) {
                 // tuple is not blocked, so add to memory so other fact handles can attempt to match
@@ -157,7 +155,7 @@ public class PhreakNotNode {
 
                 constraints.updateFromFactHandle( contextEntry,
                                                   wm,
-                                                  rightTuple.getFactHandle() );
+                                                  rightTuple.getFactHandleForEvaluation() );
                 for ( LeftTuple leftTuple = notNode.getFirstLeftTuple( rightTuple, ltm, it ); leftTuple != null; ) {
                     // preserve next now, in case we remove this leftTuple
                     LeftTuple temp = (LeftTuple) it.next( leftTuple );
@@ -253,7 +251,7 @@ public class PhreakNotNode {
 
             // if we where not blocked before (or changed buckets), or the previous blocker no longer blocks, then find the next blocker
             if (blocker == null || !constraints.isAllowedCachedLeft(contextEntry,
-                                                                    blocker.getFactHandle())) {
+                                                                    blocker.getFactHandleForEvaluation())) {
                 if (blocker != null) {
                     // remove previous blocker if it exists, as we know it doesn't block any more
                     blocker.removeBlocked(leftTuple);
@@ -262,7 +260,7 @@ public class PhreakNotNode {
                 // find first blocker, because it's a modify, we need to start from the beginning again
                 for (RightTuple newBlocker = firstRightTuple; newBlocker != null; newBlocker = (RightTuple) rightIt.next(newBlocker)) {
                     if (constraints.isAllowedCachedLeft(contextEntry,
-                                                        newBlocker.getFactHandle())) {
+                                                        newBlocker.getFactHandleForEvaluation())) {
                         leftTuple.setBlocker(newBlocker);
                         newBlocker.addBlocked(leftTuple);
 
@@ -398,7 +396,7 @@ public class PhreakNotNode {
                         // cannot select a RightTuple queued in the delete list
                         // There may be UPDATE RightTuples too, but that's ok. They've already been re-added to the correct bucket, safe to be reprocessed.
                         if ( leftTuple.getStagedType() != LeftTuple.DELETE && newBlocker.getStagedType() != LeftTuple.DELETE &&
-                             constraints.isAllowedCachedLeft( contextEntry, newBlocker.getFactHandle() ) ) {
+                             constraints.isAllowedCachedLeft( contextEntry, newBlocker.getFactHandleForEvaluation() ) ) {
 
                             leftTuple.setBlocker( newBlocker );
                             newBlocker.addBlocked( leftTuple );
@@ -507,7 +505,7 @@ public class PhreakNotNode {
                     // we know that older tuples have been checked so continue next
                     for (RightTuple newBlocker = rootBlocker; newBlocker != null; newBlocker = (RightTuple) it.next(newBlocker)) {
                         if (constraints.isAllowedCachedLeft(contextEntry,
-                                                            newBlocker.getFactHandle())) {
+                                                            newBlocker.getFactHandleForEvaluation())) {
                             leftTuple.setBlocker(newBlocker);
                             newBlocker.addBlocked(leftTuple);
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryNode.java
@@ -72,7 +72,6 @@ public class PhreakQueryNode {
             DroolsQuery dquery = queryNode.createDroolsQuery(leftTuple, handle, stackEntry,
                                                              qmem.getSegmentMemory().getPathMemories(),
                                                              qmem,
-                                                             qmem.getResultLeftTuples(),
                                                              stackEntry.getSink(), wm);
 
             LeftInputAdapterNode lian = (LeftInputAdapterNode) qmem.getQuerySegmentMemory().getRootNode();

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -17,7 +17,6 @@ package org.drools.core.phreak;
 
 import org.drools.core.base.DroolsQuery;
 import org.drools.core.common.BetaConstraints;
-import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.NetworkNode;
@@ -51,14 +50,12 @@ import org.drools.core.reteoo.ReactiveFromNode;
 import org.drools.core.reteoo.RiaPathMemory;
 import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.RightTuple;
-import org.drools.core.reteoo.RightTupleImpl;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.TimerNode;
 import org.drools.core.reteoo.TimerNode.TimerNodeMemory;
 import org.drools.core.reteoo.TupleMemory;
 import org.drools.core.rule.ContextEntry;
-import org.drools.core.spi.PropagationContext;
 import org.drools.core.spi.Tuple;
 import org.drools.core.util.FastIterator;
 import org.drools.core.util.LinkedList;
@@ -622,7 +619,7 @@ public class RuleNetworkEvaluator {
         } else {
             bm = (BetaMemory) nodeMem;
         }
-
+        TupleSets<RightTuple> rightTuples = bm.getStagedRightTuples();
 
         // Build up iteration array for other sinks
         BetaNode[] bns = null;
@@ -646,90 +643,76 @@ public class RuleNetworkEvaluator {
         for (LeftTuple leftTuple = srcTuples.getInsertFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
 
-            PropagationContext pctx = leftTuple.getPropagationContext();
-            InternalFactHandle handle = riaNode.createFactHandle(leftTuple, pctx, wm);
-
-            RightTuple rightTuple = new RightTupleImpl(handle, betaNode);
-            leftTuple.setContextObject( handle );
-            rightTuple.setPropagationContext(pctx);
-
             if ( bm.getStagedRightTuples().isEmpty() ) {
                 bm.setNodeDirtyWithoutNotify();
             }
-            bm.getStagedRightTuples().addInsert(rightTuple);
+            leftTuple.clearStaged();
+            rightTuples.addInsert( (RightTuple) leftTuple );
 
             if (bns != null) {
                 // Add peered RightTuples, they are attached to FH - unlink LeftTuples that has a peer ref
                 for (int i = 0; i < length; i++) {
-                    rightTuple = new RightTupleImpl(handle, bns[i]);
-                    rightTuple.setPropagationContext(pctx);
+                    //rightTuple = new RightTupleImpl(handle, bns[i]);
+                    //rightTuple.setPropagationContext(pctx);
 
                     if ( bms[i].getStagedRightTuples().isEmpty() ) {
                         bms[i].setNodeDirtyWithoutNotify();
                     }
-                    bms[i].getStagedRightTuples().addInsert(rightTuple);
+                    //bms[i].getStagedRightTuples().addInsert(rightTuple);
+                    bms[i].getStagedRightTuples().addInsert((RightTuple)leftTuple);
                 }
             }
 
 
-            leftTuple.clearStaged();
             leftTuple = next;
         }
 
         for (LeftTuple leftTuple = srcTuples.getDeleteFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
 
-            InternalFactHandle handle = (InternalFactHandle) leftTuple.getContextObject();
-            RightTuple rightTuple = handle.getFirstRightTuple();
-            TupleSets<RightTuple> rightTuples = bm.getStagedRightTuples();
-
             if ( rightTuples.isEmpty() ) {
                 bm.setNodeDirtyWithoutNotify();
             }
-            rightTuples.addDelete(rightTuple);
+            leftTuple.clearStaged();
+            rightTuples.addDelete((RightTuple)leftTuple);
 
             if (bns != null) {
                 // Add peered RightTuples, they are attached to FH - unlink LeftTuples that has a peer ref
                 for (int i = 0; i < length; i++) {
-                    rightTuple = rightTuple.getHandleNext();
+                    leftTuple = leftTuple.getHandleNext();
                     rightTuples = bms[i].getStagedRightTuples();
                     if ( rightTuples.isEmpty() ) {
                         bms[i].setNodeDirtyWithoutNotify();
                     }
-                    rightTuples.addDelete(rightTuple);
+                    rightTuples.addDelete((RightTuple)leftTuple);
                 }
             }
 
-            leftTuple.clearStaged();
             leftTuple = next;
         }
 
         for (LeftTuple leftTuple = srcTuples.getUpdateFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
 
-            InternalFactHandle handle = (InternalFactHandle) leftTuple.getContextObject();
-            RightTuple rightTuple = handle.getFirstRightTuple();
-            TupleSets<RightTuple> rightTuples = bm.getStagedRightTuples();
-
             if ( rightTuples.isEmpty() ) {
                 bm.setNodeDirtyWithoutNotify();
             }
-            rightTuples.addUpdate(rightTuple);
+            leftTuple.clearStaged();
+            rightTuples.addUpdate((RightTuple)leftTuple);
 
             if (bns != null) {
                 // Add peered RightTuples, they are attached to FH - unlink LeftTuples that has a peer ref
                 for (int i = 0; i < length; i++) {
-                    rightTuple = rightTuple.getHandleNext();
+                    leftTuple = leftTuple.getHandleNext();
                     rightTuples = bms[i].getStagedRightTuples();
 
                     if ( rightTuples.isEmpty() ) {
                         bms[i].setNodeDirtyWithoutNotify();
                     }
-                    rightTuples.addUpdate(rightTuple);
+                    rightTuples.addUpdate((RightTuple)leftTuple);
                 }
             }
 
-            leftTuple.clearStaged();
             leftTuple = next;
         }
 
@@ -738,13 +721,13 @@ public class RuleNetworkEvaluator {
 
     public static void findLeftTupleBlocker(BetaNode betaNode, TupleMemory rtm,
                                              ContextEntry[] contextEntry, BetaConstraints constraints,
-                                             LeftTuple leftTuple, FastIterator it, boolean useLeftMemory) {
+                                             LeftTuple leftTuple, boolean useLeftMemory) {
         // This method will also remove rightTuples that are from subnetwork where no leftmemory use used
-
+        FastIterator it = betaNode.getRightIterator(rtm);
         for (RightTuple rightTuple = betaNode.getFirstRightTuple(leftTuple, rtm, null, it); rightTuple != null; ) {
             RightTuple nextRight = (RightTuple) it.next(rightTuple);
             if (constraints.isAllowedCachedLeft(contextEntry,
-                                                rightTuple.getFactHandle())) {
+                                                rightTuple.getFactHandleForEvaluation())) {
                 leftTuple.setBlocker(rightTuple);
 
                 if (useLeftMemory) {

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -180,7 +180,7 @@ public class RuleNetworkEvaluator {
             // copy across the results, if any from the query node memory
             QueryElementNodeMemory qmem = (QueryElementNodeMemory) nodeMem;
             qmem.setNodeCleanWithoutNotify();
-            trgTuples.addAll(qmem.getResultLeftTuples());
+            qmem.getResultLeftTuples().addTo(trgTuples);
         }
 
         LeftTupleSinkNode sink = entry.getSink();
@@ -451,7 +451,7 @@ public class RuleNetworkEvaluator {
 
         // result tuples can happen when reactivity occurs inside of the query, prior to evaluation
         // we will need special behaviour to add the results again, when this query result resumes
-        trgTuples.addAll(qmem.getResultLeftTuples());
+        qmem.getResultLeftTuples().addTo( trgTuples );
         qmem.setNodeCleanWithoutNotify();
 
         if (!srcTuples.isEmpty()) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/BaseLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BaseLeftTuple.java
@@ -19,7 +19,6 @@ package org.drools.core.reteoo;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.spi.PropagationContext;
-import org.drools.core.spi.Tuple;
 import org.drools.core.util.index.TupleList;
 
 import java.util.Arrays;
@@ -51,6 +50,8 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
     protected TupleList        memory;
 
     private LeftTuple            peer;
+
+    private volatile short       stagedTypeForQueries;
 
     public BaseLeftTuple() {
         // constructor needed for serialisation
@@ -647,5 +648,13 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
     @Override
     public void retractTuple( PropagationContext context, InternalWorkingMemory workingMemory ) {
         getTupleSink().retractLeftTuple( this, context, workingMemory );
+    }
+
+    public short getStagedTypeForQueries() {
+        return stagedTypeForQueries;
+    }
+
+    public void setStagedTypeForQueries( short stagedTypeForQueries ) {
+        this.stagedTypeForQueries = stagedTypeForQueries;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/BaseLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BaseLeftTuple.java
@@ -17,7 +17,9 @@
 package org.drools.core.reteoo;
 
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.spi.PropagationContext;
+import org.drools.core.spi.Tuple;
 import org.drools.core.util.index.TupleList;
 
 import java.util.Arrays;
@@ -630,5 +632,20 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
     @Override
     public ObjectTypeNode.Id getInputOtnId() {
         return sink != null ? getTupleSink().getLeftInputOtnId() : null;
+    }
+
+    @Override
+    public LeftTupleSource getTupleSource() {
+        return sink != null ? getTupleSink().getLeftTupleSource() : null;
+    }
+
+    @Override
+    public void modifyTuple( PropagationContext context, InternalWorkingMemory workingMemory) {
+        getTupleSink().modifyLeftTuple( this, context, workingMemory );
+    }
+
+    @Override
+    public void retractTuple( PropagationContext context, InternalWorkingMemory workingMemory ) {
+        getTupleSink().retractLeftTuple( this, context, workingMemory );
     }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/BaseTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BaseTuple.java
@@ -46,7 +46,7 @@ public abstract class BaseTuple implements Tuple {
         return getObject(declaration.getPattern().getOffset());
     }
 
-    public final Object getContextObject() {
+    public Object getContextObject() {
         return this.contextObject;
     }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BetaNode.java
@@ -301,8 +301,7 @@ public abstract class BetaNode extends LeftTupleSource
         RightTuple rightTuple = modifyPreviousTuples.peekRightTuple();
 
         // if the peek is for a different OTN we assume that it is after the current one and then this is an assert
-        while ( rightTuple != null &&
-                rightTuple.getTupleSink().getRightInputOtnId().before( getRightInputOtnId()) ) {
+        while ( rightTuple != null && rightTuple.getInputOtnId().before( getRightInputOtnId() ) ) {
             modifyPreviousTuples.removeRightTuple();
 
             // we skipped this node, due to alpha hashing, so retract now
@@ -312,7 +311,7 @@ public abstract class BetaNode extends LeftTupleSource
             rightTuple = modifyPreviousTuples.peekRightTuple();
         }
 
-        if ( rightTuple != null && rightTuple.getTupleSink().getRightInputOtnId().equals( getRightInputOtnId()) ) {
+        if ( rightTuple != null && rightTuple.getInputOtnId().equals( getRightInputOtnId()) ) {
             modifyPreviousTuples.removeRightTuple();
             rightTuple.reAdd();
             if ( context.getModificationMask().intersects(getRightInferredMask()) ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/CompositeLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/CompositeLeftTupleSinkAdapter.java
@@ -68,11 +68,9 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
                                               final InternalWorkingMemory workingMemory) {
         LeftTuple childLeftTuple = rightTuple.getFirstChild();
         while ( childLeftTuple != null ) {
-            childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                               context,
-                                                               workingMemory );            
+            childLeftTuple.modifyTuple( context, workingMemory );
             childLeftTuple = childLeftTuple.getRightParentNext();
-        }        
+        }
     }
 
     public void propagateAssertLeftTuple(final LeftTuple leftTuple,
@@ -135,10 +133,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
         LeftTuple child = leftTuple.getFirstChild();
         while ( child != null ) {
             LeftTuple temp = child.getHandleNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         child,
-                                         child.getTupleSink() );
+            child.retractTuple( context, workingMemory );
             child.unlinkFromRightParent();
             child.unlinkFromLeftParent();
             child = temp;
@@ -152,10 +147,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
         InternalFactHandle rightParent = child.getRightParent().getFactHandle();
         while ( child != null ) {
             LeftTuple temp = child.getHandleNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         child,
-                                         child.getTupleSink() );
+            child.retractTuple( context, workingMemory );
             child.unlinkFromRightParent();
             child.unlinkFromLeftParent();
             child = temp;
@@ -169,10 +161,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
         LeftTuple child = rightTuple.getFirstChild();
         while ( child != null ) {
             LeftTuple temp = child.getRightParentNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         child,
-                                         child.getTupleSink() );
+            child.retractTuple( context, workingMemory );
             child.unlinkFromLeftParent();
             child.unlinkFromRightParent();
             child = temp;
@@ -249,24 +238,6 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
                               workingMemory );
     }
 
-    /**
-     * This is a hook method that may be overriden by subclasses. Please keep it
-     * protected.
-     *
-     * @param context
-     * @param workingMemory
-     * @param leftTuple
-     * @param sink
-     */
-    protected void doPropagateRetractLeftTuple(PropagationContext context,
-                                               InternalWorkingMemory workingMemory,
-                                               LeftTuple leftTuple,
-                                               LeftTupleSink sink) {
-        sink.retractLeftTuple( leftTuple,
-                               context,
-                               workingMemory );
-    }
-
     public void doPropagateModifyObject(InternalFactHandle factHandle,
                                         ModifyPreviousTuples modifyPreviousTuples,
                                         PropagationContext context,
@@ -307,9 +278,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
 
             // preserve the current LeftTuple, as we need to iterate to the next before re-adding
             LeftTuple temp = childLeftTuple;
-            childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                               context,
-                                                               workingMemory );
+            childLeftTuple.modifyTuple( context, workingMemory );
             childLeftTuple = childLeftTuple.getHandleNext();
             temp.reAddRight();
         }
@@ -328,9 +297,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
 
             // preserve the current LeftTuple, as we need to iterate to the next before re-adding
             LeftTuple temp = childLeftTuple;
-            childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                               context,
-                                                               workingMemory );
+            childLeftTuple.modifyTuple( context, workingMemory );
             childLeftTuple = childLeftTuple.getRightParentNext();
             temp.reAddLeft();
         }
@@ -342,9 +309,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
                                               InternalWorkingMemory workingMemory,
                                               boolean tupleMemoryEnabled) {
         for ( LeftTuple childLeftTuple = leftTuple.getFirstChild(); childLeftTuple != null; childLeftTuple = childLeftTuple.getHandleNext() ) {
-            childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                               context,
-                                                               workingMemory );
+            childLeftTuple.modifyTuple( context, workingMemory );
         }
     }
 
@@ -357,10 +322,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
             // this will iterate for each child node when the
             // the current node is shared     
             LeftTuple temp = childLeftTuple.getHandleNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         childLeftTuple,
-                                         childLeftTuple.getTupleSink() );
+            childLeftTuple.retractTuple( context, workingMemory );
             childLeftTuple.unlinkFromRightParent();
             childLeftTuple.unlinkFromLeftParent();
             childLeftTuple = temp;
@@ -377,10 +339,7 @@ public class CompositeLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter 
             // this will iterate for each child node when the
             // the current node is shared     
             LeftTuple temp = childLeftTuple.getRightParentNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         childLeftTuple,
-                                         childLeftTuple.getTupleSink() );
+            childLeftTuple.retractTuple( context, workingMemory );
             childLeftTuple.unlinkFromRightParent();
             childLeftTuple.unlinkFromLeftParent();
             childLeftTuple = temp;

--- a/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/EntryPointNode.java
@@ -25,7 +25,6 @@ import org.drools.core.common.PropagationContextFactory;
 import org.drools.core.common.RuleBasePartitionId;
 import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.reteoo.LeftInputAdapterNode.LiaNodeMemory;
-import org.drools.core.reteoo.ObjectTypeNode.ObjectTypeNodeMemory;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.core.rule.EntryPointId;
 import org.drools.core.spi.ObjectType;
@@ -287,14 +286,14 @@ public class EntryPointNode extends ObjectSource
     }
 
     public void doDeleteObject(PropagationContext pctx, InternalWorkingMemory wm, LeftTuple leftTuple) {
-        LeftInputAdapterNode liaNode = (LeftInputAdapterNode) leftTuple.getTupleSink().getLeftTupleSource();
-        LiaNodeMemory lm = ( LiaNodeMemory )  wm.getNodeMemory( liaNode );
+        LeftInputAdapterNode liaNode = leftTuple.getTupleSource();
+        LiaNodeMemory lm = wm.getNodeMemory( liaNode );
         LeftInputAdapterNode.doDeleteObject(leftTuple, pctx, lm.getSegmentMemory(), wm, liaNode, true, lm);
     }
 
     public void doRightDelete(PropagationContext pctx, InternalWorkingMemory wm, RightTuple rightTuple) {
         rightTuple.setPropagationContext( pctx );
-        rightTuple.getTupleSink().retractRightTuple(rightTuple, pctx, wm);
+        rightTuple.retractTuple( pctx, wm );
     }
 
     public void modifyObject(InternalFactHandle factHandle,
@@ -454,7 +453,7 @@ public class EntryPointNode extends ObjectSource
             if ( objectTypeConf.getConcreteObjectTypeNode() != null && newObjectType.isAssignableFrom( objectTypeConf.getConcreteObjectTypeNode().getObjectType() ) ) {
                 objectTypeConf.resetCache();
                 ObjectTypeNode sourceNode = objectTypeConf.getConcreteObjectTypeNode();
-                Iterator<InternalFactHandle> it = ((ObjectTypeNodeMemory) workingMemory.getNodeMemory( sourceNode )).iterator();
+                Iterator<InternalFactHandle> it = workingMemory.getNodeMemory( sourceNode ).iterator();
                 while ( it.hasNext() ) {
                     sink.assertObject( it.next(),
                                        context,

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -365,13 +365,13 @@ public class LeftInputAdapterNode extends LeftTupleSource
             SegmentUtilities.createSegmentMemory( this, workingMemory );
         }
 
-        if ( leftTuple != null && leftTuple.getTupleSink().getLeftInputOtnId().equals( otnId ) ) {
+        if ( leftTuple != null && leftTuple.getInputOtnId().equals( otnId ) ) {
             modifyPreviousTuples.removeLeftTuple();
             leftTuple.reAdd();
             LeftTupleSink sink = getSinkPropagator().getFirstLeftTupleSink();
             BitMask mask = sink.getLeftInferredMask();
             if ( context.getModificationMask().intersects( mask) ) {
-                doUpdateObject( leftTuple, context, workingMemory, (LeftInputAdapterNode) leftTuple.getTupleSink().getLeftTupleSource(), true, lm, lm.getSegmentMemory() );
+                doUpdateObject( leftTuple, context, workingMemory, (LeftInputAdapterNode) leftTuple.getTupleSource(), true, lm, lm.getSegmentMemory() );
                 if (leftTuple instanceof Activation) {
                     ((Activation)leftTuple).setActive(true);
                 }
@@ -390,10 +390,10 @@ public class LeftInputAdapterNode extends LeftTupleSource
 
     private static LeftTuple processDeletesFromModify(ModifyPreviousTuples modifyPreviousTuples, PropagationContext context, InternalWorkingMemory workingMemory, Id otnId) {
         LeftTuple leftTuple = modifyPreviousTuples.peekLeftTuple();
-        while ( leftTuple != null && leftTuple.getTupleSink().getLeftInputOtnId().before( otnId ) ) {
+        while ( leftTuple != null && leftTuple.getInputOtnId().before( otnId ) ) {
             modifyPreviousTuples.removeLeftTuple();
 
-            LeftInputAdapterNode prevLiaNode = (LeftInputAdapterNode) leftTuple.getTupleSink().getLeftTupleSource();
+            LeftInputAdapterNode prevLiaNode = (LeftInputAdapterNode) leftTuple.getTupleSource();
             LiaNodeMemory prevLm = workingMemory.getNodeMemory( prevLiaNode );
             SegmentMemory prevSm = prevLm.getSegmentMemory();
             doDeleteObject( leftTuple, context, prevSm, workingMemory, prevLiaNode, true, prevLm );

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTuple.java
@@ -22,18 +22,13 @@ public interface LeftTuple extends Tuple {
     void reAddLeft();
     void reAddRight();
 
-    LeftTupleSink getTupleSink();
-
-    /* Had to add the set method because sink adapters must override 
+    /* Had to add the set method because sink adapters must override
      * the tuple sink set when the tuple was created.
      */
     void setLeftTupleSink(LeftTupleSink sink);
 
     LeftTuple getLeftParent();
     void setLeftParent(LeftTuple leftParent);
-
-    LeftTuple getHandlePrevious();
-    LeftTuple getHandleNext();
 
     RightTuple getRightParent();
     void setRightParent(RightTuple rightParent);
@@ -58,7 +53,4 @@ public interface LeftTuple extends Tuple {
 
     void setPeer(LeftTuple peer);
     LeftTuple getPeer();
-
-    LeftTuple getStagedPrevious();
-    LeftTuple getStagedNext();
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTuple.java
@@ -53,4 +53,7 @@ public interface LeftTuple extends Tuple {
 
     void setPeer(LeftTuple peer);
     LeftTuple getPeer();
+
+    short getStagedTypeForQueries();
+    void setStagedTypeForQueries( short stagedTypeForQueries );
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSink.java
@@ -34,8 +34,6 @@ public interface LeftTupleSink
     Externalizable,
     Sink {
 
-    short getType();
-    
     /**
      * Assert a new <code>ReteTuple</code>.
      *

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSource.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSource.java
@@ -145,8 +145,7 @@ public abstract class LeftTupleSource extends BaseNode
         }
 
         if ( sinkPropagator instanceof SingleLeftTupleSinkAdapter ) {
-            final CompositeLeftTupleSinkAdapter sinkAdapter;
-            sinkAdapter = new CompositeLeftTupleSinkAdapter( this.getPartitionId() );
+            CompositeLeftTupleSinkAdapter sinkAdapter = new CompositeLeftTupleSinkAdapter( this.getPartitionId() );
             sinkAdapter.addTupleSink( sinkPropagator.getSinks()[0] );
             sinkAdapter.addTupleSink( tupleSink );
             return sinkAdapter;
@@ -253,7 +252,7 @@ public abstract class LeftTupleSource extends BaseNode
 
     private LeftTupleSource unwrapLeftInput(LeftTupleSource leftInput) {
         if (leftInput.getType() == NodeTypeEnums.FromNode || leftInput.getType() == NodeTypeEnums.ReactiveFromNode) {
-            return ((LeftTupleSink)leftInput).getLeftTupleSource();
+            return leftInput.getLeftTupleSource();
         }
         return leftInput;
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSourceUtils.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftTupleSourceUtils.java
@@ -29,20 +29,20 @@ public class LeftTupleSourceUtils {
                                          ObjectTypeNode.Id leftInputOtnId,
                                          BitMask leftInferredMask) {
         LeftTuple leftTuple = modifyPreviousTuples.peekLeftTuple();
-        while ( leftTuple != null && leftTuple.getTupleSink().getLeftInputOtnId() != null &&
-                leftTuple.getTupleSink().getLeftInputOtnId().before( leftInputOtnId ) ) {
+        while ( leftTuple != null && leftTuple.getInputOtnId() != null &&
+                leftTuple.getInputOtnId().before( leftInputOtnId ) ) {
             modifyPreviousTuples.removeLeftTuple();
 
             // we skipped this node, due to alpha hashing, so retract now
-            ((LeftInputAdapterNode) leftTuple.getTupleSink().getLeftTupleSource()).retractLeftTuple( leftTuple,
-                                                                                                         context,
-                                                                                                         workingMemory );
+            ((LeftInputAdapterNode) leftTuple.getTupleSource()).retractLeftTuple( leftTuple,
+                                                                                  context,
+                                                                                  workingMemory );
 
             leftTuple = modifyPreviousTuples.peekLeftTuple();
         }
 
-        if ( leftTuple != null && leftTuple.getTupleSink().getLeftInputOtnId() != null &&
-             leftTuple.getTupleSink().getLeftInputOtnId().equals( leftInputOtnId ) ) {
+        if ( leftTuple != null && leftTuple.getInputOtnId() != null &&
+             leftTuple.getInputOtnId().equals( leftInputOtnId ) ) {
             modifyPreviousTuples.removeLeftTuple();
             leftTuple.reAdd();
             if ( context.getModificationMask().intersects( leftInferredMask ) ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ObjectTypeNode.java
@@ -322,18 +322,17 @@ public class ObjectTypeNode extends ObjectSource
                                        final InternalWorkingMemory workingMemory) {
         for (RightTuple rightTuple = factHandle.getFirstRightTuple(); rightTuple != null; ) {
             RightTuple nextRightTuple = rightTuple.getHandleNext();
-            rightTuple.getTupleSink().retractRightTuple(rightTuple,
-                                                             context,
-                                                             workingMemory);
+            rightTuple.retractTuple( context, workingMemory);
             rightTuple = nextRightTuple;
         }
         factHandle.clearRightTuples();
 
         for (LeftTuple leftTuple = factHandle.getFirstLeftTuple(); leftTuple != null; leftTuple = leftTuple.getHandleNext()) {
             // must go via the LiaNode, so that the fact counter is updated, for linking
-            ((LeftInputAdapterNode) leftTuple.getTupleSink().getLeftTupleSource()).retractLeftTuple(leftTuple,
-                                                                                                        context,
-                                                                                                        workingMemory);
+            LeftTupleSink sink = leftTuple.getTupleSink();
+            ((LeftInputAdapterNode) sink.getLeftTupleSource()).retractLeftTuple(leftTuple,
+                                                                                context,
+                                                                                workingMemory);
         }
         factHandle.clearLeftTuples();
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/PropagationQueuingNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PropagationQueuingNode.java
@@ -178,16 +178,14 @@ public class PropagationQueuingNode extends ObjectSource
             BetaNode betaNode = (BetaNode) s;
             RightTuple rightTuple = modifyPreviousTuples.peekRightTuple();
             while ( rightTuple != null &&
-                    rightTuple.getTupleSink().getRightInputOtnId().before( betaNode.getRightInputOtnId() ) ) {
+                    rightTuple.getInputOtnId().before( betaNode.getRightInputOtnId() ) ) {
                 modifyPreviousTuples.removeRightTuple();
                 // we skipped this node, due to alpha hashing, so retract now
-                rightTuple.getTupleSink().retractRightTuple( rightTuple,
-                                                                  context,
-                                                                  workingMemory );
+                rightTuple.retractTuple( context, workingMemory );
                 rightTuple = modifyPreviousTuples.peekRightTuple();
             }
 
-            if ( rightTuple != null && rightTuple.getTupleSink().getRightInputOtnId().equals( betaNode.getRightInputOtnId() ) ) {
+            if ( rightTuple != null && rightTuple.getInputOtnId().equals( betaNode.getRightInputOtnId() ) ) {
                 modifyPreviousTuples.removeRightTuple();
                 rightTuple.reAdd();
                 if ( context.getModificationMask().intersects( betaNode.getRightInferredMask() ) ) {
@@ -463,16 +461,12 @@ public class PropagationQueuingNode extends ObjectSource
                              final InternalWorkingMemory workingMemory ) {
 
             for ( RightTuple rightTuple = (RightTuple) this.handle.getFirstRightTuple(); rightTuple != null; rightTuple = rightTuple.getHandleNext() ) {
-                rightTuple.getTupleSink().retractRightTuple( rightTuple,
-                                                                  context,
-                                                                  workingMemory );
+                rightTuple.retractTuple( context, workingMemory );
             }
             this.handle.clearRightTuples();
 
             for ( LeftTuple leftTuple = (LeftTuple) this.handle.getFirstLeftTuple(); leftTuple != null; leftTuple = leftTuple.getHandleNext() ) {
-                leftTuple.getTupleSink().retractLeftTuple( leftTuple,
-                                                               context,
-                                                               workingMemory );
+                leftTuple.retractTuple(  context, workingMemory );
             }
             this.handle.clearLeftTuples();
             context.evaluateActionQueue( workingMemory );

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -119,7 +119,7 @@ public class RightInputAdapterNode extends ObjectSource
     }
     
     public LeftTuple createPeer(LeftTuple original) {
-        JoinNodeLeftTuple peer = new JoinNodeLeftTuple();
+        SubnetworkTuple peer = new SubnetworkTuple();
         peer.initPeer( (BaseLeftTuple) original, this );
         original.setPeer( peer );
         return peer;
@@ -267,26 +267,26 @@ public class RightInputAdapterNode extends ObjectSource
     public LeftTuple createLeftTuple(InternalFactHandle factHandle,
                                      Sink sink,
                                      boolean leftTupleMemoryEnabled) {
-        return new JoinNodeLeftTuple(factHandle, sink, leftTupleMemoryEnabled );
+        return new SubnetworkTuple(factHandle, sink, leftTupleMemoryEnabled );
     }
 
     public LeftTuple createLeftTuple(final InternalFactHandle factHandle,
                                      final LeftTuple leftTuple,
                                      final Sink sink) {
-        return new JoinNodeLeftTuple(factHandle,leftTuple, sink );
+        return new SubnetworkTuple(factHandle,leftTuple, sink );
     }
 
     public LeftTuple createLeftTuple(LeftTuple leftTuple,
                                      Sink sink,
                                      PropagationContext pctx,
                                      boolean leftTupleMemoryEnabled) {
-        return new JoinNodeLeftTuple(leftTuple,sink, pctx, leftTupleMemoryEnabled );
+        return new SubnetworkTuple(leftTuple,sink, pctx, leftTupleMemoryEnabled );
     }
 
     public LeftTuple createLeftTuple(LeftTuple leftTuple,
                                      RightTuple rightTuple,
                                      Sink sink) {
-        return new JoinNodeLeftTuple(leftTuple, rightTuple, sink );
+        return new SubnetworkTuple(leftTuple, rightTuple, sink );
     }   
     
     public LeftTuple createLeftTuple(LeftTuple leftTuple,
@@ -295,7 +295,7 @@ public class RightInputAdapterNode extends ObjectSource
                                      LeftTuple currentRightChild,
                                      Sink sink,
                                      boolean leftTupleMemoryEnabled) {
-        return new JoinNodeLeftTuple(leftTuple, rightTuple, currentLeftChild, currentRightChild, sink, leftTupleMemoryEnabled );        
+        return new SubnetworkTuple(leftTuple, rightTuple, currentLeftChild, currentRightChild, sink, leftTupleMemoryEnabled );
     }
 
     public LeftTupleSource getLeftTupleSource() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTuple.java
@@ -16,6 +16,7 @@
 
 package org.drools.core.reteoo;
 
+import org.drools.core.common.InternalFactHandle;
 import org.drools.core.spi.Tuple;
 
 public interface RightTuple extends Tuple {
@@ -33,4 +34,6 @@ public interface RightTuple extends Tuple {
 
     TupleMemory getTempRightTupleMemory();
     void setTempRightTupleMemory( TupleMemory tempRightTupleMemory );
+
+    InternalFactHandle getFactHandleForEvaluation();
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTuple.java
@@ -20,11 +20,6 @@ import org.drools.core.spi.Tuple;
 
 public interface RightTuple extends Tuple {
 
-    RightTuple getHandlePrevious();
-    RightTuple getHandleNext();
-
-    RightTupleSink getTupleSink();
-
     LeftTuple getBlocked();
     void setBlocked( LeftTuple leftTuple );
     void addBlocked( LeftTuple leftTuple );
@@ -38,7 +33,4 @@ public interface RightTuple extends Tuple {
 
     TupleMemory getTempRightTupleMemory();
     void setTempRightTupleMemory( TupleMemory tempRightTupleMemory );
-
-    RightTuple getStagedPrevious();
-    RightTuple getStagedNext();
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTupleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTupleImpl.java
@@ -17,6 +17,8 @@
 package org.drools.core.reteoo;
 
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.spi.PropagationContext;
 import org.drools.core.spi.Tuple;
 import org.drools.core.util.index.TupleList;
 
@@ -256,5 +258,20 @@ public class RightTupleImpl extends BaseTuple implements RightTuple {
     @Override
     public ObjectTypeNode.Id getInputOtnId() {
         return sink != null ? getTupleSink().getRightInputOtnId() : null;
+    }
+
+    @Override
+    public LeftTupleSource getTupleSource() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void modifyTuple( PropagationContext context, InternalWorkingMemory workingMemory) {
+        getTupleSink().modifyRightTuple( this, context, workingMemory );
+    }
+
+    @Override
+    public void retractTuple( PropagationContext context, InternalWorkingMemory workingMemory ) {
+        getTupleSink().retractRightTuple( this, context, workingMemory );
     }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTupleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTupleImpl.java
@@ -274,4 +274,8 @@ public class RightTupleImpl extends BaseTuple implements RightTuple {
     public void retractTuple( PropagationContext context, InternalWorkingMemory workingMemory ) {
         getTupleSink().retractRightTuple( this, context, workingMemory );
     }
+
+    public InternalFactHandle getFactHandleForEvaluation() {
+        return getFactHandle();
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightTupleSink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightTupleSink.java
@@ -21,8 +21,6 @@ import org.drools.core.spi.PropagationContext;
 
 public interface RightTupleSink extends Sink {
 
-    short getType();
-
     void assertRightTuple( final RightTuple rightTuple,
                            final PropagationContext context,
                            final InternalWorkingMemory workingMemory );

--- a/drools-core/src/main/java/org/drools/core/reteoo/SingleLeftTupleSinkAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SingleLeftTupleSinkAdapter.java
@@ -55,13 +55,8 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                               final PropagationContext context,
                                               final InternalWorkingMemory workingMemory) {
         LeftTuple childLeftTuple = rightTuple.getFirstChild();
-        childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                           context,
-                                                           workingMemory );       
+        childLeftTuple.modifyTuple( context, workingMemory );
     }
-    
-    
-    
 
     public void propagateAssertLeftTuple(final LeftTuple leftTuple,
                                          final RightTuple rightTuple,
@@ -97,10 +92,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
         LeftTuple child = leftTuple.getFirstChild();
         while ( child != null ) { 
             LeftTuple temp = child.getHandleNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         child,
-                                         child.getTupleSink() );
+            child.retractTuple( context, workingMemory );
             child.unlinkFromRightParent();
             child.unlinkFromLeftParent();
             child = temp;
@@ -113,10 +105,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
         LeftTuple child = leftTuple.getFirstChild();
         while ( child != null ) {
             LeftTuple temp = child.getHandleNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         child,
-                                         child.getTupleSink() );
+            child.retractTuple( context, workingMemory );
             //workingMemory.getFactHandleFactory().destroyFactHandle( child.getRightParent().getFactHandle() );
             child.unlinkFromRightParent();
             child.unlinkFromLeftParent();
@@ -130,10 +119,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
         LeftTuple child = rightTuple.getFirstChild();
         while ( child != null ) {
             LeftTuple temp = child.getRightParentNext();
-            doPropagateRetractLeftTuple( context,
-                                         workingMemory,
-                                         child,
-                                         child.getTupleSink() );
+            child.retractTuple( context, workingMemory );
             child.unlinkFromLeftParent();
             child.unlinkFromRightParent();
             child = temp;
@@ -221,21 +207,6 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                    workingMemory );
     }
 
-    /**
-     * This is a hook method that may be overriden by subclasses. Please keep it
-     * package protected.
-     */
-    protected void doPropagateRetractLeftTuple(PropagationContext context,
-                                               InternalWorkingMemory workingMemory,
-                                               LeftTuple child,
-                                               LeftTupleSink tupleSink) {
-        tupleSink.retractLeftTuple( child,
-                                    context,
-                                    workingMemory );
-    }
-
-    // related to true modify
-    
     public void propagateModifyObject(InternalFactHandle factHandle,
                                       ModifyPreviousTuples modifyPreviousTuples,
                                       PropagationContext context,
@@ -251,9 +222,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                                    PropagationContext context,
                                                    InternalWorkingMemory workingMemory,
                                                    boolean tupleMemoryEnabled) {
-        childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                           context,
-                                                           workingMemory );
+        childLeftTuple.modifyTuple( context, workingMemory );
         // re-order right to keep order consistency
         childLeftTuple.reAddRight();
         return childLeftTuple.getHandleNext();
@@ -264,9 +233,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                                    PropagationContext context,
                                                    InternalWorkingMemory workingMemory,
                                                    boolean tupleMemoryEnabled) {
-        childLeftTuple.getTupleSink().modifyLeftTuple( childLeftTuple,
-                                                           context,
-                                                           workingMemory );
+        childLeftTuple.modifyTuple( context, workingMemory );
         // re-order right to keep order consistency
         childLeftTuple.reAddLeft();
         return childLeftTuple.getRightParentNext();
@@ -277,9 +244,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                               InternalWorkingMemory workingMemory,
                                               boolean tupleMemoryEnabled) {
         // not shared, so only one child
-        leftTuple.getFirstChild().getTupleSink().modifyLeftTuple( leftTuple.getFirstChild(),
-                                                                      context,
-                                                                      workingMemory );
+        leftTuple.getFirstChild().modifyTuple( context, workingMemory );
     }
 
     public LeftTuple propagateRetractChildLeftTuple(LeftTuple childLeftTuple,
@@ -287,10 +252,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                                     PropagationContext context,
                                                     InternalWorkingMemory workingMemory) {
         LeftTuple temp = childLeftTuple.getHandleNext();
-        doPropagateRetractLeftTuple( context,
-                                     workingMemory,
-                                     childLeftTuple,
-                                     childLeftTuple.getTupleSink() );
+        childLeftTuple.retractTuple( context, workingMemory );
         childLeftTuple.unlinkFromRightParent();
         childLeftTuple.unlinkFromLeftParent();
         return temp;
@@ -301,10 +263,7 @@ public class SingleLeftTupleSinkAdapter extends AbstractLeftTupleSinkAdapter {
                                                     PropagationContext context,
                                                     InternalWorkingMemory workingMemory) {
         LeftTuple temp = childLeftTuple.getRightParentNext();
-        doPropagateRetractLeftTuple( context,
-                                     workingMemory,
-                                     childLeftTuple,
-                                     childLeftTuple.getTupleSink() );
+        childLeftTuple.retractTuple( context, workingMemory );
         childLeftTuple.unlinkFromRightParent();
         childLeftTuple.unlinkFromLeftParent();
         return temp;

--- a/drools-core/src/main/java/org/drools/core/reteoo/Sink.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/Sink.java
@@ -22,4 +22,5 @@ import org.drools.core.common.NetworkNode;
  * A simple markup interfaces for Sink types
  */
 public interface Sink extends NetworkNode {
+
 }

--- a/drools-core/src/main/java/org/drools/core/reteoo/SubnetworkTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/SubnetworkTuple.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.reteoo;
+
+import org.drools.core.common.DefaultFactHandle;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.spi.PropagationContext;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SubnetworkTuple extends BaseLeftTuple implements RightTuple {
+
+    private LeftTuple blocked;
+    private LeftTuple tempBlocked;
+
+    private TupleMemory tempRightTupleMemory;
+
+    private RightTuple tempNextRightTuple;
+
+    private static final AtomicInteger idGenerator = new AtomicInteger( 0 );
+    private InternalFactHandle factHandleForEvaluation = new DefaultFactHandle(idGenerator.decrementAndGet(), this);
+
+    public SubnetworkTuple() {
+        // constructor needed for serialisation
+    }
+
+    // ------------------------------------------------------------
+    // Constructors
+    // ------------------------------------------------------------
+    public SubnetworkTuple(final InternalFactHandle factHandle,
+                           final Sink sink,
+                           final boolean leftTupleMemoryEnabled) {
+        super(factHandle, sink, leftTupleMemoryEnabled);
+    }
+
+    public SubnetworkTuple(final InternalFactHandle factHandle,
+                           final LeftTuple leftTuple,
+                           final Sink sink) {
+        super( factHandle, leftTuple, sink );
+    }
+
+    public SubnetworkTuple(final LeftTuple leftTuple,
+                           final Sink sink,
+                           final PropagationContext pctx,
+                           final boolean leftTupleMemoryEnabled) {
+        super(leftTuple, sink, pctx, leftTupleMemoryEnabled);
+    }
+
+    public SubnetworkTuple(final LeftTuple leftTuple,
+                           final RightTuple rightTuple,
+                           final Sink sink) {
+        super(leftTuple, rightTuple, sink);
+    }
+
+    public SubnetworkTuple(final LeftTuple leftTuple,
+                           final RightTuple rightTuple,
+                           final Sink sink,
+                           final boolean leftTupleMemoryEnabled) {
+        this(leftTuple,
+             rightTuple,
+             null,
+             null,
+             sink,
+             leftTupleMemoryEnabled);
+    }
+
+    public SubnetworkTuple(final LeftTuple leftTuple,
+                           final RightTuple rightTuple,
+                           final LeftTuple currentLeftChild,
+                           final LeftTuple currentRightChild,
+                           final Sink sink,
+                           final boolean leftTupleMemoryEnabled) {
+        super(leftTuple,
+              rightTuple,
+              currentLeftChild,
+              currentRightChild,
+              sink,
+              leftTupleMemoryEnabled);
+    }
+
+    public InternalFactHandle getFactHandleForEvaluation() {
+        return factHandleForEvaluation;
+    }
+
+    public LeftTuple getBlocked() {
+        return this.blocked;
+    }
+
+    public void setBlocked(LeftTuple leftTuple) {
+        this.blocked = leftTuple;
+    }
+
+    public void addBlocked(LeftTuple leftTuple) {
+        if ( this.blocked != null && leftTuple != null ) {
+            leftTuple.setBlockedNext( this.blocked );
+            this.blocked.setBlockedPrevious( leftTuple );
+        }
+        this.blocked = leftTuple;
+    }
+
+    public void removeBlocked(LeftTuple leftTuple) {
+        LeftTuple previous =  leftTuple.getBlockedPrevious();
+        LeftTuple next =  leftTuple.getBlockedNext();
+        if ( previous != null && next != null ) {
+            //remove  from middle
+            previous.setBlockedNext( next );
+            next.setBlockedPrevious( previous );
+        } else if ( next != null ) {
+            //remove from first
+            this.blocked = next;
+            next.setBlockedPrevious( null );
+        } else if ( previous != null ) {
+            //remove from end
+            previous.setBlockedNext( null );
+        } else {
+            this.blocked = null;
+        }
+        leftTuple.clearBlocker();
+    }
+
+    public LeftTuple getTempBlocked() {
+        return tempBlocked;
+    }
+
+    public void setTempBlocked(LeftTuple tempBlocked) {
+        this.tempBlocked = tempBlocked;
+    }
+
+    public RightTuple getTempNextRightTuple() {
+        return tempNextRightTuple;
+    }
+
+    public void setTempNextRightTuple(RightTuple tempNextRightTuple) {
+        this.tempNextRightTuple = tempNextRightTuple;
+    }
+
+    public TupleMemory getTempRightTupleMemory() {
+        return tempRightTupleMemory;
+    }
+
+    public void setTempRightTupleMemory(TupleMemory tempRightTupleMemory) {
+        this.tempRightTupleMemory = tempRightTupleMemory;
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/reteoo/WindowNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/WindowNode.java
@@ -161,7 +161,6 @@ public class WindowNode extends ObjectSource
                              final PropagationContext pctx,
                              final InternalWorkingMemory workingMemory) {
         EventFactHandle evFh = ( EventFactHandle ) factHandle;
-        int index = 0;
         for (AlphaNodeFieldConstraint constraint : constraints) {
             if (!constraint.isAllowed(evFh, workingMemory)) {
                 return;
@@ -203,7 +202,6 @@ public class WindowNode extends ObjectSource
         originalFactHandle.quickCloneUpdate( cloneFactHandle ); // make sure all fields are updated
 
         // behavior modify
-        int index = 0;
         boolean isAllowed = true;
         for (AlphaNodeFieldConstraint constraint : constraints) {
             if (!constraint.isAllowed(cloneFactHandle,
@@ -235,17 +233,16 @@ public class WindowNode extends ObjectSource
         RightTuple rightTuple = modifyPreviousTuples.peekRightTuple();
 
         // if the peek is for a different OTN we assume that it is after the current one and then this is an assert
-        while ( rightTuple != null &&
-                rightTuple.getTupleSink().getRightInputOtnId().before( getRightInputOtnId() ) ) {
+        while ( rightTuple != null && rightTuple.getInputOtnId().before( getRightInputOtnId() ) ) {
             modifyPreviousTuples.removeRightTuple();
 
             // we skipped this node, due to alpha hashing, so retract now
             rightTuple.setPropagationContext( context );
-            rightTuple.getTupleSink().retractRightTuple( rightTuple, context, wm );
+            rightTuple.retractTuple( context, wm );
             rightTuple = modifyPreviousTuples.peekRightTuple();
         }
 
-        if ( rightTuple != null && rightTuple.getTupleSink().getRightInputOtnId().equals( getRightInputOtnId()) ) {
+        if ( rightTuple != null && rightTuple.getInputOtnId().equals( getRightInputOtnId()) ) {
             modifyPreviousTuples.removeRightTuple();
             rightTuple.reAdd();
             modifyRightTuple( rightTuple, context, wm );

--- a/drools-core/src/main/java/org/drools/core/spi/Tuple.java
+++ b/drools-core/src/main/java/org/drools/core/spi/Tuple.java
@@ -17,6 +17,8 @@
 package org.drools.core.spi;
 
 import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.NetworkNode;
 import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.Sink;
@@ -112,7 +114,7 @@ public interface Tuple extends Serializable, Entry<Tuple> {
     Tuple getStagedPrevious();
     void setStagedPrevious( Tuple stagePrevious );
 
-    Tuple getStagedNext();
+    <T extends Tuple> T getStagedNext();
     void setStagedNext( Tuple stageNext );
 
     void clear();
@@ -128,7 +130,7 @@ public interface Tuple extends Serializable, Entry<Tuple> {
     Tuple getPrevious();
     void setPrevious( Tuple previous );
 
-    Sink getTupleSink();
+    <S extends Sink> S getTupleSink();
 
     TupleList getMemory();
     void setMemory( TupleList memory );
@@ -145,11 +147,16 @@ public interface Tuple extends Serializable, Entry<Tuple> {
     LeftTuple getLastChild();
     void setLastChild( LeftTuple firstChild );
 
-    Tuple getHandlePrevious();
+    <T extends Tuple> T getHandlePrevious();
     void setHandlePrevious( Tuple leftParentLeft );
 
-    Tuple getHandleNext();
+    <T extends Tuple> T getHandleNext();
     void setHandleNext( Tuple leftParentright );
 
     ObjectTypeNode.Id getInputOtnId();
+
+    <N extends NetworkNode> N getTupleSource();
+
+    void modifyTuple( PropagationContext context, InternalWorkingMemory workingMemory );
+    void retractTuple( PropagationContext context, InternalWorkingMemory workingMemory );
 }

--- a/drools-core/src/test/java/org/drools/core/reteoo/test/ReteDslTestEngine.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/test/ReteDslTestEngine.java
@@ -791,15 +791,11 @@ public class ReteDslTestEngine {
                                                                        wm );
                             } else {
                                 for ( RightTuple rightTuple = handle.getFirstRightTuple(); rightTuple != null; rightTuple = (RightTuple) rightTuple.getHandleNext() ) {
-                                    rightTuple.getTupleSink().retractRightTuple( rightTuple,
-                                                                                      pContext,
-                                                                                      wm );
+                                    rightTuple.retractTuple( pContext, wm );
                                 }
                                 handle.clearRightTuples();
                                 for ( LeftTuple leftTuple = handle.getFirstLeftTuple(); leftTuple != null; leftTuple = (LeftTuple) leftTuple.getHandleNext() ) {
-                                    leftTuple.getTupleSink().retractLeftTuple( leftTuple,
-                                                                                   pContext,
-                                                                                   wm );
+                                    leftTuple.retractTuple( pContext, wm );
                                 }
                                 handle.clearLeftTuples();
                             }

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteAccumulateNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteAccumulateNode.java
@@ -894,7 +894,7 @@ public class ReteAccumulateNode extends AccumulateNode {
             if ( parent.getFirstChild() == matchings[0] ) {
                 parent.setFirstChild( null );
             }
-            parent.setLastChild( matchings[0].getHandlePrevious() );
+            parent.setLastChild( (LeftTuple) matchings[0].getHandlePrevious() );
             if ( parent.getLastChild() != null ) {
                 parent.getLastChild().setHandleNext( null );
                 matchings[0].setHandlePrevious( null );

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteBetaNodeUtils.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteBetaNodeUtils.java
@@ -187,9 +187,7 @@ public class ReteBetaNodeUtils {
 
             // we skipped this node, due to alpha hashing, so retract now
             rightTuple.setPropagationContext(context);
-            rightTuple.getTupleSink().retractRightTuple(rightTuple,
-                                                             context,
-                                                             wm);
+            rightTuple.retractTuple(context, wm);
             rightTuple = modifyPreviousTuples.peekRightTuple();
         }
 

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteEntryPointNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteEntryPointNode.java
@@ -48,9 +48,7 @@ public class ReteEntryPointNode extends EntryPointNode {
     }
 
     public void doDeleteObject(PropagationContext pctx, InternalWorkingMemory wm, LeftTuple leftTuple) {
-        leftTuple.getTupleSink().retractLeftTuple(leftTuple,
-                                                      pctx,
-                                                      wm);
+        leftTuple.retractTuple( pctx, wm );
     }
 
     public void assertQuery(final InternalFactHandle factHandle,

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteLeftInputAdapterNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteLeftInputAdapterNode.java
@@ -70,9 +70,7 @@ public class ReteLeftInputAdapterNode extends LeftInputAdapterNode {
     public void retractLeftTuple(LeftTuple leftTuple,
                                  PropagationContext context,
                                  InternalWorkingMemory workingMemory) {
-        leftTuple.getTupleSink().retractLeftTuple( leftTuple,
-                                                       context,
-                                                       workingMemory );
+        leftTuple.retractTuple( context, workingMemory );
 
     }
 

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteQueryElementNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteQueryElementNode.java
@@ -606,7 +606,7 @@ public class ReteQueryElementNode extends QueryElementNode {
                     node.getSinkPropagator().doPropagateAssertLeftTuple(context,
                                                                         workingMemory,
                                                                         childLeftTuple,
-                                                                        childLeftTuple.getTupleSink());
+                                                                        (LeftTupleSink) childLeftTuple.getTupleSink());
                 }
                 rightTuple = tmp;
             }

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteQueryElementNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteQueryElementNode.java
@@ -82,7 +82,7 @@ public class ReteQueryElementNode extends QueryElementNode {
         InternalFactHandle handle = createFactHandle(context, workingMemory, leftTuple);
 
         DroolsQuery queryObject = createDroolsQuery(leftTuple, handle,
-                                                    null, null, null, null, null,
+                                                    null, null, null, null,
                                                     workingMemory);
 
         QueryInsertAction action = new QueryInsertAction(context,

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteRightInputAdapterNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteRightInputAdapterNode.java
@@ -88,16 +88,12 @@ public class ReteRightInputAdapterNode extends RightInputAdapterNode {
         final InternalFactHandle factHandle = (InternalFactHandle) tuple.getContextObject();
 
         for ( RightTuple rightTuple = factHandle.getFirstRightTuple(); rightTuple != null; rightTuple = rightTuple.getHandleNext() ) {
-            rightTuple.getTupleSink().retractRightTuple( rightTuple,
-                                                              context,
-                                                              workingMemory );
+            rightTuple.retractTuple( context, workingMemory );
         }
         factHandle.clearRightTuples();
 
         for ( LeftTuple leftTuple = factHandle.getLastLeftTuple(); leftTuple != null; leftTuple = leftTuple.getHandleNext() ) {
-            leftTuple.getTupleSink().retractLeftTuple( leftTuple,
-                                                           context,
-                                                           workingMemory );
+            leftTuple.retractTuple( context, workingMemory );
         }
         factHandle.clearLeftTuples();
     }
@@ -111,9 +107,7 @@ public class ReteRightInputAdapterNode extends RightInputAdapterNode {
 
         // propagate it
         for ( RightTuple rightTuple = handle.getFirstRightTuple(); rightTuple != null; rightTuple = rightTuple.getHandleNext() ) {
-            rightTuple.getTupleSink().modifyRightTuple( rightTuple,
-                                                             context,
-                                                             workingMemory );
+            rightTuple.modifyTuple( context, workingMemory );
         }
     }
 

--- a/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteRuleTerminalNode.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/nodes/ReteRuleTerminalNode.java
@@ -52,7 +52,7 @@ public class ReteRuleTerminalNode extends RuleTerminalNode {
             return;
         }
 
-        final InternalAgenda agenda = (InternalAgenda) workingMemory.getAgenda();
+        final InternalAgenda agenda = workingMemory.getAgenda();
 
         boolean fire = agenda.createActivation( leftTuple,  context,
                                                 workingMemory,  this );
@@ -64,7 +64,7 @@ public class ReteRuleTerminalNode extends RuleTerminalNode {
     public void modifyLeftTuple(LeftTuple leftTuple,
                                 PropagationContext context,
                                 InternalWorkingMemory workingMemory) {
-        InternalAgenda agenda = (InternalAgenda) workingMemory.getAgenda();
+        InternalAgenda agenda = workingMemory.getAgenda();
 
         // we need the inserted facthandle so we can update the network with new Activation
         Object o = leftTuple.getContextObject();
@@ -112,7 +112,7 @@ public class ReteRuleTerminalNode extends RuleTerminalNode {
         Activation activation = (Activation) obj;
         activation.setMatched( false );
 
-        InternalAgenda agenda = (InternalAgenda) workingMemory.getAgenda();
+        InternalAgenda agenda = workingMemory.getAgenda();
 
         agenda.cancelActivation( leftTuple,
                                  context,
@@ -126,8 +126,7 @@ public class ReteRuleTerminalNode extends RuleTerminalNode {
     public void cancelMatch(AgendaItem match, InternalWorkingMemoryActions workingMemory) {
         match.cancel();
         if ( match.isQueued() ) {
-            LeftTuple leftTuple = (LeftTuple)match.getTuple();
-            leftTuple.getTupleSink().retractLeftTuple( leftTuple, (PropagationContext) match.getPropagationContext(), workingMemory );
+            match.getTuple().retractTuple( match.getPropagationContext(), workingMemory );
         }
     }
 

--- a/drools-reteoo/src/test/java/org/drools/reteoo/integrationtests/Misc2Test.java
+++ b/drools-reteoo/src/test/java/org/drools/reteoo/integrationtests/Misc2Test.java
@@ -798,11 +798,11 @@ public class Misc2Test extends CommonTestMethodBase {
         ksession.insert(new A(2, 2, 2, 2));
 
         LeftTuple leftTuple = ((DefaultFactHandle) fh).getFirstLeftTuple();
-        ObjectTypeNode.Id letTupleOtnId = leftTuple.getTupleSink().getLeftInputOtnId();
+        ObjectTypeNode.Id letTupleOtnId = leftTuple.getInputOtnId();
         leftTuple = leftTuple.getHandleNext();
         while ( leftTuple != null ) {
-            assertTrue( letTupleOtnId.before( leftTuple.getTupleSink().getLeftInputOtnId() ) );
-            letTupleOtnId = leftTuple.getTupleSink().getLeftInputOtnId();
+            assertTrue( letTupleOtnId.before( leftTuple.getInputOtnId() ) );
+            letTupleOtnId = leftTuple.getInputOtnId();
             leftTuple = leftTuple.getHandleNext();
         }
     }

--- a/drools-reteoo/src/test/java/org/drools/reteoo/nodes/FromNodeTest.java
+++ b/drools-reteoo/src/test/java/org/drools/reteoo/nodes/FromNodeTest.java
@@ -349,7 +349,7 @@ public class FromNodeTest {
                       memory.getBetaMemory().getLeftTupleMemory().size() );
         assertNull( memory.getBetaMemory().getRightTupleMemory() );
         RightTuple rightTuple2 = tuple.getFirstChild().getRightParent();
-        RightTuple rightTuple1 = tuple.getFirstChild().getHandleNext().getRightParent();
+        RightTuple rightTuple1 = ( (LeftTuple) tuple.getFirstChild().getHandleNext() ).getRightParent();
         assertFalse( rightTuple1.equals( rightTuple2 ) );
         assertNull( tuple.getFirstChild().getHandleNext().getHandleNext() );
 


### PR DESCRIPTION
This pull request is made of 2 commits. 

The first commit is a further refactor of the Left/RightTuple intended to allow to have a Tuple implementation that is both a Left and a RightTuple. I'm keeping it separated because it is a nice and useful refactor and I'd like to merge it regardless if we will be able to avoid wrapping the LeftTuple created by a subnetwork into a RightTuple.

The second commit contains a new Tuple implementation called SubnetworkTuple that now is the Tuple generated by RightInputAdapterNode. Since the SubnetworkTuple implements both LeftTuple and RightTuple is no longer necessary to wrap the JoinNodeLeftTuple originally created by the RightInputAdapterNode into a RightTuple in order to propagate it on the right.

This isn't yet ready to be merged since there is one last test failing. In particular BackwardChainingTest.testInsertionOrderTwo throws the following NPE

java.lang.NullPointerException
    at org.drools.core.common.TupleSetsImpl.removeInsert(TupleSetsImpl.java:143)
    at org.drools.core.reteoo.QueryElementNode$UnificationNodeViewChangedEventListener.rowUpdated(QueryElementNode.java:531)
    at org.drools.core.phreak.PhreakQueryTerminalNode.doLeftUpdates(PhreakQueryTerminalNode.java:117)
    at org.drools.core.phreak.PhreakQueryTerminalNode.doNode(PhreakQueryTerminalNode.java:50)
    at org.drools.core.phreak.RuleNetworkEvaluator.innerEval(RuleNetworkEvaluator.java:310)
    at org.drools.core.phreak.RuleNetworkEvaluator.evalStackEntry(RuleNetworkEvaluator.java:225)
    at org.drools.core.phreak.RuleNetworkEvaluator.outerEval(RuleNetworkEvaluator.java:168)
    at org.drools.core.phreak.RuleNetworkEvaluator.evaluateNetwork(RuleNetworkEvaluator.java:120)
    at org.drools.core.phreak.RuleExecutor.reEvaluateNetwork(RuleExecutor.java:194)
    at org.drools.core.phreak.RuleExecutor.evaluateNetworkAndFire(RuleExecutor.java:73)
    at org.drools.core.common.DefaultAgenda.fireNextItem(DefaultAgenda.java:1003)
    at org.drools.core.common.DefaultAgenda.fireLoop(DefaultAgenda.java:1346)
    at org.drools.core.common.DefaultAgenda.fireAllRules(DefaultAgenda.java:1284)
    at org.drools.core.impl.StatefulKnowledgeSessionImpl.internalFireAllRules(StatefulKnowledgeSessionImpl.java:1303)
    at org.drools.core.impl.StatefulKnowledgeSessionImpl.fireAllRules(StatefulKnowledgeSessionImpl.java:1293)
    at org.drools.core.impl.StatefulKnowledgeSessionImpl.fireAllRules(StatefulKnowledgeSessionImpl.java:1274)
    at org.drools.compiler.integrationtests.BackwardChainingTest.testInsertionOrderTwo(BackwardChainingTest.java:2279)

@mdproctor It would be great if you could review what I have done so far and, if you have time, also to give a look at that last failing test, since I haven't been able to understand what's going wrong there.
