### PR TITLE
[DROOLS-1200] Multibyte bind variable name fails with java dialect

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/UnicodeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/UnicodeTest.java
@@ -26,12 +26,14 @@ import org.kie.api.KieServices;
 import org.kie.api.command.Command;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.QueryResultsRow;
 import org.kie.api.runtime.rule.Variable;
 import org.kie.internal.builder.DecisionTableInputType;
+import org.kie.internal.utils.KieHelper;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -235,6 +237,24 @@ public class UnicodeTest {
         Assertions.assertThat(l.contains("svítilna")).isTrue();
         Assertions.assertThat(l.contains("obálka")).isTrue();
         Assertions.assertThat(l.contains("klíč")).isTrue();
+    }
+
+    @Test
+    public void testMutibyteJavaDialect() {
+        // DROOLS-1200
+        String drl =
+                "rule R dialect \"java\" when\n" +
+                "  Ｄ: String( )\n" +
+                "then\n" +
+                "  System.out.println( Ｄ.toString() );\n" +
+                "end\n";
+
+        KieSession kieSession = new KieHelper().addContent( drl, ResourceType.DRL )
+                                               .build().newKieSession();
+
+        kieSession.insert( "Hello" );
+        int fired = kieSession.fireAllRules();
+        Assertions.assertThat( fired ).isEqualTo( 1 );
     }
 
     // japanese person


### PR DESCRIPTION
- Unit test
