### PR TITLE
DROOLS-1199 Memory leak in KieScanner

### DIFF
--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -827,7 +827,6 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
             averageMemory = averageMemory + usedMemory;
             if ((i % numberOfAveragedIterations) == 0) {
                 averageMemory = averageMemory / numberOfAveragedIterations;
-                // Ignore the first comparison, because first average memory can be low due to some initialization not completed.
                 if (averageMemoryFootprints.size() > 0) {
                     final long previousAverageMemory = averageMemoryFootprints.get(averageMemoryFootprints.size() - 1);
                     if (averageMemory > previousAverageMemory) {

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -783,6 +783,83 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         ks.getRepository().removeKieModule(releaseId);
     }
 
+    @Test
+    public void testScannerMemoryFootprint() throws IOException {
+        final KieServices kieServices = KieServices.Factory.get();
+        final ReleaseId releaseId = kieServices.newReleaseId("org.kie", "scanner-memory-test", "1.0-SNAPSHOT");
+
+        final MavenRepository repository = getMavenRepository();
+
+        final InternalKieModule kJar = createKieJar(kieServices, releaseId, "rule1");
+        repository.installArtifact(releaseId, kJar, createKPom(fileManager, releaseId));
+
+        final KieContainer kieContainer = kieServices.newKieContainer(releaseId);
+        final KieScanner kieScanner = kieServices.newKieScanner(kieContainer);
+
+        kieScanner.start(20);
+        try {
+            measureMemoryFootprint(1000, 100, 5, 30);
+        } finally {
+            kieScanner.stop();
+        }
+    }
+
+    private void measureMemoryFootprint(final int numberOfIterations, final int numberOfAveragedIterations,
+            final int acceptedNumberOfMemoryRaises, final long waitEachIterationMillis) {
+        long lastTimeInMillis = System.currentTimeMillis();
+
+        final Runtime runtime = Runtime.getRuntime();
+
+        int memoryRaiseCount = 0;
+
+        long averageMemory = 0;
+        final List<Long> averageMemoryFootprints = new ArrayList<Long>();
+
+        for (int i = 1; i < numberOfIterations; i++) {
+            waitForMillis(waitEachIterationMillis, lastTimeInMillis);
+            lastTimeInMillis = System.currentTimeMillis();
+
+            final long usedMemory = runtime.totalMemory() - runtime.freeMemory();
+            averageMemory = averageMemory + usedMemory;
+            if ((i % numberOfAveragedIterations) == 0) {
+                averageMemory = averageMemory / numberOfAveragedIterations;
+                // Ignore the first comparison, because first average memory can be low due to some initialization not completed.
+                if (averageMemoryFootprints.size() > 0) {
+                    final long previousAverageMemory = averageMemoryFootprints.get(averageMemoryFootprints.size() - 1);
+                    if (averageMemory > previousAverageMemory) {
+                        memoryRaiseCount++;
+                    } else {
+                        memoryRaiseCount = 0;
+                    }
+                    assertFalse(
+                            "Memory raised during " + (acceptedNumberOfMemoryRaises + 1)
+                                    + " consecutive measurements, there is probably some memory leak! "
+                                    + getMemoryMeasurmentsString(averageMemoryFootprints),
+                            memoryRaiseCount > acceptedNumberOfMemoryRaises);
+                }
+                System.out.println("Average memory: " + averageMemory);
+                averageMemoryFootprints.add(averageMemory);
+                averageMemory = 0;
+            }
+        }
+    }
+
+    private void waitForMillis(final long millis, final long startTimeMillis) {
+        while ((System.currentTimeMillis() - startTimeMillis) < millis) {
+            // do nothing - wait
+        }
+    }
+
+    private String getMemoryMeasurmentsString(final List<Long> memoryMeasurements) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Measured used memory: ");
+        for (int i = 1; i <= memoryMeasurements.size(); i++) {
+            final Long measurement = memoryMeasurements.get(i - 1) / 1024 / 1024;
+            builder.append(i + ": " + measurement + " MB; ");
+        }
+        return builder.toString();
+    }
+
     private InternalKieModule createKieJarWithGDRL(KieServices ks, ReleaseId releaseId, String rule) throws IOException {
         KieFileSystem kfs = createKieFileSystemWithKProject(ks, false);
         kfs.writePomXML(getPom(releaseId));

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -35,6 +35,8 @@ import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.scanner.embedder.MavenEmbedderUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,6 +51,8 @@ import static org.kie.scanner.MavenRepository.getMavenRepository;
 
 @RunWith(Parameterized.class)
 public class KieRepositoryScannerTest extends AbstractKieCiTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(KieRepositoryScannerTest.class);
 
     private final boolean useWiredComponentProvider;
 
@@ -837,7 +841,7 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
                                     + getMemoryMeasurmentsString(averageMemoryFootprints),
                             memoryRaiseCount > acceptedNumberOfMemoryRaises);
                 }
-                System.out.println("Average memory: " + averageMemory);
+                logger.debug("Average memory: " + averageMemory);
                 averageMemoryFootprints.add(averageMemory);
                 averageMemory = 0;
             }


### PR DESCRIPTION
- Added reproducer for issue [1]. Issue is related to Plexus, because when using WiredComponentProvider instead of PlexusComponentProvider in MavenEmbedderUtils, issue is not there. 

[1] https://issues.jboss.org/browse/DROOLS-1199
