### PR TITLE
flush reentrant working memory actions when eager evaluation is enforced

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/SynchronizedBypassPropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SynchronizedBypassPropagationList.java
@@ -59,7 +59,11 @@ public class SynchronizedBypassPropagationList extends SynchronizedPropagationLi
     @Override
     public void flush() {
         if (!executing.get()) {
-            super.flush();
+            PropagationEntry head = takeAll();
+            while (head != null) {
+                flush( workingMemory, head );
+                head = takeAll();
+            }
         }
     }
 


### PR DESCRIPTION
this is a copy of #684 to allow test of jbpm test case for drools-1089 - don't merge it - it will be closed when jBPM is verified and #684 will be merged as expected.
