### PR TITLE
DROOLS-1025 Added TestContext to AddRemoveRules tests + new NPE fail discovered.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
-import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -23,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.io.ResourceType;
 import org.kie.internal.KnowledgeBase;
@@ -46,6 +46,7 @@ public abstract class AbstractAddRemoveRulesTest {
         assumeTrue("true".equals(System.getProperty("runTurtleTests")));
     }
 
+    // TODO - remove these two methods - they are also in TestContext
     protected KnowledgeBuilder createKnowledgeBuilder(final KnowledgeBase kbase, final String drl) {
         final KnowledgeBuilder kbuilder;
         if (kbase == null) {
@@ -56,7 +57,7 @@ public abstract class AbstractAddRemoveRulesTest {
 
         kbuilder.add(ResourceFactory.newByteArrayResource(drl.getBytes()), ResourceType.DRL);
         if (kbuilder.hasErrors()) {
-            fail(kbuilder.getErrors().toString());
+            Assert.fail(kbuilder.getErrors().toString());
         }
         return kbuilder;
     }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
@@ -19,12 +19,10 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.io.ResourceType;
 import org.kie.internal.KnowledgeBase;
@@ -119,79 +117,5 @@ public abstract class AbstractAddRemoveRulesTest {
             result += kiePackage.getRules().size();
         }
         return result;
-    }
-
-    private void checkSessionInitialized(final StatefulKnowledgeSession session) {
-        if (session == null) {
-            throw new IllegalStateException("Session is not initialized! Please, initialize session first.");
-        }
-    }
-
-    private StatefulKnowledgeSession createNewSession(final String[] drls, final List resultsList,
-            final Map<String, Object> additionalGlobals) {
-        final StatefulKnowledgeSession session = buildSessionInSteps(drls);
-        session.setGlobal("list", resultsList);
-        if (additionalGlobals != null) {
-            insertGlobalsIntoSession(session, additionalGlobals);
-        }
-        return session;
-    }
-
-    private void addRulesToSession(final StatefulKnowledgeSession session, final String[] drls,
-            final boolean reimportAllRules) {
-        for (String drl : drls) {
-            final KnowledgeBuilder kBuilder;
-            if (reimportAllRules) {
-                kBuilder = createKnowledgeBuilder(session.getKieBase(), drl);
-            } else {
-                kBuilder = createKnowledgeBuilder(null, drl);
-            }
-            session.getKieBase().addKnowledgePackages(kBuilder.getKnowledgePackages());
-        }
-    }
-
-    private void removeRulesFromSession(final StatefulKnowledgeSession session, final String[] ruleNames) {
-        final KieBase kieBase = session.getKieBase();
-        for (String ruleName : ruleNames) {
-            kieBase.removeRule(PKG_NAME_TEST, ruleName);
-        }
-    }
-
-    private void insertFactsIntoSession(final StatefulKnowledgeSession session, final Object[] facts) {
-        for (Object fact: facts) {
-            session.insert(fact);
-        }
-    }
-
-    private void insertGlobalsIntoSession(final StatefulKnowledgeSession session, final Map<String, Object> globals) {
-        for (Map.Entry<String, Object> globalEntry : globals.entrySet()) {
-            session.setGlobal(globalEntry.getKey(), globalEntry.getValue());
-        }
-    }
-
-    private String createTestFailMessage(final List<TestOperation> testOperations, final int operationIndex,
-            final Collection<String> expectedResults, final Collection<String> actualResults) {
-        final StringBuilder messageBuilder = new StringBuilder();
-        final String lineSeparator = System.getProperty("line.separator");
-        messageBuilder.append("Test failed on " + operationIndex + ". operation! Operations:" + lineSeparator);
-        int index = 1;
-        for (TestOperation testOperation : testOperations) {
-            messageBuilder.append(index + ". " + testOperation.toString());
-            messageBuilder.append(lineSeparator);
-            index++;
-        }
-        if (expectedResults != null && actualResults != null) {
-            messageBuilder.append( "Expected results: " + lineSeparator + "[" );
-            for ( String expectedResult : expectedResults ) {
-                messageBuilder.append( expectedResult + " " );
-            }
-            messageBuilder.append( "]" + lineSeparator );
-            messageBuilder.append( "Actual results: " + lineSeparator + "[" );
-            for ( String actualResult : actualResults ) {
-                messageBuilder.append( actualResult + " " );
-            }
-        }
-        messageBuilder.append("]" + lineSeparator);
-        return messageBuilder.toString();
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesTest.java
@@ -15,6 +15,18 @@
 
 package org.drools.compiler.integrationtests.incrementalcompilation;
 
+import static org.drools.compiler.integrationtests.incrementalcompilation.IncrementalCompilationTest.rulestoMap;
+import static org.junit.Assert.*;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.reteoo.LeftTuple;
@@ -37,18 +49,6 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.runtime.StatelessKnowledgeSession;
 import org.kie.internal.utils.KieHelper;
-
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.drools.compiler.integrationtests.incrementalcompilation.IncrementalCompilationTest.rulestoMap;
-import static org.junit.Assert.*;
 
 public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
 
@@ -2208,5 +2208,62 @@ public class AddRemoveRulesTest extends AbstractAddRemoveRulesTest {
 
         this.deleteRule(rule2Name);
         assertNull( tuple.getPeer() );
+    }
+
+    @Test
+    public void testAddRemoveFacts() {
+        final String rule1 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE1_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   not(not(Integer() and Integer())) \n" +
+                " then\n" +
+                "   list.add('" + RULE1_NAME + "'); \n" +
+                " end";
+
+        final String rule2 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE2_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   exists(Integer() and Integer()) \n" +
+                " then\n" +
+                "   list.add('" + RULE2_NAME + "'); \n" +
+                " end";
+
+        final String rule3 = " package " + PKG_NAME_TEST + ";\n" +
+                " global java.util.List list\n" +
+                " rule " + RULE3_NAME + " \n" +
+                " when \n" +
+                "   Integer() \n" +
+                "   exists(Integer() and Integer()) \n" +
+                "   String() \n" +
+                " then\n" +
+                "   list.add('" + RULE3_NAME + "'); \n" +
+                " end";
+
+        final List resultsList = new ArrayList();
+        final Map<String, Object> globals = new HashMap<String, Object>();
+        globals.put("list", resultsList);
+        final TestContext context = new TestContext(PKG_NAME_TEST, globals, resultsList);
+
+        final AddRemoveTestBuilder builder = new AddRemoveTestBuilder();
+        builder.addOperation(TestOperationType.CREATE_SESSION, new String[]{rule1, rule2, rule3})
+                .addOperation(TestOperationType.INSERT_FACTS, new Object[]{1, "1"});
+
+        context.executeTestOperations(builder.build());
+        builder.clear();
+
+        final Set<FactHandle> sessionFacts = context.getActualSessionFactHandles();
+
+        builder.addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{RULE1_NAME, RULE2_NAME, RULE3_NAME})
+                .addOperation(TestOperationType.REMOVE_RULES, new String[]{RULE1_NAME, RULE2_NAME})
+                .addOperation(TestOperationType.ADD_RULES, new String[]{rule1, rule2})
+                .addOperation(TestOperationType.REMOVE_FACTS, sessionFacts.toArray(new FactHandle[]{}))
+                .addOperation(TestOperationType.FIRE_RULES)
+                .addOperation(TestOperationType.CHECK_RESULTS, new String[]{});
+        context.executeTestOperations(builder.build());
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestBuilder.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestBuilder.java
@@ -36,6 +36,10 @@ public class AddRemoveTestBuilder {
         return testPlan;
     }
 
+    public void clear() {
+        testPlan.clear();
+    }
+
     public static List<List<TestOperation>> getTestPlan(final String rule1, final String rule2,
             final String rule1Name, final String rule2Name, final Object[] facts) {
         final List<List<TestOperation>> testPlan = new ArrayList<List<TestOperation>>();

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestBuilder.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveTestBuilder.java
@@ -17,6 +17,7 @@ package org.drools.compiler.integrationtests.incrementalcompilation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class AddRemoveTestBuilder {
     private final List<TestOperation> testPlan = new ArrayList<TestOperation>();

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestContext.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestContext.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.integrationtests.incrementalcompilation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.core.reteoo.ReteDumper;
+import org.junit.Assert;
+import org.kie.api.KieBase;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class TestContext {
+
+    private final Map<FactHandle, Object> actualSessionFacts = new HashMap<FactHandle, Object>();
+    private final List<TestOperation> executedOperations = new ArrayList<TestOperation>();
+
+    private final Map<String, Object> sessionGlobals;
+    private final String rulesPackageName;
+    private final List resultsList;
+
+    private StatefulKnowledgeSession session;
+
+    private boolean failFast = true;
+    private final List<String> errorMessages = new ArrayList<String>();
+
+    public TestContext(final String rulesPackageName, final Map<String, Object> sessionGlobals,
+            final List resultsList) {
+        this.rulesPackageName = rulesPackageName;
+        this.sessionGlobals = sessionGlobals;
+        this.resultsList = resultsList;
+    }
+
+    public TestContext(final String rulesPackageName, final Map<String, Object> sessionGlobals,
+            final List resultsList, final boolean failFast) {
+        this.rulesPackageName = rulesPackageName;
+        this.sessionGlobals = sessionGlobals;
+        this.resultsList = resultsList;
+        this.failFast = failFast;
+    }
+
+    public void executeTestOperations(final List<TestOperation> testOperations) {
+        for (TestOperation testOperation : testOperations) {
+            try {
+                executeTestOperation(testOperation);
+            } catch (Exception e) {
+                throw new RuntimeException(createTestFailMessage(testOperations, null, null), e);
+            }
+        }
+    }
+
+    public void executeTestOperation(final TestOperation testOperation) {
+        final TestOperationType testOperationType = testOperation.getType();
+        final Object testOperationParameter = testOperation.getParameter();
+        if (testOperationType != TestOperationType.CREATE_SESSION) {
+            checkSessionInitialized();
+        }
+        switch (testOperationType) {
+            case CREATE_SESSION:
+                createSession((String[]) testOperationParameter, false);
+                break;
+            case ADD_RULES:
+                addRules((String[]) testOperationParameter, false);
+                break;
+            case ADD_RULES_REINSERT_OLD:
+                addRules((String[]) testOperationParameter, true);
+                break;
+            case REMOVE_RULES:
+                removeRules((String[]) testOperationParameter);
+                break;
+            case FIRE_RULES:
+                session.fireAllRules();
+                break;
+            case INSERT_FACTS:
+                insertFacts((Object[]) testOperationParameter);
+                break;
+            case REMOVE_FACTS:
+                removeFacts((FactHandle[]) testOperationParameter);
+                break;
+            case CHECK_RESULTS:
+                checkResults((String[]) testOperationParameter);
+                break;
+            case DUMP_RETE:
+                ReteDumper.dumpRete((KieSession) session);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported test operation: " + testOperationType + "!");
+        }
+    }
+
+    public void dumpRete() {
+        checkSessionInitialized();
+        ReteDumper.dumpRete((KieSession) session);
+    }
+
+    public Map<FactHandle, Object> getActualSessionFacts() {
+        return actualSessionFacts;
+    }
+
+    public List<TestOperation> getExecutedOperations() {
+        return executedOperations;
+    }
+
+    public void clearExecutedOperations() {
+        executedOperations.clear();
+    }
+
+    public StatefulKnowledgeSession getSession() {
+        return session;
+    }
+
+    public Object getSessionGlobal(final String sessionGlobalName) {
+        return sessionGlobals.get(sessionGlobalName);
+    }
+
+    public boolean isFailFast() {
+        return failFast;
+    }
+
+    public void setFailFast(final boolean failFast) {
+        this.failFast = failFast;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public void clearErrorMessages() {
+        errorMessages.clear();
+    }
+
+    private void checkSessionInitialized() {
+        if (session == null) {
+            throw new IllegalStateException("Session is not initialized! Please, initialize session first.");
+        }
+    }
+
+    private void addRules(final String[] drls, final boolean reuseKieBaseWhenAddingRules) {
+        for (String drl : drls) {
+            final KnowledgeBuilder kBuilder;
+            if (reuseKieBaseWhenAddingRules) {
+                kBuilder = createKnowledgeBuilder(session.getKieBase(), drl);
+            } else {
+                kBuilder = createKnowledgeBuilder(null, drl);
+            }
+            session.getKieBase().addKnowledgePackages(kBuilder.getKnowledgePackages());
+        }
+    }
+
+    private void removeRules(final String[] ruleNames) {
+        final KieBase kieBase = session.getKieBase();
+        for (String ruleName : ruleNames) {
+            kieBase.removeRule(rulesPackageName, ruleName);
+        }
+    }
+
+    private void insertFacts(final Object[] facts) {
+        for (Object fact: facts) {
+            actualSessionFacts.put(session.insert(fact), fact);
+        }
+    }
+
+    private void removeFacts(final FactHandle[] factHandles) {
+        for (FactHandle factHandle : factHandles) {
+            session.delete(factHandle);
+            actualSessionFacts.remove(factHandle);
+        }
+    }
+
+    private void checkResults(final String[] expectedResults) {
+        final Set<String> expectedResultsSet = new HashSet<String>();
+        expectedResultsSet.addAll(Arrays.asList(expectedResults));
+
+        if (((expectedResultsSet.size() > 0) && (resultsList.size() == 0))
+                || !expectedResultsSet.containsAll(resultsList)
+                || !resultsList.containsAll(expectedResultsSet)) {
+            if (failFast) {
+                Assert.fail(createTestFailMessage(executedOperations, expectedResultsSet, resultsList));
+            } else {
+                errorMessages.add(createTestFailMessage(executedOperations, expectedResultsSet, resultsList));
+            }
+        }
+        resultsList.clear();
+    }
+
+    private void createSession(final String[] drls, final boolean reuseKieBaseWhenAddingRules) {
+        if (session != null) {
+            actualSessionFacts.clear();
+            session.dispose();
+        }
+        session = buildSessionInSteps(drls, reuseKieBaseWhenAddingRules);
+        if (sessionGlobals != null) {
+            insertGlobals(session, sessionGlobals);
+        }
+    }
+
+    private StatefulKnowledgeSession buildSessionInSteps(final String[] drls,
+            final boolean reuseKieBaseWhenAddingRules) {
+        if (drls == null || drls.length == 0) {
+            return KnowledgeBaseFactory.newKnowledgeBase().newStatefulKnowledgeSession();
+        } else {
+            String drl = drls[0];
+            final KnowledgeBuilder kbuilder = createKnowledgeBuilder(null, drl);
+            final KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+            kbase.addKnowledgePackages(kbuilder.getKnowledgePackages());
+
+            final StatefulKnowledgeSession kSession = kbase.newStatefulKnowledgeSession();
+
+            for (int i = 1; i < drls.length; i++) {
+                drl = drls[i];
+                final KnowledgeBuilder kbuilder2;
+                if (reuseKieBaseWhenAddingRules) {
+                    kbuilder2 = createKnowledgeBuilder(kSession.getKieBase(), drl);
+                } else {
+                    kbuilder2 = createKnowledgeBuilder(null, drl);
+                }
+                kSession.getKieBase().addKnowledgePackages(kbuilder2.getKnowledgePackages());
+            }
+            return kSession;
+        }
+    }
+
+    private KnowledgeBuilder createKnowledgeBuilder(final KnowledgeBase kbase, final String drl) {
+        final KnowledgeBuilder kbuilder;
+        if (kbase == null) {
+            kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        } else {
+            kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder(kbase);
+        }
+
+        kbuilder.add(ResourceFactory.newByteArrayResource(drl.getBytes()), ResourceType.DRL);
+        if (kbuilder.hasErrors()) {
+            throw new RuntimeException("Knowledge contains errors: " + kbuilder.getErrors().toString());
+        }
+        return kbuilder;
+    }
+
+    private void insertGlobals(final StatefulKnowledgeSession session, final Map<String, Object> globals) {
+        for (Map.Entry<String, Object> globalEntry : globals.entrySet()) {
+            session.setGlobal(globalEntry.getKey(), globalEntry.getValue());
+        }
+    }
+
+    private String createTestFailMessage(final List<TestOperation> testOperations,
+            final Collection<String> expectedResults, final Collection<String> actualResults) {
+        final StringBuilder messageBuilder = new StringBuilder();
+        final String lineSeparator = System.getProperty("line.separator");
+        messageBuilder.append("Expected results are different than actual after operations:" + lineSeparator);
+        int index = 1;
+        for (TestOperation testOperation : testOperations) {
+            messageBuilder.append(index + ". " + testOperation.toString());
+            messageBuilder.append(lineSeparator);
+            index++;
+        }
+        if (expectedResults != null && actualResults != null) {
+            messageBuilder.append( "Expected results: " + lineSeparator + "[" );
+            for ( String expectedResult : expectedResults ) {
+                messageBuilder.append( expectedResult + " " );
+            }
+            messageBuilder.append( "]" + lineSeparator );
+            messageBuilder.append( "Actual results: " + lineSeparator + "[" );
+            for ( String actualResult : actualResults ) {
+                messageBuilder.append( actualResult + " " );
+            }
+        }
+        messageBuilder.append("]" + lineSeparator);
+        return messageBuilder.toString();
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestContext.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestContext.java
@@ -113,6 +113,7 @@ public class TestContext {
             default:
                 throw new IllegalArgumentException("Unsupported test operation: " + testOperationType + "!");
         }
+        executedOperations.add(testOperation);
     }
 
     public void dumpRete() {
@@ -122,6 +123,10 @@ public class TestContext {
 
     public Map<FactHandle, Object> getActualSessionFacts() {
         return actualSessionFacts;
+    }
+
+    public Set<FactHandle> getActualSessionFactHandles() {
+        return actualSessionFacts.keySet();
     }
 
     public List<TestOperation> getExecutedOperations() {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestOperationType.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/TestOperationType.java
@@ -19,5 +19,18 @@ package org.drools.compiler.integrationtests.incrementalcompilation;
  * Represents possible test operations in incremental compilation tests.
  */
 public enum TestOperationType {
-    CREATE_SESSION, ADD_RULES, ADD_RULES_REINSERT_OLD, REMOVE_RULES, CHECK_RESULTS, FIRE_RULES, INSERT_FACTS, DUMP_RETE
+    CREATE_SESSION,
+
+    ADD_RULES,
+    ADD_RULES_REINSERT_OLD,
+    REMOVE_RULES,
+
+    INSERT_FACTS,
+    REMOVE_FACTS,
+
+    FIRE_RULES,
+
+    CHECK_RESULTS,
+
+    DUMP_RETE
 }


### PR DESCRIPTION
- Created new TestContext, so we can batch TestOperations and observe state of the engine during tests. 
- Found new NPE - reproducer is test method AddRemoveRulesTest.testAddRemoveFacts(). 

Stacktrace: http://pastebin.com/Cngs78d9
