### PR TITLE
Faster check if pojo has property change listener support.

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/ClassObjectTypeConf.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ClassObjectTypeConf.java
@@ -35,6 +35,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -149,14 +150,13 @@ public class ClassObjectTypeConf
     }
 
     private boolean checkPropertyListenerSupport( Class<?> clazz ) {
-        Method method = null;
-        try {
-            method = clazz.getMethod( "addPropertyChangeListener",
-                                      ADD_REMOVE_PROPERTY_CHANGE_LISTENER_ARG_TYPES );
-        } catch (Exception e) {
-            // intentionally left empty
+        for (Method method : clazz.getMethods()) {
+            if ("addPropertyChangeListener".equals(method.getName()) &&
+                    Arrays.deepEquals(ADD_REMOVE_PROPERTY_CHANGE_LISTENER_ARG_TYPES, method.getParameterTypes())){
+                return true;
+            }
         }
-        return method != null;
+        return false;
     }
 
     /**


### PR DESCRIPTION
Checking if class has `addPropertyChangeListener` via `Class#getMethod` is very slow, as it throws exception, populating its stacktrace is quite an expensie operation. In many usecases all objects injected to session may not have this method, so this operation is not rear. Looking for method by name is faster and increases overall performance. In our application this gave ~ 1.7 better throughput.
