### PR TITLE
DROOLS-1176 Persistence tests doesn't use transactions for handling LOBs in Postgresql Plus

### DIFF
--- a/kie-test-util/src/main/java/org/kie/test/util/db/PersistenceUtil.java
+++ b/kie-test-util/src/main/java/org/kie/test/util/db/PersistenceUtil.java
@@ -296,7 +296,7 @@ public class PersistenceUtil {
 
         // Postgresql has a "Large Object" api which REQUIRES the use of transactions
         //  since @Lob/byte array is actually stored in multiple tables.
-        if (databaseDriverClassName.startsWith("org.postgresql")) {
+        if (databaseDriverClassName.startsWith("org.postgresql") || databaseDriverClassName.startsWith("com.edb")) {
             useTransactions = true;
         }
         return useTransactions;


### PR DESCRIPTION
- Added com.edb driver handling to PersistenceUtil.useTransactions() method.

Master PR: https://github.com/droolsjbpm/drools/pull/783

This is needed for testing next planned 6.4.x builds on Postgresql Plus. 
