### PR TITLE
DROOLS-1271 Fixed testEventWithShortExpiration test.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
@@ -127,9 +127,14 @@ public class CepJavaTypeTest extends CommonTestMethodBase {
 
         ksession.insert(new MyMessage("ATrigger" ) );
         assertEquals( 1, ksession.fireAllRules() );
-
-        Thread.sleep(2L);
-        ksession.fireAllRules();
+        waitBusy(2L);
+        assertEquals( 0, ksession.fireAllRules() );
+        waitBusy(30L);
+        // Expire action is put into propagation queue by timer job, so there
+        // can be a race condition where it puts it there right after previous fireAllRules
+        // flushes the queue. So there needs to be another flush -> another fireAllRules
+        // to flush the queue.
+        assertEquals( 0, ksession.fireAllRules() );
         assertEquals( 0, ksession.getObjects().size() );
     }
 }


### PR DESCRIPTION
Related to this PR: https://github.com/droolsjbpm/drools/pull/892
- Fixed similar test that uses annotations in Java class. 
