### PR TITLE
[DROOLS-1074] fix usage of org.kie.spring.KModuleSpringMarshaller

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -158,11 +158,11 @@ public class ClasspathKieProject extends AbstractKieProject {
         }
     }
 
-    private static void fetchKModuleFromSpring(URL kModuleUrl, String fixedURL){
+    private static void fetchKModuleFromSpring(URL kModuleUrl, String fixedURL) {
         try{
             Class clazz = Class.forName("org.kie.spring.KModuleSpringMarshaller");
-            Method method = clazz.getDeclaredMethod("fromXML", java.net.URL.class, String.class);
-            method.invoke(null, kModuleUrl, fixedURL);
+            Method method = clazz.getDeclaredMethod("fromXML", java.net.URL.class);
+            method.invoke(null, kModuleUrl);
         } catch (Exception e) {
             log.error("It is necessary to have the kie-spring module on the path in order to create a KieProject from a spring context", e);
             throw new RuntimeException(e);
@@ -370,7 +370,7 @@ public class ClasspathKieProject extends AbstractKieProject {
         } else {
             if (url.toString().contains("-spring.xml")){
                 urlPath = urlPath.substring( 0, urlPath.length() - ("/" + KieModuleModelImpl.KMODULE_SPRING_JAR_PATH).length() );
-            } else {
+            } else if (url.toString().endsWith(KieModuleModelImpl.KMODULE_JAR_PATH)) {
                 urlPath = urlPath.substring( 0,
                         urlPath.length() - ("/" + KieModuleModelImpl.KMODULE_JAR_PATH).length() );
             }

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/ClasspathKieProjectTransformUrlToFileSystemPathTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/ClasspathKieProjectTransformUrlToFileSystemPathTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.kie.builder.impl;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ClasspathKieProjectTransformUrlToFileSystemPathTest {
+
+    @Parameterized.Parameters(name = "URL={0}, expectedPath={1}")
+    public static Collection<Object[]> data() throws Exception {
+        return Arrays.asList(new Object[][] {
+                { new URL("file:/some-path-to-the-module/target/test-classes"), "/some-path-to-the-module/target/test-classes" },
+                { new URL("file:/some-path-to-the-module/target/test-classes/META-INF/kmodule.xml"), "/some-path-to-the-module/target/test-classes" },
+                { new URL("jar:file:/C:/proj/parser/jar/parser.jar!/test.xml"), "/C:/proj/parser/jar/parser.jar" }
+        });
+    }
+    @Parameterized.Parameter(0)
+    public URL url;
+
+    @Parameterized.Parameter(1)
+    public String expectedPath;
+
+
+    @Test
+    public void testTransformUrl() {
+        String actualPath = ClasspathKieProject.fixURLFromKProjectPath(url);
+        Assertions.assertThat(actualPath).isEqualTo(expectedPath);
+    }
+}


### PR DESCRIPTION
- fixed the reflective call to the method from kie-spring
  (removed not needed argument)
- fixed the URL/path parsing method to strip the suffix
  KieModuleModelImpl.KMODULE_JAR_PATH only if the path
  actually ends with it (otherwise we are incorrectly stripping
  content from paths which do not end with that suffix)

Same change already on 6.4.x (https://github.com/droolsjbpm/drools/pull/680)
