### PR TITLE
[6.5.x] RHBPMS-856: Condition column headers are not getting reflected when a XLS Decision Table is converted to Guided Decision Table

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitor.java
@@ -71,6 +71,18 @@ public class RuleModelVisitor {
         this.model.addRhsItem( action );
     }
 
+    public RuleModelVisitor( IPattern[] lhs,
+                             Map<InterpolationVariable, Integer> vars ) {
+        this.vars = vars;
+        this.model.lhs = lhs;
+    }
+
+    public RuleModelVisitor( IAction[] rhs,
+                             Map<InterpolationVariable, Integer> vars ) {
+        this.vars = vars;
+        this.model.rhs = rhs;
+    }
+
     private void parseStringPattern( String text ) {
         if ( text == null || text.length() == 0 ) {
             return;
@@ -129,7 +141,7 @@ public class RuleModelVisitor {
         }
     }
 
-    //ActionInsertFact, ActionSetField, ActionpdateField
+    //ActionInsertFact, ActionSetField, ActionUpdateField
     private void visitActionFieldList( ActionInsertFact afl ) {
         String factType = afl.getFactType();
         for ( ActionFieldValue afv : afl.getFieldValues() ) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
@@ -85,14 +85,6 @@ public class BRLActionColumn extends ActionCol52
     }
 
     @Override
-    public void setHeader( String header ) {
-        super.setHeader( header );
-        for ( BRLActionVariableColumn variable : this.childColumns ) {
-            variable.setHeader( header );
-        }
-    }
-
-    @Override
     public void setHideColumn( boolean hideColumn ) {
         super.setHideColumn( hideColumn );
         for ( BRLActionVariableColumn variable : this.childColumns ) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
@@ -85,14 +85,6 @@ public class BRLConditionColumn extends ConditionCol52
     }
 
     @Override
-    public void setHeader( String header ) {
-        super.setHeader( header );
-        for ( BRLConditionVariableColumn variable : this.childColumns ) {
-            variable.setHeader( header );
-        }
-    }
-
-    @Override
     public void setHideColumn( boolean hideColumn ) {
         super.setHideColumn( hideColumn );
         for ( BRLConditionVariableColumn variable : this.childColumns ) {


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-856

This is the corollary of https://github.com/droolsjbpm/drools/pull/889 for 6.5.x
