### PR TITLE
DROOLS-1229 Event expiration cycles itself when expiring events from large set of same rules with "after" operator

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -1818,12 +1818,14 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         }
 
         private void expireLeftTuple(LeftTuple leftTuple) {
-            leftTuple.setExpired( true );
-            for ( LeftTuple child = leftTuple.getFirstChild(); child != null; child = child.getHandleNext() ) {
-                expireLeftTuple(child);
-            }
-            for ( LeftTuple peer = leftTuple.getPeer(); peer != null; peer = peer.getPeer() ) {
-                expireLeftTuple(peer);
+            if (!leftTuple.isExpired()) {
+                leftTuple.setExpired( true );
+                for ( LeftTuple child = leftTuple.getFirstChild(); child != null; child = child.getHandleNext() ) {
+                    expireLeftTuple(child);
+                }
+                for ( LeftTuple peer = leftTuple.getPeer(); peer != null; peer = peer.getPeer() ) {
+                    expireLeftTuple(peer);
+                }
             }
         }
 

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Event.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Event.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.common.util;
+package org.drools.testcoverage.common.model;
 
-import org.kie.api.KieBaseConfiguration;
-import org.kie.api.builder.model.KieBaseModel;
-import org.kie.api.builder.model.KieModuleModel;
+public interface Event {
 
-/**
- * Basic provider class for KieBaseModel instances.
- */
-public interface KieBaseModelProvider {
-    KieBaseModel getKieBaseModel(KieModuleModel kieModuleModel);
-    KieBaseConfiguration getKieBaseConfiguration();
+    long getTimeValue();
+
+    long getDuration();
+
+    void setTimeValue(long timeValue);
+
+    void setDuration(long duration);
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventA.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.common.model;
+
+public class EventA implements Event, Comparable<EventA> {
+
+    private long timeValue;
+    private long duration;
+
+    public EventA() {
+        //
+    }
+
+    @Override
+    public long getTimeValue() {
+        return timeValue;
+    }
+
+    @Override
+    public void setTimeValue(final long timeValue) {
+        this.timeValue = timeValue;
+    }
+
+    @Override
+    public long getDuration() {
+        return duration;
+    }
+
+    @Override
+    public void setDuration(final long duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public int compareTo(final EventA o) {
+        if (timeValue > o.getTimeValue()) return 1;
+        if (timeValue < o.getTimeValue()) return -1;
+        // time of insertion is same for both events, so does not matter which is first
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "EventA{" +
+                "timeValue=" + timeValue +
+                ", duration=" + duration +
+                '}';
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/EventB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.common.util;
+package org.drools.testcoverage.common.model;
 
-import org.kie.api.KieBaseConfiguration;
-import org.kie.api.builder.model.KieBaseModel;
-import org.kie.api.builder.model.KieModuleModel;
+public class EventB extends EventA {
 
-/**
- * Basic provider class for KieBaseModel instances.
- */
-public interface KieBaseModelProvider {
-    KieBaseModel getKieBaseModel(KieModuleModel kieModuleModel);
-    KieBaseConfiguration getKieBaseConfiguration();
+    @Override
+    public String toString() {
+        return "EventB{" +
+                "timeValue=" + getTimeValue() +
+                ", duration=" + getDuration() +
+                '}';
+    }
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
@@ -16,10 +16,12 @@
 
 package org.drools.testcoverage.common.util;
 
+import org.kie.api.KieBaseConfiguration;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
+import org.kie.internal.KnowledgeBaseFactory;
 
 /**
  * Represents various tested KieBase configurations.
@@ -40,6 +42,14 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
             kieBaseModel.setDefault(true);
             return kieBaseModel;
         }
+
+        @Override
+        public KieBaseConfiguration getKieBaseConfiguration() {
+            final KieBaseConfiguration kieBaseConfiguration = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+            kieBaseConfiguration.setOption(EventProcessingOption.CLOUD);
+            kieBaseConfiguration.setOption(EqualityBehaviorOption.IDENTITY);
+            return kieBaseConfiguration;
+        }
     },
 
     /**
@@ -55,6 +65,14 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
             kieBaseModel.setEqualsBehavior(EqualityBehaviorOption.EQUALITY);
             kieBaseModel.setDefault(true);
             return kieBaseModel;
+        }
+
+        @Override
+        public KieBaseConfiguration getKieBaseConfiguration() {
+            final KieBaseConfiguration kieBaseConfiguration = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+            kieBaseConfiguration.setOption(EventProcessingOption.CLOUD);
+            kieBaseConfiguration.setOption(EqualityBehaviorOption.EQUALITY);
+            return kieBaseConfiguration;
         }
     },
 
@@ -72,6 +90,14 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
             kieBaseModel.setDefault(true);
             return kieBaseModel;
         }
+
+        @Override
+        public KieBaseConfiguration getKieBaseConfiguration() {
+            final KieBaseConfiguration kieBaseConfiguration = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+            kieBaseConfiguration.setOption(EventProcessingOption.STREAM);
+            kieBaseConfiguration.setOption(EqualityBehaviorOption.IDENTITY);
+            return kieBaseConfiguration;
+        }
     },
 
     /**
@@ -87,6 +113,14 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
             kieBaseModel.setEqualsBehavior(EqualityBehaviorOption.EQUALITY);
             kieBaseModel.setDefault(true);
             return kieBaseModel;
+        }
+
+        @Override
+        public KieBaseConfiguration getKieBaseConfiguration() {
+            final KieBaseConfiguration kieBaseConfiguration = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+            kieBaseConfiguration.setOption(EventProcessingOption.STREAM);
+            kieBaseConfiguration.setOption(EqualityBehaviorOption.EQUALITY);
+            return kieBaseConfiguration;
         }
     }
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FusionAfterBeforeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/regression/FusionAfterBeforeTest.java
@@ -16,12 +16,17 @@
 
 package org.drools.testcoverage.regression;
 
+import java.io.StringReader;
 import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-
 import org.assertj.core.api.Assertions;
 import org.drools.core.time.SessionPseudoClock;
 import org.drools.testcoverage.common.listener.TrackingAgendaEventListener;
+import org.drools.testcoverage.common.model.Event;
+import org.drools.testcoverage.common.model.EventA;
+import org.drools.testcoverage.common.model.EventB;
 import org.drools.testcoverage.common.model.Message;
 import org.drools.testcoverage.common.model.MessageEvent;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
@@ -33,13 +38,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.kie.api.KieBase;
+import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
+import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.utils.KieHelper;
 
 /**
  * Test to verify BRMS-582 (use of 'after' and 'before' operators ends with NPE)
@@ -102,4 +111,58 @@ public class FusionAfterBeforeTest {
         + firedCount + " time(s)!").isEqualTo(actuallyFired);
     }
 
+    @Test(timeout = 10000)
+    public void testExpireEventsWhenSharingAllRules() throws InstantiationException, IllegalAccessException {
+        final StringBuilder drlBuilder = new StringBuilder();
+        for (int i = 0; i < 64; i++) {
+            drlBuilder.append(" import " + EventA.class.getCanonicalName() + ";\n");
+            drlBuilder.append(" import " + EventB.class.getCanonicalName() + ";\n");
+            drlBuilder.append(" declare " + EventA.class.getName() + " @role( event ) @duration(duration) end");
+            drlBuilder.append(" declare " + EventB.class.getName() + " @role( event ) @duration(duration) end");
+            drlBuilder.append(" rule R" + i + " when \n");
+            drlBuilder.append("   $event1: " + EventA.class.getName() + "()\n");
+            drlBuilder.append("   $event2: " + EventB.class.getName() + "(this != $event1, this after [1,10] $event1)\n");
+            drlBuilder.append( "then end\n" );
+        }
+
+        final SortedSet<Event> events = new TreeSet<Event>();
+        events.addAll(getEvents(EventA.class, 64 / 2, 2, 100, 0));
+        events.addAll(getEvents(EventB.class, 64 / 2, 5, 100, 0));
+
+        final KieSessionConfiguration sessionConf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        sessionConf.setOption(ClockTypeOption.get("pseudo"));
+        final KieSession kieSession =
+                new KieHelper().addContent(drlBuilder.toString(), ResourceType.DRL).build(kieBaseTestConfiguration.getKieBaseConfiguration()).newKieSession(sessionConf, null);
+
+        Assertions.assertThat(insertEventsAndFire(kieSession, events)).isEqualTo(2048);
+    }
+
+    private <T extends Event> SortedSet<T> getEvents(final Class<T> eventClass, final int eventsCount,
+            final long startTime, final long timeIncrement, long duration) throws IllegalAccessException, InstantiationException {
+        final SortedSet<T> resultList = new TreeSet<T>();
+
+        long actualTime = startTime;
+        for (int i = 0; i < eventsCount; i++) {
+            final T event = eventClass.newInstance();
+            event.setTimeValue(actualTime);
+            event.setDuration(duration);
+            resultList.add(event);
+            actualTime = actualTime + timeIncrement;
+        }
+        return resultList;
+    }
+
+    private int insertEventsAndFire(final KieSession kieSession, final SortedSet<Event> events) {
+        final SessionPseudoClock sessionClock = kieSession.getSessionClock();
+
+        final long startTime = sessionClock.getCurrentTime();
+        int fireCount = 0;
+        for (Event event : events) {
+            final long eventTime = startTime + event.getTimeValue();
+            sessionClock.advanceTime(eventTime - sessionClock.getCurrentTime(), TimeUnit.MILLISECONDS);
+            kieSession.insert(event);
+            fireCount += kieSession.fireAllRules();
+        }
+        return fireCount;
+    }
 }


### PR DESCRIPTION
- Added reproducer. 
- Added proposed fix which ignores already expired tuples when recursing through tuple chain.
