### PR TITLE
Not closed FileInputStream Object caused "To many open files" IOException

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
@@ -55,16 +55,26 @@ public class FileKieModule extends AbstractKieModule implements InternalKieModul
 
     @Override
     public byte[] getBytes(String pResourceName) {
-        try {
+    	FileInputStream input = null;
+    	try {
             File resource = new File( file, pResourceName);
             if( resource.exists() ) {
-                return IoUtils.readBytesFromInputStream( new FileInputStream( resource ) );
+            	input = new FileInputStream( resource );
+				return IoUtils.readBytesFromInputStream( input );
             } else {
                 return null;
             }
-        } catch ( Exception e ) {
-            throw new RuntimeException("Unable to get bytes for: " + new File( file, pResourceName) );
-        }
+        } catch ( IOException e ) {
+            throw new RuntimeException("Unable to get bytes for: " + new File( file, pResourceName) +" "+e.getMessage());
+        } finally {
+			if(input != null){
+				try {
+					input.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
@@ -54,27 +54,27 @@ public class FileKieModule extends AbstractKieModule implements InternalKieModul
 
 
     @Override
-    public byte[] getBytes(String pResourceName) {
-    	FileInputStream input = null;
-    	try {
+    public byte[] getBytes(String pResourceName ) {
+        FileInputStream input = null;
+        try {
             File resource = new File( file, pResourceName);
             if( resource.exists() ) {
-            	input = new FileInputStream( resource );
-				return IoUtils.readBytesFromInputStream( input );
+                input = new FileInputStream( resource );
+                return IoUtils.readBytesFromInputStream( input );
             } else {
                 return null;
             }
         } catch ( IOException e ) {
-            throw new RuntimeException("Unable to get bytes for: " + new File( file, pResourceName) +" "+ e.getMessage());
+            throw new RuntimeException("Unable to get bytes for: " + new File( file, pResourceName) + " " +e.getMessage());
         } finally {
-			if( input != null ) {
-				try {
-					input.close();
-				} catch ( IOException e ) {
-					e.printStackTrace();
-				}
-			}
-		}
+            if( input != null ){
+                try {
+                    input.close();
+                } catch ( IOException e ) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/FileKieModule.java
@@ -65,12 +65,12 @@ public class FileKieModule extends AbstractKieModule implements InternalKieModul
                 return null;
             }
         } catch ( IOException e ) {
-            throw new RuntimeException("Unable to get bytes for: " + new File( file, pResourceName) +" "+e.getMessage());
+            throw new RuntimeException("Unable to get bytes for: " + new File( file, pResourceName) +" "+ e.getMessage());
         } finally {
-			if(input != null){
+			if( input != null ) {
 				try {
 					input.close();
-				} catch (IOException e) {
+				} catch ( IOException e ) {
 					e.printStackTrace();
 				}
 			}


### PR DESCRIPTION
In our case, this part caused endless loop(blocking system resources) in the jenkins build process(tests execution) and was returning incorrect error message. The getBytes method was not closing FileInputStream at the end of reading files and caused IOException "To many open files". 
