### PR TITLE
-Flushing had an incorrect smemIndex++, which would skip the sm that …

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -1936,7 +1936,7 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
         runAddRemoveTest(builder.build(), new HashMap<String, Object>());
     }
 
-    @Test @Ignore
+    @Test
     public void testSubNetworkWithNot4() {
         final String rule1 = "package " + PKG_NAME_TEST + ";" +
                              "global java.util.List list\n" +

--- a/drools-core/src/main/java/org/drools/core/common/BaseNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/BaseNode.java
@@ -27,6 +27,7 @@ import org.kie.api.definition.rule.Rule;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Collection;
 
 /**
  * The base class for all Rete nodes.
@@ -191,5 +192,9 @@ public abstract class BaseNode
 
     public boolean isAssociatedWith( Rule rule ) {
         return this.associations.contains( rule );
+    }
+
+    public Collection<Rule> getRuleAssociations() {
+        return this.associations.keys();
     }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakQueryTerminalNode.java
@@ -169,7 +169,8 @@ public class PhreakQueryTerminalNode {
 
             // node must be marked as dirty
             ((QueryElementNodeMemory)stackEntry.getNodeMem()).setNodeDirtyWithoutNotify();
-            if (stackEntry.getLiaNode()== ((LeftTupleSink)rootEntry.getTupleSink()).getLeftTupleSource()) {
+
+            if (stackEntry.getRmem().getPathEndNode().getPathNodes()[0] == ((LeftTupleSink)rootEntry.getTupleSink()).getLeftTupleSource()) {
                 // query is recursive, so just re-add the stack entry to the current stack. This happens for reactive queries, triggered by a beta node right input
                 stack.add(stackEntry);
             } else {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -471,7 +471,7 @@ public class PhreakTimerNode {
         RuleNetworkEvaluator rne = new RuleNetworkEvaluator();
         LinkedList<StackEntry> outerStack = new LinkedList<StackEntry>();
 
-        rne.outerEval(lian, pmem, sink, bit, tm,
+        rne.outerEval(pmem, sink, bit, tm,
                       smems, smemIndex, trgLeftTuples,
                       wm, new LinkedList<StackEntry>(), true,
                       pmem.getRuleAgendaItem().getRuleExecutor());

--- a/drools-core/src/main/java/org/drools/core/phreak/StackEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/StackEntry.java
@@ -33,7 +33,6 @@ import org.drools.core.util.AbstractBaseLinkedListNode;
 * To change this template use File | Settings | File Templates.
 */
 public class StackEntry extends AbstractBaseLinkedListNode<StackEntry> {
-    private final LeftInputAdapterNode liaNode;
     private final long                 bit;
     private final NetworkNode          node;
     private final LeftTupleSinkNode    sink;
@@ -46,8 +45,7 @@ public class StackEntry extends AbstractBaseLinkedListNode<StackEntry> {
     private final boolean              processRian;
 
 
-    public StackEntry(LeftInputAdapterNode liaNode,
-                      NetworkNode node,
+    public StackEntry(NetworkNode node,
                       long bit,
                       LeftTupleSinkNode sink,
                       PathMemory pmem,
@@ -57,7 +55,6 @@ public class StackEntry extends AbstractBaseLinkedListNode<StackEntry> {
                       TupleSets<LeftTuple> trgTuples,
                       boolean resumeFromNextNode,
                       boolean processRian) {
-        this.liaNode = liaNode;
         this.bit = bit;
         this.node = node;
         this.sink = sink;
@@ -68,12 +65,6 @@ public class StackEntry extends AbstractBaseLinkedListNode<StackEntry> {
         this.trgTuples = trgTuples;
         this.resumeFromNextNode = resumeFromNextNode;
         this.processRian = processRian;
-    }
-
-
-
-    public LeftInputAdapterNode getLiaNode() {
-        return this.liaNode;
     }
 
     public long getBit() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
@@ -40,7 +40,6 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.drools.core.reteoo.PropertySpecificUtil.*;
@@ -154,19 +153,19 @@ public abstract class AbstractTerminalNode extends BaseNode implements TerminalN
 
     public PathMemory createMemory(RuleBaseConfiguration config, InternalWorkingMemory wm) {
         PathMemory pmem = new PathMemory(this);
-        initPathMemory(pmem, this, null, wm, null );
+        initPathMemory(pmem, null, wm, null);
         return pmem;
     }
 
     /**
      * Creates and return the node memory
      */
-    public static void initPathMemory(PathMemory pmem, LeftTupleNode endNode, LeftTupleSource startTupleSource, InternalWorkingMemory wm, Rule removingRule) {
+    public static void initPathMemory(PathMemory pmem, LeftTupleSource startTupleSource, InternalWorkingMemory wm, Rule removingRule) {
         int counter = 1;
         long allLinkedTestMask = 0;
 
-        LeftTupleSource tupleSource = endNode.getLeftTupleSource();
-        if ( SegmentUtilities.isRootNode(endNode, removingRule)) {
+        LeftTupleSource tupleSource = pmem.getPathEndNode().getLeftTupleSource();
+        if ( SegmentUtilities.isRootNode(pmem.getPathEndNode(), removingRule)) {
             counter++;
         }
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RightInputAdapterNode.java
@@ -132,7 +132,7 @@ public class RightInputAdapterNode extends ObjectSource
         RiaNodeMemory rianMem = new RiaNodeMemory();
 
         RiaPathMemory pmem = new RiaPathMemory(this);
-        AbstractTerminalNode.initPathMemory(pmem, this, getStartTupleSource(), wm, null );
+        AbstractTerminalNode.initPathMemory(pmem, getStartTupleSource(), wm, null);
         rianMem.setRiaPathMemory(pmem);
         
         return rianMem;

--- a/drools-core/src/main/java/org/drools/core/util/Bag.java
+++ b/drools-core/src/main/java/org/drools/core/util/Bag.java
@@ -99,6 +99,10 @@ public class Bag<T> implements Collection<T>, Serializable {
         return false;
     }
 
+    public Collection<T> keys() {
+        return map.keySet();
+    }
+
     @Override
     public boolean containsAll( Collection<?> c ) {
         return map.keySet().containsAll( c );


### PR DESCRIPTION
…needed flushing.

-Refactored the flushing methods to have more shared code
-Removed the redundant lian argument to various network evaluation methods
-Removed the break from findPmemToBeFlushed, as this was causing pmems not to be flushed, that needed it
-removed redundant endNode argument
