### PR TITLE
[BZ-1312164] guided-dtables: configure correct classloader for xstream

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTXMLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTXMLPersistence.java
@@ -105,6 +105,10 @@ public class GuidedDTXMLPersistence {
         xt.alias( "valueNumeric",
                   Number.class,
                   BigDecimal.class );
+
+        // this is needed for OSGi as XStream needs to be able to load classes from the guided-dtable module
+        // and the default classloader for XStream bundle in OSGi does not have access to those classes
+        xt.setClassLoader( getClass().getClassLoader() );
     }
 
     public static GuidedDTXMLPersistence getInstance() {


### PR DESCRIPTION
@manstis, @mariofusco please take a look. This fixes the issue I am facing, but I am not 100% sure I am setting the correct classloader. If I understand correctly, this XStream instance just needs access to classes in the guided-dtable module, so if that is the case it should be correct to use the getClass().getClasloader(). However, in case it would also need access to user (domain?) classes which are in different bundle, this might not work.

I am also trying to create simple reproducer in droolsjbpm-integration repo (as we need to run it on karaf).
