### PR TITLE
[DROOLS-1320] fix org.kie.scanner import package name

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -238,8 +238,8 @@
               org.eclipse.jdt.*;version="[0,1)";resolution:=optional,
               org.osgi.*;resolution:=optional,
               org.jbpm.process.instance.impl;resolution:=optional,
+              org.kie.scanner;resolution:=optional,
               =org.kie.spring;resolution:=optional,
-              =org.kie.scanner.*;resolution:=optional,
               *
             </Import-Package>
             <Export-Package>


### PR DESCRIPTION
@mariofusco, @jiripetrlik please take a look. This fixes the issue with POM parsing under OSGi.
