### PR TITLE
- DROOLS-972: adding cdi scopes examples and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dependency-reduced-pom.xml
 
 # these modules don't exist anymore on master
 /drools-clips/
+/drools-examples-cdi/drools-example-cdi-scopes/target/
+/drools-examples-cdi/cdi-example-scopes/target/

--- a/drools-examples-cdi/cdi-example-scopes/pom.xml
+++ b/drools-examples-cdi/cdi-example-scopes/pom.xml
@@ -1,0 +1,93 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-examples-cdi</artifactId>
+      <version>7.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>cdi-example-scopes</artifactId>
+   
+    <packaging>jar</packaging>
+
+    <name>cdi-example-scopes</name>
+    
+   
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.1.11.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-api</artifactId>
+        </dependency>
+       
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>     
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.cdictrl</groupId>
+            <artifactId>deltaspike-cdictrl-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.cdictrl</groupId>
+            <artifactId>deltaspike-cdictrl-weld</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-se-embedded-1.1</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+       
+    </dependencies>
+</project>

--- a/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScopeContext.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScopeContext.java
@@ -1,0 +1,75 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+
+
+/**
+ *
+ * @author salaboy
+ */
+public class KieBusinessScopeContext implements Context, Serializable {
+
+    private Map<String, Object> somewhere = new HashMap<String, Object>();
+
+    public KieBusinessScopeContext() {
+        System.out.println(">>> Creating a new context instance");
+    }
+
+    
+  // Get the scope type of the context object.
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return KieBusinessScoped.class;
+    }
+
+    // Return an existing instance of certain contextual type or create a new instance by calling
+    // javax.enterprise.context.spi.Contextual.create(CreationalContext) and return the new instance.
+    
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        Bean bean = (Bean) contextual;
+        // you can store the bean somewhere
+        if (somewhere.containsKey(bean.getName())) {
+            return (T) somewhere.get(bean.getName());
+        } else {
+            T t = (T) bean.create(creationalContext);
+            somewhere.put(bean.getName(), t);
+            return t;
+        }
+    }
+
+    // Return an existing instance of a certain contextual type or a null value.
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Contextual<T> contextual) {
+        Bean bean = (Bean) contextual;
+        // you can store the bean somewhere
+        if (somewhere.containsKey(bean.getName())) {
+            return (T) somewhere.get(bean.getName());
+        } else {
+            return null;
+        }
+    }
+
+  // Determines if the context object is active.
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+   
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScopeExtension.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScopeExtension.java
@@ -1,0 +1,27 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.io.Serializable;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+/**
+ *
+ * @author salaboy
+ */
+public class KieBusinessScopeExtension implements Extension, Serializable {
+
+    public void addACustomScope(@Observes final BeforeBeanDiscovery event) {
+        event.addScope(KieBusinessScoped.class, true, false);
+    }
+
+    public void registerACustomScopeContext(@Observes final AfterBeanDiscovery event) {
+        event.addContext(new KieBusinessScopeContext());
+    }
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScoped.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScoped.java
@@ -1,0 +1,21 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Scope;
+
+/**
+ *
+ * @author salaboy
+ */
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE,ElementType.METHOD,ElementType.FIELD})
+public @interface KieBusinessScoped {}

--- a/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScopedRules.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/java/org/drools/workshop/KieBusinessScopedRules.java
@@ -1,0 +1,36 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.kie.api.cdi.KReleaseId;
+import org.kie.api.cdi.KSession;
+import org.kie.api.runtime.KieSession;
+
+/**
+ *
+ * @author salaboy
+ */
+@KieBusinessScoped
+@Named("rules")
+public class KieBusinessScopedRules {
+    
+    @Inject
+    @KSession
+    @KReleaseId(groupId = "org.drools.workshop", artifactId = "my-first-drools-kjar", version = "1.0-SNAPSHOT")
+    private KieSession kSession;
+
+    public KieSession getkSession() {
+        return kSession;
+    }
+
+    public void setkSession(KieSession kSession) {
+        this.kSession = kSession;
+    }
+    
+    
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/main/resources/META-INF/beans.xml
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/drools-examples-cdi/cdi-example-scopes/src/main/resources/META-INF/kmodule.xml
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,2 @@
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+</kmodule>

--- a/drools-examples-cdi/cdi-example-scopes/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.drools.workshop.KieBusinessScopeExtension

--- a/drools-examples-cdi/cdi-example-scopes/src/main/resources/logging.properties
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/resources/logging.properties
@@ -1,0 +1,2 @@
+java.util.logging.ConsoleHandler.level=FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/drools-examples-cdi/cdi-example-scopes/src/main/resources/rules.drl
+++ b/drools-examples-cdi/cdi-example-scopes/src/main/resources/rules.drl
@@ -1,0 +1,8 @@
+package org.drools.workshop;
+
+rule "My First Drools Rule"
+    when
+        $o: Object()
+    then
+        System.out.println(" >>> Rule Fired for Object: "+$o.toString());
+end

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/ApplicationScopedRulesJUnitTest.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/ApplicationScopedRulesJUnitTest.java
@@ -1,0 +1,95 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+
+import javax.inject.Inject;
+import org.apache.deltaspike.cdise.api.ContextControl;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author salaboy
+ */
+@RunWith(Arquillian.class)
+public class ApplicationScopedRulesJUnitTest {
+
+    public ApplicationScopedRulesJUnitTest() {
+    }
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClasses(MyBean.class, MyApplicationScopedBean.class)
+                .addPackages(true, "org.apache.deltaspike")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+//        System.out.println(war.toString(true));
+        return jar;
+    }
+    
+    @Inject
+    private MyApplicationScopedBean myApplicationBean;
+
+    @Test
+    public void helloApplicationScoped() {
+        Assert.assertNotNull(myApplicationBean);
+        ContextControl ctxCtrl = BeanProvider.getContextualReference(ContextControl.class);
+
+        ctxCtrl.startContext(ApplicationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+
+        int myBeanHashcode = myApplicationBean.getMyBean().hashCode();
+        int myKieSessionHashcode = myApplicationBean.getkSession().hashCode();
+
+        int result = myApplicationBean.doSomething("hello 0");
+        Assert.assertEquals(1, result);
+
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+        
+
+        Assert.assertEquals(myBeanHashcode, myApplicationBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, myApplicationBean.getkSession().hashCode());
+
+
+        myBeanHashcode = myApplicationBean.getMyBean().hashCode();
+        myKieSessionHashcode = myApplicationBean.getkSession().hashCode();
+
+        result = myApplicationBean.doSomething("hello 1");
+        Assert.assertEquals(1, result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        
+        Assert.assertEquals(myBeanHashcode, myApplicationBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, myApplicationBean.getkSession().hashCode());
+
+
+        result = myApplicationBean.doSomething("hello 2");
+        Assert.assertEquals(1, result);
+       
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ApplicationScoped.class);
+        
+
+    }
+
+  
+    
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/ConversationScopedRulesJUnitTest.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/ConversationScopedRulesJUnitTest.java
@@ -1,0 +1,149 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+
+import javax.inject.Inject;
+import org.apache.deltaspike.cdise.api.ContextControl;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author salaboy
+ */
+@RunWith(Arquillian.class)
+public class ConversationScopedRulesJUnitTest {
+
+    public ConversationScopedRulesJUnitTest() {
+    }
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClasses(MyBean.class, MyConversationScopedBean.class)
+                .addPackages(true, "org.apache.deltaspike")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+//        System.out.println(war.toString(true));
+        return jar;
+    }
+
+    @Inject
+    private MyConversationScopedBean myConversationBean;
+
+    @Test
+    @Ignore
+    public void helloConversationScoped() {
+        Assert.assertNotNull(myConversationBean);
+        ContextControl ctxCtrl = BeanProvider.getContextualReference(ContextControl.class);
+
+        ctxCtrl.startContext(SessionScoped.class);
+        ctxCtrl.startContext(ConversationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        myConversationBean.begin();
+        int myBeanHashcode = myConversationBean.getMyBean().hashCode();
+        int myKieSessionHashcode = myConversationBean.getkSession().hashCode();
+
+        int result = myConversationBean.doSomething("hello 0");
+        Assert.assertEquals(1, result);
+
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, myConversationBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, myConversationBean.getkSession().hashCode());
+
+        myBeanHashcode = myConversationBean.getMyBean().hashCode();
+        myKieSessionHashcode = myConversationBean.getkSession().hashCode();
+
+        result = myConversationBean.doSomething("hello 1");
+        Assert.assertEquals(1, result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, myConversationBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, myConversationBean.getkSession().hashCode());
+
+        result = myConversationBean.doSomething("hello 2");
+        Assert.assertEquals(1, result);
+
+        myBeanHashcode = myConversationBean.getMyBean().hashCode();
+        myKieSessionHashcode = myConversationBean.getkSession().hashCode();
+
+        myConversationBean.end();
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ConversationScoped.class);
+
+        ctxCtrl.startContext(ConversationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        myConversationBean.begin();
+        
+        Assert.assertNotEquals(myBeanHashcode, myConversationBean.getMyBean().hashCode());
+        Assert.assertNotEquals(myKieSessionHashcode, myConversationBean.getkSession().hashCode());
+        result = myConversationBean.doSomething("hello 3");
+        Assert.assertEquals(1, result);
+
+        myBeanHashcode = myConversationBean.getMyBean().hashCode();
+        myKieSessionHashcode = myConversationBean.getkSession().hashCode();
+        
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, myConversationBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, myConversationBean.getkSession().hashCode());
+
+        myBeanHashcode = myConversationBean.getMyBean().hashCode();
+        myKieSessionHashcode = myConversationBean.getkSession().hashCode();
+
+        result = myConversationBean.doSomething("hello 4");
+        Assert.assertEquals(1, result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, myConversationBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, myConversationBean.getkSession().hashCode());
+
+        result = myConversationBean.doSomething("hello 5");
+        Assert.assertEquals(1, result);
+
+        myBeanHashcode = myConversationBean.getMyBean().hashCode();
+        myKieSessionHashcode = myConversationBean.getkSession().hashCode();
+        myConversationBean.end();
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ConversationScoped.class);
+
+        ctxCtrl.startContext(ConversationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+        
+        
+        myConversationBean.begin();
+        Assert.assertNotEquals(myBeanHashcode, myConversationBean.getMyBean().hashCode());
+        Assert.assertNotEquals(myKieSessionHashcode, myConversationBean.getkSession().hashCode());
+        myConversationBean.end();
+        
+        
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ConversationScoped.class);
+        ctxCtrl.stopContext(SessionScoped.class);
+
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyApplicationScopedBean.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyApplicationScopedBean.java
@@ -1,0 +1,48 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.kie.api.cdi.KSession;
+import org.kie.api.runtime.KieSession;
+
+/**
+ *
+ * @author salaboy
+ */
+@ApplicationScoped
+public class MyApplicationScopedBean {
+
+    @Inject
+    @KSession
+//    @KReleaseId(groupId = "org.drools.workshop", artifactId = "my-first-drools-kjar", version = "1.0-SNAPSHOT")
+    private KieSession kSession;
+
+    @Inject
+    private MyBean myBean;
+
+    public MyApplicationScopedBean() {
+        System.out.println(">>> new MyApplicationScopedBean: " + this.hashCode());
+
+    }
+
+    public int doSomething(String string) {
+        System.out.println(" >> Doing Something: " + string);
+        kSession.insert(string);
+        String doSomething = myBean.doSomething(string);
+        return kSession.fireAllRules();
+    }
+
+    public KieSession getkSession() {
+        return kSession;
+    }
+
+    public MyBean getMyBean() {
+        return myBean;
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyBean.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyBean.java
@@ -1,0 +1,31 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.enterprise.inject.spi.PassivationCapable;
+
+/**
+ *
+ * @author salaboy
+ */
+public class MyBean implements PassivationCapable, Serializable {
+
+    public MyBean() {
+    }
+
+    public String getId() {
+        return "MyBean-"+UUID.randomUUID().toString();
+    }
+    
+    
+    
+    public String doSomething(String text){
+        System.out.println("Doing Something with: "+text);
+        return text + " processed!";
+    }
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyConversationScopedBean.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyConversationScopedBean.java
@@ -1,0 +1,74 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.enterprise.context.Conversation;
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.inject.spi.PassivationCapable;
+import javax.inject.Inject;
+import org.kie.api.cdi.KReleaseId;
+import org.kie.api.cdi.KSession;
+import org.kie.api.runtime.KieSession;
+
+/**
+ *
+ * @author salaboy
+ */
+@ConversationScoped
+public class MyConversationScopedBean implements PassivationCapable, Serializable{
+
+    @Inject
+    private Conversation conversation;
+    
+    @Inject
+    @KSession
+//    @KReleaseId(groupId = "org.drools.workshop", artifactId = "my-first-drools-kjar", version = "1.0-SNAPSHOT")
+    private KieSession kSession;
+
+    @Inject
+    private MyBean myBean;
+
+    public MyConversationScopedBean() {
+        System.out.println(">>> new MyConversationScopedBean: " + this.hashCode());
+
+    }
+
+    public String getId() {
+        return "MyConversationScopedBean-"+UUID.randomUUID().toString();
+    }
+    
+    
+
+    public int doSomething(String string) {
+        System.out.println(" >> Doing Something: " + string);
+        kSession.insert(string);
+        String doSomething = myBean.doSomething(string);
+        return kSession.fireAllRules();
+    }
+
+    public KieSession getkSession() {
+        return kSession;
+    }
+
+    public MyBean getMyBean() {
+        return myBean;
+    }
+    
+    public void begin(){
+        conversation.begin();
+    }
+    
+    public void begin(String id){
+        conversation.begin(id);
+    }
+    
+    public void end(){
+        conversation.end();
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyRequestScopedBean.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MyRequestScopedBean.java
@@ -1,0 +1,49 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import org.kie.api.cdi.KReleaseId;
+import org.kie.api.cdi.KSession;
+import org.kie.api.runtime.KieSession;
+
+/**
+ *
+ * @author salaboy
+ */
+@RequestScoped
+public class MyRequestScopedBean {
+
+    @Inject
+    @KSession
+//    @KReleaseId(groupId = "org.drools.workshop", artifactId = "my-first-drools-kjar", version = "1.0-SNAPSHOT")
+    private KieSession kSession;
+
+    @Inject
+    private MyBean myBean;
+
+    public MyRequestScopedBean() {
+        System.out.println(">>> new MyRequestBean: " + this.hashCode());
+
+    }
+
+    public int doSomething(String string) {
+        System.out.println(" >> Doing Something: " + string);
+        kSession.insert(string);
+        String doSomething = myBean.doSomething(string);
+        return kSession.fireAllRules();
+    }
+
+    public KieSession getkSession() {
+        return kSession;
+    }
+
+    public MyBean getMyBean() {
+        return myBean;
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MySessionScopedBean.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MySessionScopedBean.java
@@ -1,0 +1,58 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.inject.spi.PassivationCapable;
+import javax.inject.Inject;
+import org.kie.api.cdi.KSession;
+import org.kie.api.runtime.KieSession;
+
+/**
+ *
+ * @author salaboy
+ */
+@SessionScoped
+public class MySessionScopedBean implements PassivationCapable, Serializable {
+
+    
+    @Inject
+    @KSession
+//    @KReleaseId(groupId = "org.drools.workshop", artifactId = "my-first-drools-kjar", version = "1.0-SNAPSHOT")
+    private KieSession kSession;
+
+    @Inject
+    private MyBean myBean;
+
+    public MySessionScopedBean() {
+        System.out.println(">>> new MySessionScopedBean: " + this.hashCode());
+
+    }
+
+    public String getId() {
+        return "MySessionScopedBean-"+UUID.randomUUID().toString();
+    }
+    
+    
+
+    public int doSomething(String string) {
+        System.out.println(" >> Doing Something: " + string);
+        kSession.insert(string);
+        String doSomething = myBean.doSomething(string);
+        return kSession.fireAllRules();
+    }
+
+    public KieSession getkSession() {
+        return kSession;
+    }
+
+    public MyBean getMyBean() {
+        return myBean;
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MySimpleConversationScopedBean.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/MySimpleConversationScopedBean.java
@@ -1,0 +1,58 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.enterprise.context.Conversation;
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.inject.spi.PassivationCapable;
+import javax.inject.Inject;
+
+/**
+ *
+ * @author salaboy
+ */
+@ConversationScoped
+public class MySimpleConversationScopedBean implements PassivationCapable, Serializable {
+
+    @Inject
+    private Conversation conversation;
+
+    @Inject
+    private MyBean myBean;
+
+    public MySimpleConversationScopedBean() {
+        System.out.println(">>> new MyConversationScopedBean: " + this.hashCode());
+
+    }
+
+    public String getId() {
+        return "MyConversationScopedBean-" + UUID.randomUUID().toString();
+    }
+
+    public String doSomething(String string) {
+        System.out.println(" >> Doing Something: " + string);
+        return myBean.doSomething(string);
+    }
+
+    public MyBean getMyBean() {
+        return myBean;
+    }
+
+    public void begin() {
+        conversation.begin();
+    }
+
+    public void begin(String id) {
+        conversation.begin(id);
+    }
+
+    public void end() {
+        conversation.end();
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/RequestScopedRulesJUnitTest.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/RequestScopedRulesJUnitTest.java
@@ -1,0 +1,99 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.RequestScoped;
+
+import javax.inject.Inject;
+import org.apache.deltaspike.cdise.api.ContextControl;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author salaboy
+ */
+@RunWith(Arquillian.class)
+public class RequestScopedRulesJUnitTest {
+
+    public RequestScopedRulesJUnitTest() {
+    }
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClasses(MyBean.class, MyRequestScopedBean.class)
+                .addPackages(true, "org.apache.deltaspike")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+//        System.out.println(war.toString(true));
+        return jar;
+    }
+    
+    @Inject
+    private MyRequestScopedBean myRequestBean;
+
+    @Test
+    @Ignore
+    public void helloRequestScoped() {
+        Assert.assertNotNull(myRequestBean);
+        ContextControl ctxCtrl = BeanProvider.getContextualReference(ContextControl.class);
+
+        ctxCtrl.startContext(RequestScoped.class);
+
+
+        int myBeanHashcode = myRequestBean.getMyBean().hashCode();
+        int myKieSessionHashcode = myRequestBean.getkSession().hashCode();
+
+        int result = myRequestBean.doSomething("hello 0");
+        Assert.assertEquals(1, result);
+
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+        
+
+        Assert.assertNotEquals(myBeanHashcode, myRequestBean.getMyBean().hashCode());
+        Assert.assertNotEquals(myKieSessionHashcode, myRequestBean.getkSession().hashCode());
+
+
+        myBeanHashcode = myRequestBean.getMyBean().hashCode();
+        myKieSessionHashcode = myRequestBean.getkSession().hashCode();
+
+        result = myRequestBean.doSomething("hello 1");
+        Assert.assertEquals(1, result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        
+        Assert.assertNotEquals(myBeanHashcode, myRequestBean.getMyBean().hashCode());
+        Assert.assertNotEquals(myKieSessionHashcode, myRequestBean.getkSession().hashCode());
+
+        result = myRequestBean.doSomething("hello 2");
+        Assert.assertEquals(1, result);
+       
+        myBeanHashcode = myRequestBean.getMyBean().hashCode();
+        myKieSessionHashcode = myRequestBean.getkSession().hashCode();
+        
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertNotEquals(myBeanHashcode, myRequestBean.getMyBean().hashCode());
+        Assert.assertNotEquals(myKieSessionHashcode, myRequestBean.getkSession().hashCode());
+
+    }
+
+  
+    
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/SessionScopedRulesJUnitTest.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/SessionScopedRulesJUnitTest.java
@@ -1,0 +1,106 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+
+import javax.inject.Inject;
+import org.apache.deltaspike.cdise.api.ContextControl;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author salaboy
+ */
+@RunWith(Arquillian.class)
+public class SessionScopedRulesJUnitTest {
+
+    public SessionScopedRulesJUnitTest() {
+    }
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClasses(MyBean.class, MySessionScopedBean.class)
+                .addPackages(true, "org.apache.deltaspike")
+//                .addAsServiceProvider(KieBusinessScopeExtension.class, KieBusinessScopeContext.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+//        System.out.println(war.toString(true));
+        return jar;
+    }
+    
+    @Inject
+    private MySessionScopedBean mySessionBean;
+
+    @Test
+    @Ignore
+    public void helloSessionScoped() {
+        Assert.assertNotNull(mySessionBean);
+        ContextControl ctxCtrl = BeanProvider.getContextualReference(ContextControl.class);
+
+        ctxCtrl.startContext(SessionScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+
+        int myBeanHashcode = mySessionBean.getMyBean().hashCode();
+        int myKieSessionHashcode = mySessionBean.getkSession().hashCode();
+
+        int result = mySessionBean.doSomething("hello 0");
+        Assert.assertEquals(1, result);
+
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+        
+
+        Assert.assertEquals(myBeanHashcode, mySessionBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, mySessionBean.getkSession().hashCode());
+
+
+        myBeanHashcode = mySessionBean.getMyBean().hashCode();
+        myKieSessionHashcode = mySessionBean.getkSession().hashCode();
+
+        result = mySessionBean.doSomething("hello 1");
+        Assert.assertEquals(1, result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        
+        Assert.assertEquals(myBeanHashcode, mySessionBean.getMyBean().hashCode());
+        Assert.assertEquals(myKieSessionHashcode, mySessionBean.getkSession().hashCode());
+
+        result = mySessionBean.doSomething("hello 2");
+        Assert.assertEquals(1, result);
+       
+        myBeanHashcode = mySessionBean.getMyBean().hashCode();
+        myKieSessionHashcode = mySessionBean.getkSession().hashCode();
+        
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(SessionScoped.class);
+        
+        
+        ctxCtrl.startContext(SessionScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+        
+        Assert.assertNotEquals(myBeanHashcode, mySessionBean.getMyBean().hashCode());
+        Assert.assertNotEquals(myKieSessionHashcode, mySessionBean.getkSession().hashCode());
+
+    }
+
+  
+    
+}

--- a/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/SimpleConversationScopedRulesJUnitTest.java
+++ b/drools-examples-cdi/cdi-example-scopes/src/test/java/org/drools/workshop/SimpleConversationScopedRulesJUnitTest.java
@@ -1,0 +1,144 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.drools.workshop;
+
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+
+import javax.inject.Inject;
+import org.apache.deltaspike.cdise.api.ContextControl;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author salaboy
+ */
+@RunWith(Arquillian.class)
+public class SimpleConversationScopedRulesJUnitTest {
+
+    public SimpleConversationScopedRulesJUnitTest() {
+    }
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClasses(MyBean.class, MySimpleConversationScopedBean.class)
+                .addPackages(true, "org.apache.deltaspike")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+//        System.out.println(war.toString(true));
+        return jar;
+    }
+
+    @Inject
+    private MySimpleConversationScopedBean mySimpleConversationBean;
+
+    @Test
+    public void helloSimpleConversationScoped() {
+        Assert.assertNotNull(mySimpleConversationBean);
+        ContextControl ctxCtrl = BeanProvider.getContextualReference(ContextControl.class);
+
+        ctxCtrl.startContext(SessionScoped.class);
+        ctxCtrl.startContext(ConversationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        mySimpleConversationBean.begin();
+        int myBeanHashcode = mySimpleConversationBean.getMyBean().hashCode();
+
+        String result = mySimpleConversationBean.doSomething("hello 0");
+        Assert.assertEquals("hello 0 processed!", result);
+
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, mySimpleConversationBean.getMyBean().hashCode());
+        
+
+        myBeanHashcode = mySimpleConversationBean.getMyBean().hashCode();
+        
+
+        result = mySimpleConversationBean.doSomething("hello 1");
+        Assert.assertEquals("hello 1 processed!", result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, mySimpleConversationBean.getMyBean().hashCode());
+
+        result = mySimpleConversationBean.doSomething("hello 2");
+        Assert.assertEquals("hello 2 processed!", result);
+
+        myBeanHashcode = mySimpleConversationBean.getMyBean().hashCode();
+        
+
+        mySimpleConversationBean.end();
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ConversationScoped.class);
+
+        ctxCtrl.startContext(ConversationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        mySimpleConversationBean.begin();
+        
+        Assert.assertNotEquals(myBeanHashcode, mySimpleConversationBean.getMyBean().hashCode());
+
+        result = mySimpleConversationBean.doSomething("hello 3");
+        Assert.assertEquals("hello 3 processed!", result);
+
+        myBeanHashcode = mySimpleConversationBean.getMyBean().hashCode();
+        
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, mySimpleConversationBean.getMyBean().hashCode());
+        
+
+        myBeanHashcode = mySimpleConversationBean.getMyBean().hashCode();
+        
+
+        result = mySimpleConversationBean.doSomething("hello 4");
+        Assert.assertEquals("hello 4 processed!", result);
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+
+        Assert.assertEquals(myBeanHashcode, mySimpleConversationBean.getMyBean().hashCode());
+        
+
+        result = mySimpleConversationBean.doSomething("hello 5");
+        Assert.assertEquals("hello 5 processed!", result);
+
+        myBeanHashcode = mySimpleConversationBean.getMyBean().hashCode();
+        
+        mySimpleConversationBean.end();
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ConversationScoped.class);
+
+        ctxCtrl.startContext(ConversationScoped.class);
+        ctxCtrl.startContext(RequestScoped.class);
+        
+        
+        mySimpleConversationBean.begin();
+        Assert.assertNotEquals(myBeanHashcode, mySimpleConversationBean.getMyBean().hashCode());
+        
+        mySimpleConversationBean.end();
+        
+        
+        ctxCtrl.stopContext(RequestScoped.class);
+        ctxCtrl.stopContext(ConversationScoped.class);
+        ctxCtrl.stopContext(SessionScoped.class);
+
+    }
+
+}

--- a/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>cdi-example-with-inclusion</artifactId>
-  <name>Drools CDI Example WIth Inclusion</name>
+  <name>Drools CDI Example With Inclusion</name>
 
   <dependencies>
     <dependency>

--- a/drools-examples-cdi/pom.xml
+++ b/drools-examples-cdi/pom.xml
@@ -16,6 +16,7 @@
   <modules>
     <module>cdi-example</module>
     <module>cdi-example-with-inclusion</module>
+    <module>cdi-example-scopes</module>
   </modules>
 
 


### PR DESCRIPTION
here are some tests showing the different scopes and behaviours for the @kie injections in general. 
Notice another PR in the droolsjbpm-build-bootstrap repository. 
