### PR TITLE
Drools rule compiler reports false Java compilation errors in Eclipse…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
@@ -332,7 +332,7 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
                             try {
                                 Class cls = pClassLoader.loadClass(pClazzName);
                                 if (cls != null) {
-                                    return true;
+                                    return false;
                                 }
                             } catch (ClassNotFoundException e) {
                                 return true;


### PR DESCRIPTION
… Neon

See https://issues.jboss.org/browse/DROOLS-1250
