### PR TITLE
GUVNOR-2477: Guided Decision Tables: Construction of DRL for 'otherwise' values includes empty String

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTDRLOtherwiseHelper.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTDRLOtherwiseHelper.java
@@ -15,14 +15,14 @@
  */
 package org.drools.workbench.models.guided.dtable.backend.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.drools.workbench.models.datamodel.rule.FieldConstraint;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Utility class to build Field Constraints for cells with "Otherwise" values
@@ -52,6 +52,11 @@ public class GuidedDTDRLOtherwiseHelper {
             StringBuilder value = new StringBuilder();
             value.append( "( " );
             for ( DTCellValue52 cv : columnData ) {
+
+                //Skip the "otherwise" cell itself
+                if ( cv.isOtherwise() ) {
+                    continue;
+                }
 
                 //Ensure cell values start and end with quotes
                 String scv = GuidedDTDRLUtilities.convertDTCellValueToString( cv );
@@ -94,6 +99,11 @@ public class GuidedDTDRLOtherwiseHelper {
             StringBuilder value = new StringBuilder();
             value.append( "( " );
             for ( DTCellValue52 cv : columnData ) {
+
+                //Skip the "otherwise" cell itself
+                if ( cv.isOtherwise() ) {
+                    continue;
+                }
 
                 //Ensure cell values start and end with quotes
                 String scv = GuidedDTDRLUtilities.convertDTCellValueToString( cv );

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
@@ -875,6 +875,11 @@ public class GuidedDTDRLPersistenceTest {
         rowDTModel1.get( 3 ).setOtherwise( true );
         data[ 1 ] = row[ 1 ];
 
+        final List<List<DTCellValue52>> allDTData = new ArrayList<List<DTCellValue52>>() {{
+            add( rowDTModel0 );
+            add( rowDTModel1 );
+        }};
+
         List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
         List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
         allColumns.add( new RowNumberCol52() );
@@ -915,7 +920,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider0,
                         rowDTModel0,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl0 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -940,7 +945,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider1,
                         rowDTModel1,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl1 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -978,6 +983,12 @@ public class GuidedDTDRLPersistenceTest {
         rowDTModel2.get( 2 ).setOtherwise( true );
         rowDTModel2.get( 3 ).setOtherwise( true );
         data[ 2 ] = row[ 2 ];
+
+        final List<List<DTCellValue52>> allDTData = new ArrayList<List<DTCellValue52>>() {{
+            add( rowDTModel0 );
+            add( rowDTModel1 );
+            add( rowDTModel2 );
+        }};
 
         List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
         List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
@@ -1019,7 +1030,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider0,
                         rowDTModel0,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl0 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1044,7 +1055,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider1,
                         rowDTModel1,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl1 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1069,7 +1080,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider2,
                         rowDTModel2,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl2 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1107,6 +1118,12 @@ public class GuidedDTDRLPersistenceTest {
         rowDTModel2.get( 2 ).setOtherwise( true );
         rowDTModel2.get( 3 ).setOtherwise( true );
         data[ 2 ] = row[ 2 ];
+
+        final List<List<DTCellValue52>> allDTData = new ArrayList<List<DTCellValue52>>() {{
+            add( rowDTModel0 );
+            add( rowDTModel1 );
+            add( rowDTModel2 );
+        }};
 
         List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
         List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
@@ -1148,7 +1165,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider0,
                         rowDTModel0,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl0 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1173,7 +1190,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider1,
                         rowDTModel1,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl1 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1198,7 +1215,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider2,
                         rowDTModel2,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl2 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1231,11 +1248,17 @@ public class GuidedDTDRLPersistenceTest {
         List<DTCellValue52> rowDTModel1 = DataUtilities.makeDataRowList( row[ 1 ] );
         data[ 1 ] = row[ 1 ];
 
-        row[ 2 ] = new String[]{ "3", "desc3", null, null };
+        row[ 2 ] = new String[]{ "3", "desc3", "", "" };
         List<DTCellValue52> rowDTModel2 = DataUtilities.makeDataRowList( row[ 2 ] );
         rowDTModel2.get( 2 ).setOtherwise( true );
         rowDTModel2.get( 3 ).setOtherwise( true );
         data[ 2 ] = row[ 2 ];
+
+        final List<List<DTCellValue52>> allDTData = new ArrayList<List<DTCellValue52>>() {{
+            add( rowDTModel0 );
+            add( rowDTModel1 );
+            add( rowDTModel2 );
+        }};
 
         List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
         List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
@@ -1277,7 +1300,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider0,
                         rowDTModel0,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl0 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1302,7 +1325,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider1,
                         rowDTModel1,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl1 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 
@@ -1327,7 +1350,7 @@ public class GuidedDTDRLPersistenceTest {
                         allPatterns,
                         rowDataProvider2,
                         rowDTModel2,
-                        DataUtilities.makeDataLists( data ),
+                        allDTData,
                         rm );
         String drl2 = RuleModelDRLPersistenceImpl.getInstance().marshal( rm );
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2477

Construction of the DRL now filters actual "otherwise" cells. This approach was preferred to changing the default constructor for `DTCellValue52` to keep a `null` value as that solution has a higher risk of causing issues elsewhere (such is our test coverage). 
