### PR TITLE
[6.5.x] RHBRMS-2596: Guided Decision Table: Unable to specify field type with Condition BRL fragment

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModel.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModel.java
@@ -106,13 +106,15 @@ public class BRLRuleModel extends RuleModel {
     }
 
     @Override
-    public SingleFieldConstraint getLHSBoundField(final String var) {
+    public SingleFieldConstraint getLHSBoundField( final String var ) {
         for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
             if ( col instanceof Pattern52 ) {
                 final Pattern52 p = (Pattern52) col;
                 for ( ConditionCol52 cc : p.getChildColumns() ) {
                     if ( cc.isBound() && cc.getBinding().equals( var ) ) {
-                        return new ConditionCol52FieldConstraintAdaptor( cc );
+                        final ConditionCol52FieldConstraintAdaptor sfcAdaptor = new ConditionCol52FieldConstraintAdaptor( cc );
+                        sfcAdaptor.setFactType( p.getFactType() );
+                        return sfcAdaptor;
                     }
                 }
             } else if ( col instanceof BRLConditionColumn ) {
@@ -121,9 +123,9 @@ public class BRLRuleModel extends RuleModel {
                     if ( p instanceof FactPattern ) {
                         final FactPattern fp = (FactPattern) p;
                         for ( FieldConstraint fc : fp.getFieldConstraints() ) {
-                            if (fc instanceof SingleFieldConstraint) {
-                                final List<String> fieldBindings = getFieldBinding(fc);
-                                if (fieldBindings.contains(var)) {
+                            if ( fc instanceof SingleFieldConstraint ) {
+                                final List<String> fieldBindings = getFieldBinding( fc );
+                                if ( fieldBindings.contains( var ) ) {
                                     return (SingleFieldConstraint) fc;
                                 }
                             }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
@@ -36,6 +36,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.models.guided.dtable.shared.model.adaptors.ActionInsertFactCol52ActionInsertFactAdaptor;
 import org.drools.workbench.models.guided.dtable.shared.model.adaptors.ActionInsertFactCol52ActionInsertLogicalFactAdaptor;
+import org.drools.workbench.models.guided.dtable.shared.model.adaptors.ConditionCol52FieldConstraintAdaptor;
 import org.drools.workbench.models.guided.dtable.shared.model.adaptors.Pattern52FactPatternAdaptor;
 import org.junit.Test;
 
@@ -239,6 +240,37 @@ public class BRLRuleModelTest {
         assertNotNull( fcr1 );
         assertTrue( fcr1 instanceof SingleFieldConstraint );
         SingleFieldConstraint fcr1sfc = (SingleFieldConstraint) fcr1;
+        assertEquals( "name",
+                      fcr1sfc.getFieldName() );
+        assertEquals( DataType.TYPE_STRING,
+                      fcr1sfc.getFieldType() );
+    }
+
+    @Test
+    public void testDecisionTableColumnsWithLHSBoundFieldsInConditionCol52() {
+        GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+
+        Pattern52 p1 = new Pattern52();
+        p1.setFactType( "Driver" );
+        p1.setBoundName( "$p1" );
+
+        ConditionCol52 c1 = new ConditionCol52();
+        c1.setFactField( "name" );
+        c1.setFieldType( DataType.TYPE_STRING );
+        c1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
+        c1.setBinding( "$c1" );
+
+        p1.getChildColumns().add( c1 );
+        dt.getConditions().add( p1 );
+
+        BRLRuleModel model = new BRLRuleModel( dt );
+
+        FieldConstraint fcr1 = model.getLHSBoundField( "$c1" );
+        assertNotNull( fcr1 );
+        assertTrue( fcr1 instanceof ConditionCol52FieldConstraintAdaptor );
+        ConditionCol52FieldConstraintAdaptor fcr1sfc = (ConditionCol52FieldConstraintAdaptor) fcr1;
+        assertEquals( "Driver",
+                      fcr1sfc.getFactType() );
         assertEquals( "name",
                       fcr1sfc.getFieldName() );
         assertEquals( DataType.TYPE_STRING,


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2596

(cherry picked from commit 463112ecfdb1bc7984496604ddc4f944f074778d)

This is the corollary of https://github.com/droolsjbpm/drools/pull/922 for 6.5.x.

ACKs for 6.5.x have been received.
