### PR TITLE
DROOLS-1192 - DialectUtil.normalizeRuleName() doesn't normalize multi…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectUtil.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/DialectUtil.java
@@ -75,7 +75,7 @@ import static org.drools.core.util.StringUtils.*;
 
 public final class DialectUtil {
 
-    private static final Pattern NON_ALPHA_REGEX = Pattern.compile("[ -/:-@\\[-`\\{-\\xff]");
+    private static final Pattern NON_ALPHA_REGEX = Pattern.compile("[ -/:-@\\[-`\\{-\\uffff]");
     private static final Pattern LINE_BREAK_FINDER = Pattern.compile( "\\r\\n|\\r|\\n" );
 
     /**

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java
@@ -31,8 +31,10 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.KieModule;
+import org.kie.api.builder.Message.Level;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieContainer;
@@ -247,5 +249,45 @@ public class I18nTest extends CommonTestMethodBase {
         assertTrue(list.contains("名称は山田花子です"));
 
         ksession.dispose();
+    }
+
+    @Test
+    public void testMultibyteRuleName() {
+        // DROOLS-1192
+        String str = "package org.drools.compiler.i18ntest;\n" +
+                "\n" +
+                "rule \"rule（hello）\"\n" +
+                "    when\n" +
+                "    then\n" +
+                "end\n";
+
+        KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        KieBuilder kbuilder = ks.newKieBuilder( kfs );
+        kbuilder.buildAll();
+
+        if ( !kbuilder.getResults().getMessages( Level.ERROR ).isEmpty() ) {
+            fail( kbuilder.getResults().getMessages( Level.ERROR ).toString() );
+        }
+    }
+
+    @Test
+    public void testMultibyteRuleNameWithWhitespace() {
+        // DROOLS-1192
+        String str = "package org.drools.compiler.i18ntest;\n" +
+                "\n" +
+                "rule \"rule （hello）\"\n" +
+                "    when\n" +
+                "    then\n" +
+                "end\n";
+
+        KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
+        KieBuilder kbuilder = ks.newKieBuilder( kfs );
+        kbuilder.buildAll();
+
+        if ( !kbuilder.getResults().getMessages( Level.ERROR ).isEmpty() ) {
+            fail( kbuilder.getResults().getMessages( Level.ERROR ).toString() );
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/rule/builder/dialect/DialectUtilTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/rule/builder/dialect/DialectUtilTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.rule.builder.dialect;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DialectUtilTest {
+
+    @Test
+    public void testNormalizeRuleName() {
+        // DROOLS-1192
+        String normalizedRuleName = DialectUtil.normalizeRuleName( "rule（hello）" );
+        for ( char ch : normalizedRuleName.toCharArray() ) {
+            assertTrue("normalizedRuleName must not include non-identifier part", Character.isJavaIdentifierPart(ch));
+        }
+    }
+}


### PR DESCRIPTION
…byte rule names

I18nTest.testMultibyteRuleName() : Failing test case described in the JIRA
I18nTest.testMultibyteRuleNameWithWhitespace() : This can be compiled because whitespace matches NON_ALPHA_REGEX.
DialectUtilTest.testNormalizeRuleName(): Low level test case
