### PR TITLE
[DROOLS-1049] fix config after upgrading jaxb2-maven-plugin from 1.5 to 2.2

### DIFF
--- a/drools-pmml/pom.xml
+++ b/drools-pmml/pom.xml
@@ -88,7 +88,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${basedir}/target/generated-sources</source>
+                <source>${project.basedir}/target/generated-sources</source>
               </sources>
             </configuration>
           </execution>
@@ -107,13 +107,18 @@
           </execution>
         </executions>
         <configuration>
-          <outputDirectory>${basedir}/target/generated-sources/java</outputDirectory>
+          <outputDirectory>${project.basedir}/target/generated-sources/java</outputDirectory>
           <packageName>org.dmg.pmml.pmml_4_2.descr</packageName>
-          <schemaDirectory>${basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2</schemaDirectory>
-          <bindingDirectory>${basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2</bindingDirectory>
+          <sources>
+            <source>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/pmml-4-2.xsd</source>
+          </sources>
+          <xjbSources>
+            <xjbSource>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/bindings.xjb</xjbSource>
+            <xjbSource>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/bindings.xml</xjbSource>
+          </xjbSources>
+          <noGeneratedHeaderComments>true</noGeneratedHeaderComments>
           <extension>true</extension>
           <clearOutputDir>false</clearOutputDir>
-          <arguments>-no-header</arguments>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Related PRs:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/141
https://github.com/droolsjbpm/droolsjbpm-integration/pull/283
