### PR TITLE
[6.4.x] [DROOLS-1065] fix ClasspathKieProject to recognize "*.jar" dirs

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -211,7 +211,7 @@ public class ClasspathKieProject extends AbstractKieProject {
             rootPath = IoUtils.asSystemSpecificPath( rootPath, rootPath.lastIndexOf( ':' ) );
         }
 
-        if ( urlPathToAdd.endsWith( ".apk" ) || urlPathToAdd.endsWith( ".jar" ) || urlPathToAdd.endsWith( "/content" ) ) {
+        if ( urlPathToAdd.endsWith( ".apk" ) || isJarFile( urlPathToAdd, rootPath ) || urlPathToAdd.endsWith( "/content" ) ) {
             pomProperties = getPomPropertiesFromZipFile(rootPath);
         } else {
             pomProperties = getPomPropertiesFromFileSystem(rootPath);
@@ -231,6 +231,17 @@ public class ClasspathKieProject extends AbstractKieProject {
             log.warn( "Unable to load pom.properties from" + urlPathToAdd );
         }
         return pomProperties;
+    }
+
+    private static boolean isJarFile(String urlPathToAdd, String rootPath) {
+        boolean result = false;
+        if (urlPathToAdd.endsWith( ".jar" )) {
+            File actualZipFile = new File( rootPath );
+            if (actualZipFile.exists() && actualZipFile.isFile()) {
+                result = true;
+            }
+        }
+        return result;
     }
 
     private static String getPomPropertiesFromZipFile(String rootPath) {

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/ClasspathKieProjectTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/ClasspathKieProjectTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.kie.builder.impl;
+
+import org.assertj.core.api.Assertions;
+import org.drools.compiler.kproject.AbstractKnowledgeTest;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.junit.Test;
+import org.kie.api.builder.ReleaseId;
+
+import java.io.File;
+
+public class ClasspathKieProjectTest extends AbstractKnowledgeTest {
+
+    private static final String MODULE_JARFILE_NAME = "jar1";
+    private static final String MODULE_JARFILE_VERSION = "1.0";
+    private static final String MODULE_JARDIR_NAME = "jar2";
+    private static final String MODULE_JARDIR_VERSION = "2.0";
+
+    @Test
+    public void testParsePomPropertiesFromJarFile() throws Exception {
+        createKieModule(MODULE_JARFILE_NAME, true, MODULE_JARFILE_VERSION);
+        final File kModuleFile = getFileManager().newFile(MODULE_JARFILE_NAME + "-" + MODULE_JARFILE_VERSION + ".jar");
+        final String pomProperties = ClasspathKieProject.getPomProperties(kModuleFile.getAbsolutePath());
+        checkPomProperties(pomProperties, MODULE_JARFILE_NAME, MODULE_JARFILE_VERSION);
+    }
+
+    @Test
+    public void testParsePomPropertiesFromJarDir() throws Exception {
+        createKieModule(MODULE_JARDIR_NAME, false, MODULE_JARDIR_VERSION);
+        final File kModuleDir = getFileManager().newFile(MODULE_JARDIR_NAME + "-" + MODULE_JARDIR_VERSION);
+        Assertions.assertThat(kModuleDir).isNotNull();
+        Assertions.assertThat(kModuleDir).isDirectory();
+        kModuleDir.renameTo(new File(kModuleDir.getAbsolutePath() + ".jar"));
+        final File kModuleFile = getFileManager().newFile(MODULE_JARDIR_NAME + "-" + MODULE_JARDIR_VERSION + ".jar");
+        final String pomProperties = ClasspathKieProject.getPomProperties(kModuleFile.getAbsolutePath());
+        checkPomProperties(pomProperties, MODULE_JARDIR_NAME, MODULE_JARDIR_VERSION);
+    }
+
+    private void checkPomProperties(final String pomProperties, final String expectedGroupId, final String expectedVersion) {
+        Assertions.assertThat(pomProperties).isNotNull();
+        final ReleaseId actualReleaseId = ReleaseIdImpl.fromPropertiesString(pomProperties);
+        Assertions.assertThat(actualReleaseId.getGroupId()).isEqualTo(expectedGroupId);
+        Assertions.assertThat(actualReleaseId.getVersion()).isEqualTo(expectedVersion);
+    }
+
+}


### PR DESCRIPTION
- test creates a kmodule jar file and a kmodule jar directory
  (ending name in ".jar") for testing that both are processed correctly

Backport of https://github.com/droolsjbpm/drools/pull/511. We were asked by community member to backport this to 6.4 (see the JIRA). I believe this is a safe change, so I would agree with backporting.

@mariofusco please take a look.
