### PR TITLE
drools-pmml: explicitly depend on EE deps to make it work on JDK9

### DIFF
--- a/drools-pmml/pom.xml
+++ b/drools-pmml/pom.xml
@@ -25,9 +25,7 @@
     <version>7.0.0-SNAPSHOT</version>
   </parent>
 
-
   <artifactId>drools-pmml</artifactId>
-  <groupId>org.drools</groupId>
 
   <name>Drools :: PMML - Compiler </name>
   <description>Support for PMML-Encoded Predictive Models</description>
@@ -65,6 +63,10 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
     </dependency>
@@ -73,14 +75,8 @@
       <artifactId>jaxb-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.xml.bind</groupId>
-      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
- works both on JDK8 and JDK9
- the drools-pmml needs to transitively bring the jaxb
  and javax.activation deps, otherwise projects depending
  on drools-pmml (e.g. drools-scorecards) still won't work
