### PR TITLE
DROOLS-1120 - KieModuleMetaData.getProcess() ignores processes define…

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaDataImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieModuleMetaDataImpl.java
@@ -186,7 +186,7 @@ public class KieModuleMetaDataImpl implements KieModuleMetaData {
             while ( entries.hasMoreElements() ) {
                 ZipEntry entry = entries.nextElement();
                 String pathName = entry.getName();
-                if(pathName.endsWith("bpmn2")){
+                if(pathName.endsWith("bpmn") || pathName.endsWith("bpmn2")){
                   processes.put(pathName, new String(readBytesFromZipEntry(jarFile, entry), UTF8_CHARSET));
                 }
                 if (!indexClass(pathName)) {


### PR DESCRIPTION
…d in file with extension bpmn

test case is included in droolsjbpm-integration as drools can't depend on jbpm thus won't be able to parse bpmn files when building kieModule
