### PR TITLE
[DROOLS-1170] drools-pmml: use 'xjc' binary instead of jaxb2-maven-pl…

### DIFF
--- a/drools-pmml/pom.xml
+++ b/drools-pmml/pom.xml
@@ -72,6 +72,16 @@
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -94,36 +104,57 @@
           </execution>
         </executions>
       </plugin>
-
-
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>jaxb2-maven-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
+            <phase>generate-sources</phase>
+            <configuration>
+              <target>
+                <echo message="Creating ${project.build.directory}/generated-sources/java"/>
+                <mkdir dir="${project.build.directory}/generated-sources/java"/>
+              </target>
+            </configuration>
             <goals>
-              <goal>xjc</goal>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- TODO: This is a temporary workaround until org.codehaus.mojo:jaxb2-maven-plugin supports JDK9.
+                 (https://github.com/mojohaus/jaxb2-maven-plugin/issues/43). We need to add the plugin back
+                 once we are sure it works on both JDK8 and JDK9.
+           Using xjc directly (instead of jaxb2-maven-plugin) to support both JDK8 and JDK9 with single configuration.
+           See https://issues.jboss.org/browse/DROOLS-1170 for more info. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-schema-types</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <outputDirectory>${project.basedir}/target/generated-sources/java</outputDirectory>
-          <packageName>org.dmg.pmml.pmml_4_2.descr</packageName>
-          <sources>
-            <source>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/pmml-4-2.xsd</source>
-          </sources>
-          <xjbSources>
-            <xjbSource>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/bindings.xjb</xjbSource>
-            <xjbSource>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/bindings.xml</xjbSource>
-          </xjbSources>
-          <noGeneratedHeaderComments>true</noGeneratedHeaderComments>
-          <extension>true</extension>
-          <clearOutputDir>false</clearOutputDir>
+          <executable>${env.JAVA_HOME}/bin/xjc</executable>
+          <arguments>
+            <argument>-enableIntrospection</argument>
+            <argument>-p</argument>
+            <argument>org.dmg.pmml.pmml_4_2.descr</argument>
+            <argument>-extension</argument>
+            <argument>-d</argument>
+            <argument>${project.build.directory}/generated-sources/java</argument>
+            <argument>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/pmml-4-2.xsd</argument>
+            <argument>-b</argument>
+            <argument>${project.basedir}/src/main/resources/xsd/org/dmg/pmml/pmml_4_2/bindings.xjb</argument>
+          </arguments>
         </configuration>
       </plugin>
-
     </plugins>
-
   </build>
 
 </project>

--- a/drools-scorecards/src/main/java/org/drools/scorecards/parser/xls/ExcelScorecardValidator.java
+++ b/drools-scorecards/src/main/java/org/drools/scorecards/parser/xls/ExcelScorecardValidator.java
@@ -45,7 +45,7 @@ class ExcelScorecardValidator {
         ExcelScorecardValidator validator = new ExcelScorecardValidator(scorecard, parseErrors);
         validator.checkForInvalidDataTypes();
         validator.checkForMissingAttributes();
-        if (scorecard.isUseReasonCodes()){
+        if (scorecard.getUseReasonCodes()){
             validator.validateReasonCodes();
             validator.validateBaselineScores();
         }

--- a/drools-scorecards/src/main/java/org/drools/scorecards/pmml/ScorecardPMMLGenerator.java
+++ b/drools-scorecards/src/main/java/org/drools/scorecards/pmml/ScorecardPMMLGenerator.java
@@ -224,7 +224,7 @@ public class ScorecardPMMLGenerator {
                 }
                 output.getOutputFields().add(outputField);
 
-                if ( pmmlScorecard.isUseReasonCodes() ) {
+                if ( pmmlScorecard.getUseReasonCodes() ) {
                     OutputField reasonCodeField = new OutputField();
                     reasonCodeField.setDataType( DATATYPE.STRING );
                     reasonCodeField.setFeature( RESULTFEATURE.REASON_CODE );

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardReasonCodeTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardReasonCodeTest.java
@@ -68,7 +68,7 @@ public class ScorecardReasonCodeTest {
         PMML pmml = scorecardCompiler.getPMMLDocument();
         for (Object serializable : pmml.getAssociationModelsAndBaselineModelsAndClusteringModels()){
             if (serializable instanceof Scorecard){
-                assertFalse(((Scorecard) serializable).isUseReasonCodes());
+                assertFalse(((Scorecard) serializable).getUseReasonCodes());
             }
         }
     }
@@ -87,7 +87,7 @@ public class ScorecardReasonCodeTest {
 
         for (Object serializable : pmmlDocument.getAssociationModelsAndBaselineModelsAndClusteringModels()){
             if (serializable instanceof Scorecard){
-                assertTrue(((Scorecard)serializable).isUseReasonCodes());
+                assertTrue(((Scorecard)serializable).getUseReasonCodes());
                 assertEquals(100.0, ((Scorecard)serializable).getInitialScore(), 0.0);
                 assertEquals("pointsBelow",((Scorecard)serializable).getReasonCodeAlgorithm());
             }


### PR DESCRIPTION
…ugin
- jaxb2-maven-plugin is not yet supported on JDK9. The original
  idea was to create new profile which would be jdk9-specific
  and use the exec-maven-plugin only there. However, this does not
  work because the classes generated directly by 'xjc' and the
  plugin are not exactly the same. The one big difference is that
  the plugin useis 'is' prefix for Boolean properties whereas
  xjc will use 'get' prefix (e.g. public Boolean isAdult() vs
  public Boolean getAdult()). It seems the later is correct as
  'is' should only be used for primitive boolean, and not for object
  type Boolean (http://download.oracle.com/otndocs/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/).
  To make the configuration easier, the plugin was removed
  and the jxc is called directly.

The only thing I am wondering about is if it save to assume the `xjc` binary is on PATH? This may not always be the case. Maybe we should use ${env.JAVA_HOME}/bin/xjc instead?

@mariofusco, @ge0ffrey could you please take a look and let me know what you think?
