### PR TITLE
[6.3.x] DROOLS-1106 - xstream xml marshaller does not work for more than one …

### DIFF
--- a/drools-core/src/main/java/org/drools/core/runtime/help/impl/XStreamXML.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/help/impl/XStreamXML.java
@@ -909,7 +909,7 @@ public class XStreamXML {
                     results.put( identifier,
                                  value );
                     reader.moveUp();
-                    reader.moveUp();
+
                 } else if ( reader.getNodeName().equals( "fact-handle" ) ) {
                     String identifier = reader.getAttribute( "identifier" );
                     facts.put( identifier,
@@ -927,6 +927,7 @@ public class XStreamXML {
                 } else {
                     throw new IllegalArgumentException( "Element '" + reader.getNodeName() + "' is not supported here" );
                 }
+                reader.moveUp();
             }
 
             return result;

--- a/drools-core/src/test/java/org/drools/core/runtime/help/impl/XStreamXMLTest.java
+++ b/drools-core/src/test/java/org/drools/core/runtime/help/impl/XStreamXMLTest.java
@@ -16,20 +16,27 @@
 package org.drools.core.runtime.help.impl;
 
 import com.thoughtworks.xstream.XStream;
-import org.drools.core.QueryResultsImpl;
 import org.drools.core.command.runtime.process.StartProcessCommand;
-import org.drools.core.command.runtime.rule.*;
+import org.drools.core.command.runtime.rule.AgendaGroupSetFocusCommand;
+import org.drools.core.command.runtime.rule.ClearActivationGroupCommand;
+import org.drools.core.command.runtime.rule.ClearAgendaCommand;
+import org.drools.core.command.runtime.rule.ClearAgendaGroupCommand;
+import org.drools.core.command.runtime.rule.ClearRuleFlowGroupCommand;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.runtime.impl.ExecutionResultImpl;
 import org.drools.core.runtime.rule.impl.FlatQueryResults;
-import org.drools.core.spi.FactHandleFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.QueryResults;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class XStreamXMLTest {
 
@@ -133,14 +140,14 @@ public class XStreamXMLTest {
                 20,
                 msg2 );
 
-        HashMap<String, Object> factHandles = new HashMap<String, Object>();
+        HashMap<String, Object> factHandles = new LinkedHashMap<String, Object>();
         factHandles.put("first", msgHandle);
         factHandles.put("second", msgHandle2);
 
         ExecutionResultImpl executionResult = new ExecutionResultImpl();
         executionResult.setFactHandles(factHandles);
 
-        HashMap<String, Object> results = new HashMap<String, Object>();
+        HashMap<String, Object> results = new LinkedHashMap<String, Object>();
         results.put("message1", msg);
         results.put("message2", msg2);
 
@@ -149,14 +156,14 @@ public class XStreamXMLTest {
         String xmlString = xstream.toXML(executionResult);
         Assert.assertEquals(
                 "<execution-results>\n" +
-                "  <result identifier=\"message2\">\n" +
-                "    <org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
-                "      <msg>Hello World again!</msg>\n" +
-                "    </org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
-                "  </result>\n" +
                 "  <result identifier=\"message1\">\n" +
                 "    <org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
                 "      <msg>Hello World!</msg>\n" +
+                "    </org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
+                "  </result>\n" +
+                "  <result identifier=\"message2\">\n" +
+                "    <org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
+                "      <msg>Hello World again!</msg>\n" +
                 "    </org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
                 "  </result>\n" +
                 "  <fact-handle identifier=\"first\" external-form=\"0:1:10:10:20:null:NON_TRAIT:org.drools.core.runtime.help.impl.XStreamXMLTest$Message\"/>\n" +

--- a/drools-core/src/test/java/org/drools/core/runtime/help/impl/XStreamXMLTest.java
+++ b/drools-core/src/test/java/org/drools/core/runtime/help/impl/XStreamXMLTest.java
@@ -20,6 +20,7 @@ import org.drools.core.QueryResultsImpl;
 import org.drools.core.command.runtime.process.StartProcessCommand;
 import org.drools.core.command.runtime.rule.*;
 import org.drools.core.common.DefaultFactHandle;
+import org.drools.core.runtime.impl.ExecutionResultImpl;
 import org.drools.core.runtime.rule.impl.FlatQueryResults;
 import org.drools.core.spi.FactHandleFactory;
 import org.junit.Assert;
@@ -111,6 +112,61 @@ public class XStreamXMLTest {
 
         ClearRuleFlowGroupCommand cmd2 = (ClearRuleFlowGroupCommand) xstream.fromXML( xmlString );
         Assert.assertEquals(cmd.getName(), cmd2.getName());
+    }
+
+    @Test
+    public void testExecutionResults() {
+
+        final Message msg = new Message("Hello World!");
+        final FactHandle msgHandle = new DefaultFactHandle( 1,
+                null,
+                10,
+                10,
+                20,
+                msg );
+
+        final Message msg2 = new Message("Hello World again!");
+        final FactHandle msgHandle2 = new DefaultFactHandle( 2,
+                null,
+                10,
+                10,
+                20,
+                msg2 );
+
+        HashMap<String, Object> factHandles = new HashMap<String, Object>();
+        factHandles.put("first", msgHandle);
+        factHandles.put("second", msgHandle2);
+
+        ExecutionResultImpl executionResult = new ExecutionResultImpl();
+        executionResult.setFactHandles(factHandles);
+
+        HashMap<String, Object> results = new HashMap<String, Object>();
+        results.put("message1", msg);
+        results.put("message2", msg2);
+
+        executionResult.setResults(results);
+
+        String xmlString = xstream.toXML(executionResult);
+        Assert.assertEquals(
+                "<execution-results>\n" +
+                "  <result identifier=\"message2\">\n" +
+                "    <org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
+                "      <msg>Hello World again!</msg>\n" +
+                "    </org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
+                "  </result>\n" +
+                "  <result identifier=\"message1\">\n" +
+                "    <org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
+                "      <msg>Hello World!</msg>\n" +
+                "    </org.drools.core.runtime.help.impl.XStreamXMLTest_-Message>\n" +
+                "  </result>\n" +
+                "  <fact-handle identifier=\"first\" external-form=\"0:1:10:10:20:null:NON_TRAIT:org.drools.core.runtime.help.impl.XStreamXMLTest$Message\"/>\n" +
+                "  <fact-handle identifier=\"second\" external-form=\"0:2:10:10:20:null:NON_TRAIT:org.drools.core.runtime.help.impl.XStreamXMLTest$Message\"/>\n" +
+                "</execution-results>",
+                xmlString );
+
+        ExecutionResultImpl executionResult2 = (ExecutionResultImpl) xstream.fromXML( xmlString );
+        Assert.assertEquals(executionResult.getFactHandles().size(), executionResult2.getFactHandles().size());
+        Assert.assertEquals(executionResult.getResults().size(), executionResult2.getResults().size());
     }
 
     @Test


### PR DESCRIPTION
this is as part of patch on 6.2.x product based on https://bugzilla.redhat.com/show_bug.cgi?id=1319548
