### PR TITLE
[BZ-1199965] enable use of Java 8 syntax in RHS

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/JavaDialectConfiguration.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/java/JavaDialectConfiguration.java
@@ -180,9 +180,7 @@ public class JavaDialectConfiguration
             case V1_7:
                 return "1.7";
             case V1_8:
-                // ecj still doesn't work with version 1.8 it generates the following error
-                // "Pb(591) Syntax error, static imports are only available if source level is 1.5 or greater"
-                return "1.7";
+                return "1.8";
             default:
                 return "1.7";
         }


### PR DESCRIPTION
Since we have upgraded to ECJ 4.4.2 ( see https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/commit/9de5cd80f30f060629e33587654be550fca3f0c7 ) it is now possible to use Java 8 syntax.
