### PR TITLE
DROOLS-1283 KieContainer registered w/in KieServices iff ID is explicit.

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieContainer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieContainer.java
@@ -45,11 +45,6 @@ public interface InternalKieContainer extends KieContainer {
     StatelessKieSession getStatelessKieSession(String kSessionName);
 
     /**
-     * Disposes all the KieSessions created in this KieContainer
-     */
-    void dispose();
-
-    /**
      * Internal use: returns the RelaseId configured while creating the Kiecontainer, 
      * or alternatively if the RelaseId was NOT configured while creating the Kiecontainer,
      * returns the the ReleaseId of the KieModule wrapped by this KieContainer. 
@@ -72,8 +67,8 @@ public interface InternalKieContainer extends KieContainer {
     KieModule getMainKieModule();
 
     /**
-     * Returns the unique ID assigned to the container.
-     * @return the unique ID assigned to the container.
+     * Returns the ID assigned to the container.
+     * @return the ID assigned to the container.
      */
 	String getContainerId();
 	

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
@@ -127,21 +127,21 @@ public class KieServicesImpl implements InternalKieServices {
     }
 
     public KieContainer newKieClasspathContainer(String containerId, ClassLoader classLoader) {
-    	String createContainerWithId = containerId;
-    	if (createContainerWithId == null) {
-    		createContainerWithId = UUID.randomUUID().toString();
+    	if (containerId == null) {
+    	    KieContainerImpl newContainer = new KieContainerImpl(UUID.randomUUID().toString(), new ClasspathKieProject(classLoader, listener), null);
+    	    return newContainer;
     	}
-    	if ( kContainers.get(createContainerWithId) == null ) {
-            KieContainerImpl newContainer = new KieContainerImpl(createContainerWithId, new ClasspathKieProject(classLoader, listener), null);
-            KieContainer check = kContainers.putIfAbsent(createContainerWithId, newContainer);
+    	if ( kContainers.get(containerId) == null ) {
+            KieContainerImpl newContainer = new KieContainerImpl(containerId, new ClasspathKieProject(classLoader, listener), null);
+            KieContainer check = kContainers.putIfAbsent(containerId, newContainer);
             if (check == null) {
 				return newContainer;
             } else {
             	newContainer.dispose();
-            	throw new IllegalStateException("There's already another KieContainer created with the id "+createContainerWithId);
+            	throw new IllegalStateException("There's already another KieContainer created with the id "+containerId);
             }
         } else {
-            throw new IllegalStateException("There's already another KieContainer created with the id "+createContainerWithId);
+            throw new IllegalStateException("There's already another KieContainer created with the id "+containerId);
         }
     }
 
@@ -187,21 +187,21 @@ public class KieServicesImpl implements InternalKieServices {
         }
         KieProject kProject = new KieModuleKieProject( kieModule, classLoader );
 
-        String createContainerWithId = containerId;
-    	if (createContainerWithId == null) {
-    		createContainerWithId = UUID.randomUUID().toString();
+    	if (containerId == null) {
+    	    KieContainerImpl newContainer = new KieContainerImpl( UUID.randomUUID().toString(), kProject, getRepository(), releaseId );
+    		return newContainer;
     	}
-    	if ( kContainers.get(createContainerWithId) == null ) {
-            KieContainerImpl newContainer = new KieContainerImpl( createContainerWithId, kProject, getRepository(), releaseId );
-            KieContainer check = kContainers.putIfAbsent(createContainerWithId, newContainer);
+    	if ( kContainers.get(containerId) == null ) {
+            KieContainerImpl newContainer = new KieContainerImpl( containerId, kProject, getRepository(), releaseId );
+            KieContainer check = kContainers.putIfAbsent(containerId, newContainer);
             if (check == null) {
             	return newContainer;
             } else {
             	newContainer.dispose();
-            	throw new IllegalStateException("There's already another KieContainer created with the id "+createContainerWithId);
+            	throw new IllegalStateException("There's already another KieContainer created with the id "+containerId);
             }
         } else {
-            throw new IllegalStateException("There's already another KieContainer created with the id "+createContainerWithId);
+            throw new IllegalStateException("There's already another KieContainer created with the id "+containerId);
         }
     }
     

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -186,7 +186,7 @@ public class MBeansMonitoringTest extends CommonTestMethodBase {
         
         // MBean are supported only via KieContainer public API.
         assertEquals(3, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote(kc1ID)+",*"), null).size());
-        ((InternalKieContainer) kc).dispose();
+        kc.dispose();
         assertEquals(0, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote(kc1ID)+",*"), null).size());
         assertEquals(3, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote("Matteo")+",*"), null).size());
     }
@@ -365,7 +365,7 @@ public class MBeansMonitoringTest extends CommonTestMethodBase {
         
         KieContainer kc2 = ks.newKieContainer( "kc2", releaseId1 );
         assertEquals(5, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote(containerId)+",*"), null).size());
-        ((InternalKieContainer) kc).dispose();
+        kc.dispose();
         assertEquals(0, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote(containerId)+",*"), null).size());
         assertEquals(1, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote("kc2")+",*"), null).size());
     }


### PR DESCRIPTION
If there is no explict ID, the KieContainer is not registered w/in
KieServices however it will still be assigned a random ID for JMX
identification.
