### PR TITLE
DROOLS-1249 DSL rule doesn't compile when DSL contains more general pattern defined before more specific pattern.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DslTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DslTest.java
@@ -354,20 +354,40 @@ public class DslTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testGreedyDsl() {
+    public void testGreedyDslSimple() {
         // BZ-1078839
-        String dsl = "[when]There is a number with value of {value}=i:Integer(intValue() == {value})\n"
-                + "[when]There is a number with=i:Integer()\n";
+        final String dsl = "[when]There is a number with=i:Integer()\n"
+                + "[when]There is a number with value of {value}=i:Integer(intValue() == {value})\n";
 
-        String dslr = "package org.test \n"
-                     + "rule 'sample rule' \n"
-                     + "when \n" + "  There is a number with value of 10\n"
-                     + "then \n" + "end \n";
+        final String dslr = "package org.test \n"
+                + "rule 'sample rule' \n"
+                + "when \n" + "  There is a number with value of 10\n"
+                + "then \n" + "end \n";
 
+        testGreedyDsl(dsl, dslr);
+    }
+
+    @Test
+    public void testGreedyDslComplicated() {
+        final String dsl = "#/ result \n"
+                + "[when]There is a number where {constraints}=i:Integer(where {constraints})\n"
+                + "[when]integer value=intValue()\n"
+                + "[when]long value=longValue()\n"
+                + "[when]where {attr:[a-zA-Z0-9()]+} is {value}={attr} == {value}\n";
+
+        final String dslr = "package org.drools.test.dsl.complicated \n"
+                + "rule 'sample rule' \n"
+                + "when \n" + "  There is a number where integer value is 10\n"
+                + "then \n" + "end \n";
+
+        testGreedyDsl(dsl, dslr);
+    }
+
+    private void testGreedyDsl(final String dsl, final String dslr) {
         KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem()
-                              .write("src/main/resources/r1.dslr", dslr)
-                              .write("src/main/resources/r1.dsl", dsl);
+                .write("src/main/resources/r1.dslr", dslr)
+                .write("src/main/resources/r1.dsl", dsl);
         Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
         assertEquals(0, results.getMessages().size());
     }


### PR DESCRIPTION
- Added reproducer - testGreedyDslSimple()
- Second test, testGreedyDslComplicated() is for checking backward compatibility - test taken from BZ [1].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1078839
