### PR TITLE
[6.4.x] RHBPMS-4166: BRMS Generates wrong source code for Guided Rules if using 'Formula'

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
@@ -119,7 +119,7 @@ class RuleModelPersistenceHelper {
             }
 
         } else if ( DataType.TYPE_STRING.equals( dataType ) ) {
-            if ( value.startsWith( "\"" ) ) {
+            if ( isStringLiteral( value ) ) {
                 return FieldNatureType.TYPE_LITERAL;
             } else {
                 return FieldNatureType.TYPE_FORMULA;
@@ -204,6 +204,34 @@ class RuleModelPersistenceHelper {
         }
 
         return nature;
+    }
+
+    private static boolean isStringLiteral( final String value ) {
+        boolean escape = false;
+        boolean inString = false;
+        for ( char c : value.toCharArray() ) {
+            if ( escape ) {
+                escape = false;
+                continue;
+            }
+            if ( !inString ) {
+                if ( !( c == ' ' || c == '\t' || c == '"' ) ) {
+                    return false;
+                }
+            }
+            if ( c == '"' ) {
+                if ( inString ) {
+                    inString = false;
+                } else {
+                    inString = true;
+                }
+            } else if ( c == '\\' ) {
+                escape = true;
+            } else {
+                escape = false;
+            }
+        }
+        return true;
     }
 
     static ModelField[] findFields( final RuleModel m,

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -8426,4 +8426,312 @@ public class RuleModelDRLPersistenceUnmarshallingTest {
                       afv2.getNature() );
     }
 
+    @Test
+    public void actionUpdateFieldWithFormula() throws Exception {
+        String drl = "package org.mortgages;\n"
+                + "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "$a : Application()\n"
+                + "then\n"
+                + "modify( $a ) {\n"
+                + "  setName( \"Pupa\" + 20 + \"Smurf\" )"
+                + "}\n"
+                + "end";
+
+        addModelField( "org.mortgages.Applicant",
+                       "this",
+                       "org.mortgages.Applicant",
+                       DataType.TYPE_THIS );
+        addModelField( "org.mortgages.Applicant",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.mortgages" );
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                           Collections.EMPTY_LIST,
+                                                                           dmo );
+
+        assertNotNull( m );
+        assertEquals( "r1",
+                      m.name );
+
+        //LHS Pattern
+        assertEquals( 1,
+                      m.lhs.length );
+        IPattern p = m.lhs[ 0 ];
+        assertTrue( p instanceof FactPattern );
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals( "Application",
+                      fp.getFactType() );
+        assertEquals( 0,
+                      fp.getNumberOfConstraints() );
+
+        assertEquals( 1,
+                      m.rhs.length );
+
+        assertTrue( m.rhs[ 0 ] instanceof ActionUpdateField );
+        ActionUpdateField auf = (ActionUpdateField) m.rhs[ 0 ];
+        assertEquals( "$a",
+                      auf.getVariable() );
+        assertEquals( 1,
+                      auf.getFieldValues().length );
+        ActionFieldValue afv0 = auf.getFieldValues()[ 0 ];
+        assertEquals( "name",
+                      afv0.getField() );
+        assertEquals( "\"Pupa\" + 20 + \"Smurf\"",
+                      afv0.getValue() );
+        assertEquals( FieldNatureType.TYPE_FORMULA,
+                      afv0.getNature() );
+    }
+
+    @Test
+    public void actionUpdateFieldWithFormulaNotEndWithString() throws Exception {
+        String drl = "package org.mortgages;\n"
+                + "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "$a : Application()\n"
+                + "then\n"
+                + "modify( $a ) {\n"
+                + "  setName( \"Pupa\" + 20 )"
+                + "}\n"
+                + "end";
+
+        addModelField( "org.mortgages.Applicant",
+                       "this",
+                       "org.mortgages.Applicant",
+                       DataType.TYPE_THIS );
+        addModelField( "org.mortgages.Applicant",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.mortgages" );
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                           Collections.EMPTY_LIST,
+                                                                           dmo );
+
+        assertNotNull( m );
+        assertEquals( "r1",
+                      m.name );
+
+        //LHS Pattern
+        assertEquals( 1,
+                      m.lhs.length );
+        IPattern p = m.lhs[ 0 ];
+        assertTrue( p instanceof FactPattern );
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals( "Application",
+                      fp.getFactType() );
+        assertEquals( 0,
+                      fp.getNumberOfConstraints() );
+
+        assertEquals( 1,
+                      m.rhs.length );
+
+        assertTrue( m.rhs[ 0 ] instanceof ActionUpdateField );
+        ActionUpdateField auf = (ActionUpdateField) m.rhs[ 0 ];
+        assertEquals( "$a",
+                      auf.getVariable() );
+        assertEquals( 1,
+                      auf.getFieldValues().length );
+        ActionFieldValue afv0 = auf.getFieldValues()[ 0 ];
+        assertEquals( "name",
+                      afv0.getField() );
+        assertEquals( "\"Pupa\" + 20",
+                      afv0.getValue() );
+        assertEquals( FieldNatureType.TYPE_FORMULA,
+                      afv0.getNature() );
+    }
+
+    @Test
+    public void actionUpdateFieldWithFormulaWithEscapedQuote() throws Exception {
+        String drl = "package org.mortgages;\n"
+                + "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "$a : Application()\n"
+                + "then\n"
+                + "modify( $a ) {\n"
+                + "  setName( \"Pupa \\\"\" + 20 + \"\\\" Smurf\" )"
+                + "}\n"
+                + "end";
+
+        addModelField( "org.mortgages.Applicant",
+                       "this",
+                       "org.mortgages.Applicant",
+                       DataType.TYPE_THIS );
+        addModelField( "org.mortgages.Applicant",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.mortgages" );
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                           Collections.EMPTY_LIST,
+                                                                           dmo );
+
+        assertNotNull( m );
+        assertEquals( "r1",
+                      m.name );
+
+        //LHS Pattern
+        assertEquals( 1,
+                      m.lhs.length );
+        IPattern p = m.lhs[ 0 ];
+        assertTrue( p instanceof FactPattern );
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals( "Application",
+                      fp.getFactType() );
+        assertEquals( 0,
+                      fp.getNumberOfConstraints() );
+
+        assertEquals( 1,
+                      m.rhs.length );
+
+        assertTrue( m.rhs[ 0 ] instanceof ActionUpdateField );
+        ActionUpdateField auf = (ActionUpdateField) m.rhs[ 0 ];
+        assertEquals( "$a",
+                      auf.getVariable() );
+        assertEquals( 1,
+                      auf.getFieldValues().length );
+        ActionFieldValue afv0 = auf.getFieldValues()[ 0 ];
+        assertEquals( "name",
+                      afv0.getField() );
+        assertEquals( "\"Pupa \\\"\" + 20 + \"\\\" Smurf\"",
+                      afv0.getValue() );
+        assertEquals( FieldNatureType.TYPE_FORMULA,
+                      afv0.getNature() );
+    }
+
+    @Test
+    public void actionSetFieldWithFormula() throws Exception {
+        String drl = "package org.mortgages;\n"
+                + "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "$a : Application()\n"
+                + "then\n"
+                + "$a.setName( \"Pupa\" + 20 + \"Smurf\" );"
+                + "end";
+
+        addModelField( "org.mortgages.Applicant",
+                       "this",
+                       "org.mortgages.Applicant",
+                       DataType.TYPE_THIS );
+        addModelField( "org.mortgages.Applicant",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.mortgages" );
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                           Collections.EMPTY_LIST,
+                                                                           dmo );
+
+        assertNotNull( m );
+        assertEquals( "r1",
+                      m.name );
+
+        //LHS Pattern
+        assertEquals( 1,
+                      m.lhs.length );
+        IPattern p = m.lhs[ 0 ];
+        assertTrue( p instanceof FactPattern );
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals( "Application",
+                      fp.getFactType() );
+        assertEquals( 0,
+                      fp.getNumberOfConstraints() );
+
+        assertEquals( 1,
+                      m.rhs.length );
+
+        assertTrue( m.rhs[ 0 ] instanceof ActionSetField );
+        ActionSetField asf = (ActionSetField) m.rhs[ 0 ];
+        assertEquals( "$a",
+                      asf.getVariable() );
+        assertEquals( 1,
+                      asf.getFieldValues().length );
+        ActionFieldValue afv0 = asf.getFieldValues()[ 0 ];
+        assertEquals( "name",
+                      afv0.getField() );
+        assertEquals( "\"Pupa\" + 20 + \"Smurf\"",
+                      afv0.getValue() );
+        assertEquals( FieldNatureType.TYPE_FORMULA,
+                      afv0.getNature() );
+    }
+
+    @Test
+    public void actionInsertFactWithFormula() throws Exception {
+        String drl = "package org.mortgages;\n"
+                + "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "$a : Application()\n"
+                + "then\n"
+                + "Applicant $a = new Applicant();\n"
+                + "$a.setName( \"Pupa\" + 20 + \"Smurf\" );\n"
+                + "insert( $a );\n"
+                + "end";
+
+        addModelField( "org.mortgages.Applicant",
+                       "this",
+                       "org.mortgages.Applicant",
+                       DataType.TYPE_THIS );
+        addModelField( "org.mortgages.Applicant",
+                       "name",
+                       String.class.getName(),
+                       DataType.TYPE_STRING );
+
+        when( dmo.getPackageName() ).thenReturn( "org.mortgages" );
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                           Collections.EMPTY_LIST,
+                                                                           dmo );
+
+        assertNotNull( m );
+        assertEquals( "r1",
+                      m.name );
+
+        //LHS Pattern
+        assertEquals( 1,
+                      m.lhs.length );
+        IPattern p = m.lhs[ 0 ];
+        assertTrue( p instanceof FactPattern );
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals( "Application",
+                      fp.getFactType() );
+        assertEquals( 0,
+                      fp.getNumberOfConstraints() );
+
+        assertEquals( 1,
+                      m.rhs.length );
+
+        assertTrue( m.rhs[ 0 ] instanceof ActionInsertFact );
+        ActionInsertFact aif = (ActionInsertFact) m.rhs[ 0 ];
+        assertEquals( "$a",
+                      aif.getBoundName() );
+        assertEquals( 1,
+                      aif.getFieldValues().length );
+        ActionFieldValue afv0 = aif.getFieldValues()[ 0 ];
+        assertEquals( "name",
+                      afv0.getField() );
+        assertEquals( "\"Pupa\" + 20 + \"Smurf\"",
+                      afv0.getValue() );
+        assertEquals( FieldNatureType.TYPE_FORMULA,
+                      afv0.getNature() );
+    }
+
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4166

(cherry picked from commit 4e4b0ee16663b9adac23ebdfa838733a79461ac9)

This is the corollary of https://github.com/droolsjbpm/drools/pull/868 for 6.4.x.
