### PR TITLE
DROOLS-1025 - AddRemove rules tests - generated rules tests using not(not()) constraint.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
@@ -83,8 +83,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule1);
-        logger.info("Rule 2: \n" + rule2);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -95,8 +93,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRulesRevertedRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule2);
-        logger.info("Rule 2: \n" + rule1);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());
@@ -107,8 +103,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testFireRulesInsertFactsFireRulesRemoveRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule1);
-        logger.info("Rule 2: \n" + rule2);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createFireRulesInsertFactsFireRulesRemoveRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -119,8 +113,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testFireRulesInsertFactsFireRulesRemoveRulesRevertedRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule2);
-        logger.info("Rule 2: \n" + rule1);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createFireRulesInsertFactsFireRulesRemoveRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());
@@ -131,8 +123,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testInsertFactsRemoveRulesFireRulesRemoveRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule1);
-        logger.info("Rule 2: \n" + rule2);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsRemoveRulesFireRulesRemoveRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -143,8 +133,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testInsertFactsRemoveRulesFireRulesRemoveRulesRevertedRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule2);
-        logger.info("Rule 2: \n" + rule1);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsRemoveRulesFireRulesRemoveRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());
@@ -155,8 +143,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRulesReinsertRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule1);
-        logger.info("Rule 2: \n" + rule2);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -167,8 +153,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRulesReinsertRulesRevertedRules() {
         checkRunTurtleTests();
-        logger.info("Rule 1: \n" + rule2);
-        logger.info("Rule 2: \n" + rule1);
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
@@ -116,47 +116,47 @@ public abstract class AbstractAddRemoveRulesTest {
             if (testOperationType != TestOperationType.CREATE_SESSION) {
                 checkSessionInitialized(session);
             }
-            switch (testOperationType) {
-                case CREATE_SESSION:
-                    session = createNewSession((String[]) testOperationParameter, resultsList, additionalGlobals);
-                    break;
-                case ADD_RULES:
-                    addRulesToSession(session, (String[]) testOperationParameter, false);
-                    break;
-                case ADD_RULES_REINSERT_OLD:
-                    addRulesToSession(session, (String[]) testOperationParameter, true);
-                    break;
-                case REMOVE_RULES:
-                    removeRulesFromSession(session, (String[]) testOperationParameter);
-                    break;
-                case FIRE_RULES:
-                    try {
+            try {
+                switch (testOperationType) {
+                    case CREATE_SESSION:
+                        session = createNewSession((String[]) testOperationParameter, resultsList, additionalGlobals);
+                        break;
+                    case ADD_RULES:
+                        addRulesToSession(session, (String[]) testOperationParameter, false);
+                        break;
+                    case ADD_RULES_REINSERT_OLD:
+                        addRulesToSession(session, (String[]) testOperationParameter, true);
+                        break;
+                    case REMOVE_RULES:
+                        removeRulesFromSession(session, (String[]) testOperationParameter);
+                        break;
+                    case FIRE_RULES:
                         session.fireAllRules();
-                    } catch (Exception e) {
-                        throw new RuntimeException( createTestFailMessage(testOperations, index, null, null), e );
-                    }
-                    break;
-                case CHECK_RESULTS:
-                    final Set<String> expectedResultsSet = new HashSet<String>();
-                    expectedResultsSet.addAll(Arrays.asList((String[])testOperationParameter));
-                    if (expectedResultsSet.size() > 0) {
+                        break;
+                    case CHECK_RESULTS:
+                        final Set<String> expectedResultsSet = new HashSet<String>();
+                        expectedResultsSet.addAll(Arrays.asList((String[]) testOperationParameter));
+                        if (expectedResultsSet.size() > 0) {
+                            assertTrue(createTestFailMessage(testOperations, index, expectedResultsSet, resultsList),
+                                    resultsList.size() > 0);
+                        }
                         assertTrue(createTestFailMessage(testOperations, index, expectedResultsSet, resultsList),
-                                resultsList.size() > 0);
-                    }
-                    assertTrue(createTestFailMessage(testOperations, index, expectedResultsSet, resultsList),
-                            expectedResultsSet.containsAll(resultsList));
-                    assertTrue(createTestFailMessage(testOperations, index, expectedResultsSet, resultsList),
-                            resultsList.containsAll(expectedResultsSet));
-                    resultsList.clear();
-                    break;
-                case INSERT_FACTS:
-                    insertFactsIntoSession(session, (Object[]) testOperationParameter);
-                    break;
-                case DUMP_RETE:
-                    ReteDumper.dumpRete( (KieSession)session );
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported test operation: " + testOperationType + "!");
+                                expectedResultsSet.containsAll(resultsList));
+                        assertTrue(createTestFailMessage(testOperations, index, expectedResultsSet, resultsList),
+                                resultsList.containsAll(expectedResultsSet));
+                        resultsList.clear();
+                        break;
+                    case INSERT_FACTS:
+                        insertFactsIntoSession(session, (Object[]) testOperationParameter);
+                        break;
+                    case DUMP_RETE:
+                        ReteDumper.dumpRete((KieSession) session);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported test operation: " + testOperationType + "!");
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(createTestFailMessage(testOperations, index, null, null), e);
             }
             index++;
         }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveGenerated2RulesNotNotTest.java
@@ -1,0 +1,22 @@
+package org.drools.compiler.integrationtests.incrementalcompilation;
+
+import java.util.Collection;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class AddRemoveGenerated2RulesNotNotTest extends AbstractAddRemoveGenerated2RulesTest {
+
+    public AddRemoveGenerated2RulesNotNotTest(final ConstraintsPair constraintsPair) {
+        super(constraintsPair);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<ConstraintsPair[]> getRulesConstraints() {
+        return generateRulesConstraintsCombinations(
+                " Integer() \n",
+                " Integer() not(not(exists(Integer() and Integer()))) \n",
+                " exists(Integer() and exists(Integer() and Integer())) \n");
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -1973,7 +1973,7 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
         runAddRemoveTest(builder.build(), new HashMap<String, Object>());
     }
 
-    @Test @Ignore
+    @Test
     public void testInsertFireRemoveWith2Nots() {
         final String rule1 = " package " + PKG_NAME_TEST + ";\n" +
                 " global java.util.List list\n" +
@@ -2013,7 +2013,7 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
 
     }
 
-    @Test @Ignore
+    @Test
     public void testInsertRemoveFireWith2Nots() {
         final String rule1 = " package " + PKG_NAME_TEST + ";\n" +
                 " global java.util.List list\n" +
@@ -2048,7 +2048,7 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
 
     }
 
-    @Test @Ignore
+    @Test
     public void testInsertFireRemoveAddWith2Nots() {
 
         final String rule1 = " package " + PKG_NAME_TEST + ";\n" +

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -1972,4 +1972,129 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
 
         runAddRemoveTest(builder.build(), new HashMap<String, Object>());
     }
+
+    @Test @Ignore
+    public void testInsertFireRemoveWith2Nots() {
+        final String rule1 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE1_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   Integer() \n" +
+                "   Integer() \n" +
+                " then\n" +
+                "   list.add('" + RULE1_NAME + "'); \n" +
+                " end";
+
+        final String rule2 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE2_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   Integer() \n" +
+                "   Integer() not(not(exists(Integer() and Integer()))) \n" +
+                " then\n" +
+                "   list.add('" + RULE2_NAME + "'); \n" +
+                " end";
+
+        final AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule2, rule1})
+                .addOperation(TestOperationType.INSERT_FACTS, new Object[] {1})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE2_NAME})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE2_NAME})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE1_NAME})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
+
+        runAddRemoveTest(builder.build(), new HashMap<String, Object>());
+
+    }
+
+    @Test @Ignore
+    public void testInsertRemoveFireWith2Nots() {
+        final String rule1 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE1_NAME + " \n" +
+                " when \n" +
+                "   exists(Integer() and exists(Integer() and Integer())) \n" +
+                "   Integer() \n" +
+                "   Integer() not(not(exists(Integer() and Integer()))) \n" +
+                " then\n" +
+                "   list.add('" + RULE1_NAME + "'); \n" +
+                " end";
+
+        final String rule2 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE2_NAME + " \n" +
+                " when \n" +
+                "   exists(Integer() and exists(Integer() and Integer())) \n" +
+                "   Integer() not(not(exists(Integer() and Integer()))) \n" +
+                "   Integer() \n" +
+                " then\n" +
+                "   list.add('" + RULE2_NAME + "'); \n" +
+                " end";
+
+        final AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.INSERT_FACTS, new Object[] {1})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE2_NAME})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME});
+
+        runAddRemoveTest(builder.build(), new HashMap<String, Object>());
+
+    }
+
+    @Test @Ignore
+    public void testInsertFireRemoveAddWith2Nots() {
+
+        final String rule1 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE1_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   Integer() \n" +
+                "   Integer() not(not(exists(Integer() and Integer()))) \n" +
+                " then\n" +
+                "   list.add('" + RULE1_NAME + "'); \n" +
+                " end";
+
+        final String rule2 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE2_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   Integer() \n" +
+                "   exists(Integer() and exists(Integer() and Integer())) \n" +
+                " then\n" +
+                "   list.add('" + RULE2_NAME + "'); \n" +
+                " end";
+
+        final AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.INSERT_FACTS, new Object[]{1})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE2_NAME})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE1_NAME})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE2_NAME})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{})
+                .addOperation(TestOperationType.ADD_RULES, new String[]{rule1})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME})
+                .addOperation(TestOperationType.ADD_RULES, new String[]{rule2})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE2_NAME})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE1_NAME, RULE2_NAME})
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
+
+        runAddRemoveTest(builder.build(), new HashMap<String, Object>());
+
+    }
 }


### PR DESCRIPTION
- Added class with generated AddRemove rule tests that use not(not(...)) constraint in rules. 
- Extracted reproducers of incremental compilation failures into AddRemoveRulesTest(last 3 tests in the class).
- Added exception catch in tests so we know which test permutation failed in case of an exception. 
