### PR TITLE
[6.5.x] RHBRMS-2642 KieContainer.newKieSession((String) null) should return the default ksession to be consistent with getKieSessionModel(null)

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -673,13 +673,16 @@ public class KieContainerImpl
     }
 
     public KieSession newKieSession(String kSessionName, Environment environment, KieSessionConfiguration conf) {
-        KieSessionModelImpl kSessionModel = (KieSessionModelImpl) getKieSessionModel(kSessionName);
+        KieSessionModelImpl kSessionModel = kSessionName != null ?
+                                            (KieSessionModelImpl) getKieSessionModel(kSessionName) :
+                                            (KieSessionModelImpl) findKieSessionModel(false);
+
         if ( kSessionModel == null ) {
             log.error("Unknown KieSession name: " + kSessionName);
             return null;
         }
         if (kSessionModel.getType() == KieSessionModel.KieSessionType.STATELESS) {
-            throw new RuntimeException("Trying to create a stateful KieSession from a stateless KieSessionModel: " + kSessionName);
+            throw new RuntimeException("Trying to create a stateful KieSession from a stateless KieSessionModel: " + kSessionModel.getName());
         }
         KieBase kBase = getKieBase( kSessionModel.getKieBaseModel().getName() );
         if ( kBase == null ) {
@@ -693,9 +696,9 @@ public class KieContainerImpl
         }
         registerLoggers(kSessionModel, kSession);
 
-        ((StatefulKnowledgeSessionImpl) kSession).initMBeans(containerId, ((InternalKnowledgeBase) kBase).getId(), kSessionName);
+        ((StatefulKnowledgeSessionImpl) kSession).initMBeans(containerId, ((InternalKnowledgeBase) kBase).getId(), kSessionModel.getName());
         
-        kSessions.put(kSessionName, kSession);
+        kSessions.put(kSessionModel.getName(), kSession);
         return kSession;
     }
 
@@ -719,13 +722,16 @@ public class KieContainerImpl
     }
 
     public StatelessKieSession newStatelessKieSession(String kSessionName, KieSessionConfiguration conf) {
-        KieSessionModelImpl kSessionModel = (KieSessionModelImpl) kProject.getKieSessionModel( kSessionName );
+        KieSessionModelImpl kSessionModel = kSessionName != null ?
+                                            (KieSessionModelImpl) getKieSessionModel(kSessionName) :
+                                            (KieSessionModelImpl) findKieSessionModel(true);
+
         if ( kSessionModel == null ) {
             log.error("Unknown KieSession name: " + kSessionName);
             return null;
         }
         if (kSessionModel.getType() == KieSessionModel.KieSessionType.STATEFUL) {
-            throw new RuntimeException("Trying to create a stateless KieSession from a stateful KieSessionModel: " + kSessionName);
+            throw new RuntimeException("Trying to create a stateless KieSession from a stateful KieSessionModel: " + kSessionModel.getName());
         }
         KieBase kBase = getKieBase( kSessionModel.getKieBaseModel().getName() );
         if ( kBase == null ) {
@@ -739,9 +745,9 @@ public class KieContainerImpl
         }
         registerLoggers(kSessionModel, statelessKieSession);
         
-        ((StatelessKnowledgeSessionImpl) statelessKieSession).initMBeans(containerId, ((InternalKnowledgeBase) kBase).getId(), kSessionName);
+        ((StatelessKnowledgeSessionImpl) statelessKieSession).initMBeans(containerId, ((InternalKnowledgeBase) kBase).getId(), kSessionModel.getName());
         
-        statelessKSessions.put(kSessionName, statelessKieSession);
+        statelessKSessions.put(kSessionModel.getName(), statelessKieSession);
         return statelessKieSession;
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieHelloWorldTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieHelloWorldTest.java
@@ -282,13 +282,14 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         KieModuleModel kproj = ks.newKieModuleModel();
 
         KieBaseModel kieBaseModel1 = kproj.newKieBaseModel("KBase1")
-                .setEqualsBehavior( EqualityBehaviorOption.EQUALITY )
-                .setEventProcessingMode( EventProcessingOption.STREAM )
-                .addPackage(pkg);
+                                          .setEqualsBehavior( EqualityBehaviorOption.EQUALITY )
+                                          .setEventProcessingMode( EventProcessingOption.STREAM )
+                                          .addPackage(pkg);
 
         KieSessionModel ksession1 = kieBaseModel1.newKieSessionModel("KSession1")
-                .setType( KieSessionType.STATEFUL )
-                .setClockType(ClockTypeOption.get("realtime"));
+                                                 .setType( KieSessionType.STATEFUL )
+                                                 .setClockType(ClockTypeOption.get("realtime"))
+                                                 .setDefault( true );
 
         return kproj;
     }
@@ -330,6 +331,20 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         ksession = ks.newKieContainer(releaseId2).newKieSession("KSession1");
         ksession.insert(new Message("Hi Universe"));
         assertEquals( 0, ksession.fireAllRules() );
+    }
+
+    @Test
+    public void testGetDefaultKieSessionWithNullName() throws Exception {
+        // DROOLS-1276
+        KieServices ks = KieServices.Factory.get();
+
+        buildVersion(ks, "Hello World", "1.0");
+
+        ReleaseId releaseId1 = ks.newReleaseId("org.kie", "hello-world", "1.0");
+
+        KieSession ksession = ks.newKieContainer(releaseId1).newKieSession((String)null);
+        ksession.insert(new Message("Hello World"));
+        assertEquals( 1, ksession.fireAllRules() );
     }
 
     private void buildVersion(KieServices ks, String message, String version) {


### PR DESCRIPTION
Backport of https://github.com/droolsjbpm/drools/commit/3165cce4d5290ba0e2f63f03859ac5407ec0814d to 6.5.x.
