### PR TITLE
GUVNOR-2030: Guided Decision Table: Empty field results in all Conditions being cancelled

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/ActionCallMethodBuilder.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/ActionCallMethodBuilder.java
@@ -143,6 +143,9 @@ public class ActionCallMethodBuilder {
                 break;
             case FieldNatureType.TYPE_VARIABLE:
                 break;
+            case FieldNatureType.TYPE_TEMPLATE:
+                paramValue = unwrapTemplateKey( param );
+                break;
             default:
                 paramValue = adjustParam( dataType,
                                           param,

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -3223,6 +3223,9 @@ public class RuleModelDRLPersistenceImpl
             case FieldNatureType.TYPE_VARIABLE:
                 paramValue = "=" + paramValue;
                 break;
+            case FieldNatureType.TYPE_TEMPLATE:
+                paramValue = unwrapTemplateKey( value );
+                break;
             default:
                 paramValue = adjustParam( dataType,
                                           value,
@@ -3926,11 +3929,16 @@ public class RuleModelDRLPersistenceImpl
                                              final BaseSingleFieldConstraint con,
                                              String value ) {
             String type = null;
-            if ( value.startsWith( "\"" ) ) {
+            if ( value.contains( "@{" ) ) {
+                con.setConstraintValueType( BaseSingleFieldConstraint.TYPE_TEMPLATE );
+                con.setValue( unwrapTemplateKey( value ) );
+
+            } else if ( value.startsWith( "\"" ) ) {
                 type = DataType.TYPE_STRING;
                 con.setConstraintValueType( SingleFieldConstraint.TYPE_LITERAL );
                 con.setValue( value.substring( 1,
                                                value.length() - 1 ) );
+
             } else if ( value.startsWith( "(" ) ) {
                 if ( operator != null && operator.contains( "in" ) ) {
                     value = unwrapParenthesis( value );
@@ -3941,6 +3949,7 @@ public class RuleModelDRLPersistenceImpl
                     con.setConstraintValueType( SingleFieldConstraint.TYPE_RET_VALUE );
                     con.setValue( unwrapParenthesis( value ) );
                 }
+
             } else {
                 if ( !Character.isDigit( value.charAt( 0 ) ) ) {
                     if ( value.equals( "true" ) || value.equals( "false" ) ) {

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
@@ -45,7 +45,24 @@ class RuleModelPersistenceHelper {
     static String unwrapParenthesis( final String s ) {
         int start = s.indexOf( '(' );
         int end = s.lastIndexOf( ')' );
+        if ( start < 0 || end < 0 ) {
+            return s;
+        }
         return s.substring( start + 1,
+                            end ).trim();
+    }
+
+    static String unwrapTemplateKey( final String s ) {
+        int start = s.indexOf( "@{" );
+        if ( start < 0 ) {
+            return s;
+        }
+        int end = s.indexOf( "}",
+                             start );
+        if ( end < 0 ) {
+            return s;
+        }
+        return s.substring( start + 2,
                             end ).trim();
     }
 
@@ -63,9 +80,11 @@ class RuleModelPersistenceHelper {
                                  final String value,
                                  final Map<String, String> boundParams,
                                  final boolean isJavaDialect ) {
-
         if ( boundParams.containsKey( value ) ) {
             return FieldNatureType.TYPE_VARIABLE;
+        }
+        if ( value.contains( "@{" ) ) {
+            return FieldNatureType.TYPE_TEMPLATE;
         }
 
         return inferFieldNature( dataType,

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -8217,4 +8217,131 @@ public class RuleModelDRLPersistenceUnmarshallingTest {
                                       RuleModelDRLPersistenceImpl.getInstance().marshal( m ) );
     }
 
+    @Test
+    //https://issues.jboss.org/browse/GUVNOR-2030
+    public void testLHSTemplateKeys() throws Exception {
+        String drl = "package org.test;\n" +
+                "rule \"MyRule\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  Person( name == \"@{k1}\" )\n" +
+                "then\n" +
+                "end";
+
+        addModelField( "org.test.Person",
+                       "this",
+                       "org.test.Person",
+                       DataType.TYPE_THIS );
+        addModelField( "org.test.Person",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.test" );
+
+        final RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                                 new ArrayList<String>(),
+                                                                                 dmo );
+
+        assertNotNull( m );
+
+        assertEquals( 1,
+                      m.lhs.length );
+        final IPattern p0 = m.lhs[ 0 ];
+        assertTrue( p0 instanceof FactPattern );
+        final FactPattern fp0 = (FactPattern) p0;
+        assertEquals( "Person",
+                      fp0.getFactType() );
+
+        assertEquals( 1,
+                      fp0.getNumberOfConstraints() );
+        assertTrue( fp0.getConstraint( 0 ) instanceof SingleFieldConstraint );
+
+        final SingleFieldConstraint sfc1 = (SingleFieldConstraint) fp0.getConstraint( 0 );
+        assertEquals( "Person",
+                      sfc1.getFactType() );
+        assertEquals( "name",
+                      sfc1.getFieldName() );
+        assertEquals( DataType.TYPE_STRING,
+                      sfc1.getFieldType() );
+        assertEquals( SingleFieldConstraint.TYPE_TEMPLATE,
+                      sfc1.getConstraintValueType() );
+        assertEquals( "k1",
+                      sfc1.getValue() );
+
+        assertEquals( 0,
+                      m.rhs.length );
+    }
+
+    @Test
+    //https://issues.jboss.org/browse/GUVNOR-2030
+    public void testRHSTemplateKeys() throws Exception {
+        String drl = "package org.test;\n" +
+                "rule \"MyRule\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  $p : Person( name == \"Fred\" )\n" +
+                "then\n" +
+                "  modify( $p ) { setName( \"@{k1}\" ) }\n" +
+                "end";
+
+        addModelField( "org.test.Person",
+                       "this",
+                       "org.test.Person",
+                       DataType.TYPE_THIS );
+        addModelField( "org.test.Person",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.test" );
+
+        final RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                                 new ArrayList<String>(),
+                                                                                 dmo );
+
+        assertNotNull( m );
+
+        assertEquals( 1,
+                      m.lhs.length );
+        final IPattern p0 = m.lhs[ 0 ];
+        assertTrue( p0 instanceof FactPattern );
+        final FactPattern fp0 = (FactPattern) p0;
+        assertEquals( "Person",
+                      fp0.getFactType() );
+
+        assertEquals( 1,
+                      fp0.getNumberOfConstraints() );
+        assertTrue( fp0.getConstraint( 0 ) instanceof SingleFieldConstraint );
+
+        final SingleFieldConstraint sfc1 = (SingleFieldConstraint) fp0.getConstraint( 0 );
+        assertEquals( "Person",
+                      sfc1.getFactType() );
+        assertEquals( "name",
+                      sfc1.getFieldName() );
+        assertEquals( DataType.TYPE_STRING,
+                      sfc1.getFieldType() );
+        assertEquals( SingleFieldConstraint.TYPE_LITERAL,
+                      sfc1.getConstraintValueType() );
+        assertEquals( "Fred",
+                      sfc1.getValue() );
+
+        assertEquals( 1,
+                      m.rhs.length );
+
+        assertTrue( m.rhs[ 0 ] instanceof ActionUpdateField );
+        ActionUpdateField auf = (ActionUpdateField) m.rhs[ 0 ];
+        assertEquals( "$p",
+                      auf.getVariable() );
+        assertEquals( 1,
+                      auf.getFieldValues().length );
+        ActionFieldValue afv = auf.getFieldValues()[ 0 ];
+        assertEquals( "name",
+                      afv.getField() );
+        assertEquals( "k1",
+                      afv.getValue() );
+        assertEquals( FieldNatureType.TYPE_TEMPLATE,
+                      afv.getNature() );
+    }
+
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
@@ -38,6 +38,7 @@ import org.drools.workbench.models.datamodel.rule.ActionWorkItemFieldValue;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.FieldConstraint;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
 import org.drools.workbench.models.datamodel.rule.FromEntryPointFactPattern;
 import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.models.datamodel.rule.IPattern;
@@ -287,12 +288,19 @@ public class GuidedDTDRLPersistence {
                 } else if ( ivs.size() > 0 ) {
 
                     //Ensure every key has a value and substitute keys for values
+                    int templateKeyCount = 0;
                     for ( InterpolationVariable variable : ivs.keySet() ) {
                         String value = rowDataProvider.getTemplateKeyValue( variable.getVarName() );
                         if ( !"".equals( value ) ) {
-                            addAction = true;
-                            break;
+                            templateKeyCount++;
                         }
+                    }
+
+                    //Ensure at least one key has a value (FreeFormLines need all values to be provided)
+                    if ( action instanceof FreeFormLine ) {
+                        addAction = templateKeyCount == ivs.size();
+                    } else if ( templateKeyCount > 0 ) {
+                        addAction = true;
                     }
                 }
 
@@ -303,7 +311,6 @@ public class GuidedDTDRLPersistence {
 
             }
         }
-
     }
 
     private boolean hasVariables( BRLActionColumn column ) {
@@ -596,13 +603,19 @@ public class GuidedDTDRLPersistence {
                     addPattern = true;
                 } else if ( ivs.size() > 0 ) {
 
-                    //Ensure every key has a value and substitute keys for values
+                    int templateKeyCount = 0;
                     for ( InterpolationVariable variable : ivs.keySet() ) {
                         String value = rowDataProvider.getTemplateKeyValue( variable.getVarName() );
                         if ( !"".equals( value ) ) {
-                            addPattern = true;
-                            break;
+                            templateKeyCount++;
                         }
+                    }
+
+                    //Ensure at least one key has a value (FreeFormLines need all values to be provided)
+                    if ( pattern instanceof FreeFormLine ) {
+                        addPattern = templateKeyCount == ivs.size();
+                    } else if ( templateKeyCount > 0 ) {
+                        addPattern = true;
                     }
                 }
 

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
@@ -22,6 +22,7 @@ import org.drools.workbench.models.datamodel.rule.ActionUpdateField;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.FieldConstraint;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.drools.workbench.models.guided.dtable.backend.util.DataUtilities;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
@@ -321,7 +322,6 @@ public class BRLRuleModelTest {
         assertNull( raif2.getFieldValues()[ 0 ].getValue() );
         assertEquals( BaseSingleFieldConstraint.TYPE_LITERAL,
                       raif2.getFieldValues()[ 0 ].getNature() );
-
     }
 
     @Test
@@ -416,7 +416,6 @@ public class BRLRuleModelTest {
         assertNull( raif3.getFieldValues()[ 0 ].getValue() );
         assertEquals( BaseSingleFieldConstraint.TYPE_LITERAL,
                       raif3.getFieldValues()[ 0 ].getNature() );
-
     }
 
     @Test
@@ -736,6 +735,7 @@ public class BRLRuleModelTest {
                 "    setName( \"Fred\" )\n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected1,
                                       drl );
 
@@ -754,6 +754,7 @@ public class BRLRuleModelTest {
                 "    setName( \"Fred\" )\n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected2,
                                       drl );
 
@@ -772,6 +773,7 @@ public class BRLRuleModelTest {
                 "    setAge( 55 ) \n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected3,
                                       drl );
     }
@@ -844,6 +846,7 @@ public class BRLRuleModelTest {
                 "    setF3( \"v3\" )\n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected,
                                       drl );
     }
@@ -915,6 +918,7 @@ public class BRLRuleModelTest {
                 "    setF3( \"v3\" )\n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected,
                                       drl );
     }
@@ -985,6 +989,7 @@ public class BRLRuleModelTest {
                 "    setF3( \"v3\" )\n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected,
                                       drl );
     }
@@ -1056,6 +1061,7 @@ public class BRLRuleModelTest {
                 "    setF3( \"v3\" )\n" +
                 "}\n" +
                 "end\n";
+
         assertEqualsIgnoreWhitespace( expected,
                                       drl );
     }
@@ -1105,7 +1111,7 @@ public class BRLRuleModelTest {
 
         //Test 1
         dt.setData( DataUtilities.makeDataLists( new Object[][]{
-                new Object[]{ 1l, "desc-row1", null, null },
+                new Object[]{ 1l, "desc-row1", "Pupa", null },
         } ) );
 
         String drl1 = p.marshal( dt );
@@ -1114,6 +1120,7 @@ public class BRLRuleModelTest {
                 "rule \"Row 1 extended-entry\"\n" +
                 "  dialect \"mvel\"\n" +
                 "  when\n" +
+                "    p1 : Smurf( name == \"Pupa\" )\n" +
                 "  then\n" +
                 "end";
 
@@ -1122,7 +1129,7 @@ public class BRLRuleModelTest {
 
         //Test 2
         dt.setData( DataUtilities.makeDataLists( new Object[][]{
-                new Object[]{ 2l, "desc-row2", "   ", 35l },
+                new Object[]{ 2l, "desc-row2", null, 35l },
         } ) );
 
         String drl2 = p.marshal( dt );
@@ -1140,7 +1147,7 @@ public class BRLRuleModelTest {
 
         //Test 3
         dt.setData( DataUtilities.makeDataLists( new Object[][]{
-                new Object[]{ 3l, "desc-row3", "", null },
+                new Object[]{ 3l, "desc-row3", "Pupa", 35l },
         } ) );
 
         String drl3 = p.marshal( dt );
@@ -1149,6 +1156,7 @@ public class BRLRuleModelTest {
                 "rule \"Row 3 extended-entry\"\n" +
                 "  dialect \"mvel\"\n" +
                 "  when\n" +
+                "    p1 : Smurf( name == \"Pupa\", age == 35 )\n" +
                 "  then\n" +
                 "end";
 
@@ -1157,7 +1165,7 @@ public class BRLRuleModelTest {
 
         //Test 4
         dt.setData( DataUtilities.makeDataLists( new Object[][]{
-                new Object[]{ 4l, "desc-row4", "", 35l },
+                new Object[]{ 4l, "desc-row4", null, null },
         } ) );
 
         String drl4 = p.marshal( dt );
@@ -1166,7 +1174,6 @@ public class BRLRuleModelTest {
                 "rule \"Row 4 extended-entry\"\n" +
                 "  dialect \"mvel\"\n" +
                 "  when\n" +
-                "    p1 : Smurf( age == 35 )\n" +
                 "  then\n" +
                 "end";
 
@@ -1282,6 +1289,100 @@ public class BRLRuleModelTest {
                 "  dialect \"mvel\"\n" +
                 "  when\n" +
                 "    p1 : Smurf( name == \"\", age == 35 )\n" +
+                "  then\n" +
+                "end";
+
+        assertEqualsIgnoreWhitespace( expected4,
+                                      drl4 );
+    }
+
+    @Test
+    public void testLHSNonEmptyStringValuesFreeFormLine() {
+        GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+        dt.setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dt.setTableName( "extended-entry" );
+
+        BRLConditionColumn brlCondition = new BRLConditionColumn();
+        FreeFormLine ffl = new FreeFormLine();
+        ffl.setText( "p1 : Smurf( name ==\"@{$f1}\", age == @{$f2} )" );
+
+        brlCondition.getDefinition().add( ffl );
+        brlCondition.getChildColumns().add( new BRLConditionVariableColumn( "$f1",
+                                                                            DataType.TYPE_STRING,
+                                                                            "Smurf",
+                                                                            "name" ) );
+        brlCondition.getChildColumns().add( new BRLConditionVariableColumn( "$f2",
+                                                                            DataType.TYPE_NUMERIC_INTEGER,
+                                                                            "Smurf",
+                                                                            "age" ) );
+
+        dt.getConditions().add( brlCondition );
+
+        GuidedDTDRLPersistence p = GuidedDTDRLPersistence.getInstance();
+
+        //Test 1
+        dt.setData( DataUtilities.makeDataLists( new Object[][]{
+                new Object[]{ 1l, "desc-row1", "Pupa", null },
+        } ) );
+
+        String drl1 = p.marshal( dt );
+        final String expected1 = "//from row number: 1\n" +
+                "//desc-row1\n" +
+                "rule \"Row 1 extended-entry\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "  then\n" +
+                "end";
+
+        assertEqualsIgnoreWhitespace( expected1,
+                                      drl1 );
+
+        //Test 2
+        dt.setData( DataUtilities.makeDataLists( new Object[][]{
+                new Object[]{ 2l, "desc-row2", null, 35l },
+        } ) );
+
+        String drl2 = p.marshal( dt );
+        final String expected2 = "//from row number: 1\n" +
+                "//desc-row2\n" +
+                "rule \"Row 2 extended-entry\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "  then\n" +
+                "end";
+
+        assertEqualsIgnoreWhitespace( expected2,
+                                      drl2 );
+
+        //Test 3
+        dt.setData( DataUtilities.makeDataLists( new Object[][]{
+                new Object[]{ 3l, "desc-row3", "Pupa", 35l },
+        } ) );
+
+        String drl3 = p.marshal( dt );
+        final String expected3 = "//from row number: 1\n" +
+                "//desc-row3\n" +
+                "rule \"Row 3 extended-entry\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "    p1 : Smurf( name == \"Pupa\", age == 35 )\n" +
+                "  then\n" +
+                "end";
+
+        assertEqualsIgnoreWhitespace( expected3,
+                                      drl3 );
+
+        //Test 4
+        dt.setData( DataUtilities.makeDataLists( new Object[][]{
+                new Object[]{ 4l, "desc-row4", null, null },
+        } ) );
+
+        String drl4 = p.marshal( dt );
+        final String expected4 = "//from row number: 1\n" +
+                "//desc-row4\n" +
+                "rule \"Row 4 extended-entry\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
                 "  then\n" +
                 "end";
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2030

This PR adds extraction of "Template Keys" to the `DRL`->`RuleModel` parsing to support use of `IPattern` and `IAction` in BRL Fragments in XLS to Guided Decision Table conversion.
