### PR TITLE
DROOLS-1235 MBean naming rework

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieContainer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieContainer.java
@@ -49,6 +49,15 @@ public interface InternalKieContainer extends KieContainer {
      */
     void dispose();
 
+    /**
+     * Internal use: returns the RelaseId configured while creating the Kiecontainer, 
+     * or alternatively if the RelaseId was NOT configured while creating the Kiecontainer,
+     * returns the the ReleaseId of the KieModule wrapped by this KieContainer. 
+     * Additionally, please notice this will always gets updated to the parameter passed as updateToVersion(ReleaseId).
+     * @see org.drools.compiler.kie.builder.impl.KieContainerImpl#KieContainerImpl(String, KieProject, org.kie.api.builder.KieRepository, ReleaseId)
+     * @see org.kie.api.runtime.KieContainer#getReleaseId()
+     * @see org.kie.api.runtime.KieContainer#updateToVersion(ReleaseId)
+     */
     ReleaseId getContainerReleaseId();
 
     long getCreationTimestamp();
@@ -61,5 +70,23 @@ public interface InternalKieContainer extends KieContainer {
      * @return the {@link KieModule} of the {@link #getReleaseId()}
      */
     KieModule getMainKieModule();
+
+    /**
+     * Returns the unique ID assigned to the container.
+     * @return the unique ID assigned to the container.
+     */
+	String getContainerId();
+	
+	/**
+	 * Returns the RelaseId configured while creating the Kiecontainer.
+	 * @return the RelaseId configured while creating the Kiecontainer.
+	 */
+	ReleaseId getConfiguredReleaseId();
+	
+	/**
+	 * Returns the actual resolved ReleaseId. 
+	 * @return the actual resolved ReleaseId. 
+	 */
+	ReleaseId getResolvedReleaseId();
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieServices.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieServices.java
@@ -17,7 +17,14 @@ package org.drools.compiler.kie.builder.impl;
 
 import org.drools.compiler.kie.builder.impl.event.KieServicesEventListerner;
 import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
 
 public interface InternalKieServices extends KieServices {
     void registerListener(KieServicesEventListerner listener);
+
+    /**
+     * Clear the containerId reference from the internal registry hold by the KieServices.
+     * Epsecially helpful to avoid leaking reference on container dispose(), to inadvertently keep a reference in the internal registry which would never be GC.
+     */
+	void clearRefToContainerId(String containerId, KieContainer containerRef);
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -512,7 +512,7 @@ public class KieContainerImpl
         } else if (conf instanceof RuleBaseConfiguration) {
             ((RuleBaseConfiguration)conf).setClassLoader(cl);
         }
-        InternalKnowledgeBase kBase = (InternalKnowledgeBase) KnowledgeBaseFactory.newKnowledgeBase( conf );
+        InternalKnowledgeBase kBase = (InternalKnowledgeBase) KnowledgeBaseFactory.newKnowledgeBase( kBaseModel.getName(), conf );
 
         kBase.addKnowledgePackages( pkgs );
         return kBase;

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -15,12 +15,32 @@
 
 package org.drools.compiler.kie.builder.impl;
 
+import static org.drools.compiler.kie.builder.impl.AbstractKieModule.buildKnowledgePackages;
+import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.filterFileInKBase;
+import static org.drools.compiler.kie.util.CDIHelper.wireListnersAndWIHs;
+import static org.drools.core.util.ClassUtils.convertResourceToClassName;
+import static org.drools.core.util.Drools.isJndiAvailable;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.management.ObjectName;
+
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.PackageBuilderErrors;
 import org.drools.compiler.kie.util.ChangeSetBuilder;
 import org.drools.compiler.kie.util.KieJarChangeSet;
 import org.drools.compiler.kproject.models.KieBaseModelImpl;
 import org.drools.compiler.kproject.models.KieSessionModelImpl;
+import org.drools.compiler.management.KieContainerMonitor;
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.ProjectClassLoader;
@@ -28,6 +48,7 @@ import org.drools.core.definitions.impl.KnowledgePackageImpl;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.StatefulKnowledgeSessionImpl;
+import org.drools.core.management.DroolsManagementAgent;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
@@ -40,6 +61,7 @@ import org.kie.api.builder.model.FileLoggerModel;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.conf.EventProcessingOption;
+import org.kie.api.conf.MBeansOption;
 import org.kie.api.event.KieRuntimeEventManager;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
@@ -60,22 +82,6 @@ import org.kie.internal.definition.KnowledgePackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static org.drools.compiler.kie.builder.impl.AbstractKieModule.buildKnowledgePackages;
-import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.filterFileInKBase;
-import static org.drools.compiler.kie.util.CDIHelper.wireListnersAndWIHs;
-import static org.drools.core.util.ClassUtils.convertResourceToClassName;
-import static org.drools.core.util.Drools.isJndiAvailable;
-
 public class KieContainerImpl
     implements
     InternalKieContainer {
@@ -91,24 +97,82 @@ public class KieContainerImpl
 
     private final KieRepository        kr;
 
+    private ReleaseId configuredReleaseId;
     private ReleaseId containerReleaseId;
+
+	private final String containerId;
 
     public KieModule getMainKieModule() {
         return kr.getKieModule(getReleaseId());
     }
-
+    
+    /**
+     * Please note: the recommended way of getting a KieContainer is relying on {@link org.kie.api.KieServices KieServices} API,
+     * for example: {@link org.kie.api.KieServices#newKieContainer(ReleaseId) KieServices.newKieContainer(...)}.
+     * The direct manual call to KieContainerImpl constructor instead would not guarantee the consistency of the supplied containerId.
+     */
     public KieContainerImpl(KieProject kProject, KieRepository kr) {
+        this("impl"+UUID.randomUUID(), kProject, kr);
+    }
+    
+    /**
+     * Please note: the recommended way of getting a KieContainer is relying on {@link org.kie.api.KieServices KieServices} API,
+     * for example: {@link org.kie.api.KieServices#newKieContainer(ReleaseId) KieServices.newKieContainer(...)}.
+     * The direct manual call to KieContainerImpl constructor instead would not guarantee the consistency of the supplied containerId.
+     */    
+    public KieContainerImpl(KieProject kProject, KieRepository kr, ReleaseId containerReleaseId) {
+        this("impl"+UUID.randomUUID(), kProject, kr, containerReleaseId);
+    }
+
+    /**
+     * Please note: the recommended way of getting a KieContainer is relying on {@link org.kie.api.KieServices KieServices} API,
+     * for example: {@link org.kie.api.KieServices#newKieContainer(ReleaseId) KieServices.newKieContainer(...)}.
+     * The direct manual call to KieContainerImpl constructor instead would not guarantee the consistency of the supplied containerId.
+     */
+    public KieContainerImpl(String containerId, KieProject kProject, KieRepository kr) {
         this.kr = kr;
         this.kProject = kProject;
+        this.containerId = containerId;
         kProject.init();
     }
-
-    public KieContainerImpl(KieProject kProject, KieRepository kr, ReleaseId containerReleaseId) {
-        this(kProject, kr);
+    
+    /**
+     * Please note: the recommended way of getting a KieContainer is relying on {@link org.kie.api.KieServices KieServices} API,
+     * for example: {@link org.kie.api.KieServices#newKieContainer(ReleaseId) KieServices.newKieContainer(...)}.
+     * The direct manual call to KieContainerImpl constructor instead would not guarantee the consistency of the supplied containerId.
+     */
+    public KieContainerImpl(String containerId, KieProject kProject, KieRepository kr, ReleaseId containerReleaseId) {
+        this(containerId, kProject, kr);
+        this.configuredReleaseId = containerReleaseId;
         this.containerReleaseId = containerReleaseId;
+        
+        initMBeans(containerId);
     }
 
-    public ReleaseId getReleaseId() {
+	private void initMBeans(String containerId) {
+		if ( MBeansOption.isEnabled( System.getProperty( MBeansOption.PROPERTY_NAME, MBeansOption.DISABLED.toString() ) ) ) {
+        	KieContainerMonitor monitor = new KieContainerMonitor(this);
+            ObjectName on = DroolsManagementAgent.createObjectNameByContainerId(containerId);
+            DroolsManagementAgent.getInstance().registerMBean( this, monitor, on );
+        }
+	}
+    
+    @Override
+    public String getContainerId() {
+    	return this.containerId;
+    }
+    
+    @Override
+    public ReleaseId getConfiguredReleaseId() {
+		return configuredReleaseId;
+	}
+    
+	@Override
+	public ReleaseId getResolvedReleaseId() {
+		return getReleaseId();
+	}
+
+	public ReleaseId getReleaseId() {
         return kProject.getGAV();
     }
 
@@ -120,6 +184,7 @@ public class KieContainerImpl
         return kProject.getCreationTimestamp();
     }
 
+    @Override
     public ReleaseId getContainerReleaseId() {
         return containerReleaseId != null ? containerReleaseId : getReleaseId();
     }
@@ -242,6 +307,8 @@ public class KieContainerImpl
             }
             rebuildAll(newReleaseId, results, newKM, modifyingUsedClass, kieBaseModel, pkgbuilder, ckbuilder);
         }
+        
+        kBase.setResolvedReleaseId(newReleaseId);
 
         for ( InternalWorkingMemory wm : kBase.getWorkingMemories() ) {
             wm.notifyWaitOnRest();
@@ -513,6 +580,9 @@ public class KieContainerImpl
             ((RuleBaseConfiguration)conf).setClassLoader(cl);
         }
         InternalKnowledgeBase kBase = (InternalKnowledgeBase) KnowledgeBaseFactory.newKnowledgeBase( kBaseModel.getName(), conf );
+        kBase.setResolvedReleaseId(containerReleaseId);
+        kBase.setContainerId(containerId);
+        kBase.initMBeans();
 
         kBase.addKnowledgePackages( pkgs );
         return kBase;
@@ -698,6 +768,7 @@ public class KieContainerImpl
         }
         kSessions.clear();
         statelessKSessions.clear();
+        ((InternalKieServices) KieServices.Factory.get()).clearRefToContainerId(this.containerId, this);
     }
 
     public KieProject getKieProject() {

--- a/drools-compiler/src/main/java/org/drools/compiler/management/KieContainerMonitor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/management/KieContainerMonitor.java
@@ -1,0 +1,39 @@
+package org.drools.compiler.management;
+
+import org.drools.compiler.kie.builder.impl.InternalKieContainer;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.management.KieContainerMonitorMXBean;
+import org.kie.api.management.GAV;
+
+public class KieContainerMonitor implements KieContainerMonitorMXBean {
+	private InternalKieContainer kieContainer;
+
+	public KieContainerMonitor(InternalKieContainer kieContainer) {
+		this.kieContainer = kieContainer;
+	}
+
+	@Override
+	public String getContainerId() {
+		return kieContainer.getContainerId();
+	}
+
+	@Override
+	public String getConfiguredReleaseIdStr() {
+		return kieContainer.getConfiguredReleaseId().toString();
+	}
+
+	@Override
+	public String getResolvedReleaseIdStr() {
+		return kieContainer.getResolvedReleaseId().toString();
+	}
+
+    @Override
+    public GAV getConfiguredReleaseId() {
+        return GAV.from(kieContainer.getConfiguredReleaseId());
+    }
+
+    @Override
+    public GAV getResolvedReleaseId() {
+        return GAV.from(kieContainer.getResolvedReleaseId());
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieContainerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieContainerTest.java
@@ -56,6 +56,33 @@ public class KieContainerTest {
         KieModule kmodule = ((InternalKieContainer) kieContainer).getMainKieModule();
         assertEquals( releaseId, kmodule.getReleaseId() );
     }
+    
+    @Test
+    public void testReleaseIdGetters() {
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "test-delete-v", "1.0.1");
+        createAndDeployJar( ks, releaseId, createDRL("ruleA") );
+
+        ReleaseId configuredReleaseId = ks.newReleaseId("org.kie", "test-delete-v", "RELEASE");
+		KieContainer kieContainer = ks.newKieContainer(configuredReleaseId);
+
+        InternalKieContainer iKieContainer = (InternalKieContainer) kieContainer;
+        assertEquals(configuredReleaseId, iKieContainer.getConfiguredReleaseId());
+        assertEquals(releaseId, iKieContainer.getResolvedReleaseId());
+        assertEquals(releaseId, iKieContainer.getReleaseId());
+        // demonstrate internal API behavior, in the future shall this be enforced?
+        assertEquals(configuredReleaseId, iKieContainer.getContainerReleaseId());
+        
+        ReleaseId newReleaseId = ks.newReleaseId("org.kie", "test-delete-v", "1.0.2");
+        createAndDeployJar( ks, newReleaseId, createDRL("ruleA") );
+        iKieContainer.updateToVersion(newReleaseId);
+        
+        assertEquals(configuredReleaseId, iKieContainer.getConfiguredReleaseId());
+        assertEquals(newReleaseId, iKieContainer.getResolvedReleaseId());
+        assertEquals(newReleaseId, iKieContainer.getReleaseId());
+        // demonstrate internal API behavior, in the future shall this be enforced?
+        assertEquals(newReleaseId, iKieContainer.getContainerReleaseId());
+    }
 
     @Test
     public void testSharedTypeDeclarationsUsingClassLoader() throws Exception {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieServicesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieServicesTest.java
@@ -1,0 +1,108 @@
+package org.drools.compiler.integrationtests;
+
+import static org.drools.compiler.integrationtests.incrementalcompilation.IncrementalCompilationTest.createAndDeployJar;
+import static org.junit.Assert.*;
+
+import org.drools.compiler.kie.builder.impl.KieContainerImpl;
+import org.drools.compiler.kie.builder.impl.KieServicesImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.runtime.KieContainer;
+
+public class KieServicesTest {
+	
+	private KieServices ks;
+
+	@Before
+	public void init() {
+		ks = KieServices.Factory.get();
+		((KieServicesImpl) ks).nullKieClasspathContainer(); 
+		((KieServicesImpl) ks).nullAllContainerIds();
+	}
+	
+	@After
+	public void shutdown() {
+		((KieServicesImpl) ks).nullKieClasspathContainer(); 
+		((KieServicesImpl) ks).nullAllContainerIds();
+	}
+	
+	@Test
+	public void testGetKieClasspathIDs() {
+		String myId = "myId";
+		
+		KieContainer c1 = ks.getKieClasspathContainer(myId);
+		
+		assertEquals(c1, ks.getKieClasspathContainer());
+		assertEquals(c1, ks.getKieClasspathContainer(myId));
+		try {
+			ks.getKieClasspathContainer("invalid");
+			fail("this is not the containerId for the global singleton.");
+		} catch (IllegalStateException is) {
+			// ok.
+		}
+	}
+	
+	@Test
+	public void testNewKieClasspathIDs() {
+		KieContainer c1 = ks.newKieClasspathContainer("id1");
+		KieContainer c2 = ks.newKieClasspathContainer("id2");
+		try {
+			ks.newKieClasspathContainer("id2");
+			fail("should not allow repeated container IDs.");
+		} catch (IllegalStateException is) {
+			// ok.
+		}
+	}
+	
+	@Test
+	public void testNewKieContainerIDs() {
+		ReleaseId releaseId = ks.newReleaseId("org.kie", "test-delete", "1.0.0");
+        createAndDeployJar( ks, releaseId, createDRL("ruleA") );
+        
+		KieContainer c1 = ks.newKieContainer("id1", releaseId);
+		KieContainer c2 = ks.newKieClasspathContainer("id2");
+		try {
+			ks.newKieContainer("id2", releaseId);
+			fail("should not allow repeated container IDs.");
+		} catch (IllegalStateException is) {
+			// ok.
+		}
+		try {
+			ks.newKieClasspathContainer("id1");
+			fail("should not allow repeated container IDs.");
+		} catch (IllegalStateException is) {
+			// ok.
+		}
+	}
+	
+	@Test
+	public void testDisposeClearTheIDReference() {
+		ReleaseId releaseId = ks.newReleaseId("org.kie", "test-delete", "1.0.0");
+        createAndDeployJar( ks, releaseId, createDRL("ruleA") );
+        
+		KieContainer c1 = ks.newKieContainer("id1", releaseId);
+		try {
+			ks.newKieClasspathContainer("id1");
+			fail("should not allow repeated container IDs.");
+		} catch (IllegalStateException is) {
+			// ok.
+		}
+		
+		((KieContainerImpl) c1).dispose();
+		
+		ks.newKieClasspathContainer("id1"); // now OK.
+	}
+
+    private String createDRL(String ruleName) {
+        return "package org.kie.test\n" +
+               "global java.util.List list\n" +
+               "rule " + ruleName + "\n" +
+               "when\n" +
+               "then\n" +
+               "list.add( drools.getRule().getName() );\n" +
+               "end\n";
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -15,51 +15,40 @@
 
 package org.drools.compiler.integrationtests;
 
-import java.io.StringReader;
-import java.lang.management.ManagementFactory;
-
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
-
+import org.drools.compiler.CommonTestMethodBase;
+import org.drools.core.ClockType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.kie.api.KieBaseConfiguration;
-import org.kie.internal.KnowledgeBase;
-import org.kie.internal.KnowledgeBaseFactory;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.builder.model.KieBaseModel;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.conf.MBeansOption;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.conf.ClockTypeOption;
 
-public class MBeansMonitoringTest {
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+
+public class MBeansMonitoringTest
+        extends CommonTestMethodBase {
+
+    public static final String KBASE1 = "KBase1";
+    private KieContainer kc;
+    private String mbeansprop;
 
     @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
-    @Test
-    public void testEventOffset() throws InterruptedException,
-                                 AttributeNotFoundException,
-                                 InstanceNotFoundException,
-                                 MalformedObjectNameException,
-                                 MBeanException,
-                                 ReflectionException,
-                                 NullPointerException {
+    public void setUp()
+            throws Exception {
+        mbeansprop = System.getProperty( MBeansOption.PROPERTY_NAME );
+        System.setProperty( MBeansOption.PROPERTY_NAME, "enabled" );
         String drl = "package org.drools.compiler.test\n" +
-        		     "import org.drools.compiler.StockTick\n" +
+                     "import org.drools.compiler.StockTick\n" +
                      "declare StockTick\n" +
                      "    @role(event)\n" +
                      "    @expires(10s)\n" +
@@ -69,35 +58,45 @@ public class MBeansMonitoringTest {
                      "    StockTick()\n" +
                      "then\n" +
                      "end";
-        KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        conf.setOption( EventProcessingOption.STREAM );
-        conf.setOption( MBeansOption.ENABLED );
 
-        KnowledgeBase kbase = loadKnowledgeBase( "monitoredKbase",
-                                                 drl,
-                                                 conf );
+        KieServices ks = KieServices.Factory.get();
 
+        KieModuleModel kproj = ks.newKieModuleModel();
+
+        KieBaseModel kieBaseModel1 = kproj.newKieBaseModel( KBASE1 ).setDefault( true )
+                .setEventProcessingMode( EventProcessingOption.STREAM );
+        KieSessionModel ksession1 = kieBaseModel1.newKieSessionModel( "KSession1" ).setDefault( true )
+                .setType( KieSessionModel.KieSessionType.STATEFUL )
+                .setClockType( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+
+        ReleaseId releaseId1 = ks.newReleaseId( "org.kie.test", "mbeans", "1.0.0" );
+        createKJar( ks, kproj, releaseId1, null, drl );
+
+        kc = ks.newKieContainer( releaseId1 );
+    }
+
+    @After
+    public void tearDown()
+            throws Exception {
+        System.setProperty( MBeansOption.PROPERTY_NAME, mbeansprop );
+    }
+
+    @Test
+    public void testEventOffset()
+            throws InterruptedException,
+                   AttributeNotFoundException,
+                   InstanceNotFoundException,
+                   MalformedObjectNameException,
+                   MBeanException,
+                   ReflectionException,
+                   NullPointerException {
+
+        KieBase kiebase = kc.getKieBase( KBASE1 );
         MBeanServer mbserver = ManagementFactory.getPlatformMBeanServer();
-        ObjectName kbOn = new ObjectName("org.drools.kbases:type=monitoredKbase");
+        ObjectName kbOn = new ObjectName( "org.drools.kbases:type=" + KBASE1 );
         mbserver.invoke( kbOn, "startInternalMBeans", new Object[0], new String[0] );
-        
-        Object expOffset = mbserver.getAttribute( new ObjectName( "org.drools.kbases:type=monitoredKbase,group=EntryPoints,EntryPoint=DEFAULT,ObjectType=org.drools.compiler.StockTick"), "ExpirationOffset" );
-        Assert.assertEquals( 10001, ((Number)expOffset).longValue() );
+
+        Object expOffset = mbserver.getAttribute( new ObjectName( "org.drools.kbases:type=" + KBASE1 + ",group=EntryPoints,EntryPoint=DEFAULT,ObjectType=org.drools.compiler.StockTick" ), "ExpirationOffset" );
+        Assert.assertEquals( 10001, ((Number) expOffset).longValue() );
     }
-
-    private KnowledgeBase loadKnowledgeBase( String id,
-                                             String drl,
-                                             KieBaseConfiguration conf ) {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource(new StringReader(drl)),
-                      ResourceType.DRL );
-        Assert.assertFalse( kbuilder.getErrors().toString(),
-                            kbuilder.hasErrors() );
-
-        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase( id,
-                                                                     conf );
-        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
-        return kbase;
-    }
-
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -16,7 +16,10 @@
 package org.drools.compiler.integrationtests;
 
 import org.drools.compiler.CommonTestMethodBase;
+import org.drools.compiler.kie.builder.impl.InternalKieContainer;
 import org.drools.core.ClockType;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.management.DroolsManagementAgent;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,74 +32,139 @@ import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.conf.MBeansOption;
+import org.kie.api.management.KieContainerMonitorMXBean;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.conf.ClockTypeOption;
 
-import javax.management.*;
 import java.lang.management.ManagementFactory;
 
-public class MBeansMonitoringTest
-        extends CommonTestMethodBase {
+import javax.management.JMX;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
-    public static final String KBASE1 = "KBase1";
-    private KieContainer kc;
+public class MBeansMonitoringTest extends CommonTestMethodBase {
+    public static final String KSESSION1 = "KSession1";
+	public static final String KBASE1 = "KBase1";
     private String mbeansprop;
 
     @Before
-    public void setUp()
-            throws Exception {
+    public void setUp() throws Exception {
         mbeansprop = System.getProperty( MBeansOption.PROPERTY_NAME );
         System.setProperty( MBeansOption.PROPERTY_NAME, "enabled" );
-        String drl = "package org.drools.compiler.test\n" +
-                     "import org.drools.compiler.StockTick\n" +
-                     "declare StockTick\n" +
-                     "    @role(event)\n" +
-                     "    @expires(10s)\n" +
-                     "end\n" +
-                     "rule X\n" +
-                     "when\n" +
-                     "    StockTick()\n" +
-                     "then\n" +
-                     "end";
-
-        KieServices ks = KieServices.Factory.get();
-
-        KieModuleModel kproj = ks.newKieModuleModel();
-
-        KieBaseModel kieBaseModel1 = kproj.newKieBaseModel( KBASE1 ).setDefault( true )
-                .setEventProcessingMode( EventProcessingOption.STREAM );
-        KieSessionModel ksession1 = kieBaseModel1.newKieSessionModel( "KSession1" ).setDefault( true )
-                .setType( KieSessionModel.KieSessionType.STATEFUL )
-                .setClockType( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
-
-        ReleaseId releaseId1 = ks.newReleaseId( "org.kie.test", "mbeans", "1.0.0" );
-        createKJar( ks, kproj, releaseId1, null, drl );
-
-        kc = ks.newKieContainer( releaseId1 );
+        
     }
 
     @After
     public void tearDown()
             throws Exception {
-        System.setProperty( MBeansOption.PROPERTY_NAME, mbeansprop );
+    	if (mbeansprop != null) {
+    		System.setProperty( MBeansOption.PROPERTY_NAME, mbeansprop );
+    	} else {
+    		System.setProperty( MBeansOption.PROPERTY_NAME, MBeansOption.DISABLED.toString() );
+    	}
     }
 
     @Test
-    public void testEventOffset()
-            throws InterruptedException,
-                   AttributeNotFoundException,
-                   InstanceNotFoundException,
-                   MalformedObjectNameException,
-                   MBeanException,
-                   ReflectionException,
-                   NullPointerException {
+    public void testEventOffset() throws Exception {
+    	String drl = "package org.drools.compiler.test\n" +
+    			"import org.drools.compiler.StockTick\n" +
+    			"declare StockTick\n" +
+    			"    @role(event)\n" +
+    			"    @expires(10s)\n" +
+    			"end\n" +
+    			"rule X\n" +
+    			"when\n" +
+    			"    StockTick()\n" +
+    			"then\n" +
+    			"end";
 
-        KieBase kiebase = kc.getKieBase( KBASE1 );
-        MBeanServer mbserver = ManagementFactory.getPlatformMBeanServer();
-        ObjectName kbOn = new ObjectName( "org.drools.kbases:type=" + KBASE1 );
-        mbserver.invoke( kbOn, "startInternalMBeans", new Object[0], new String[0] );
+    	KieServices ks = KieServices.Factory.get();
 
-        Object expOffset = mbserver.getAttribute( new ObjectName( "org.drools.kbases:type=" + KBASE1 + ",group=EntryPoints,EntryPoint=DEFAULT,ObjectType=org.drools.compiler.StockTick" ), "ExpirationOffset" );
-        Assert.assertEquals( 10001, ((Number) expOffset).longValue() );
+    	KieModuleModel kproj = ks.newKieModuleModel();
+
+    	KieBaseModel kieBaseModel1 = kproj.newKieBaseModel( KBASE1 ).setDefault( true )
+    			.setEventProcessingMode( EventProcessingOption.STREAM );
+    	KieSessionModel ksession1 = kieBaseModel1.newKieSessionModel( KSESSION1 ).setDefault( true )
+    			.setType( KieSessionModel.KieSessionType.STATEFUL )
+    			.setClockType( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+
+    	ReleaseId releaseId1 = ks.newReleaseId( "org.kie.test", "mbeans", "1.0.0" );
+    	createKJar( ks, kproj, releaseId1, null, drl );
+
+    	KieContainer kc = ks.newKieContainer( releaseId1 );
+
+    	KieBase kiebase = kc.getKieBase( KBASE1 );
+    	MBeanServer mbserver = ManagementFactory.getPlatformMBeanServer();
+
+    	ObjectName kbOn = DroolsManagementAgent.createObjectNameFor((InternalKnowledgeBase) kiebase);
+    	mbserver.invoke( kbOn, "startInternalMBeans", new Object[0], new String[0] );
+
+    	Object expOffset = mbserver.getAttribute( new ObjectName( kbOn + ",group=EntryPoints,EntryPoint=DEFAULT,ObjectType=org.drools.compiler.StockTick" ), "ExpirationOffset" );
+    	Assert.assertEquals( 10001, ((Number) expOffset).longValue() );
+    }
+    
+    @Test
+    public void testContainerMBeans() throws Exception {
+    	String drl = "package org.drools.compiler.test\n" +
+    			"import org.drools.compiler.StockTick\n" +
+    			"declare StockTick\n" +
+    			"    @role(event)\n" +
+    			"    @expires(10s)\n" +
+    			"end\n" +
+    			"rule X\n" +
+    			"when\n" +
+    			"    StockTick()\n" +
+    			"then\n" +
+    			"end";
+
+    	KieServices ks = KieServices.Factory.get();
+
+    	KieModuleModel kproj = ks.newKieModuleModel();
+
+    	KieBaseModel kieBaseModel1 = kproj.newKieBaseModel( KBASE1 ).setDefault( true )
+    			.setEventProcessingMode( EventProcessingOption.STREAM );
+    	KieSessionModel ksession1 = kieBaseModel1.newKieSessionModel( KSESSION1 ).setDefault( true )
+    			.setType( KieSessionModel.KieSessionType.STATEFUL )
+    			.setClockType( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+
+    	ReleaseId releaseId1 = ks.newReleaseId( "org.kie.test", "mbeans", "1.0.0" );
+    	createKJar( ks, kproj, releaseId1, null, drl );
+    	
+    	KieContainer kc = ks.newKieContainer( releaseId1 );
+    	KieBase kiebase = kc.getKieBase( KBASE1 );
+    	kc.newKieSession(KSESSION1);
+    	kiebase.newKieSession();
+    	
+    	String kc1ID = ((InternalKieContainer) kc).getContainerId();
+    	
+    	ReleaseId verRelease = ks.newReleaseId("org.kie.test", "mbeans", "RELEASE" );
+        KieContainer kc2 = ks.newKieContainer( "Matteo", verRelease );
+    	kc2.newKieSession(KSESSION1);
+    	
+    	MBeanServer mbserver = ManagementFactory.getPlatformMBeanServer();
+    	
+    	KieContainerMonitorMXBean c1Monitor = JMX.newMXBeanProxy(
+    			mbserver,
+    			DroolsManagementAgent.createObjectNameByContainerId(kc1ID),
+    	        KieContainerMonitorMXBean.class);
+    	assertEquals(releaseId1.toExternalForm(), c1Monitor.getConfiguredReleaseIdStr());
+    	assertEquals(releaseId1.toExternalForm(), c1Monitor.getResolvedReleaseIdStr());
+    	
+    	assertTrue(c1Monitor.getConfiguredReleaseId().sameGAVof(releaseId1));
+        assertTrue(c1Monitor.getResolvedReleaseId().sameGAVof(releaseId1));
+        assertEquals(releaseId1.getVersion(), c1Monitor.getConfiguredReleaseId().getVersion());
+        assertEquals(releaseId1.getVersion(), c1Monitor.getResolvedReleaseId().getVersion());
+    	
+    	KieContainerMonitorMXBean c2Monitor = JMX.newMXBeanProxy(
+    			mbserver,
+    			DroolsManagementAgent.createObjectNameByContainerId("Matteo"),
+    	        KieContainerMonitorMXBean.class);
+    	assertEquals(verRelease.toExternalForm(), c2Monitor.getConfiguredReleaseIdStr());
+    	assertEquals(releaseId1.toExternalForm(), c2Monitor.getResolvedReleaseIdStr());
+    	
+        assertTrue(c2Monitor.getConfiguredReleaseId().sameGAVof(verRelease));
+        assertTrue(c2Monitor.getResolvedReleaseId().sameGAVof(releaseId1));
+        assertEquals(verRelease.getVersion(), c2Monitor.getConfiguredReleaseId().getVersion());
+        assertEquals(releaseId1.getVersion(), c2Monitor.getResolvedReleaseId().getVersion());
     }
 }

--- a/drools-core/src/main/java/org/drools/core/impl/InternalKnowledgeBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalKnowledgeBase.java
@@ -29,6 +29,7 @@ import org.drools.core.rule.TypeDeclaration;
 import org.drools.core.spi.FactHandleFactory;
 import org.drools.core.spi.PropagationContext;
 import org.drools.core.util.TripleStore;
+import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.process.Process;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.Environment;
@@ -132,4 +133,11 @@ public interface InternalKnowledgeBase extends KnowledgeBase {
 
     TypeDeclaration getTypeDeclaration( Class<?> clazz );
     Collection<TypeDeclaration> getTypeDeclarations();
+
+	ReleaseId getResolvedReleaseId();
+	void setResolvedReleaseId(ReleaseId currentReleaseId);
+	String getContainerId();
+	void setContainerId(String containerId);
+	void initMBeans();
+
 }

--- a/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
+++ b/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
@@ -41,8 +41,10 @@ public class DroolsManagementAgent
     implements
     KieManagementAgentMBean {
 
-    private static final String           MBEAN_NAME = "org.drools:type=DroolsManagementAgent";
+    private static final String           MBEAN_NAME = "org.kie:type=DroolsManagementAgent";
 
+	private static final String CONTAINER_NAME_PREFIX = "org.kie";
+	
     private static DroolsManagementAgent  INSTANCE;
     private static MBeanServer            mbs;
 
@@ -75,6 +77,24 @@ public class DroolsManagementAgent
         }
         return INSTANCE;
     }
+    
+
+	public static ObjectName createObjectNameFor(InternalKnowledgeBase kbase) {
+		return DroolsManagementAgent.createObjectName(
+					DroolsManagementAgent.createObjectNameByContainerId(kbase.getContainerId())
+					+ ",kbaseId=" + ObjectName.quote(kbase.getId())
+					);
+	}
+	
+	public static ObjectName createObjectNameFor(InternalWorkingMemory ksession) {
+		return DroolsManagementAgent.createObjectName(
+				DroolsManagementAgent.createObjectNameFor(ksession.getKnowledgeBase()) + 
+				",group=Sessions,ksessionId=Session-"+ksession.getIdentifier());
+	}
+	
+	public static ObjectName createObjectNameByContainerId(String containerId) {
+		return DroolsManagementAgent.createObjectName(CONTAINER_NAME_PREFIX + ":kcontainerId="+ObjectName.quote(containerId));
+	}
 
     /* (non-Javadoc)
      * @see org.drools.core.reteoo.monitoring.DroolsManagementAgentMBean#getRulebaseCount()
@@ -136,6 +156,7 @@ public class DroolsManagementAgent
                                 mbl );
                 }
                 mbl.add( name );
+                logger.debug( "Registered {} into the platform MBean Server", name );
             }
         } catch ( Exception e ) {
             logger.error( "Unable to register mbean " + name + " into the platform MBean Server", e );

--- a/drools-core/src/main/java/org/drools/core/management/KieSessionMonitoringImpl.java
+++ b/drools-core/src/main/java/org/drools/core/management/KieSessionMonitoringImpl.java
@@ -21,6 +21,7 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.management.KieSessionMonitoringImpl.AgendaStats.AgendaStatsData;
 import org.drools.core.management.KieSessionMonitoringImpl.ProcessStats.ProcessInstanceStatsData;
 import org.drools.core.management.KieSessionMonitoringImpl.ProcessStats.ProcessStatsData;
+import org.kie.api.cdi.KBase;
 import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessNodeLeftEvent;
 import org.kie.api.event.process.ProcessNodeTriggeredEvent;
@@ -46,8 +47,6 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class KieSessionMonitoringImpl implements KieSessionMonitoringMBean {
 
-    private static final String KSESSION_PREFIX = "org.drools.kbases";
-    
     private static final long NANO_TO_MILLISEC = 1000000;
     
     private InternalWorkingMemory ksession;
@@ -59,7 +58,7 @@ public class KieSessionMonitoringImpl implements KieSessionMonitoringMBean {
     public KieSessionMonitoringImpl(InternalWorkingMemory ksession) {
         this.ksession = ksession;
         this.kbase = ksession.getKnowledgeBase();
-        this.name = DroolsManagementAgent.createObjectName(KSESSION_PREFIX + ":type="+kbase.getId()+",group=Sessions,sessionId=Session-"+ksession.getIdentifier());
+        this.name = DroolsManagementAgent.createObjectNameFor(ksession);
         this.agendaStats = new AgendaStats();
         this.processStats = new ProcessStats();
         this.ksession.addEventListener( agendaStats );

--- a/drools-core/src/main/java/org/drools/core/management/KnowledgeBaseMonitoring.java
+++ b/drools-core/src/main/java/org/drools/core/management/KnowledgeBaseMonitoring.java
@@ -53,6 +53,7 @@ import org.drools.core.base.ClassObjectType;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
+import org.kie.api.builder.ReleaseId;
 import org.kie.api.management.KieBaseConfigurationMonitorMBean;
 import org.kie.api.management.ObjectTypeNodeMonitorMBean;
 import org.slf4j.Logger;
@@ -74,8 +75,6 @@ public class KnowledgeBaseMonitoring
 
     private static final String OP_STOP_INTERNAL_MBEANS  = "stopInternalMBeans";
     private static final String OP_START_INTERNAL_MBEANS = "startInternalMBeans";
-
-    private static final String KBASE_PREFIX = "org.drools.kbases";
 
     // ************************************************************************************************
     // MBean attributes
@@ -116,7 +115,7 @@ public class KnowledgeBaseMonitoring
     // Constructor
     public KnowledgeBaseMonitoring(InternalKnowledgeBase kbase) {
         this.kbase = kbase;
-        this.name = DroolsManagementAgent.createObjectName(KBASE_PREFIX + ":type=" + kbase.getId());
+        this.name = DroolsManagementAgent.createObjectNameFor(kbase);
 
         initOpenMBeanInfo();
     }
@@ -233,7 +232,7 @@ public class KnowledgeBaseMonitoring
                 ObjectTypeNodeMonitor otnm = new ObjectTypeNodeMonitor( otn );
                 try {
                     final StandardMBean adapter = new StandardMBean(otnm, ObjectTypeNodeMonitorMBean.class);
-                    ObjectName name = DroolsManagementAgent.createObjectName( this.name.getCanonicalName() + ",group=EntryPoints,EntryPoint=" + otnm.getNameSufix() + ",ObjectType=" + ((ClassObjectType) otn.getObjectType()).getClassName() );
+                    ObjectName name = DroolsManagementAgent.createObjectName( this.name.toString() + ",group=EntryPoints,EntryPoint=" + otnm.getNameSufix() + ",ObjectType=" + ((ClassObjectType) otn.getObjectType()).getClassName() );
                     DroolsManagementAgent.getInstance().registerMBean( kbase,
                                                                        adapter,
                                                                        name );
@@ -245,7 +244,7 @@ public class KnowledgeBaseMonitoring
         final KieBaseConfigurationMonitor kbcm = new KieBaseConfigurationMonitor( kbase.getConfiguration() );
         try {
             final StandardMBean adapter = new StandardMBean(kbcm, KieBaseConfigurationMonitorMBean.class);
-            ObjectName name = DroolsManagementAgent.createObjectName( this.name.getCanonicalName() + ",group=Configuration" );
+            ObjectName name = DroolsManagementAgent.createObjectName( this.name.toString() + ",group=Configuration" );
             DroolsManagementAgent.getInstance().registerMBean( kbase,
                                                                adapter,
                                                                name );


### PR DESCRIPTION
Depends on droolsjbpm/droolsjbpm-knowledge#150
- give KieContainer an optional user defined name
- KieContainer MBean and various refactorings.
- jargon: containerId 
- jargon: configuredReleaseId, resolvedReleaseId
- unit testing
- assuming the containerId can be "recycled" on dispose.
- introducing test for KieServices API with containerId.
- fixing other tests.
- avoid using lock and leverage ConcurrentMap without java8
- fixing objectname conventions.
