### PR TITLE
[ENTESB-4802] add workaround for Fuse 6 + Java 8 + ECJ issue

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -195,7 +195,10 @@
               javax.enterprise.*;resolution:=optional,
               org.antlr.*;resolution:=optional,
               org.codehaus.janino.*;resolution:=optional,
-              org.eclipse.jdt.*;resolution:=optional,
+              <!-- Hack/workaround: relying on ECJ package version [0,1) is needed as ECJ does not export specific package
+                   versions (and thus the version defaults to 0.0.0). This is just a workaround as proper fix needs be done
+                   in ECJ directly to export the versions correctly in the MANIFEST.MF. -->
+              org.eclipse.jdt.*;version="[0,1)";resolution:=optional,
               org.osgi.*;resolution:=optional,
               =org.kie.spring;resolution:=optional,
               =org.kie.scanner.*;resolution:=optional,


### PR DESCRIPTION
- Fuse 6.2.1 is distributed with PAX Web JSP bundle. That bundle
  exports ECJ packages with version 3.2.5, which is quite old
  and does not work properly with Java 8. We need to be able to
  override that version, and use the ECJ Drools is being tested
  with. Without the explicit dependency on the version [0,1), the
  latest available one (3.2.5, which is fact much older) gets wired
  and thus results in failures. Proper fix is to pursuade Eclipse
  JDT team to export the packages with specific versions, and then
  fix the drools-compiler metadata to use those versions
