### PR TITLE
Drools 1180 Migrate QE tests upstream

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+import org.kie.api.KieServices;
+import org.kie.api.io.Resource;
+
+public class DrlParserTest extends ParserTests {
+
+    public DrlParserTest(File file) {
+        super(file);
+    }
+
+    @Parameters
+    public static Collection<Object[]> getParameters() {
+        return getTestParamsFromFiles(getFiles("drl"));
+    }
+
+    @Test
+    public void testParserSmoke() {
+        final Resource fileResource = KieServices.Factory.get().getResources().newFileSystemResource(file);
+        KieBaseUtil.getKieBuilderFromResources(true, fileResource);
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DrlParserTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
 
-public class DrlParserTest extends ParserTests {
+public class DrlParserTest extends ParserTest {
 
     public DrlParserTest(File file) {
         super(file);

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DslParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DslParserTest.java
@@ -27,7 +27,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
 
-public class DslParserTest extends ParserTests {
+public class DslParserTest extends ParserTest {
     private final File dsl;
 
     public DslParserTest(File dslr, File dsl) {

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DslParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/DslParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+import org.kie.api.KieServices;
+import org.kie.api.io.Resource;
+
+public class DslParserTest extends ParserTests {
+    private final File dsl;
+
+    public DslParserTest(File dslr, File dsl) {
+        super(dslr);
+        this.dsl = dsl;
+    }
+
+    @Parameters
+    public static Collection<Object[]> getParameters() {
+        final Set<Object[]> set = new HashSet<>();
+
+        for (File f : getFiles("dsl", "dslr")) {
+            final String dslPath = f.getAbsolutePath();
+            final File dsl = new File(dslPath.substring(0, dslPath.length() - 1));
+            set.add(new Object[] { dsl, f });
+        }
+
+        return set;
+    }
+
+    @Test
+    public void testParserDsl() {
+        final Resource dslResource = KieServices.Factory.get().getResources().newFileSystemResource(dsl);
+        final Resource dslrResource = KieServices.Factory.get().getResources().newFileSystemResource(file);
+        KieBaseUtil.getKieBuilderFromResources(true, dslResource, dslrResource);
+    }
+
+    @Test
+    public void testParserDsl2() {
+        final Resource dslResource = KieServices.Factory.get().getResources().newFileSystemResource(dsl);
+        final Resource dslrResource = KieServices.Factory.get().getResources().newFileSystemResource(file);
+        KieBaseUtil.getKieBuilderFromResources(true, dslrResource, dslResource);
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/ParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/ParserTest.java
@@ -38,13 +38,13 @@ import org.junit.runners.Parameterized;
  * 
  */
 @RunWith(Parameterized.class)
-public abstract class ParserTests {
+public abstract class ParserTest {
     private static final String PARSER_RESOURCES_DIR_PATH = "src/test/resources/org/drools/testcoverage/functional/parser";
     private static final File PARSER_RESOURCES_DIR = new File(PARSER_RESOURCES_DIR_PATH);
 
     protected final File file;
 
-    public ParserTests(File file) {
+    public ParserTest(File file) {
         this.file = file;
     }
 

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/ParserTests.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/ParserTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests ability to parse resources. To add a test to this class simply add a
+ * drl file into test-resource/parser-tests/ to appropriate directory.
+ * 
+ * Directories: - to test DRL files use drl directory - to test DSL use dsl
+ * directory, both DSL and DSLR files must have the same name to be matched
+ * together - for files that should be part of smoke test use smoke directory
+ * (these does not necessarily have to be DRL) - in case of any other file type
+ * new folder can be added
+ * 
+ */
+@RunWith(Parameterized.class)
+public abstract class ParserTests {
+    private static final String PARSER_RESOURCES_DIR_PATH = "src/test/resources/org/drools/testcoverage/functional/parser";
+    private static final File PARSER_RESOURCES_DIR = new File(PARSER_RESOURCES_DIR_PATH);
+
+    protected final File file;
+
+    public ParserTests(File file) {
+        this.file = file;
+    }
+
+    protected static List<File> getFiles(final String directory) {
+        return getFiles(directory, null);
+    }
+
+    protected static List<File> getFiles(final String directory, final String extension) {
+        final List<File> result = new ArrayList<File>();
+
+        final File[] files = new File(PARSER_RESOURCES_DIR, directory).listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (!f.getName().startsWith(".") && (extension == null || f.getName().endsWith("." + extension))) {
+                    result.add(f);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    protected static Collection<Object[]> getTestParamsFromFiles(Collection<File> files) {
+        final Set<Object[]> set = new HashSet<>();
+
+        for (File file : files) {
+            set.add(new Object[] { file });
+        }
+
+        return set;
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+import org.kie.api.KieServices;
+import org.kie.api.io.Resource;
+
+public class SmokeParserTest extends ParserTests {
+
+    public SmokeParserTest(File file) {
+        super(file);
+    }
+
+    @Parameters
+    public static Collection<Object[]> getParameters() {
+        return getTestParamsFromFiles(getFiles("smoke"));
+    }
+
+    @Test
+    public void testParserSmoke() {
+        final Resource fileResource = KieServices.Factory.get().getResources().newFileSystemResource(file);
+        KieBaseUtil.getKieBuilderFromResources(true, fileResource);
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/parser/SmokeParserTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
 
-public class SmokeParserTest extends ParserTests {
+public class SmokeParserTest extends ParserTest {
 
     public SmokeParserTest(File file) {
         super(file);

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/logicalInsertFromCollectionTest.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/logicalInsertFromCollectionTest.drl
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.testcoverage.functional
 
 import java.util.Collection;

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/BRMS-395.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/BRMS-395.drl
@@ -14,26 +14,20 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
-
-rule "Insert All Person Objects"
-    when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+declare DroolsTest
+    arg: int
 end
 
-rule "Print Person Name"
+
+rule "test"
     when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        DroolsTest( arg == (1 + 1) );
+        // REMOVE THE COMMENTED PARTS BELOW TO GET THE EXCEPTION:
+        (or eval(true);
+        eval(true);
+        )
+    then
+        System.out.println( "it works!" );
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/asterisk-imports.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/asterisk-imports.drl
@@ -14,26 +14,23 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+import org.drools.testcoverage.common.model.*
+import java.util.*
 
-rule "Insert All Person Objects"
-    when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+declare ListWrapper
+    original : List
 end
 
-rule "Print Person Name"
+declare org.drools.testcoverage.common.model.Person
+    @role(event)
+end
+
+rule "rule 1"
     when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        //conditions
+    then
+        Person p = new Person();
+        p.setName("Lord Tyranus");
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/end-comment.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/end-comment.drl
@@ -14,26 +14,12 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
-
-rule "Insert All Person Objects"
+rule simple
     when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+    then
+       System.out.println("Hello world!");
 end
 
-rule "Print Person Name"
-    when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
-end
+// some end comment

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/str-operator.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/str-operator.drl
@@ -14,26 +14,11 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
-
-rule "Insert All Person Objects"
+rule "str with or"
     when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
-end
-
-rule "Print Person Name"
-    when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        Class(name str[startsWith] "org.jboss.qa" || name str[endsWith] "Test")
+    then
+        // consequences
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/whitespaces.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/drl/whitespaces.drl
@@ -14,26 +14,33 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
-
-rule "Insert All Person Objects"
-    when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+declare Something
+    someAttribute : String
 end
 
-rule "Print Person Name"
+declare SomethingElse
+    someAttribute : String
+end
+
+rule "1" when then end
+
+rule "2" when str:String() then end
+
+rule "3" when str: String() then end
+
+rule "4" when str : String() then end
+
+rule "5" when str :String() then end
+
+rule"6" when then end rule"7" when then end
+
+// according to Wolgang Laune's ideas on drools-dev mailing list
+rule "8"
     when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        Something ( a1: someAttribute )
+        Something ( a2 :someAttribute )
+        Something ( a3:someAttribute )
+    then
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/basic.dsl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/basic.dsl
@@ -1,0 +1,9 @@
+[condition][]There is a person=$p : Person()
+[condition][]- {field:\w*}  {operator}  {value:\d*}={field}  {operator}  {value}
+[condition][]- named {name}=name == "{name}"
+[condition][]- equals {variable}=this := {variable}
+[condition][]is equal to===
+[condition][]is greater than=>
+[consequence][]Print hello=System.out.println("Hello world!");
+[consequence][]Consequences=//consequences
+[condition][]- with a {what} {attr}={attr} {what!positive?>0/negative?<0/zero?==0/ERROR}

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/basic.dslr
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/basic.dslr
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+import org.drools.testcoverage.common.model.*
 
-rule "Insert All Person Objects"
+expander basic.dsl
+
+/*
+    Some comment about the rule basic
+*/
+rule basic
     when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
-end
-
-rule "Print Person Name"
-    when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        There is a person
+            - named tomason
+            - age is equal to 22
+    then
+        Consequences
+        Print hello
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/dslQuery.dsl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/dslQuery.dsl
@@ -1,0 +1,9 @@
+[condition][]There is a person {var}={var} : Person()
+[condition][]There is a person=Person()
+[condition][]Person {var} is mature=isMature({var};)
+[condition][]- {field:\w*}  {operator}  {value:\d*}={field}  {operator}  {value}
+[condition][]- equals {variable}={variable} := this
+[condition][]is equal to===
+[condition][]is greater than=>
+[consequence][]Print hello=System.out.println("Hello world!");
+[consequence][]Consequences=//consequences

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/dslQuery.dslr
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/dslQuery.dslr
@@ -14,26 +14,22 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+import org.drools.testcoverage.common.model.*
 
-rule "Insert All Person Objects"
-    when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+expander dslQuery.dsl
+
+query "isMature"(Person p)
+    There is a person
+        - age is greater than 18
+        - equals p
 end
 
-rule "Print Person Name"
+rule "mature person"
     when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        There is a person $person
+        Person $person is mature
+    then
+        Consequences
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/miscelaneous.dsl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/miscelaneous.dsl
@@ -1,0 +1,18 @@
+[keyword]balík=package
+[keyword]definuj=declare
+[keyword]pravidlo=rule
+[keyword]kdykoli=when
+[keyword]potom=then
+[keyword]konec=end
+[keyword]priorita=salience
+[keyword]necyklit=no-loop
+[keyword]řetězec=String
+[keyword]číslo=int
+[keyword]Člověk=Person
+[keyword]jméno=name
+[keyword]věk=age
+
+[when]Poznač člověka {var}={var} : Person()
+[condition]Je nějaký člověk=Person()
+[then]Pozdrav od {var}=System.out.println("Hello world from " + {var}.toString() + "!");
+[consequence]Pozdrav=System.out.println("Hello world!");

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/miscelaneous.dslr
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/miscelaneous.dslr
@@ -14,26 +14,28 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+definuj Člověk
+    jméno : řetězec
+    věk : číslo
+konec
 
-rule "Insert All Person Objects"
-    when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
-end
+expander miscelaneous.dsl
 
-rule "Print Person Name"
-    when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
-end
+pravidlo "jedna"
+    @anotace("Příliš žluťoučký kůň úpěl ďábelské ódy")
+    kdykoli
+        Poznač člověka $p
+    potom
+        Pozdrav od $p
+konec
+
+pravidlo "dva"
+    necyklit
+    priorita 5
+    kdykoli
+        Je nějaký člověk
+    potom
+        Pozdrav
+konec

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/sample.dsl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/sample.dsl
@@ -1,0 +1,1 @@
+[*][]hello=System.out.println("Hello world!");

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/sample.dslr
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/dsl/sample.dslr
@@ -14,26 +14,12 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+expander sample.dsl
 
-rule "Insert All Person Objects"
+rule "simple"
     when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
-end
-
-rule "Print Person Name"
-    when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+    then
+        hello
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/cep.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/cep.drl
@@ -14,26 +14,42 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import org.drools.testcoverage.common.model.Message
+declare Event
+    @role( event )
+    @expires( 1d )
+    id : int @key
 
-declare TestEvent
-   @role( event )
-   @expires(10s)
-   id : String
+    eventTimestamp : java.util.Date @timestamp
+    eventDuration : long @duration
 end
 
-rule "Is It There"
+rule "TestEntryPoint"
     when
-        TestEvent() from entry-point "test"
+        Event() from entry-point EventStream
     then
-        insert(new Message("Found a TestEvent"));
+        //consequences
 end
 
-rule "Accumulate Count"
+rule "TestDuration"
+    duration( 1s )
     when
-        $n : Number() from accumulate($t : TestEvent() from entry-point "test", count($t))
+        Event() from entry-point EventStream
     then
-        insert(new Message("Found " + $n + " events"));
+        //consequences
+end
+
+rule "TestTimeWindow"
+    when
+        Event() over window:time(1h) from entry-point EventStream
+    then
+        //consequences
+end
+
+rule "TestLengthWindow"
+    when
+        Event() over window:length(1) from entry-point EventStream
+    then
+        //consequences
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/conditionals.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/conditionals.drl
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser
+
+rule "TestAndInfix"
+    when
+        String() and Integer ()
+    then
+        //consequences
+end
+
+rule "TestAndPrefix"
+    when
+        (and String() Integer () )
+    then
+        //consequences
+end
+
+rule "TestOrInfix"
+    when
+        String() or Integer ()
+    then
+        //consequences
+end
+
+rule "TestOrPrefix"
+    when
+        (or String() Integer () )
+    then
+        //consequences
+end
+
+rule "TestNot"
+    when
+        not( String( ) )
+    then
+        //consequences
+end
+
+rule "TestExists"
+    when
+        exists( String( ) )
+    then
+        //consequences
+end
+
+rule "TestForall"
+    when
+        forall( String( ) )
+    then
+        //consequences
+end
+
+rule "TestFrom"
+    when
+        $list : java.util.List()
+        String() from $list
+    then
+        //consequences
+end
+
+rule "TestCollect"
+    when
+        $list : java.util.ArrayList()
+            from collect( Integer(this > 5) )
+    then
+        //consequences
+end
+
+rule "TestAccumulate1"
+    when
+        $avg : Number() from accumulate ( $d : Double (), average ($d) )
+    then
+        //consequences
+end
+
+rule "TestAccumulate2"
+    when
+        $dx : Number (doubleValue > 0) from accumulate ( $d : Double (),
+                    init   ( double ex = 0; double ex2 = 0; int count = 0; ),
+                    action ( count++; ex += $d; ex2 += $d * $d; ),
+                    reverse( count--; ex -= $d; ex2 -= $d * $d; ),
+                    result ( (ex / count) * (ex / count) - (ex2 / count) ) )
+    then
+        //consequences
+end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/declared.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/declared.drl
@@ -14,26 +14,18 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+import java.util.Collection
 
-rule "Insert All Person Objects"
-    when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+declare Person
+    id : int @key
+    name : String
 end
 
-rule "Print Person Name"
+rule "TestPerson"
     when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        Person( id == 6, name == "name" )
+    then
+        //consequences
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/drools-5.2.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/drools-5.2.drl
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser
+
+declare Person
+    id : int @key
+    name : String
+end
+
+declare Employee extends Person
+    salary : double
+end
+
+rule "TestStr1"
+    when
+        String( this str[startsWith] "foo")
+    then
+        //consequences
+end
+
+rule "TestStr2"
+    when
+        String( this str[endsWith] "bar")
+    then
+        //consequences
+end
+
+rule "TestStr3"
+    when
+        String( this str[length] 6)
+    then
+        //consequences
+end
+
+rule "TestIn"
+    when
+        $s : String(this == "foobar")
+        String( this in ( "foo", "bar", $s ) )
+    then
+        //consequences
+end
+
+rule "TestEmployee"
+    when
+        Employee ( name == "employee", salary > 99.96 )
+    then
+        //consequences
+end
+
+rule "TestConstructors"
+    when
+        Object()
+    then
+        Person p1 = new Person();
+        Person p2 = new Person(9);
+        Person p3 = new Person(99, "myname");
+
+        Employee e1 = new Employee();
+        Employee e2 = new Employee(9);
+        Employee e3 = new Employee(99, "myname", 100.00);
+
+        Person pe = new Employee();
+end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/imports.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/imports.drl
@@ -14,26 +14,22 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.regression
+package org.drools.testcoverage.functional.parser
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import org.drools.testcoverage.regression.PropertyListenerTest.Person;
+import org.drools.testcoverage.common.model.*
+import java.util.Set
+import java.util.HashSet
 
-rule "Insert All Person Objects"
+rule "TestImport"
     when
-        $people : ArrayList()
-    then 
-        for (Object person : $people) {
-            insert(person, true);
-        }
-        retract($people);
+        Message()
+    then
+        //consequences
 end
 
-rule "Print Person Name"
+rule "TestImport2"
     when
-        $person : Person($name:name)
-    then 
-        System.out.println("Print name of person: " + $name);
+        Object()
+    then
+        Set<Message> m = new HashSet<Message>();
 end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/operators.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/operators.drl
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser
+
+import java.util.Collection
+
+declare CollectionTestFact
+    id : int @key
+    strings : Collection
+end
+
+rule "TestMatches"
+    when
+        String( this matches "\\w" )
+    then
+        //consequences
+end
+
+rule "TestNotMatches"
+    when
+        String( this matches "\\d" )
+    then
+        //consequences
+end
+
+rule "TestContains"
+    when
+        CollectionTestFact( strings contains "teststring" )
+    then
+        //consequences
+end
+
+rule "TestNotContains"
+    when
+        CollectionTestFact( strings not contains "teststring" )
+    then
+        //consequences
+end
+
+rule "TestExcludes"
+    when
+        CollectionTestFact( strings excludes "teststring" )
+    then
+        //consequences
+end
+
+rule "TestMemberOf"
+    when
+        CollectionTestFact( s : strings )
+        String( this memberOf s )
+    then
+        //consequences
+end
+
+rule "TestNotMemberOf"
+    when
+        CollectionTestFact( s : strings )
+        String( this not memberOf s )
+    then
+        //consequences
+end
+
+rule "TestSoundslike"
+    when
+        String( this soundslike "foobar" )
+    then
+        //consequences
+end
+
+////////////////////////
+// Temporal operators //
+////////////////////////
+rule "TestAfter"
+    when
+        $e : String( )
+             Integer( this after[4m, 5m] $e )
+    then
+        //consequences
+end
+
+rule "TestBefore"
+    when
+        $e : String( )
+             Integer( this before[4m, 5m] $e )
+    then
+        //consequences
+end
+
+rule "TestCoincides"
+    when
+        $e : String( )
+             Integer( this coincides[10s, 1m] $e )
+    then
+        //consequences
+end
+
+rule "TestDuring"
+    when
+        $e : String( )
+             Integer( this during[1s, 1m, 1h, 1d] $e )
+    then
+        //consequences
+end
+
+rule "TestFinishes"
+    when
+        $e : String( )
+             Integer( this finishes[10s] $e )
+    then
+        //consequences
+end
+
+rule "TestFinishedBy"
+    when
+        $e : String( )
+             Integer( this finishedby[10s] $e )
+    then
+        //consequences
+end
+
+rule "TestIncludes"
+    when
+        $e : String( )
+             Integer( this includes[1s, 1m, 1h, 1d] $e )
+    then
+        //consequences
+end
+
+rule "TestMeets"
+    when
+        $e : String( )
+             Integer( this meets[10s] $e )
+    then
+        //consequences
+end
+
+rule "TestMetBy"
+    when
+        $e : String( )
+             Integer( this metby[1s] $e )
+    then
+        //consequences
+end
+
+rule "TestOverlaps"
+    when
+        $e : String( )
+             Integer( this overlaps[1s, 1m] $e )
+    then
+        //consequences
+end
+
+rule "TestOverlappedBy"
+    when
+        $e : String( )
+             Integer( this overlappedby[1s, 1m] $e )
+    then
+        //consequences
+end
+
+rule "TestStarts"
+    when
+        $e : String( )
+             Integer( this starts[1s] $e )
+    then
+        //consequences
+end
+
+rule "TestStartedBy"
+    when
+        $e : String( )
+             Integer( this startedby[1s] $e )
+    then
+        //consequences
+end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/query.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/query.drl
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser
+
+query "TestEmptyQuery"
+    //conditions
+end
+
+query "TestSimpleQuery"
+    d : Double()
+end
+
+query "TestParametrizedQuery" (double max)
+    d : Double ( this < max )
+end
+
+
+// more advanced tests from the Drools 5.2.0 introduction
+
+declare Location
+    thing : String 
+    location : String 
+end
+
+query isContainedIn( String x, String y ) 
+    Location( x := thing, y := location)
+    or 
+    ( Location(z := thing, y := location) and ?isContainedIn( x := x, z := y ) )
+end
+
+// the same using positional arguments
+
+query isContainedIn2( String x, String y ) 
+    Location(x, y;)
+    or 
+    ( Location(z, y;) and ?isContainedIn(x, z;) )
+end
+
+
+

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/rhs.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/parser/smoke/rhs.drl
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.parser
+
+rule "TestInsert"
+    when
+        //conditions
+    then
+        insert("testString");
+end
+
+rule "TestNewInstance1"
+    when
+        //conditions
+    then
+        java.util.List<String> strings = new java.util.ArrayList<String>();
+
+        insert(strings);
+end
+
+rule "TestModify"
+    when
+        $list : java.util.List()
+    then
+        modify ($list) {
+            add("foo");
+        }
+end
+
+rule "TestUpdate"
+    when
+        $list : java.util.List()
+    then
+        $list.add("bar");
+
+        update($list);
+end
+
+rule "TestRetract"
+    when
+        $list : java.util.List()
+    then
+        retract($list);
+end
+
+rule "TestInsertLogical"
+    when
+        //conditions
+    then
+        java.util.List<String> strings = new java.util.ArrayList<String>();
+
+        insertLogical(strings);
+end
+
+rule "TestDrools"
+    when
+        //conditions
+    then
+        drools.halt();
+        drools.getWorkingMemory();
+        drools.setFocus("agenda-group");
+        drools.getRule();
+        drools.getTuple();
+end
+
+rule "TestKcontext"
+    when
+        //conditions
+    then
+        System.out.println(kcontext);
+        kcontext.getKnowledgeRuntime();
+end

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/regression/fusionAfterBeforeTest.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/regression/fusionAfterBeforeTest.drl
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.testcoverage.regression
 
 import org.drools.testcoverage.common.model.*

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/regression/unwantedStringConversionTest.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/regression/unwantedStringConversionTest.drl
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.testcoverage.regression
  
 import org.drools.testcoverage.regression.UnwantedStringConversionTest.Message;


### PR DESCRIPTION
This is fourth in a series of PRs that migrate some tests from QE regression test suite upstream (there will be more).

Migrated test classes that inherit from ParsersTest class in QE regression test suite.
