### PR TITLE
[6.5.x] DROOLS-987 - always set agenda group focus in a propagation entry

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
@@ -675,7 +675,7 @@ public class DefaultAgenda
             group.addNodeInstance( processInstanceId, nodeInstanceId );
             group.setActive( true );
         }
-        setFocus( group );
+        group.setFocus();
         ((EventSupport) this.workingMemory).getAgendaEventSupport().fireAfterRuleFlowGroupActivated( group,
                                                                                                      this.workingMemory );
         this.workingMemory.notifyWaitOnRest();


### PR DESCRIPTION
(cherry picked from commit eaa02798bfcd43bdec14b3cc14893c3212e1074c)
