### PR TITLE
GUVNOR-2706: Adding Multibyte class name Java file fails with 'The public type <class name> must be defined in its own file' in business-central

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
@@ -36,6 +36,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -102,7 +104,7 @@ public class MemoryFileSystem
         if ( lastSlashPos >= 0 ) {
             Folder folder = getFolder( path.substring( 0,
                                                        lastSlashPos ) );
-            String name = path.substring( lastSlashPos + 1 );
+            String name = decode( path ).substring( lastSlashPos + 1 );
             return new MemoryFile( this,
                                    name,
                                    folder );
@@ -165,7 +167,7 @@ public class MemoryFileSystem
     }
 
     public boolean existsFolder(MemoryFolder folder) {
-        return existsFolder( folder.getPath().toPortableString() ); 
+        return existsFolder( folder.getPath().toPortableString() );
     }
 
     public boolean existsFolder(String path) {
@@ -182,14 +184,14 @@ public class MemoryFileSystem
         return fileContents.containsKey(MemoryFolder.trimLeadingAndTrailing(path));
     }
 
-    public void createFolder(MemoryFolder folder) {                
+    public void createFolder(MemoryFolder folder) {
         // create current, if it does not exist.
         if ( !existsFolder( folder ) ) {
             // create parent if it does not exist
             if ( !existsFolder( ( MemoryFolder) folder.getParent() ) ) {
                 createFolder( (MemoryFolder) folder.getParent() );
             }
-            
+
             folders.put( folder.getPath().toPortableString(),
                          new HashSet<Resource>() );
 
@@ -436,12 +438,12 @@ public class MemoryFileSystem
             }
         }
     }
-    
+
     public void writeAsFs(java.io.File file) {
         file.mkdir();
         writeAsFs(this.getRootFolder(), file);
-    }    
-    
+    }
+
     public void writeAsFs(Folder f,
                           java.io.File file1) {
         for ( Resource rs : f.getMembers() ) {
@@ -459,7 +461,7 @@ public class MemoryFileSystem
                 }
             }
         }
-    }    
+    }
 
     private void writeJarEntries(Folder f,
                                  ZipOutputStream out) throws IOException {
@@ -519,11 +521,11 @@ public class MemoryFileSystem
         }
         return mfs;
     }
-    
+
     public static MemoryFileSystem readFromJar(byte[] jarFile) {
         return readFromJar( new ByteArrayInputStream( jarFile ) );
     }
-    
+
     public static MemoryFileSystem readFromJar(InputStream jarFile) {
         MemoryFileSystem mfs = new MemoryFileSystem();
         JarInputStream zipFile = null;
@@ -552,7 +554,7 @@ public class MemoryFileSystem
         }
         return mfs;
     }
-    
+
     public String findPomProperties() {
         for( Entry<String, byte[]> content : fileContents.entrySet() ) {
             if ( content.getKey().endsWith( "pom.properties" ) && content.getKey().startsWith( "META-INF/maven/" ) ) {
@@ -569,5 +571,13 @@ public class MemoryFileSystem
             clone.write(entry.getKey(), entry.getValue());
         }
         return clone;
+    }
+
+    private String decode( final String path ) {
+        try {
+            return URLDecoder.decode( path, "UTF-8" );
+        } catch ( UnsupportedEncodingException e ) {
+            return path;
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/io/memory/MemoryFileSystemTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/io/memory/MemoryFileSystemTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.compiler.io.memory;
+
+import org.drools.compiler.compiler.io.File;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MemoryFileSystemTest {
+
+    private MemoryFileSystem memoryFileSystem;
+
+    @Before
+    public void setup() {
+        memoryFileSystem = new MemoryFileSystem();
+    }
+
+    @Test
+    public void testGetEnglishFileName() throws Exception {
+        final File file = memoryFileSystem.getFile( "path/path/File.java" );
+
+        assertEquals( "File.java", file.getName() );
+    }
+
+    @Test
+    public void testGetJapaneseFileName() throws Exception {
+        final File file = memoryFileSystem.getFile( "path/path/%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.java" );
+
+        assertEquals( "あいうえお.java", file.getName() );
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2706
- Before:
  ![rhbrms-2-before](https://cloud.githubusercontent.com/assets/1079279/18876650/e13ed746-84a0-11e6-8b01-cead291ff945.gif)
- After:
  ![rhbrms-2-after](https://cloud.githubusercontent.com/assets/1079279/18876661/e749883e-84a0-11e6-81e7-8d4debd6a9c5.gif)
