### PR TITLE
DROOLS-1322 JPAKnowledgeService session does not support mbeans

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
@@ -108,7 +108,7 @@ public class KieServicesImpl implements InternalKieServices {
         }
 
         if (containerId != null && !classpathKContainerId.equals(containerId)) {
-        	throw new IllegalStateException("The default global singletong KieClasspathContainer was already created with id "+classpathKContainerId);
+        	throw new IllegalStateException("The default global singleton KieClasspathContainer was already created with id "+classpathKContainerId);
         }
         
         return classpathKContainer;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -17,6 +17,7 @@ package org.drools.compiler.integrationtests;
 
 import org.drools.compiler.CommonTestMethodBase;
 import org.drools.compiler.kie.builder.impl.InternalKieContainer;
+import org.drools.compiler.kie.builder.impl.KieServicesImpl;
 import org.drools.core.ClockType;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.management.DroolsManagementAgent;
@@ -67,13 +68,17 @@ public class MBeansMonitoringTest extends CommonTestMethodBase {
 
     @Before
     public void setUp() throws Exception {
+        ((KieServicesImpl) KieServices.Factory.get()).nullKieClasspathContainer();
+        ((KieServicesImpl) KieServices.Factory.get()).nullAllContainerIds();
         mbeansprop = System.getProperty( MBeansOption.PROPERTY_NAME );
         System.setProperty( MBeansOption.PROPERTY_NAME, "enabled" );    
     }
 
     @After
     public void tearDown() throws Exception {
-    	if (mbeansprop != null) {
+        ((KieServicesImpl) KieServices.Factory.get()).nullKieClasspathContainer();
+        ((KieServicesImpl) KieServices.Factory.get()).nullAllContainerIds();
+        if (mbeansprop != null) {
     		System.setProperty( MBeansOption.PROPERTY_NAME, mbeansprop );
     	} else {
     		System.setProperty( MBeansOption.PROPERTY_NAME, MBeansOption.DISABLED.toString() );

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
 package org.drools.compiler.integrationtests;
 
 import org.drools.compiler.CommonTestMethodBase;

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -2179,7 +2179,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         @Override
         public void clearProcessInstances() {
-            throw new UnsupportedOperationException( );
+            // do nothing.
         }
 
         @Override

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -28,6 +28,8 @@ import org.drools.core.command.runtime.UnpersistableCommand;
 import org.drools.core.common.EndOperationListener;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.impl.StatefulKnowledgeSessionImpl;
 import org.drools.core.marshalling.impl.KieSessionInitializer;
 import org.drools.core.marshalling.impl.MarshallingConfigurationImpl;
 import org.drools.core.runtime.process.InternalProcessRuntime;
@@ -129,7 +131,13 @@ public class SingleSessionCommandService
         // create session but bypass command service
         this.ksession = kbase.newKieSession( conf,
                                              this.env );
-
+        
+        // In order to get the InternalKnowledgeBase is better go through local ksession as the parameter 'kbase' might be a CDI proxy
+        InternalKnowledgeBase internalKnowledgeBase = (InternalKnowledgeBase) this.ksession.getKieBase();
+        StatefulKnowledgeSessionImpl statefulKnowledgeSessionImpl = (StatefulKnowledgeSessionImpl) this.ksession;
+        // DROOLS-1322
+        statefulKnowledgeSessionImpl.initMBeans(internalKnowledgeBase.getContainerId(), internalKnowledgeBase.getId(), "persistent");
+        
         this.marshallingHelper = new SessionMarshallingHelper( this.ksession, conf );
         
         MarshallingConfigurationImpl config = (MarshallingConfigurationImpl) this.marshallingHelper.getMarshaller().getMarshallingConfiguration();
@@ -261,7 +269,12 @@ public class SingleSessionCommandService
         while (iterator.hasNext()) {
             addInterceptor(iterator.next(), false);
         }
-
+        
+        // In order to get the InternalKnowledgeBase is better go through local ksession as the parameter 'kbase' might be a CDI proxy
+        InternalKnowledgeBase internalKnowledgeBase = (InternalKnowledgeBase) this.ksession.getKieBase();
+        StatefulKnowledgeSessionImpl statefulKnowledgeSessionImpl = (StatefulKnowledgeSessionImpl) this.ksession;
+        // DROOLS-1322
+        statefulKnowledgeSessionImpl.initMBeans(internalKnowledgeBase.getContainerId(), internalKnowledgeBase.getId(), "persistent");
     }
 
     public class JpaSessionInitializer implements KieSessionInitializer {

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/SingleSessionCommandService.java
@@ -132,11 +132,7 @@ public class SingleSessionCommandService
         this.ksession = kbase.newKieSession( conf,
                                              this.env );
         
-        // In order to get the InternalKnowledgeBase is better go through local ksession as the parameter 'kbase' might be a CDI proxy
-        InternalKnowledgeBase internalKnowledgeBase = (InternalKnowledgeBase) this.ksession.getKieBase();
-        StatefulKnowledgeSessionImpl statefulKnowledgeSessionImpl = (StatefulKnowledgeSessionImpl) this.ksession;
-        // DROOLS-1322
-        statefulKnowledgeSessionImpl.initMBeans(internalKnowledgeBase.getContainerId(), internalKnowledgeBase.getId(), "persistent");
+        initKieSessionMBeans(this.ksession);
         
         this.marshallingHelper = new SessionMarshallingHelper( this.ksession, conf );
         
@@ -160,6 +156,13 @@ public class SingleSessionCommandService
         if (timerJobFactoryManager instanceof CommandServiceTimerJobFactoryManager) {
            ( (CommandServiceTimerJobFactoryManager) timerJobFactoryManager ).setCommandService( this );
         }
+    }
+
+    private void initKieSessionMBeans(KieSession ksession) {
+        InternalKnowledgeBase internalKnowledgeBase = (InternalKnowledgeBase) ksession.getKieBase();
+        StatefulKnowledgeSessionImpl statefulKnowledgeSessionImpl = (StatefulKnowledgeSessionImpl) ksession;
+        // DROOLS-1322
+        statefulKnowledgeSessionImpl.initMBeans(internalKnowledgeBase.getContainerId(), internalKnowledgeBase.getId(), "persistent");
     }
     
     public SingleSessionCommandService( Long sessionId,
@@ -270,11 +273,7 @@ public class SingleSessionCommandService
             addInterceptor(iterator.next(), false);
         }
         
-        // In order to get the InternalKnowledgeBase is better go through local ksession as the parameter 'kbase' might be a CDI proxy
-        InternalKnowledgeBase internalKnowledgeBase = (InternalKnowledgeBase) this.ksession.getKieBase();
-        StatefulKnowledgeSessionImpl statefulKnowledgeSessionImpl = (StatefulKnowledgeSessionImpl) this.ksession;
-        // DROOLS-1322
-        statefulKnowledgeSessionImpl.initMBeans(internalKnowledgeBase.getContainerId(), internalKnowledgeBase.getId(), "persistent");
+        initKieSessionMBeans(this.ksession);
     }
 
     public class JpaSessionInitializer implements KieSessionInitializer {

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
@@ -1,0 +1,112 @@
+package org.drools.persistence.monitoring;
+
+import org.drools.compiler.kie.builder.impl.KieServicesImpl;
+import org.drools.core.management.DroolsManagementAgent;
+import org.drools.persistence.util.DroolsPersistenceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.model.KieSessionModel.KieSessionType;
+import org.kie.api.conf.MBeansOption;
+import org.kie.api.management.KieContainerMonitorMXBean;
+import org.kie.api.management.KieSessionMonitoringMXBean;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieContainer;
+import org.kie.internal.persistence.jpa.JPAKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.JMX;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+
+import static org.drools.persistence.util.DroolsPersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
+import static org.drools.persistence.util.DroolsPersistenceUtil.createEnvironment;
+import static org.junit.Assert.assertEquals;
+
+public class MonitoringWithJPAKnowledgeServiceTest {
+    private static Logger LOG = LoggerFactory.getLogger(MonitoringWithJPAKnowledgeServiceTest.class);
+    
+    private Map<String, Object> context;
+    private Environment env;
+    
+    public MonitoringWithJPAKnowledgeServiceTest() { 
+    }
+    
+    private String mbeansprop;
+
+    @Before
+    public void setUp() throws Exception {
+        ((KieServicesImpl) KieServices.Factory.get()).nullKieClasspathContainer();
+        ((KieServicesImpl) KieServices.Factory.get()).nullAllContainerIds();
+        mbeansprop = System.getProperty( MBeansOption.PROPERTY_NAME );
+        System.setProperty( MBeansOption.PROPERTY_NAME, "enabled" );    
+        
+        context = DroolsPersistenceUtil.setupWithPoolingDataSource(DROOLS_PERSISTENCE_UNIT_NAME);
+        env = createEnvironment(context);
+    }
+        
+    @After
+    public void tearDown() throws Exception {
+        ((KieServicesImpl) KieServices.Factory.get()).nullKieClasspathContainer();
+        ((KieServicesImpl) KieServices.Factory.get()).nullAllContainerIds();
+        if (mbeansprop != null) {
+            System.setProperty( MBeansOption.PROPERTY_NAME, mbeansprop );
+        } else {
+            System.setProperty( MBeansOption.PROPERTY_NAME, MBeansOption.DISABLED.toString() );
+        }
+        
+        DroolsPersistenceUtil.cleanUp(context);
+    }
+
+
+    @Test
+    public void testBasic() throws MalformedObjectNameException {
+        MBeanServer mbserver = ManagementFactory.getPlatformMBeanServer();
+        KieServices ks = KieServices.Factory.get();
+
+        String containerId = "testcontainer-"+System.currentTimeMillis();
+        KieContainer kc = ks.newKieClasspathContainer(containerId);
+        
+        KieContainerMonitorMXBean c1Monitor = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy(containerId),
+                KieContainerMonitorMXBean.class);
+        KieBase kb = kc.getKieBase("org.kie.monitoring.kbase1");
+
+        // Use JPAKnowledgeService to create the KieSession 
+        StatefulKnowledgeSession statefulKieSession = JPAKnowledgeService.newStatefulKnowledgeSession(kb, null, env);
+        long sessionIdentifier = statefulKieSession.getIdentifier();
+        
+        statefulKieSession.insert("String1");
+        statefulKieSession.fireAllRules();
+        
+        KieSessionMonitoringMXBean statefulKieSessionMonitor = JMX.newMXBeanProxy(
+                mbserver,
+                DroolsManagementAgent.createObjectNameBy(containerId, "org.kie.monitoring.kbase1", KieSessionType.STATEFUL, "persistent"),
+                KieSessionMonitoringMXBean.class);
+        assertEquals(1, statefulKieSessionMonitor.getTotalMatchesFired() );
+        
+        // There should be 3 mbeans for KieContainer, KieBase and KieSession.
+        assertEquals(3, mbserver.queryNames(new ObjectName("org.kie:kcontainerId="+ObjectName.quote(containerId)+",*"), null).size());
+        
+        // needs to be done separately:
+        statefulKieSession.dispose();
+        
+        StatefulKnowledgeSession deserialized = JPAKnowledgeService.loadStatefulKnowledgeSession(sessionIdentifier, kb, null, createEnvironment(context));
+        deserialized.insert("String2");
+        deserialized.fireAllRules();
+        
+        // the mbean does not persist state, but in this case consolidate by grouping the fire of the former session and the deserialized one 
+        assertEquals(2, statefulKieSessionMonitor.getTotalMatchesFired() );
+        
+        kc.dispose();
+    }
+
+}

--- a/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
+++ b/drools-persistence-jpa/src/test/java/org/drools/persistence/monitoring/MonitoringWithJPAKnowledgeServiceTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
 package org.drools.persistence.monitoring;
 
 import org.drools.compiler.kie.builder.impl.KieServicesImpl;

--- a/drools-persistence-jpa/src/test/resources/logback-test.xml
+++ b/drools-persistence-jpa/src/test/resources/logback-test.xml
@@ -13,6 +13,8 @@
   <!-- bitronix -->
   <logger name="bitronix.tm.twopc.Preparer" level="error"/>
   <logger name="bitronix.tm.Configuration" level="error" />
+  
+  <logger name="org.drools.core.management" level="debug"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-persistence-jpa/src/test/resources/logback-test.xml
+++ b/drools-persistence-jpa/src/test/resources/logback-test.xml
@@ -13,8 +13,6 @@
   <!-- bitronix -->
   <logger name="bitronix.tm.twopc.Preparer" level="error"/>
   <logger name="bitronix.tm.Configuration" level="error" />
-  
-  <logger name="org.drools.core.management" level="debug"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />


### PR DESCRIPTION
As per email thread, this enable MBeans also for KieSession created/loaded via JPAKnowledgeService. But it does not clean-up this MBean if the KieContainer is disposed as it's not aware (as before) of KieSession created via the KieBase directly, so KieSession-MBeans created this way will need manual clean-up if necessary.
