### PR TITLE
[BZ-1317026] serialization for stated and logical delete implementation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/command/runtime/rule/DeleteCommand.java
+++ b/drools-core/src/main/java/org/drools/core/command/runtime/rule/DeleteCommand.java
@@ -35,6 +35,7 @@ public class DeleteCommand
 
     private DisconnectedFactHandle handle;
 
+    @XmlElement
     private FactHandle.State fhState = FactHandle.State.ALL;
 
     public DeleteCommand() {


### PR DESCRIPTION
This fixes the failing test `org.kie.remote.jaxb.gen.GeneratedClassesCompatibilityTest.roundTripTest` in droolsjbpm-integration.
