### PR TITLE
Drools rule compiler reports false Java compilation errors in Eclipse Neon

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
@@ -19,6 +19,7 @@ package org.drools.compiler.commons.jci.compilers;
 import org.drools.compiler.commons.jci.problems.CompilationProblem;
 import org.drools.compiler.commons.jci.readers.ResourceReader;
 import org.drools.compiler.commons.jci.stores.ResourceStore;
+import org.drools.core.common.ProjectClassLoader;
 import org.drools.core.util.ClassUtils;
 import org.drools.core.util.IoUtils;
 import org.eclipse.jdt.core.compiler.IProblem;
@@ -321,6 +322,9 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
             }
 
             private boolean isPackage( final String pClazzName ) {
+                if (pClassLoader instanceof ProjectClassLoader) {
+                    return ((ProjectClassLoader)pClassLoader).isPackage(pClazzName);
+                }
                 InputStream is = null;
                 try {
                     is = pClassLoader.getResourceAsStream(ClassUtils.convertClassToResourcePath(pClazzName));
@@ -332,7 +336,7 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
                             try {
                                 Class cls = pClassLoader.loadClass(pClazzName);
                                 if (cls != null) {
-                                    return true;
+                                    return false;
                                 }
                             } catch (ClassNotFoundException e) {
                                 return true;
@@ -352,6 +356,7 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
                         }
                     }
                 }
+
             }
 
             public boolean isPackage( char[][] parentPackageName, char[] pPackageName ) {

--- a/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
@@ -291,6 +291,17 @@ public class ProjectClassLoader extends ClassLoader {
         return resources;
     }
 
+    public boolean isPackage(String name) {
+        String parentName = name + ".";
+        Package[] packages = Package.getPackages();
+        for (Package p : packages) {
+            if (p.getName().equals(name) || p.getName().equals(parentName))
+                return true;
+        }
+        return false;
+    }
+
+
     private static class ResourcesEnum implements Enumeration<URL> {
 
         private URL providedResource;


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-1250
