### PR TITLE
[6.5.x] GUVNOR-2617: Operator for Condition can not be changed.

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BaseColumnFieldDiffImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BaseColumnFieldDiffImpl.java
@@ -94,8 +94,10 @@ public class BaseColumnFieldDiffImpl implements BaseColumnFieldDiff {
 
     /**
      * Check whether two Objects are equal or both null.
-     * @param s1 The object.
-     * @param s2 The other  object.
+     * @param s1
+     *         The object.
+     * @param s2
+     *         The other  object.
      * @return Whether two Objects are equal or both null
      */
     public static boolean isEqualOrNull( Object s1,
@@ -113,14 +115,20 @@ public class BaseColumnFieldDiffImpl implements BaseColumnFieldDiff {
 
     /**
      * Check whether two Objects are equal or both null.
-     * @param dcv1 The DTCellValue52.
-     * @param dcv2 The other DTCellValue52.
+     * @param dcv1
+     *         The DTCellValue52.
+     * @param dcv2
+     *         The other DTCellValue52.
      * @return Whether two DTCellValue52s are equal or both null
      */
     public static boolean isEqualOrNull( final DTCellValue52 dcv1,
                                          final DTCellValue52 dcv2 ) {
         if ( dcv1 == null && dcv2 == null ) {
             return true;
+        } else if ( dcv1 == null && dcv2 != null ) {
+            return false;
+        } else if ( dcv1 != null && dcv2 == null ) {
+            return false;
         } else if ( !dcv1.getDataType().equals( dcv2.getDataType() ) ) {
             return false;
         } else {
@@ -180,8 +188,10 @@ public class BaseColumnFieldDiffImpl implements BaseColumnFieldDiff {
 
     /**
      * Check whether two List are same size or both null.
-     * @param s1 The fist list..
-     * @param s2 The other  list.
+     * @param s1
+     *         The fist list..
+     * @param s2
+     *         The other  list.
      * @return Whether two List are same size or both null
      */
     public static boolean isEqualOrNull( List s1,
@@ -199,8 +209,10 @@ public class BaseColumnFieldDiffImpl implements BaseColumnFieldDiff {
 
     /**
      * Check whether two Map are same size or both null.
-     * @param s1 The fist Map..
-     * @param s2 The other  Map.
+     * @param s1
+     *         The fist Map..
+     * @param s2
+     *         The other  Map.
      * @return Whether two Map are same size or both null
      */
 

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52.java
@@ -109,6 +109,9 @@ public class DTColumnConfig52
     }
 
     protected Object extractDefaultValue( final DTCellValue52 dcv ) {
+        if ( dcv == null ) {
+            return null;
+        }
         switch ( dcv.getDataType() ) {
             case BOOLEAN:
                 return dcv.getBooleanValue();

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BaseColumnFieldDiffImplTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BaseColumnFieldDiffImplTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class BaseColumnFieldDiffImplTest {
+
+    @Parameterized.Parameter(0)
+    public DTCellValue52 dcv1;
+
+    @Parameterized.Parameter(1)
+    public DTCellValue52 dcv2;
+
+    @Parameterized.Parameter(2)
+    public boolean isEqual;
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> data() {
+        return new ArrayList<Object[]>() {{
+            add( new Object[]{ null, null, true } );
+            add( new Object[]{ new DTCellValue52( "hello" ), null, false } );
+            add( new Object[]{ new DTCellValue52( 1 ), null, false } );
+            add( new Object[]{ new DTCellValue52( 1.0 ), null, false } );
+            add( new Object[]{ new DTCellValue52( 1.0f ), null, false } );
+            add( new Object[]{ new DTCellValue52( 1L ), null, false } );
+            add( new Object[]{ null, new DTCellValue52( "hello" ), false } );
+            add( new Object[]{ null, new DTCellValue52( 1 ), false } );
+            add( new Object[]{ null, new DTCellValue52( 1.0 ), false } );
+            add( new Object[]{ null, new DTCellValue52( 1.0f ), false } );
+            add( new Object[]{ null, new DTCellValue52( 1L ), false } );
+            add( new Object[]{ new DTCellValue52( "hello" ), new DTCellValue52( "hello" ), true } );
+            add( new Object[]{ new DTCellValue52( 1 ), new DTCellValue52( 1 ), true } );
+            add( new Object[]{ new DTCellValue52( 1.0 ), new DTCellValue52( 1.0 ), true } );
+            add( new Object[]{ new DTCellValue52( 1.0f ), new DTCellValue52( 1.0f ), true } );
+            add( new Object[]{ new DTCellValue52( 1L ), new DTCellValue52( 1L ), true } );
+        }};
+    }
+
+    @Test
+    public void check() {
+        assertEquals( isEqual,
+                      BaseColumnFieldDiffImpl.isEqualOrNull( dcv1,
+                                                             dcv2 ) );
+    }
+
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ColumnTestBase.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ColumnTestBase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ColumnTestBase {
+
+    protected void checkSingleDiff(String fieldName, Object oldValue, Object newValue, DTColumnConfig52 column1, DTColumnConfig52 column2) {
+        List<BaseColumnFieldDiff> diff = column1.diff(column2);
+        assertSingleDiff(fieldName, oldValue, newValue, diff);
+    }
+
+    protected void checkDiffEmpty(DTColumnConfig52 column1, DTColumnConfig52 column2) {
+        assertSingleDiffEmpty(column1.diff(column2));
+    }
+
+    protected void checkSingleDiff(String fieldName, Object oldValue, Object newValue, Pattern52 column1, Pattern52 column2) {
+        List<BaseColumnFieldDiff> diff = column1.diff(column2);
+        assertSingleDiff(fieldName, oldValue, newValue, diff);
+    }
+
+    protected void checkDiffEmpty(Pattern52 column1, Pattern52 column2) {
+        assertSingleDiffEmpty(column1.diff(column2));
+    }
+
+    private void assertSingleDiff(String fieldName, Object oldValue, Object newValue, List<BaseColumnFieldDiff> diff) {
+        assertNotNull(diff);
+        assertEquals(1, diff.size());
+        assertEquals(fieldName, diff.get(0).getFieldName());
+        assertEquals(oldValue, diff.get(0).getOldValue());
+        assertEquals(newValue, diff.get(0).getValue());
+    }
+
+    private void assertSingleDiffEmpty(List<BaseColumnFieldDiff> diff) {
+        assertNotNull(diff);
+        assertEquals(0, diff.size());
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52Test.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import java.util.List;
+
+import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52.*;
+import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_DEFAULT_VALUE;
+import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HEADER;
+import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HIDE_COLUMN;
+import static org.junit.Assert.*;
+
+public class ConditionCol52Test extends ColumnTestBase {
+
+    private ConditionCol52 column1;
+    private ConditionCol52 column2;
+
+    @Before
+    public void setup() {
+        column1 = new ConditionCol52();
+        column1.setFactField( "field" );
+        column1.setFieldType( "Type" );
+        column1.setOperator( "==" );
+        column1.setValueList( "a,b,c" );
+        column1.setBinding( "$var" );
+        column1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
+        column1.setHeader( "header" );
+        column1.setHideColumn( false );
+        column1.setDefaultValue( new DTCellValue52( "default" ) );
+
+        column2 = new ConditionCol52();
+        column2.setFactField( "field" );
+        column2.setFieldType( "Type" );
+        column2.setOperator( "==" );
+        column2.setValueList( "a,b,c" );
+        column2.setBinding( "$var" );
+        column2.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
+        column2.setHeader( "header" );
+        column2.setHideColumn( false );
+        column2.setDefaultValue( new DTCellValue52( "default" ) );
+    }
+
+    @Test
+    public void testDiffEmpty() {
+        checkDiffEmpty( column1, column2 );
+    }
+
+    @Test
+    public void testDiffFactField() {
+        column1.setFactField( "field1" );
+        column2.setFactField( "field2" );
+
+        checkSingleDiff( FIELD_FACT_FIELD,
+                         "field1",
+                         "field2",
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffFieldType() {
+        column1.setFieldType( "Type1" );
+        column2.setFieldType( "Type2" );
+
+        checkSingleDiff( FIELD_FIELD_TYPE,
+                         "Type1",
+                         "Type2",
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffOperator() {
+        column1.setOperator( "<" );
+        column2.setOperator( ">" );
+
+        checkSingleDiff( FIELD_OPERATOR,
+                         "<",
+                         ">",
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffValueList() {
+        column1.setValueList( "v,a,l,u,e" );
+        column2.setValueList( "l,i,s,t" );
+
+        checkSingleDiff( FIELD_VALUE_LIST,
+                         "v,a,l,u,e",
+                         "l,i,s,t",
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffBinding() {
+        column1.setBinding( "$var1" );
+        column2.setBinding( "$var2" );
+
+        checkSingleDiff( FIELD_BINDING,
+                         "$var1",
+                         "$var2",
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffConstraintType() {
+        column1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_PREDICATE );
+        column2.setConstraintValueType( BaseSingleFieldConstraint.TYPE_RET_VALUE );
+
+        checkSingleDiff( FIELD_CONSTRAINT_VALUE_TYPE,
+                         BaseSingleFieldConstraint.TYPE_PREDICATE,
+                         BaseSingleFieldConstraint.TYPE_RET_VALUE,
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffDefaultValueOriginalValueIsNull() {
+        column1.setDefaultValue( null );
+        column2.setDefaultValue( new DTCellValue52( "default" ) );
+
+        checkSingleDiff( FIELD_DEFAULT_VALUE,
+                         null,
+                         "default",
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffDefaultValueNewValueIsNull() {
+        column1.setDefaultValue( new DTCellValue52( "default" ) );
+        column2.setDefaultValue( null );
+
+        checkSingleDiff( FIELD_DEFAULT_VALUE,
+                         "default",
+                         null,
+                         column1,
+                         column2 );
+    }
+
+    @Test
+    public void testDiffAll() {
+        column1.setFactField( "field1" );
+        column1.setFieldType( "Type1" );
+        column1.setOperator( "<" );
+        column1.setValueList( "v,a,l,u,e" );
+        column1.setBinding( "$var1" );
+        column1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_PREDICATE );
+        column1.setHeader( "header1" );
+        column1.setHideColumn( false );
+        column1.setDefaultValue( new DTCellValue52( "default1" ) );
+        column2.setFactField( "field2" );
+        column2.setFieldType( "Type2" );
+        column2.setOperator( ">" );
+        column2.setValueList( "l,i,s,t" );
+        column2.setBinding( "$var2" );
+        column2.setConstraintValueType( BaseSingleFieldConstraint.TYPE_RET_VALUE );
+        column2.setHeader( "header2" );
+        column2.setHideColumn( true );
+        column2.setDefaultValue( new DTCellValue52( "default2" ) );
+
+        List<BaseColumnFieldDiff> diff = column1.diff( column2 );
+        assertNotNull( diff );
+        assertEquals( 9,
+                      diff.size() );
+        assertEquals( FIELD_HIDE_COLUMN,
+                      diff.get( 0 ).getFieldName() );
+        assertEquals( false,
+                      diff.get( 0 ).getOldValue() );
+        assertEquals( true,
+                      diff.get( 0 ).getValue() );
+        assertEquals( FIELD_DEFAULT_VALUE,
+                      diff.get( 1 ).getFieldName() );
+        assertEquals( "default1",
+                      diff.get( 1 ).getOldValue() );
+        assertEquals( "default2",
+                      diff.get( 1 ).getValue() );
+        assertEquals( FIELD_HEADER,
+                      diff.get( 2 ).getFieldName() );
+        assertEquals( "header1",
+                      diff.get( 2 ).getOldValue() );
+        assertEquals( "header2",
+                      diff.get( 2 ).getValue() );
+        assertEquals( FIELD_FACT_FIELD,
+                      diff.get( 3 ).getFieldName() );
+        assertEquals( "field1",
+                      diff.get( 3 ).getOldValue() );
+        assertEquals( "field2",
+                      diff.get( 3 ).getValue() );
+        assertEquals( FIELD_FIELD_TYPE,
+                      diff.get( 4 ).getFieldName() );
+        assertEquals( "Type1",
+                      diff.get( 4 ).getOldValue() );
+        assertEquals( "Type2",
+                      diff.get( 4 ).getValue() );
+        assertEquals( FIELD_OPERATOR,
+                      diff.get( 5 ).getFieldName() );
+        assertEquals( "<",
+                      diff.get( 5 ).getOldValue() );
+        assertEquals( ">",
+                      diff.get( 5 ).getValue() );
+        assertEquals( FIELD_VALUE_LIST,
+                      diff.get( 6 ).getFieldName() );
+        assertEquals( "v,a,l,u,e",
+                      diff.get( 6 ).getOldValue() );
+        assertEquals( "l,i,s,t",
+                      diff.get( 6 ).getValue() );
+        assertEquals( FIELD_BINDING,
+                      diff.get( 7 ).getFieldName() );
+        assertEquals( "$var1",
+                      diff.get( 7 ).getOldValue() );
+        assertEquals( "$var2",
+                      diff.get( 7 ).getValue() );
+        assertEquals( FIELD_CONSTRAINT_VALUE_TYPE,
+                      diff.get( 8 ).getFieldName() );
+        assertEquals( BaseSingleFieldConstraint.TYPE_PREDICATE,
+                      diff.get( 8 ).getOldValue() );
+        assertEquals( BaseSingleFieldConstraint.TYPE_RET_VALUE,
+                      diff.get( 8 ).getValue() );
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2617

This is the corollary of https://github.com/droolsjbpm/drools/pull/850 for 6.5.x

(cherry picked from commit 0d08aacf888bcd3f4c811c5837feff592af56fee)

(I also had to add `ColumnTestBase` and `ConditionCol52Test` from `master` to `6.5.x`).
