### PR TITLE
[6.4.x] GUVNOR-2455: Guided Decision Tree: Unable to re-open trees using data-type suffixes (d, f, L) in Actions

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/ActionCallMethodBuilder.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/ActionCallMethodBuilder.java
@@ -131,6 +131,8 @@ public class ActionCallMethodBuilder {
 
     private ActionFieldFunction getActionFieldFunction( String param,
                                                         String dataType ) {
+        param = removeNumericSuffix( param,
+                                     dataType );
         final int fieldNature = inferFieldNature( dataType,
                                                   param,
                                                   boundParams,

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -3177,7 +3177,7 @@ public class RuleModelDRLPersistenceImpl
 
     private ActionFieldValue buildFieldValue( final boolean isJavaDialect,
                                               String field,
-                                              final String value,
+                                              String value,
                                               final String dataType,
                                               final Map<String, String> boundParams ) {
         if ( value.contains( "wiWorkItem.getResult" ) ) {
@@ -3210,6 +3210,8 @@ public class RuleModelDRLPersistenceImpl
             }
         }
 
+        value = removeNumericSuffix( value,
+                                     dataType );
         final int fieldNature = inferFieldNature( dataType,
                                                   value,
                                                   boundParams,

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
@@ -402,4 +402,27 @@ class RuleModelPersistenceHelper {
         return methods;
     }
 
+    static String removeNumericSuffix( final String value,
+                                       final String dataType ) {
+        if ( DataType.TYPE_NUMERIC_DOUBLE.equals( dataType ) ) {
+            if ( value.endsWith( "d" ) ) {
+                return value.substring( 0,
+                                        value.indexOf( "d" ) );
+            }
+        } else if ( DataType.TYPE_NUMERIC_FLOAT.equals( dataType ) ) {
+            if ( value.endsWith( "f" ) ) {
+                return value.substring( 0,
+                                        value.indexOf( "f" ) );
+            }
+
+        } else if ( DataType.TYPE_NUMERIC_LONG.equals( dataType ) ) {
+            if ( value.endsWith( "L" ) ) {
+                return value.substring( 0,
+                                        value.indexOf( "L" ) );
+
+            }
+        }
+        return value;
+    }
+
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2455

The issue was that `double`, `float` and `long` data-types have `d`, `f` and `L` appended to their value in the generated `DRL` that lead to the fields being interpreted as `Formula` (that are unsupported by the Guided Decision Tree editor) when unmarshalling DRL->Model.

(cherry picked from commit 8ead67da82d8dd2603275ecbec777ed0e0bdaf09)
