### PR TITLE
DROOLS-1237 MBean statistics from String property to proper JMX table

### DIFF
--- a/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
+++ b/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
@@ -21,8 +21,6 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.event.KieRuntimeEventManager;
 import org.kie.api.management.KieManagementAgentMBean;
-import org.kie.api.management.KieSessionMonitoringMBean;
-import org.kie.api.management.StatelessKieSessionMonitoringMBean;
 import org.kie.internal.runtime.StatelessKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,8 +158,7 @@ public class DroolsManagementAgent
                     } else {
                         try {
                             StatelessKieSessionMonitoringImpl mbean = new StatelessKieSessionMonitoringImpl( cbsKey.kcontainerId, cbsKey.kbaseId, cbsKey.ksessionName );
-                            final StandardMBean adapter = new StandardMBean( mbean, StatelessKieSessionMonitoringMBean.class );
-                            registerMBean( cbsKey, adapter, mbean.getName() );
+                            registerMBean( cbsKey, mbean, mbean.getName() );
                             mbeansRefs.put(cbsKey, mbean);
                             return mbean;
                         } catch ( Exception e ) {
@@ -177,8 +174,7 @@ public class DroolsManagementAgent
                     } else {
                         try {
                             KieSessionMonitoringImpl mbean = new KieSessionMonitoringImpl( cbsKey.kcontainerId, cbsKey.kbaseId, cbsKey.ksessionName );
-                            final StandardMBean adapter = new StandardMBean( mbean, KieSessionMonitoringMBean.class );
-                            registerMBean( cbsKey, adapter, mbean.getName() );
+                            registerMBean( cbsKey, mbean, mbean.getName() );
                             mbeansRefs.put(cbsKey, mbean);
                             return mbean;
                         } catch ( Exception e ) {

--- a/drools-core/src/main/java/org/drools/core/management/KieSessionMonitoringImpl.java
+++ b/drools-core/src/main/java/org/drools/core/management/KieSessionMonitoringImpl.java
@@ -5,9 +5,9 @@ import javax.management.ObjectName;
 import org.drools.core.common.InternalWorkingMemoryActions;
 import org.kie.api.builder.model.KieSessionModel.KieSessionType;
 import org.kie.api.event.KieRuntimeEventManager;
-import org.kie.api.management.KieSessionMonitoringMBean;
+import org.kie.api.management.KieSessionMonitoringMXBean;
 
-public class KieSessionMonitoringImpl extends GenericKieSessionMonitoringImpl implements KieSessionMonitoringMBean {
+public class KieSessionMonitoringImpl extends GenericKieSessionMonitoringImpl implements KieSessionMonitoringMXBean {
     
     private ObjectName name;
 

--- a/drools-core/src/main/java/org/drools/core/management/StatelessKieSessionMonitoringImpl.java
+++ b/drools-core/src/main/java/org/drools/core/management/StatelessKieSessionMonitoringImpl.java
@@ -12,9 +12,9 @@ import org.kie.api.event.KieRuntimeEventManager;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.ObjectInsertedEvent;
 import org.kie.api.event.rule.ObjectUpdatedEvent;
-import org.kie.api.management.StatelessKieSessionMonitoringMBean;
+import org.kie.api.management.StatelessKieSessionMonitoringMXBean;
 
-public class StatelessKieSessionMonitoringImpl extends GenericKieSessionMonitoringImpl implements StatelessKieSessionMonitoringMBean {
+public class StatelessKieSessionMonitoringImpl extends GenericKieSessionMonitoringImpl implements StatelessKieSessionMonitoringMXBean {
 
     private ObjectName name;
     public RuleRuntimeStats ruleRuntimeStats;


### PR DESCRIPTION
Depends on droolsjbpm/droolsjbpm-knowledge#166

MBean currently provide statistics as a String property list for
historical reasons.
As JMX supports Table as Maps, rework them as proper JMX Table support.
