### PR TITLE
[DROOLS-787] remove unnecessary synchronization in Process*Factory classes

### DIFF
--- a/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactory.java
@@ -21,36 +21,40 @@ import org.kie.internal.utils.ServiceRegistryImpl;
 
 public class ProcessRuntimeFactory {
 
-    private static boolean initialized;
-    private static ProcessRuntimeFactoryService provider;
-
     private static final String PROVIDER_CLASS = "org.jbpm.process.instance.ProcessRuntimeFactoryServiceImpl";
 
+    private static ProcessRuntimeFactoryService provider = initializeProvider();
+
+    private static ProcessRuntimeFactoryService initializeProvider() {
+        ProcessRuntimeFactoryService service = null;
+        try {
+            ServiceRegistryImpl.getInstance().addDefault(ProcessRuntimeFactoryService.class, PROVIDER_CLASS);
+            service = ServiceRegistryImpl.getInstance().get(ProcessRuntimeFactoryService.class);
+            setProcessRuntimeFactoryService(ServiceRegistryImpl.getInstance().get(ProcessRuntimeFactoryService.class ) );
+        } catch (IllegalArgumentException e) {
+            // intentionally ignored
+        }
+        return service;
+    }
+
+    /**
+     * This method is used in jBPM OSGi Activators as we need a way to force re-initialization when starting
+     * the bundles.
+     */
+    public static synchronized void reInitializeProvider() {
+        provider = initializeProvider();
+    }
+
     public static InternalProcessRuntime newProcessRuntime(StatefulKnowledgeSessionImpl workingMemory) {
-        ProcessRuntimeFactoryService provider = getProcessRuntimeFactoryService();
         return provider == null ? null : provider.newProcessRuntime(workingMemory);
     }
 
-    public static synchronized void setProcessRuntimeFactoryService(ProcessRuntimeFactoryService provider) {
+    public static void setProcessRuntimeFactoryService(ProcessRuntimeFactoryService provider) {
         ProcessRuntimeFactory.provider = provider;
     }
 
-    public static synchronized ProcessRuntimeFactoryService getProcessRuntimeFactoryService() {
-        if (provider == null && !initialized) {
-            initialized = true;
-            try {
-                loadProvider();
-            } catch (IllegalArgumentException e) { }
-        }
+    public static ProcessRuntimeFactoryService getProcessRuntimeFactoryService() {
         return provider;
     }
 
-    private static void loadProvider() {
-        ServiceRegistryImpl.getInstance().addDefault( ProcessRuntimeFactoryService.class, PROVIDER_CLASS );
-        setProcessRuntimeFactoryService(ServiceRegistryImpl.getInstance().get( ProcessRuntimeFactoryService.class ) );
-    }
-
-    public static synchronized void resetInitialization() {
-        initialized = false;
-    }
 }

--- a/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactoryService.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/process/ProcessRuntimeFactoryService.java
@@ -25,8 +25,6 @@ import org.kie.api.Service;
  */
 public interface ProcessRuntimeFactoryService extends Service {
 
-    public InternalProcessRuntime newProcessRuntime(InternalWorkingMemory workingMemory);
-    
-    
+    InternalProcessRuntime newProcessRuntime(InternalWorkingMemory workingMemory);
 
 }


### PR DESCRIPTION
- the providers are initialized only once by default, so most of
  the synchronization could be removed. This use case
  covers the standard (non-OSGi) use cases as the provider class
  will be on classpath when doing the initializaiton. In OSGi,
  we need a way to force re-initialization as the provider class
  might not have been available when calling the initialize method
  the first time (e.g. the jBPM bundles were not yet started). But
  once activating the jBPM bundles, we want to make sure the Drools
  engine is aware of the jBPM-related factories.
- simple getters/setters do not need synchronization as assignment
  of object reference is atomic
- synchronization is left only in the reInitialize*() methods.
  Since they are called only once in the Activators it should
  not bring any noticible performance penalty

@mariofusco, @mswiderski  would be great if you could take a look to make sure I haven't overlooked something.
