### PR TITLE
[DROOLS-1051] KieScanner does not initialize if missing to locate ...

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -354,10 +354,14 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
     private Map<ReleaseId, DependencyDescriptor> indexAtifacts(ArtifactResolver artifactResolver) {
         Map<ReleaseId, DependencyDescriptor> depsMap = new HashMap<ReleaseId, DependencyDescriptor>();
         for (DependencyDescriptor dep : artifactResolver.getAllDependecies()) {
-            Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
-            log.debug( artifact + " resolved to  " + artifact.getFile() );
-            if (isKJar(artifact.getFile())) {
-                depsMap.put(dep.getReleaseIdWithoutVersion(), new DependencyDescriptor(artifact));
+            if ( !"test".equals(dep.getScope()) && !"provided".equals(dep.getScope()) && !"system".equals(dep.getScope()) ) {
+                Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
+                log.debug( artifact + " resolved to  " + artifact.getFile() );
+                if (isKJar(artifact.getFile())) {
+                    depsMap.put(dep.getReleaseIdWithoutVersion(), new DependencyDescriptor(artifact));
+                }
+            } else {
+                log.debug("{} does not need to be resolved because in scope {}", dep, dep.getScope());
             }
         }
         return depsMap;


### PR DESCRIPTION
...a kjar dependency of test scope.

See Jboss JIRA https://issues.jboss.org/browse/DROOLS-1051

Suppose a kjar has a test scope dependency which may not be resolvable
at runtime; the KieContainer will be created correctly (warning raised
in log) but the initialization of the KieScanner fail with NPE.
Expected behavior: also the KieScanner shall be able to initialize if
the KieContainer is working correctly.

Description of proposed patch.
Problem is that if the dependency "dep" is not resolvable at runtime,
the method artifactResolver.resolveArtifact(...) will return a null, and
in turn a NPE, and in turn will fail the initialization of the
KieScanner.
Proposal is to null guard the rest of the above mentioned code - if the
variable "artifact" is not resolved, not considered as a KJar.

The ideal would be to have also the scope in the dependency/artifact
information, so to check for this specifically, but frankly couldn't
locate this data to propose a better patch for now - in case just reject
it and let me know a few pointers I'm keen in getting it corrected
because we have this issue on our projects.

Many thanks.
