### PR TITLE
Fix and unify logback*.xml configs

### DIFF
--- a/drools-beliefs/src/test/resources/logback-test.xml
+++ b/drools-beliefs/src/test/resources/logback-test.xml
@@ -3,9 +3,7 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/drools-compiler/src/test/resources/logback-test.xml
+++ b/drools-compiler/src/test/resources/logback-test.xml
@@ -3,18 +3,15 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
+  <logger name="org.kie" level="info"/>
   <logger name="org.drools" level="info"/>
-  <!-- logger name="org.mortbay" level="warn"/ -->
 
-  <root level="info"><!-- TODO We probably want to set default level to warn instead -->
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
-

--- a/drools-core/src/test/resources/logback-test.xml
+++ b/drools-core/src/test/resources/logback-test.xml
@@ -3,17 +3,15 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="debug"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
-

--- a/drools-decisiontables/src/test/resources/logback-test.xml
+++ b/drools-decisiontables/src/test/resources/logback-test.xml
@@ -3,17 +3,15 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
   <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
-

--- a/drools-examples-api/default-kiesession-from-file/src/main/resources/logback.xml
+++ b/drools-examples-api/default-kiesession-from-file/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
 

--- a/drools-examples-api/default-kiesession/src/main/resources/logback.xml
+++ b/drools-examples-api/default-kiesession/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
 

--- a/drools-examples-api/kie-module-from-multiple-files/src/main/resources/logback.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/src/main/resources/logback.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="debug"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/kiebase-inclusion/src/main/resources/logback.xml
+++ b/drools-examples-api/kiebase-inclusion/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/kiecontainer-from-kierepo/src/main/resources/logback.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/kiefilesystem-example/src/main/resources/logback.xml
+++ b/drools-examples-api/kiefilesystem-example/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/kiemodulemodel-example/src/main/resources/logback.xml
+++ b/drools-examples-api/kiemodulemodel-example/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/multiple-kbases/src/main/resources/logback.xml
+++ b/drools-examples-api/multiple-kbases/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="info">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/named-kiesession-from-file/src/main/resources/logback.xml
+++ b/drools-examples-api/named-kiesession-from-file/src/main/resources/logback.xml
@@ -3,9 +3,7 @@
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
+            <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/drools-examples-api/named-kiesession/src/main/resources/logback.xml
+++ b/drools-examples-api/named-kiesession/src/main/resources/logback.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-api/reactive-kiesession/src/main/resources/logback.xml
+++ b/drools-examples-api/reactive-kiesession/src/main/resources/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
 

--- a/drools-examples-cdi/cdi-example-with-inclusion/src/main/resources/META-INF/logback.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/src/main/resources/META-INF/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples-cdi/cdi-example/src/main/resources/META-INF/logback.xml
+++ b/drools-examples-cdi/cdi-example/src/main/resources/META-INF/logback.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <!-- %l lowers performance -->
-            <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-            <pattern>%d [%t] %-5p %m%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.jboss.weld" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jboss.weld" level="info"/>
 
-    <root level="info"><!-- TODO We probably want to set default level to warn instead -->
-        <appender-ref ref="consoleAppender"/>
-    </root>
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
+  </root>
 
 </configuration>
-

--- a/drools-examples/src/main/resources/logback.xml
+++ b/drools-examples/src/main/resources/logback.xml
@@ -3,12 +3,11 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
+  <logger name="org.kie" level="info"/>
   <logger name="org.drools" level="info"/>
 
   <root level="warn">
@@ -16,4 +15,5 @@
   </root>
 
 </configuration>
+
 

--- a/drools-persistence-jpa/src/test/resources/logback-test.xml
+++ b/drools-persistence-jpa/src/test/resources/logback-test.xml
@@ -3,34 +3,19 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] |%c| %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
   <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
   <!-- bitronix -->
   <logger name="bitronix.tm.twopc.Preparer" level="error"/>
-  <logger name="bitronix.tm.recovery.Recoverer" level="warn" />
-  <logger name="bitronix.tm.BitronixTransactionManager" level="warn" />
   <logger name="bitronix.tm.Configuration" level="error" />
-  
 
-  <!--  hibernate  -->
-  <logger name="java.sql.DatabaseMetaData" level="warn" />
-  
-  <logger name="org.hibernate" level="warn"/>
-  <logger name="org.hibernate.cfg.search" level="warn"/>
-  <logger name="org.hibernate.cfg.annotations" level="warn"/>
-  <logger name="org.hibernate.cfg.AnnotationBinder" level="warn"/>
-  <logger name="org.hibernate.cfg.SettingsFactory" level="warn"/>
-  <logger name="org.hibernate.tool.hbm2ddl" level="warn"/>
-
-  <root level="info"><!-- TODO We probably want to set default level to warn instead -->
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
-

--- a/drools-reteoo/src/test/resources/logback-test.xml
+++ b/drools-reteoo/src/test/resources/logback-test.xml
@@ -3,16 +3,14 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
+  <logger name="org.kie" level="info"/>
   <logger name="org.drools" level="info"/>
-  <!-- logger name="org.mortbay" level="warn"/ -->
 
-  <root level="info"><!-- TODO We probably want to set default level to warn instead -->
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/resources/logback-test.xml
@@ -3,15 +3,16 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="org.drools" level="info"/>
   <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
+

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/resources/logback-test.xml
@@ -3,15 +3,16 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="org.drools" level="info"/>
   <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
+

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/resources/logback-test.xml
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/resources/logback-test.xml
@@ -3,16 +3,14 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t|%C] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <!--  set to debug to see test output -->
-  <logger name="org.drools.workbench.models.commons.backend.rule" level="info" />
+  <logger name="org.kie" level="info" />
+  <logger name="org.drools" level="info" />
   
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 

--- a/kie-ci/src/test/resources/logback-test.xml
+++ b/kie-ci/src/test/resources/logback-test.xml
@@ -3,18 +3,15 @@
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
-      <pattern>%d [%t] %-5p %m%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <!-- change to debug to see test output -->
-  <logger name="org.kie.api.builder" level="info"/>
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
 
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="consoleAppender" />
   </root>
 
 </configuration>
-

--- a/kie-test-util/src/test/resources/logback-test.xml
+++ b/kie-test-util/src/test/resources/logback-test.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
- <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-      <!-- %l lowers performance -->
-      <!--<pattern>%d [%t] %-5p %l%n %m%n</pattern> -->
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <layout class="org.kie.test.util.logging.FilteredPatternLayout">
-      <pattern>%d [%t|%C] %-5p %m%n</pattern>
-      <param name="ConversionPattern" value="%-5p  %c %F(%M:%L) %d{dd.MM.yyyy HH:mm:ss}  %m%n" />
-      <param name="Filter" value="sun.reflect" />
-      <param name="Filter" value="org.junit" />
-      <param name="Filter" value="org.eclipse.jdt.internal" />
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+      <param name="ConversionPattern" value="%-5p  %c %F(%M:%L) %d{dd.MM.yyyy HH:mm:ss}  %m%n"/>
+      <param name="Filter" value="sun.reflect"/>
+      <param name="Filter" value="org.junit"/>
+      <param name="Filter" value="org.eclipse.jdt.internal"/>
     </layout>
   </appender>
 
-  <root level="info">
-    <appender-ref ref="consoleAppender" />
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="debug"/>
+
+  <root level="warn">
+    <appender-ref ref="consoleAppender"/>
   </root>
 
 </configuration>


### PR DESCRIPTION
- using the %line _may_ lower performance,
  but I was not able to observe any difference
  when running the drools build (mvn clean install -T10).
  I believe the line number gives useful info when trying to
  determine what is going wrong.

Basically I just unified the message patterns, set the default logging level to WARN and configured `org.kie` and `org.drools` packages to long also INFO messages.

We also need to figure out how to share the default `logback-test.xml` as it is ridiculous to have to copy&paste the config into every new module. This sounds promising, but will need to take a deeper look: http://blog.sonatype.com/2008/04/how-to-share-resources-across-projects-in-maven/

@mrietveld would mind quickly reviewing this?
