### PR TITLE
Delete unnecessary @Ignore in drools-examples-api tests

### DIFF
--- a/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromByteArrayExampleTest.java
+++ b/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromByteArrayExampleTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.example.api.defaultkiesessionfromfile;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;

--- a/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromFileExampleTest.java
+++ b/drools-examples-api/default-kiesession-from-file/src/test/java/org/drools/example/api/defaultkiesessionfromfile/DefaultKieSessionFromFileExampleTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.example.api.defaultkiesessionfromfile;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/drools-examples-api/kie-module-from-multiple-files/src/test/java/org/drools/example/api/kiemodulefrommultiplefiles/KieModuleFromMultipleFilesExampleTest.java
+++ b/drools-examples-api/kie-module-from-multiple-files/src/test/java/org/drools/example/api/kiemodulefrommultiplefiles/KieModuleFromMultipleFilesExampleTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.example.api.kiemodulefrommultiplefiles;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/drools-examples-api/kiecontainer-from-kierepo/src/test/java/org/drools/example/api/kiecontainerfromkierepo/KieContainerFromKieRepoExampleTest.java
+++ b/drools-examples-api/kiecontainer-from-kierepo/src/test/java/org/drools/example/api/kiecontainerfromkierepo/KieContainerFromKieRepoExampleTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.example.api.kiecontainerfromkierepo;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -28,7 +27,6 @@ public class KieContainerFromKieRepoExampleTest {
     private static final String NL = System.getProperty("line.separator");
     
     @Test
-    @Ignore
     public void testGo() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);

--- a/drools-examples-api/kiemodulemodel-example/src/test/java/org/drools/example/api/kiemodulemodel/KieModuleModelExampleTest.java
+++ b/drools-examples-api/kiemodulemodel-example/src/test/java/org/drools/example/api/kiemodulemodel/KieModuleModelExampleTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.example.api.kiemodulemodel;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/drools-examples-api/named-kiesession-from-file/src/test/java/org/drools/example/api/namedkiesessionfromfile/NamedKieSessionFromFileExampleTest.java
+++ b/drools-examples-api/named-kiesession-from-file/src/test/java/org/drools/example/api/namedkiesessionfromfile/NamedKieSessionFromFileExampleTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.example.api.namedkiesessionfromfile;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -26,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 public class NamedKieSessionFromFileExampleTest {
 
     @Test
-    @Ignore
     public void testGo() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);


### PR DESCRIPTION
Found these leftovers after prheak refactoring while I was reading some community documentation. Should no longer be necessary, the tests are passing.
