### PR TITLE
GUVNOR-2173 - Asset Oracle: Change Impact prediction: Setting Resources for Descr instances

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassDefinitionFactory.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/ClassDefinitionFactory.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,6 +14,21 @@
 */
 
 package org.drools.compiler.builder.impl;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.compiler.compiler.TypeDeclarationError;
@@ -40,21 +55,7 @@ import org.drools.core.util.ClassUtils;
 import org.drools.core.util.asm.ClassFieldInspector;
 import org.kie.api.definition.type.Key;
 import org.kie.api.definition.type.Position;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import org.kie.api.io.Resource;
 
 public class ClassDefinitionFactory {
 
@@ -318,7 +319,7 @@ public class ClassDefinitionFactory {
         return fieldDefs;
     }
 
-    public static void populateDefinitionFromClass( ClassDefinition def, Class<?> concrete, boolean asTrait ) {
+    public static void populateDefinitionFromClass( ClassDefinition def, Resource resource, Class<?> concrete, boolean asTrait ) {
         try {
             def.setClassName( concrete.getName() );
             if ( concrete.getSuperclass() != null ) {
@@ -348,6 +349,7 @@ public class ClassDefinitionFactory {
 
                     Class ret = methods.get( fieldName ).getReturnType();
                     TypeFieldDescr field = new TypeFieldDescr(  );
+                    field.setResource(resource);
                     field.setFieldName( fieldName );
                     field.setPattern( new PatternDescr( ret.getName() ) );
                     field.setIndex( position != null ? position.value() : -1 );

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -1731,6 +1731,7 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
             InternalKnowledgePackage pkg = pkgRegistry.getPackage();
             DialectCompiletimeRegistry ctr = pkgRegistry.getDialectCompiletimeRegistry();
             RuleDescr dummy = new RuleDescr(wd.getName() + " Window Declaration");
+            dummy.setResource(packageDescr.getResource());
             dummy.addAttribute(new AttributeDescr("dialect", "java"));
             RuleBuildContext context = new RuleBuildContext(this,
                                                             dummy,
@@ -1760,7 +1761,6 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
     }
 
     private void addFunction(final FunctionDescr functionDescr) {
-        functionDescr.setResource(this.resource);
         PackageRegistry pkgRegistry = this.pkgRegistryMap.get(functionDescr.getNamespace());
         Dialect dialect = pkgRegistry.getDialectCompiletimeRegistry().getDialect(functionDescr.getDialect());
         dialect.addFunction(functionDescr,

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationBuilder.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -297,6 +297,7 @@ public class TypeDeclarationBuilder {
                         altDescr = foreignPackages.get( typeDescr.getNamespace() );
                     } else {
                         altDescr = new PackageDescr(typeDescr.getNamespace());
+                        altDescr.setResource(packageDescr.getResource());
                         foreignPackages.put( typeDescr.getNamespace(), altDescr );
                     }
 
@@ -363,6 +364,7 @@ public class TypeDeclarationBuilder {
                                           typeDescr.getNamespace());
                         tempDescr.setTrait( true );
                         tempDescr.addSuperType(typeDescr.getType());
+                        tempDescr.setResource(type.getResource());
                         TypeDeclaration tempDeclr = new TypeDeclaration(target);
                         tempDeclr.setKind(TypeDeclaration.Kind.TRAIT);
                         tempDeclr.setTypesafe(type.isTypesafe());
@@ -426,7 +428,7 @@ public class TypeDeclarationBuilder {
     protected void updateTraitDefinition( TypeDeclaration type,
                                           Class concrete,
                                           boolean asTrait ) {
-        ClassDefinitionFactory.populateDefinitionFromClass( type.getTypeClassDef(), concrete, asTrait );
+        ClassDefinitionFactory.populateDefinitionFromClass( type.getTypeClassDef(), type.getResource(), concrete, asTrait );
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationCache.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationCache.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -197,7 +197,7 @@ public class TypeDeclarationCache {
 
     private ClassDefinition setClassDefinitionOnTypeDeclaration( Class<?> cls, TypeDeclaration typeDeclaration ) {
         ClassDefinition clsDef = new ClassDefinition();
-        ClassDefinitionFactory.populateDefinitionFromClass( clsDef, cls, cls.getAnnotation( Trait.class ) != null );
+        ClassDefinitionFactory.populateDefinitionFromClass( clsDef, typeDeclaration.getResource(), cls, cls.getAnnotation( Trait.class ) != null );
         typeDeclaration.setTypeClassDef(clsDef);
         return clsDef;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationConfigurator.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/TypeDeclarationConfigurator.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/MVELDumper.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/MVELDumper.java
@@ -162,6 +162,7 @@ public class MVELDumper extends ReflectiveVisitor implements ExpressionRewriter 
     private void processBinding(StringBuilder sbuilder, BindingDescr bind, ConstraintConnectiveDescr parent, boolean isInsideRelCons, MVELDumperContext context) {
         String expr = bind.getExpression().trim();
         AtomicExprDescr atomicExpr = new AtomicExprDescr(expr);
+        atomicExpr.setResource(parent.getResource());
         String[] constrAndExpr = processImplicitConstraints(expr, atomicExpr, parent, parent.getDescrs().indexOf( bind ), context );
 
         if ( isInsideRelCons ) {

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/BaseDescrBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/BaseDescrBuilderImpl.java
@@ -22,17 +22,20 @@ import org.drools.compiler.lang.descr.BaseDescr;
 /**
  * A base class for all DescrBuilders
  */
-public class BaseDescrBuilderImpl<P extends DescrBuilder<?,?>, T extends BaseDescr>
+public class BaseDescrBuilderImpl<P extends DescrBuilder<?,? extends BaseDescr>, T extends BaseDescr>
     implements
     DescrBuilder<P, T> {
 
     protected T descr;
     protected P parent;
 
-    protected BaseDescrBuilderImpl(final P parent, 
+    protected BaseDescrBuilderImpl(final P parent,
                                    final T descr) {
         this.parent = parent;
         this.descr = descr;
+        if( parent != null ) {
+            this.descr.setResource(parent.getDescr().getResource());
+        }
     }
 
     public DescrBuilder<P, T> startLocation( int line,
@@ -62,7 +65,7 @@ public class BaseDescrBuilderImpl<P extends DescrBuilder<?,?>, T extends BaseDes
     public T getDescr() {
         return descr;
     }
-    
+
     public P end() {
         return parent;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/CEDescrBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/CEDescrBuilderImpl.java
@@ -94,17 +94,17 @@ public class CEDescrBuilderImpl<P extends DescrBuilder< ? , ? >, T extends Annot
      */
     public AccumulateDescrBuilder<CEDescrBuilder<P, T>> accumulate() {
         // here we have to do a trick as a top level accumulate is just an accumulate
-        // whose result pattern is Object[] 
-        
+        // whose result pattern is Object[]
+
         // create a linked Object[] pattern and set it to query false
         PatternDescrBuilder<CEDescrBuilder<P,T>> pdb = pattern("Object[]").isQuery( false );
-        
-        // create the accumulate builder with this CE as its parent 
+
+        // create the accumulate builder with this CE as its parent
         AccumulateDescrBuilder<CEDescrBuilder<P, T>> accumulate = new AccumulateDescrBuilderImpl<CEDescrBuilder<P, T>>(this);
-        
+
         // set the accumulate descriptor as the source of that pattern descr
         pdb.getDescr().setSource( accumulate.getDescr() );
-        
+
         // return the accumulate builder, that has the properly set parent
         return accumulate;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/FieldDescrBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/FieldDescrBuilderImpl.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -46,7 +46,7 @@ public class FieldDescrBuilderImpl<T extends DescrBuilder<?,?>> extends BaseDesc
     }
 
     public FieldDescrBuilder type( String type ) {
-        descr.setPattern( new PatternDescr( type ) );
+        descr.setPattern( new PatternDescr( type ) ); // resource set for new PatternDescr in setPattern
         return this;
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/PackageDescrBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/PackageDescrBuilderImpl.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -49,6 +49,7 @@ public class PackageDescrBuilderImpl extends BaseDescrBuilderImpl<PackageDescrBu
     private PackageDescrBuilderImpl(Resource resource) {
         this();
         this.resource = resource;
+        this.descr.setResource(resource);
     }
 
     public static PackageDescrBuilder newPackage() {
@@ -128,8 +129,8 @@ public class PackageDescrBuilderImpl extends BaseDescrBuilderImpl<PackageDescrBu
     }
 
     private <T extends BaseDescr> T initDescr(DescrBuilder<PackageDescrBuilder, T> builder) {
+        // resource for new descr already set in builder
         T descr = builder.getDescr();
-        descr.setResource(resource);
         descr.setNamespace(descr.getNamespace());
         return descr;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/PatternDescrBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/PatternDescrBuilderImpl.java
@@ -64,6 +64,7 @@ public class PatternDescrBuilderImpl<P extends DescrBuilder< ?, ? >> extends Bas
         ExprConstraintDescr constr = new ExprConstraintDescr( constraint );
         constr.setType( ExprConstraintDescr.Type.NAMED );
         constr.setPosition( descr.getConstraint().getDescrs().size() );
+        constr.setResource(descr.getResource());
         descr.addConstraint( constr );
         return this;
     }
@@ -73,6 +74,7 @@ public class PatternDescrBuilderImpl<P extends DescrBuilder< ?, ? >> extends Bas
         ExprConstraintDescr constr = new ExprConstraintDescr( constraint );
         constr.setType( positional ? ExprConstraintDescr.Type.POSITIONAL : ExprConstraintDescr.Type.NAMED );
         constr.setPosition( descr.getConstraint().getDescrs().size() );
+        constr.setResource(descr.getResource());
         descr.addConstraint( constr );
         return this;
     }
@@ -80,9 +82,11 @@ public class PatternDescrBuilderImpl<P extends DescrBuilder< ?, ? >> extends Bas
     public PatternDescrBuilder<P> bind( String var,
                                         String target,
                                         boolean isUnification ) {
-        descr.addConstraint( new BindingDescr( var,
-                                               target,
-                                               isUnification ) );
+        BindingDescr bindDescr = new BindingDescr( var,
+                                                   target,
+                                                   isUnification );
+        bindDescr.setResource(descr.getResource());
+        descr.addConstraint( bindDescr );
         return this;
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/SourceDescrBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/api/impl/SourceDescrBuilderImpl.java
@@ -40,12 +40,14 @@ public class SourceDescrBuilderImpl<P extends PatternDescrBuilder<?>> extends Ba
     public P expression( String expression ) {
         FromDescr from = new FromDescr();
         from.setDataSource( new MVELExprDescr( expression ) );
+        from.setResource(descr.getResource());
         descr.setSource( from );
         return parent;
     }
 
     public P entryPoint( String entryPoint ) {
         EntryPointDescr ep = new EntryPointDescr( entryPoint );
+        ep.setResource(descr.getResource());
         descr.setSource( ep );
         return parent;
     }
@@ -64,6 +66,7 @@ public class SourceDescrBuilderImpl<P extends PatternDescrBuilder<?>> extends Ba
 
     public P window( String window ) {
         WindowReferenceDescr wd = new WindowReferenceDescr( window );
+        wd.setResource(descr.getResource());
         descr.setSource( wd );
         return parent;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AbstractClassTypeDeclarationDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AbstractClassTypeDeclarationDescr.java
@@ -141,6 +141,8 @@ public abstract class AbstractClassTypeDeclarationDescr extends AnnotatedBaseDes
         if ( this.fields == null ) {
             this.fields = new LinkedHashMap<String, TypeFieldDescr>();
         }
+        // Setting the resource on the field does not seem to be necessary (because it's always already been set)
+        // but I'm leaving in this just to be safe..
         field.setResource(getResource());
         this.fields.put( field.getFieldName(), field );
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AnnotatedBaseDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AnnotatedBaseDescr.java
@@ -101,6 +101,7 @@ public class AnnotatedBaseDescr extends BaseDescr
         }
         AnnotationDescr annotation = new AnnotationDescr( name,
                                                           value );
+        annotation.setResource(getResource());
         return this.annotations.put( annotation.getName(),
                                      annotation );
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ConstraintConnectiveDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ConstraintConnectiveDescr.java
@@ -19,6 +19,8 @@ package org.drools.compiler.lang.descr;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kie.api.io.Resource;
+
 /**
  * A descriptor to represent logical connectives in constraints, like
  * &&, || and ^. 
@@ -88,7 +90,15 @@ public class ConstraintConnectiveDescr extends AnnotatedBaseDescr {
             addDescr( baseDescr );
         }
     }
-    
+
+    @Override
+    public void setResource(Resource resource) {
+        super.setResource(resource);
+        for( BaseDescr descr : descrs )  {
+            descr.setResource(resource);
+        }
+    }
+    ;
     @Override
     public String toString() {
         return "["+this.connective+" "+descrs+" ]";

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/FieldConstraintDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/FieldConstraintDescr.java
@@ -68,7 +68,13 @@ public class FieldConstraintDescr extends BaseDescr {
     public RestrictionConnectiveDescr getRestriction() {
         return this.restriction;
     }
-    
+
+    @Override
+    public void setResource(org.kie.api.io.Resource resource) {
+        super.setResource(resource);
+        this.restriction.setResource(resource);
+    };
+
     @Override
     public String toString() {
         return fieldName + " " + restriction;

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ForallDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ForallDescr.java
@@ -70,6 +70,7 @@ public class ForallDescr extends BaseDescr
             PatternDescr base = (PatternDescr) original.clone();
             base.getDescrs().clear();
             base.setIdentifier( BASE_IDENTIFIER );
+            base.setResource(original.getResource());
             return base;
         }
         return null;
@@ -91,6 +92,7 @@ public class ForallDescr extends BaseDescr
             PatternDescr original = (PatternDescr) this.patterns.get( 0 );
             PatternDescr remaining = (PatternDescr) original.clone();
             remaining.addConstraint( new ExprConstraintDescr( "this == " + BASE_IDENTIFIER ) );
+            remaining.setResource(original.getResource());
             return Collections.singletonList( (BaseDescr)remaining );
         }
         return Collections.emptyList();

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/PatternDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/PatternDescr.java
@@ -177,6 +177,12 @@ public class PatternDescr extends AnnotatedBaseDescr
         this.source = source;
     }
 
+    @Override
+    public void setResource(org.kie.api.io.Resource resource) {
+        super.setResource(resource);
+        ((BaseDescr) this.constraint).setResource(resource);
+    };
+
     /**
      * @return the behaviors
      */

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/RelationalExprDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/RelationalExprDescr.java
@@ -73,10 +73,7 @@ public class RelationalExprDescr extends BaseDescr {
     }
 
     public void setOperator( String operator ) {
-        if( this.operator == null ) {
-            this.operator = new OperatorDescr();
-        }
-        this.operator.setOperator( operator );
+        createOrGetOperator().setOperator( operator );
     }
 
     public boolean isNegated() {
@@ -84,10 +81,7 @@ public class RelationalExprDescr extends BaseDescr {
     }
 
     public void setNegated( boolean negated ) {
-        if( this.operator == null ) {
-            this.operator = new OperatorDescr();
-        }
-        this.operator.setNegated( negated );
+        createOrGetOperator().setNegated( negated );
     }
 
     public List<String> getParameters() {
@@ -112,10 +106,15 @@ public class RelationalExprDescr extends BaseDescr {
     }
 
     public void setParameters( List<String> parameters ) {
+        createOrGetOperator().setParameters( parameters );
+    }
+
+    private OperatorDescr createOrGetOperator() {
         if( this.operator == null ) {
             this.operator = new OperatorDescr();
+            this.operator.setResource(getResource());
         }
-        this.operator.setParameters( parameters );
+        return this.operator;
     }
     
     public OperatorDescr getOperatorDescr() {

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/RuleDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/RuleDescr.java
@@ -250,6 +250,12 @@ public class RuleDescr extends AnnotatedBaseDescr
     }
 
     @Override
+    public void setResource(org.kie.api.io.Resource resource) {
+        super.setResource(resource);
+        this.lhs.setResource(resource);
+    };
+
+    @Override
     public String toString() {
         return "[Rule name='" + this.name + "']";
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/TypeFieldDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/TypeFieldDescr.java
@@ -113,6 +113,7 @@ public class TypeFieldDescr extends AnnotatedBaseDescr
      */
     public void setPattern( PatternDescr pattern ) {
         this.pattern = pattern;
+        this.pattern.setResource(getResource());
     }
 
     public String toString() {

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/GroupElementBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/GroupElementBuilder.java
@@ -53,6 +53,9 @@ public class GroupElementBuilder
         // iterate over child descriptors
         for ( final BaseDescr child : cedescr.getDescrs() ) {
             // gets child to build
+
+            // child.setResource(..) does not seem to be necessary (since builderImpls have already set the resource for all children)
+            // but leaving it in here to be save
             child.setResource( context.getRuleDescr().getResource() );
             child.setNamespace( context.getRuleDescr().getNamespace() );
 

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
@@ -1898,6 +1898,7 @@ public class PatternBuilder
                                                          final String expression ) {
         DrlExprParser parser = new DrlExprParser( context.getConfiguration().getLanguageLevel() );
         ConstraintConnectiveDescr result = parser.parse( expression );
+        result.setResource(patternDescr.getResource());
 
         if (result == null) {
             context.addError(new DescrBuildError(context.getParentDescr(),

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/DescrResourceSetTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/DescrResourceSetTest.java
@@ -1,0 +1,94 @@
+package org.drools.compiler.compiler;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.lang.descr.PackageDescr;
+import org.drools.core.io.impl.InputStreamResource;
+import org.junit.Test;
+import org.kie.internal.builder.KnowledgeBuilderConfiguration;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DescrResourceSetTest {
+
+    protected static final transient Logger logger = LoggerFactory.getLogger(KnowledgeBuilderImpl.class);
+
+    private static final PackageDescrResourceVisitor visitor = new PackageDescrResourceVisitor();
+    private static final KnowledgeBuilderConfiguration conf = KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration();
+
+    @Test
+    public void drlFilesTest() throws Exception {
+        Set<File> drlFiles = getDrlFiles();
+        for( File drl : drlFiles ) {
+            final DrlParser parser = new DrlParser(((KnowledgeBuilderConfigurationImpl)conf).getLanguageLevel());
+            InputStreamResource resource = new InputStreamResource(new FileInputStream(drl));
+            PackageDescr pkgDescr = parser.parse(resource);
+            if( parser.hasErrors() ) {
+                continue;
+            }
+            visitor.visit(pkgDescr);
+        }
+        logger.debug( drlFiles.size() + " drl tested.");
+    }
+
+    private Set<File> getDrlFiles() throws Exception {
+        URL url = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+        File dir = new File(url.toURI());
+        assertTrue("Does not exist: " + url.toString(), dir.exists());
+
+        final FileFilter drlFilter = new FileFilter() {
+            @Override
+            public boolean accept( File file ) {
+                return file.getName().endsWith(".drl");
+            }
+        };
+        final FileFilter dirFilter = new FileFilter() {
+            @Override
+            public boolean accept( File file ) {
+                return file.isDirectory();
+            }
+        };
+
+        Set<File> drls = new TreeSet<File>(new Comparator<File>() {
+
+            @Override
+            public int compare( File o1, File o2 ) {
+                if( o1 == o2 ) {
+                    return 0;
+                } else if( o1 == null ) {
+                    return 1;
+                } else if( o2 == null ) {
+                   return -1;
+                } else {
+                   return o1.getAbsolutePath().compareTo(o2.getAbsolutePath());
+                }
+            }
+        });
+
+        // BFS recursive search
+        Queue<File> dirs = new LinkedList<File>();
+        dirs.add(dir);
+
+        while( ! dirs.isEmpty() ) {
+            dir = dirs.poll();
+            drls.addAll(Arrays.asList(dir.listFiles(drlFilter)));
+            dirs.addAll(Arrays.asList(dir.listFiles(dirFilter)));
+        }
+
+        return drls;
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/PackageDescrResourceVisitor.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/PackageDescrResourceVisitor.java
@@ -1,0 +1,408 @@
+package org.drools.compiler.compiler;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.drools.compiler.lang.descr.AccessorDescr;
+import org.drools.compiler.lang.descr.AccumulateDescr;
+import org.drools.compiler.lang.descr.AccumulateImportDescr;
+import org.drools.compiler.lang.descr.ActionDescr;
+import org.drools.compiler.lang.descr.AndDescr;
+import org.drools.compiler.lang.descr.AnnotatedBaseDescr;
+import org.drools.compiler.lang.descr.AnnotationDescr;
+import org.drools.compiler.lang.descr.AtomicExprDescr;
+import org.drools.compiler.lang.descr.AttributeDescr;
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.compiler.lang.descr.BehaviorDescr;
+import org.drools.compiler.lang.descr.BindingDescr;
+import org.drools.compiler.lang.descr.CollectDescr;
+import org.drools.compiler.lang.descr.ConstraintConnectiveDescr;
+import org.drools.compiler.lang.descr.DeclarativeInvokerDescr;
+import org.drools.compiler.lang.descr.EntryPointDeclarationDescr;
+import org.drools.compiler.lang.descr.EnumDeclarationDescr;
+import org.drools.compiler.lang.descr.EvalDescr;
+import org.drools.compiler.lang.descr.ExistsDescr;
+import org.drools.compiler.lang.descr.ExprConstraintDescr;
+import org.drools.compiler.lang.descr.FactTemplateDescr;
+import org.drools.compiler.lang.descr.FieldConstraintDescr;
+import org.drools.compiler.lang.descr.FieldTemplateDescr;
+import org.drools.compiler.lang.descr.ForallDescr;
+import org.drools.compiler.lang.descr.FromDescr;
+import org.drools.compiler.lang.descr.FunctionDescr;
+import org.drools.compiler.lang.descr.FunctionImportDescr;
+import org.drools.compiler.lang.descr.GlobalDescr;
+import org.drools.compiler.lang.descr.ImportDescr;
+import org.drools.compiler.lang.descr.LiteralRestrictionDescr;
+import org.drools.compiler.lang.descr.MVELExprDescr;
+import org.drools.compiler.lang.descr.NamedConsequenceDescr;
+import org.drools.compiler.lang.descr.NotDescr;
+import org.drools.compiler.lang.descr.OrDescr;
+import org.drools.compiler.lang.descr.PackageDescr;
+import org.drools.compiler.lang.descr.PatternDescr;
+import org.drools.compiler.lang.descr.PredicateDescr;
+import org.drools.compiler.lang.descr.QueryDescr;
+import org.drools.compiler.lang.descr.RelationalExprDescr;
+import org.drools.compiler.lang.descr.RuleDescr;
+import org.drools.compiler.lang.descr.TypeDeclarationDescr;
+import org.drools.compiler.lang.descr.TypeFieldDescr;
+import org.drools.compiler.lang.descr.WindowDeclarationDescr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PackageDescrResourceVisitor {
+
+    private static final Logger logger = LoggerFactory.getLogger(PackageDescrResourceVisitor.class);
+
+    private static void checkResource( BaseDescr descr ) {
+        if( descr != null ) {
+            assertNotNull(descr.getClass().getSimpleName() + ".resource is null!", descr.getResource());
+        }
+    }
+
+    private void visit( final Object descr ) {
+        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        String lastMethodName = null;
+        for( int i = 0; i < 5; ++i ) {
+            String thisMethodName = stack[i].getMethodName() + ":" + stack[i].getLineNumber();
+            if( thisMethodName.equals(lastMethodName) ) {
+                fail("Infinite loop detected!");
+            }
+            lastMethodName = thisMethodName;
+        }
+
+        if( descr instanceof AccessorDescr ) {
+            visit((AccessorDescr) descr);
+        } else if( descr instanceof AccumulateDescr ) {
+            visit((AccumulateDescr) descr);
+        } else if( descr instanceof ActionDescr ) {
+            visit((ActionDescr) descr);
+        } else if( descr instanceof AndDescr ) {
+            visit((AndDescr) descr);
+        } else if( descr instanceof AnnotationDescr ) {
+            visit((AnnotationDescr) descr);
+        } else if( descr instanceof AtomicExprDescr ) {
+            visit((AtomicExprDescr) descr);
+        } else if( descr instanceof AttributeDescr ) {
+            visit((AttributeDescr) descr);
+        } else if( descr instanceof BindingDescr ) {
+            visit((BindingDescr) descr);
+        } else if( descr instanceof CollectDescr ) {
+            visit((CollectDescr) descr);
+        } else if( descr instanceof ConstraintConnectiveDescr ) {
+            visit((ConstraintConnectiveDescr) descr);
+        } else if( descr instanceof ExistsDescr ) {
+            visit((ExistsDescr) descr);
+        } else if( descr instanceof ExprConstraintDescr ) {
+            visit((ExprConstraintDescr) descr);
+        } else if( descr instanceof FactTemplateDescr ) {
+            visit((FactTemplateDescr) descr);
+        } else if( descr instanceof FieldConstraintDescr ) {
+            visit((FieldConstraintDescr) descr);
+        } else if( descr instanceof FieldTemplateDescr ) {
+            visit((FieldTemplateDescr) descr);
+        } else if( descr instanceof ForallDescr ) {
+            visit((ForallDescr) descr);
+        } else if( descr instanceof FromDescr ) {
+            visit((FromDescr) descr);
+        } else if( descr instanceof FunctionDescr ) {
+            visit((FunctionDescr) descr);
+        } else if( descr instanceof FunctionImportDescr ) {
+            visit((FunctionImportDescr) descr);
+        } else if( descr instanceof GlobalDescr ) {
+            visit((GlobalDescr) descr);
+        } else if( descr instanceof ImportDescr ) {
+            visit((ImportDescr) descr);
+        } else if( descr instanceof LiteralRestrictionDescr ) {
+            visit((LiteralRestrictionDescr) descr);
+        } else if( descr instanceof MVELExprDescr ) {
+            visit((MVELExprDescr) descr);
+        } else if( descr instanceof NotDescr ) {
+            visit((NotDescr) descr);
+        } else if( descr instanceof OrDescr ) {
+            visit((OrDescr) descr);
+        } else if( descr instanceof PackageDescr ) {
+            visit((PackageDescr) descr);
+        } else if( descr instanceof PatternDescr ) {
+            visit((PatternDescr) descr);
+        } else if( descr instanceof PredicateDescr ) {
+            visit((PredicateDescr) descr);
+        } else if( descr instanceof QueryDescr ) {
+            visit((QueryDescr) descr);
+        } else if( descr instanceof RelationalExprDescr ) {
+            visit((RelationalExprDescr) descr);
+        } else if( descr instanceof RuleDescr ) {
+            visit((RuleDescr) descr);
+        } else if( descr instanceof TypeDeclarationDescr ) {
+            visit((TypeDeclarationDescr) descr);
+        } else if( descr instanceof TypeFieldDescr ) {
+            visit((TypeFieldDescr) descr);
+        } else if( descr instanceof WindowDeclarationDescr ) {
+            visit((WindowDeclarationDescr) descr);
+        } else if( descr instanceof NamedConsequenceDescr  ) {
+            visit((NamedConsequenceDescr) descr);
+        } else if( descr instanceof EvalDescr  ) {
+            visit((EvalDescr) descr);
+        } else if( descr instanceof BehaviorDescr  ) {
+            visit((BehaviorDescr) descr);
+        } else {
+            throw new RuntimeException("xx DID NOT VISIT: " + descr.getClass().getName());
+        }
+    }
+
+    protected void visit( final AccessorDescr descr ) {
+        checkResource(descr);
+        for( DeclarativeInvokerDescr d : descr.getInvokersAsArray() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final AccumulateDescr descr ) {
+        checkResource(descr);
+        visit(descr.getInputPattern());
+        for( BaseDescr d : descr.getDescrs() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final ActionDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final AndDescr descr ) {
+        checkResource(descr);
+        for( BaseDescr baseDescr : descr.getDescrs() ) {
+            visit(baseDescr);
+        }
+    }
+
+    protected void visit( final AnnotatedBaseDescr descr ) {
+        checkResource(descr);
+        for( BaseDescr annoDescr : descr.getAnnotations() ) {
+            visit(annoDescr);
+        }
+    }
+
+    protected void visit( final AtomicExprDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final AttributeDescr descr ) {
+
+    }
+
+    protected void visit( final BindingDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final CollectDescr descr ) {
+        checkResource(descr);
+        visit(descr.getInputPattern());
+        for( BaseDescr d : descr.getDescrs() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final ConstraintConnectiveDescr descr ) {
+        checkResource(descr);
+        for( BaseDescr d : descr.getDescrs() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final ExistsDescr descr ) {
+        checkResource(descr);
+        for( Object o : descr.getDescrs() ) {
+            visit(o);
+        }
+    }
+
+    protected void visit( final ExprConstraintDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final FactTemplateDescr descr ) {
+        checkResource(descr);
+        for( FieldTemplateDescr d : descr.getFields() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final FieldConstraintDescr descr ) {
+        checkResource(descr);
+        for( Object o : descr.getRestrictions() ) {
+            visit(o);
+        }
+    }
+
+    protected void visit( final FieldTemplateDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final ForallDescr descr ) {
+        checkResource(descr);
+        visit(descr.getBasePattern());
+        for( BaseDescr o : descr.getDescrs() ) {
+            visit(o);
+        }
+    }
+
+    protected void visit( final FromDescr descr ) {
+        checkResource(descr);
+        for( BaseDescr d : descr.getDescrs() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final FunctionDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final FunctionImportDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final GlobalDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final ImportDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final LiteralRestrictionDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final MVELExprDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final NotDescr descr ) {
+        checkResource(descr);
+        // NotDescr isn't type-safe
+        for( Object o : descr.getDescrs() ) {
+            visit(o);
+        }
+    }
+
+    protected void visit( final OrDescr descr ) {
+        checkResource(descr);
+        for( BaseDescr d : descr.getDescrs() ) {
+            visit(d);
+        }
+    }
+
+    protected void visit( final PackageDescr descr ) {
+        if( descr == null ) { return; }
+        checkResource(descr);
+        for( ImportDescr importDescr : descr.getImports() ) {
+            visit(importDescr);
+        }
+        for( FunctionImportDescr funcImportDescr : descr.getFunctionImports() ) {
+            visit(funcImportDescr);
+        }
+        for( AccumulateImportDescr accImportDescr : descr.getAccumulateImports() ) {
+            visit(accImportDescr);
+        }
+        for( AttributeDescr attrDescr : descr.getAttributes() ) {
+            visit(attrDescr);
+        }
+        for( GlobalDescr globDesc : descr.getGlobals() ) {
+            visit(globDesc);
+        }
+        for( FunctionDescr funcDescr : descr.getFunctions() ) {
+            visit(funcDescr);
+        }
+        for( RuleDescr ruleDescr : descr.getRules() ) {
+            visit(ruleDescr);
+        }
+        for( TypeDeclarationDescr typeDescr : descr.getTypeDeclarations() ) {
+            visit(typeDescr);
+        }
+        for( EntryPointDeclarationDescr entryDescr : descr.getEntryPointDeclarations() ) {
+            visit(entryDescr);
+        }
+        for( WindowDeclarationDescr windowDescr : descr.getWindowDeclarations() ) {
+            visit(windowDescr);
+        }
+        for( EnumDeclarationDescr enumDescr : descr.getEnumDeclarations() ) {
+            visit(enumDescr);
+        }
+    }
+
+    protected void visit( final PatternDescr descr ) {
+        checkResource(descr);
+        visit(descr.getConstraint());
+        for( BaseDescr behaDescr : descr.getBehaviors() ) {
+            visit(behaDescr);
+        }
+    }
+
+    protected void visit( final PredicateDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final QueryDescr descr ) {
+        checkResource(descr);
+        visit(descr.getLhs());
+        for( AttributeDescr attrDescr : descr.getAttributes().values() ) {
+            visit(attrDescr);
+        }
+    }
+
+    protected void visit( final RelationalExprDescr descr ) {
+        checkResource(descr);
+        visit(descr.getLeft());
+        visit(descr.getRight());
+    }
+
+    protected void visit( final RuleDescr descr ) {
+        checkResource(descr);
+        for( AttributeDescr d : descr.getAttributes().values() ) {
+            visit(d);
+        }
+        visit(descr.getLhs());
+        visitConsequence(descr.getConsequence());
+        for( Object o : descr.getNamedConsequences().values() ) {
+            visitConsequence(o);
+        }
+    }
+
+    protected void visitConsequence( final Object consequence ) {
+        if( consequence instanceof BaseDescr ) {
+            visit(consequence);
+        }
+    }
+
+    protected void visit( final TypeDeclarationDescr descr ) {
+        checkResource(descr);
+        for( TypeFieldDescr fieldDescr : descr.getFields().values() ) {
+            visit(fieldDescr);
+        }
+    }
+
+    protected void visit( final TypeFieldDescr descr ) {
+        if( descr == null ) {
+            return;
+        }
+        checkResource(descr);
+        visit(descr.getOverriding());
+    }
+
+    protected void visit( final WindowDeclarationDescr descr ) {
+        checkResource(descr);
+        visit(descr.getPattern());
+    }
+
+    protected void visit( final NamedConsequenceDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final EvalDescr descr ) {
+        checkResource(descr);
+    }
+
+    protected void visit( final BehaviorDescr descr ) {
+        checkResource(descr);
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MiscTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MiscTest.java
@@ -85,6 +85,7 @@ import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.impl.EnvironmentFactory;
+import org.drools.core.io.impl.InputStreamResource;
 import org.drools.core.marshalling.impl.ClassObjectMarshallingStrategyAcceptor;
 import org.drools.core.marshalling.impl.IdentityPlaceholderResolverStrategy;
 import org.drools.core.reteoo.LeftTuple;
@@ -104,6 +105,7 @@ import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.AgendaEventListener;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.RuleRuntimeEventListener;
+import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
 import org.kie.api.runtime.Environment;
@@ -2350,7 +2352,8 @@ import static org.mockito.Mockito.*;
      @Test
      public void testDumpers() throws Exception {
          final DrlParser parser = new DrlParser( LanguageLevelOption.DRL5 );
-         final PackageDescr pkg = parser.parse( new InputStreamReader( getClass().getResourceAsStream( "test_Dumpers.drl" ) ) );
+         Resource resource = new InputStreamResource( getClass().getResourceAsStream( "test_Dumpers.drl" ) );
+         final PackageDescr pkg = parser.parse( resource );
 
          if ( parser.hasErrors() ) {
              for ( DroolsError error : parser.getErrors() ) {


### PR DESCRIPTION
@mariofusco These are a bunch of little changes that make sure that the `Resource` field for all *`Descr` classes is set. 

The biggest/most influential change is in the [BaseDescrBuilderImpl](https://github.com/droolsjbpm/drools/compare/master...mrietveld:pr-add-resources-to-descrs?expand=1#diff-84d9edfff0efb7387d0706dc56ac8cb5R36) class. 

There was no easy way to make sure that these changes worked, so I took a "regression"/"everything" approach with [this test](https://github.com/droolsjbpm/drools/compare/master...mrietveld:pr-add-resources-to-descrs?expand=1#diff-b3b365fd5adf5bfa68aaeb8fd9ea4be9R34).
