### PR TITLE
Don't report turtle tests as skipped

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  
+
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.drools</groupId>
@@ -15,6 +15,7 @@
   <name>Drools :: Compiler</name>
 
   <properties>
+    <excludedGroups>org.drools.compiler.TurtleTestCategory</excludedGroups>
     <surefire.forkCount>2</surefire.forkCount>
   </properties>
 
@@ -156,14 +157,14 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope><!-- HACK for OSGi: should be <optional>true</optional> instead -->
     </dependency>
-    
+
     <dependency><!-- It works in any CDI container, but the weld CDI container is used for testing -->
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>
     </dependency>
-         
-   <!-- test: byteman -->
+
+    <!-- test: byteman -->
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman</artifactId>
@@ -187,7 +188,38 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <configuration>
+            <excludeFilterFile>${project.basedir}/src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.jboss.byteman</groupId>
+        <artifactId>byteman-rulecheck-maven-plugin</artifactId>
+        <version>${version.org.jboss.byteman}</version>
+        <executions>
+          <execution>
+            <id>rulecheck-test</id>
+            <goals>
+              <goal>rulecheck</goal>
+            </goals>
+            <phase>test-compile</phase>
+            <configuration>
+              <includes>
+                <include>**/*.btm</include>
+              </includes>
+              <verbose>true</verbose>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -221,38 +253,21 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${project.basedir}/src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
-        </configuration>
-      </plugin>
-     
-      <plugin>
-        <groupId>org.jboss.byteman</groupId>
-        <artifactId>byteman-rulecheck-maven-plugin</artifactId>
-        <version>${version.org.jboss.byteman}</version>
-        <executions>
-          <execution>
-            <id>rulecheck-test</id>
-            <goals>
-              <goal>rulecheck</goal>
-            </goals>
-            <phase>test-compile</phase>
-            <configuration>
-              <includes>
-                <include>**/*.btm</include>
-              </includes>
-              <verbose>true</verbose>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
-  
+
   <profiles>
+    <profile>
+      <id>runTurtleTests</id>
+      <activation>
+        <property>
+          <name>runTurtleTests</name>
+        </property>
+      </activation>
+      <properties>
+        <excludedGroups/>
+      </properties>
+    </profile>
     <profile>
       <id>grammarsProfile</id>
       <activation>
@@ -350,5 +365,5 @@
       </build>
     </profile>
   </profiles>
-  
+
 </project>

--- a/drools-compiler/src/test/java/org/drools/compiler/TurtleTestCategory.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/TurtleTestCategory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler;
+
+/**
+ * Serves as a JUnit's {@link org.junit.experimental.categories.Category} to mark turtle tests (tests which are slow
+ * and should not be executed by default). These slow tests can be then enabled by defining property `runTurtleTests`
+ */
+public class TurtleTestCategory {
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveGenerated2RulesTest.java
@@ -82,7 +82,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -92,7 +91,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRulesRevertedRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());
@@ -102,7 +100,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testFireRulesInsertFactsFireRulesRemoveRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createFireRulesInsertFactsFireRulesRemoveRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -112,7 +109,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testFireRulesInsertFactsFireRulesRemoveRulesRevertedRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createFireRulesInsertFactsFireRulesRemoveRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());
@@ -122,7 +118,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testInsertFactsRemoveRulesFireRulesRemoveRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsRemoveRulesFireRulesRemoveRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -132,7 +127,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testInsertFactsRemoveRulesFireRulesRemoveRulesRevertedRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsRemoveRulesFireRulesRemoveRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());
@@ -142,7 +136,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRulesReinsertRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(
                         rule1, rule2, RULE1_NAME, RULE2_NAME, getFacts());
@@ -152,7 +145,6 @@ public abstract class AbstractAddRemoveGenerated2RulesTest extends AbstractAddRe
 
     @Test(timeout = 10000)
     public void testInsertFactsFireRulesRemoveRulesReinsertRulesRevertedRules() {
-        checkRunTurtleTests();
         final List<List<TestOperation>> testPlans =
                 AddRemoveTestBuilder.createInsertFactsFireRulesRemoveRulesReinsertRulesTestPlan(
                         rule2, rule1, RULE2_NAME, RULE1_NAME, getFacts());

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AbstractAddRemoveRulesTest.java
@@ -22,7 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.drools.compiler.TurtleTestCategory;
 import org.junit.Assert;
+import org.junit.experimental.categories.Category;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.io.ResourceType;
 import org.kie.internal.KnowledgeBase;
@@ -35,16 +37,13 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 /**
  * Abstract class for tests that test adding and removing rules at runtime.
  */
+@Category(TurtleTestCategory.class)
 public abstract class AbstractAddRemoveRulesTest {
 
     protected static final String PKG_NAME_TEST = "com.rules";
     protected static final String RULE1_NAME = "R1";
     protected static final String RULE2_NAME = "R2";
     protected static final String RULE3_NAME = "R3";
-
-    protected static void checkRunTurtleTests() {
-        assumeTrue("true".equals(System.getProperty("runTurtleTests")));
-    }
 
     // TODO - remove these two methods - they are also in TestContext
     protected KnowledgeBuilder createKnowledgeBuilder(final KnowledgeBase kbase, final String drl) {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAddDeleteFactsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRemoveRulesAddDeleteFactsTest.java
@@ -42,7 +42,6 @@ public class AddRemoveRulesAddDeleteFactsTest extends AbstractAddRemoveRulesTest
 
     @Test
     public void testAddRemoveRulesAddRemoveFacts() {
-        checkRunTurtleTests();
         final List resultsList = new ArrayList();
         final Map<String, Object> sessionGlobals = new HashMap<String, Object>();
         sessionGlobals.put("list", resultsList);


### PR DESCRIPTION
- reporting the thousands of generated tests
  as skipped skews the overall "skipped tests"
  statistics which is very bad
- before the change 25k tests were reported as skipped
- turtle tests can be executed using specific property, e.g.
  `mvn clean test -DrunTurtleTests`

Backport of #837. 
