### PR TITLE
JBPM-5114 - Nested Map<String, Map<String, Object>[]> objects can not be de/serialized correctly

### DIFF
--- a/drools-core/src/main/java/org/drools/core/xml/jaxb/util/JaxbUnknownAdapter.java
+++ b/drools-core/src/main/java/org/drools/core/xml/jaxb/util/JaxbUnknownAdapter.java
@@ -199,7 +199,7 @@ public class JaxbUnknownAdapter extends XmlAdapter<Object, Object> {
                     // create and fill array
                     Object realArr = Array.newInstance(realArrComponentType, objArr.length);
                     for( int i = 0; i < length; ++i ) {
-                        Array.set(realArr, i, objArr[i]);
+                        Array.set(realArr, i, convertSerializedObjectToObject(objArr[i]));
                     }
                     return realArr;
                 default:


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-5114

This use case is particular important for migration. (See other PR for more info). 
List of PRs: 
- https://github.com/droolsjbpm/drools/pull/782
- https://github.com/droolsjbpm/droolsjbpm-integration/pull/469 (contains test)
