### PR TITLE
RHBPMS-856: Condition column headers are not getting reflected when a XLS Decision Table is converted to Guided Decision Table

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitor.java
@@ -71,6 +71,18 @@ public class RuleModelVisitor {
         this.model.addRhsItem( action );
     }
 
+    public RuleModelVisitor( IPattern[] lhs,
+                             Map<InterpolationVariable, Integer> vars ) {
+        this.vars = vars;
+        this.model.lhs = lhs;
+    }
+
+    public RuleModelVisitor( IAction[] rhs,
+                             Map<InterpolationVariable, Integer> vars ) {
+        this.vars = vars;
+        this.model.rhs = rhs;
+    }
+
     private void parseStringPattern( String text ) {
         if ( text == null || text.length() == 0 ) {
             return;
@@ -129,7 +141,7 @@ public class RuleModelVisitor {
         }
     }
 
-    //ActionInsertFact, ActionSetField, ActionpdateField
+    //ActionInsertFact, ActionSetField, ActionUpdateField
     private void visitActionFieldList( ActionInsertFact afl ) {
         String factType = afl.getFactType();
         for ( ActionFieldValue afv : afl.getFieldValues() ) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
@@ -15,12 +15,12 @@
  */
 package org.drools.workbench.models.guided.dtable.shared.model;
 
-import static java.lang.Math.min;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.drools.workbench.models.datamodel.rule.IAction;
+
+import static java.lang.Math.*;
 
 /**
  * An Action column defined with a BRL fragment
@@ -71,7 +71,7 @@ public class BRLActionColumn extends ActionCol52
     private List<BaseColumnFieldDiff> getColumnDiffs( List<BRLActionVariableColumn> otherChildColumns ) {
         int commonLength = min( this.childColumns.size(), otherChildColumns.size() );
         List<BaseColumnFieldDiff> result = new ArrayList<>();
-        for ( int i = 0; i < commonLength; i ++ ) {
+        for ( int i = 0; i < commonLength; i++ ) {
             result.addAll( this.childColumns.get( i ).diff( otherChildColumns.get( i ) ) );
         }
         result.addAll( getDiffsForUnpairedColumns( this.childColumns, commonLength, false ) );
@@ -84,10 +84,11 @@ public class BRLActionColumn extends ActionCol52
                                                                   boolean added ) {
         List<BaseColumnFieldDiff> result = new ArrayList<>();
         if ( addedChildColumns.size() > commonLength ) {
-            for ( BRLActionVariableColumn column : addedChildColumns.subList( commonLength, addedChildColumns.size() ) )
+            for ( BRLActionVariableColumn column : addedChildColumns.subList( commonLength, addedChildColumns.size() ) ) {
                 result.add( new BaseColumnFieldDiffImpl( FIELD_CHILD_COLUMNS,
-                                                         (added) ? null : column,
-                                                         (added) ? column : null ) );
+                                                         ( added ) ? null : column,
+                                                         ( added ) ? column : null ) );
+            }
         }
         return result;
     }
@@ -106,14 +107,6 @@ public class BRLActionColumn extends ActionCol52
 
     public void setChildColumns( List<BRLActionVariableColumn> childColumns ) {
         this.childColumns = childColumns;
-    }
-
-    @Override
-    public void setHeader( String header ) {
-        super.setHeader( header );
-        for ( BRLActionVariableColumn variable : this.childColumns ) {
-            variable.setHeader( header );
-        }
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
@@ -15,12 +15,12 @@
  */
 package org.drools.workbench.models.guided.dtable.shared.model;
 
-import static java.lang.Math.min;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.drools.workbench.models.datamodel.rule.IPattern;
+
+import static java.lang.Math.*;
 
 /**
  * A Condition column defined with a BRL fragment
@@ -71,7 +71,7 @@ public class BRLConditionColumn extends ConditionCol52
     private List<BaseColumnFieldDiff> getColumnDiffs( List<BRLConditionVariableColumn> otherChildColumns ) {
         int commonLength = min( this.childColumns.size(), otherChildColumns.size() );
         List<BaseColumnFieldDiff> result = new ArrayList<>();
-        for ( int i = 0; i < commonLength; i ++ ) {
+        for ( int i = 0; i < commonLength; i++ ) {
             result.addAll( this.childColumns.get( i ).diff( otherChildColumns.get( i ) ) );
         }
         result.addAll( getDiffsForUnpairedColumns( this.childColumns, commonLength, false ) );
@@ -84,10 +84,11 @@ public class BRLConditionColumn extends ConditionCol52
                                                                   boolean added ) {
         List<BaseColumnFieldDiff> result = new ArrayList<>();
         if ( addedChildColumns.size() > commonLength ) {
-            for ( BRLConditionVariableColumn column : addedChildColumns.subList( commonLength, addedChildColumns.size() ) )
+            for ( BRLConditionVariableColumn column : addedChildColumns.subList( commonLength, addedChildColumns.size() ) ) {
                 result.add( new BaseColumnFieldDiffImpl( FIELD_CHILD_COLUMNS,
-                                                         (added) ? null : column,
-                                                         (added) ? column : null ) );
+                                                         ( added ) ? null : column,
+                                                         ( added ) ? column : null ) );
+            }
         }
         return result;
     }
@@ -106,14 +107,6 @@ public class BRLConditionColumn extends ConditionCol52
 
     public void setChildColumns( List<BRLConditionVariableColumn> childColumns ) {
         this.childColumns = childColumns;
-    }
-
-    @Override
-    public void setHeader( String header ) {
-        super.setHeader( header );
-        for ( BRLConditionVariableColumn variable : this.childColumns ) {
-            variable.setHeader( header );
-        }
     }
 
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-856

This PR adds a couple of new constructors to `RuleModelVisitor` for use within `drools-wb`. Furthermore `BRLConditionColumn.setHeader(..)` and `BRLActionColumn.setHeadet(..)` overrides were removed as they are called by Errai when unmarshalling a Guided Decision Table which leads to undesirable results. I checked use of the (removed) overridden methods and we populate the header of child columns there too - so the override was not necessary anyway.
