### PR TITLE
[6.3.x] GUVNOR-2444: Guided Decision Table: Can't add columns/rows

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTCellValue52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTCellValue52.java
@@ -36,7 +36,7 @@ public class DTCellValue52 {
     private Date valueDate;
     private Number valueNumeric;
     private String valueString;
-    private DataTypes dataType;
+    private DataTypes dataType = DataTypes.STRING;
 
     //Does this cell represent "all other values" to those explicitly defined for the column
     private boolean isOtherwise;

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/DTCellValue52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/DTCellValue52Test.java
@@ -128,4 +128,29 @@ public class DTCellValue52Test {
                       dcv.getStringValue() );
     }
 
+    @Test
+    public void testDefaultValue() throws Exception {
+        final DTCellValue52 defaultValue = new DTCellValue52( 1 );
+        final DTCellValue52 clone = new DTCellValue52( defaultValue );
+        assertEquals( DataType.DataTypes.NUMERIC_INTEGER,
+                      clone.getDataType() );
+        assertNull( clone.getBooleanValue() );
+        assertNull( clone.getDateValue() );
+        assertEquals( 1,
+                      clone.getNumericValue() );
+        assertNull( clone.getStringValue() );
+    }
+
+    @Test
+    public void testDefaultValueNull() throws Exception {
+        final DTCellValue52 defaultValue = null;
+        final DTCellValue52 clone = new DTCellValue52( defaultValue );
+        assertEquals( DataType.DataTypes.STRING,
+                      clone.getDataType() );
+        assertNull( clone.getBooleanValue() );
+        assertNull( clone.getDateValue() );
+        assertNull( clone.getNumericValue() );
+        assertNull( clone.getStringValue() );
+    }
+
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2444

This is the corollary of https://github.com/droolsjbpm/drools/pull/667 for 6.3.x

This was a regression introduced by https://bugzilla.redhat.com/show_bug.cgi?id=1301055

(cherry picked from commit 3e1588a69ff607b0648cdc0bbebec92b7d528c49)
