### PR TITLE
RHBPMS-3962, JBPM-5306 - 'InvalidClassException' error after upgradin…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/time/SelfRemovalJobContext.java
+++ b/drools-core/src/main/java/org/drools/core/time/SelfRemovalJobContext.java
@@ -21,6 +21,9 @@ import org.drools.core.time.impl.TimerJobInstance;
 import java.util.Map;
 
 public class SelfRemovalJobContext implements JobContext {
+
+    private static final long serialVersionUID = 614425985040796356L;
+
     protected final JobContext jobContext;
     protected final Map<Long, TimerJobInstance> timerInstances;
 


### PR DESCRIPTION
…g from BPMS 6.0.3 to 6.1.0

added serialVersionUID that matches same that was auto generated as this was generated using serialver tool
