### PR TITLE
DROOLS-1316 Missing MBean for Classpath KieContainer causes RHQ/JON p…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -137,6 +137,7 @@ public class KieContainerImpl
         this.kProject = kProject;
         this.containerId = containerId;
         kProject.init();
+        initMBeans(containerId);
     }
     
     /**
@@ -148,8 +149,6 @@ public class KieContainerImpl
         this(containerId, kProject, kr);
         this.configuredReleaseId = containerReleaseId;
         this.containerReleaseId = containerReleaseId;
-        
-        initMBeans(containerId);
     }
 
 	private void initMBeans(String containerId) {

--- a/drools-compiler/src/main/java/org/drools/compiler/management/KieContainerMonitor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/management/KieContainerMonitor.java
@@ -5,7 +5,7 @@ import org.kie.api.management.KieContainerMonitorMXBean;
 import org.kie.api.management.GAV;
 
 public class KieContainerMonitor implements KieContainerMonitorMXBean {
-	private InternalKieContainer kieContainer;
+    private InternalKieContainer kieContainer;
 
 	public KieContainerMonitor(InternalKieContainer kieContainer) {
 		this.kieContainer = kieContainer;
@@ -18,21 +18,29 @@ public class KieContainerMonitor implements KieContainerMonitorMXBean {
 
 	@Override
 	public String getConfiguredReleaseIdStr() {
-		return kieContainer.getConfiguredReleaseId().toString();
+		return ( kieContainer.getConfiguredReleaseId() != null )
+		        ? kieContainer.getConfiguredReleaseId().toString()
+		        : KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID.toString() ;
 	}
 
 	@Override
 	public String getResolvedReleaseIdStr() {
-		return kieContainer.getResolvedReleaseId().toString();
+		return ( kieContainer.getResolvedReleaseId() != null )
+		        ? kieContainer.getResolvedReleaseId().toString()
+		        : KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID.toString() ;
 	}
 
     @Override
     public GAV getConfiguredReleaseId() {
-        return GAV.from(kieContainer.getConfiguredReleaseId());
+        return ( kieContainer.getConfiguredReleaseId() != null )
+                ? GAV.from(kieContainer.getConfiguredReleaseId())
+                : KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID ;
     }
 
     @Override
     public GAV getResolvedReleaseId() {
-        return GAV.from(kieContainer.getResolvedReleaseId());
+        return ( kieContainer.getResolvedReleaseId() != null )
+                ? GAV.from(kieContainer.getResolvedReleaseId())
+                : KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID ;
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -79,6 +79,68 @@ public class MBeansMonitoringTest extends CommonTestMethodBase {
     		System.setProperty( MBeansOption.PROPERTY_NAME, MBeansOption.DISABLED.toString() );
     	}
     }
+    
+    @Test
+    public void testKieClasspathMBeans() throws Exception {
+        MBeanServer mbserver = ManagementFactory.getPlatformMBeanServer();
+        KieServices ks = KieServices.Factory.get();
+
+        KieContainer kc = ks.getKieClasspathContainer("myID");
+        
+        KieContainerMonitorMXBean c1Monitor = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy("myID"),
+                KieContainerMonitorMXBean.class);
+        KieBase kb = kc.getKieBase("org.kie.monitoring.kbase1");
+        KieSession statefulKieSession = kc.newKieSession("org.kie.monitoring.kbase1.ksession1");
+        StatelessKieSession statelessKieSession = kc.newStatelessKieSession("org.kie.monitoring.kbase1.ksession2");
+        
+        KieSessionMonitoringMXBean statefulKieSessionMonitor = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy("myID", "org.kie.monitoring.kbase1", KieSessionType.STATEFUL, "org.kie.monitoring.kbase1.ksession1"),
+                KieSessionMonitoringMXBean.class);
+        StatelessKieSessionMonitoringMXBean statelessKieSessionMonitor = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy("myID", "org.kie.monitoring.kbase1", KieSessionType.STATEFUL, "org.kie.monitoring.kbase1.ksession1"),
+                StatelessKieSessionMonitoringMXBean.class);
+        
+        assertEquals("myID", c1Monitor.getContainerId() );
+        assertTrue(c1Monitor.getConfiguredReleaseId().sameGAVof(KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID));
+        assertTrue(c1Monitor.getResolvedReleaseId().sameGAVof(KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID));
+        assertEquals("org.kie.monitoring.kbase1.ksession1", statefulKieSessionMonitor.getKieSessionName());
+        assertEquals("org.kie.monitoring.kbase1",           statefulKieSessionMonitor.getKieBaseId());
+        assertEquals("org.kie.monitoring.kbase1.ksession1", statelessKieSessionMonitor.getKieSessionName());
+        assertEquals("org.kie.monitoring.kbase1",           statelessKieSessionMonitor.getKieBaseId());
+        
+        
+        KieContainer kc2 = ks.newKieClasspathContainer("myID2");
+        KieContainerMonitorMXBean c2Monitor = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy("myID2"),
+                KieContainerMonitorMXBean.class);
+        KieBase kb2 = kc2.getKieBase("org.kie.monitoring.kbase1");
+        KieSession statefulKieSession2 = kc2.newKieSession("org.kie.monitoring.kbase1.ksession1");
+        StatelessKieSession statelessKieSession2 = kc2.newStatelessKieSession("org.kie.monitoring.kbase1.ksession2");
+        KieSessionMonitoringMXBean statefulKieSessionMonitor2 = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy("myID2", "org.kie.monitoring.kbase1", KieSessionType.STATEFUL, "org.kie.monitoring.kbase1.ksession1"),
+                KieSessionMonitoringMXBean.class);
+        StatelessKieSessionMonitoringMXBean statelessKieSessionMonitor2 = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy("myID2", "org.kie.monitoring.kbase1", KieSessionType.STATEFUL, "org.kie.monitoring.kbase1.ksession1"),
+                StatelessKieSessionMonitoringMXBean.class);
+        
+        assertEquals("myID2", c2Monitor.getContainerId() );
+        assertTrue(c2Monitor.getConfiguredReleaseId().sameGAVof(KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID));
+        assertTrue(c2Monitor.getResolvedReleaseId().sameGAVof(KieContainerMonitorMXBean.CLASSPATH_KIECONTAINER_RELEASEID));
+        assertEquals("org.kie.monitoring.kbase1.ksession1", statefulKieSessionMonitor2.getKieSessionName());
+        assertEquals("org.kie.monitoring.kbase1",           statefulKieSessionMonitor2.getKieBaseId());
+        assertEquals("org.kie.monitoring.kbase1.ksession1", statelessKieSessionMonitor2.getKieSessionName());
+        assertEquals("org.kie.monitoring.kbase1",           statelessKieSessionMonitor2.getKieBaseId());
+        
+        kc.dispose();
+        kc2.dispose();
+    }
 
     @Test
     public void testEventOffset() throws Exception {

--- a/drools-compiler/src/test/resources/META-INF/kmodule.xml
+++ b/drools-compiler/src/test/resources/META-INF/kmodule.xml
@@ -16,4 +16,9 @@
     </kbase>
 
     <kbase name="xsdKieBase" packages="org.drools.compiler.integrationtests.xsd" />
+    
+    <kbase name="org.kie.monitoring.kbase1" equalsBehavior="equality" packages="org.drools.compiler.integrationtests.monitoring" eventProcessingMode="stream">
+        <ksession name="org.kie.monitoring.kbase1.ksession1" type="stateful" clockType="pseudo"/>
+        <ksession name="org.kie.monitoring.kbase1.ksession2" type="stateless" clockType="realtime"/>
+    </kbase>
 </kmodule>

--- a/drools-compiler/src/test/resources/logback-test.xml
+++ b/drools-compiler/src/test/resources/logback-test.xml
@@ -9,6 +9,8 @@
 
   <logger name="org.kie" level="info"/>
   <logger name="org.drools" level="info"/>
+  
+  <logger name="org.drools.core.management" level="debug"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/monitoring/monitoring.drl
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/monitoring/monitoring.drl
@@ -1,0 +1,8 @@
+package org.drools.compiler.integrationtests.monitoring;
+
+rule "just a rule"
+when
+    $s : String()
+then
+    System.out.println($s);
+end


### PR DESCRIPTION
…lug-in failure to display the whole hierarchy

Depends on droolsjbpm/droolsjbpm-knowledge#174 .

This solves the problem of RHQ/JON unable to discover the 1st level parent MXBean for the KieContainer making the MXBean available also when the KieContainer is created from the Classpath, the full 3-level hierarchy is built. 
Functional test with RHQ:
![screenshot from 2016-10-03 16-28-50](https://cloud.githubusercontent.com/assets/1699252/19041239/96dc0c64-8987-11e6-9de7-5a6ee655650a.png)
In the screenshot, the Jconsole and JVisualVM is showing the reference nesting of the 3 level, and the actual result on RHQ corresponds correctly. This screenshot has been taken using the demo application[1] using the Classpath KieContainer:

```
public static void main(String[] args) {
    KieServices ks = KieServices.Factory.get();
    KieContainer kcontainer = ks.getKieClasspathContainer("abcContainer");

    KieSession ksession = kcontainer.newKieSession("rules-session");
    ...
}
```

[1] https://github.com/jomarko/drools-project
