### PR TITLE
DROOLS-1335 fix for kie-server related issue as custom implements ReleaseId

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -153,7 +153,7 @@ public class KieRepositoryImpl
             return null;
         }
 
-        String pomPropertiesPath = ((ReleaseIdImpl)releaseId).getPomPropertiesPath();
+        String pomPropertiesPath = ReleaseIdImpl.getPomPropertiesPath(releaseId);
         URL pomPropertiesUrl = contextClassLoader.getResource( pomPropertiesPath );
         if (pomPropertiesUrl == null) {
             return null;

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
@@ -86,11 +86,19 @@ public class ReleaseIdImpl implements ReleaseId, Externalizable {
     }
 
     public String getPomXmlPath() {
-        return "META-INF/maven/" + groupId + "/" + artifactId + "/pom.xml";
+        return getPomXmlPath(this);
     }
 
     public String getPomPropertiesPath() {
-        return "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+        return getPomPropertiesPath(this);
+    }
+
+    public static String getPomXmlPath(ReleaseId releaseId) {
+        return "META-INF/maven/" + releaseId.getGroupId() + "/" + releaseId.getArtifactId() + "/pom.xml";
+    }
+    
+    public static String getPomPropertiesPath(ReleaseId releaseId) {
+        return "META-INF/maven/" + releaseId.getGroupId() + "/" + releaseId.getArtifactId() + "/pom.properties";
     }
 
     public String getCompilationCachePathPrefix() {


### PR DESCRIPTION
Proposed fix for kie-server related issue, given the custom 
implementation of ReleaseId.

E.g.: `org.kie.server.api.model.ReleaseId cannot be cast to org.drools.compiler.kproject.ReleaseIdImpl`

 Stack Trace

```
java.lang.ClassCastException: org.kie.server.api.model.ReleaseId cannot be cast to org.drools.compiler.kproject.ReleaseIdImpl
    at org.drools.compiler.kie.builder.impl.KieRepositoryImpl.checkClasspathForKieModule(KieRepositoryImpl.java:156)
    at org.drools.compiler.kie.builder.impl.KieRepositoryImpl.getKieModule(KieRepositoryImpl.java:136)
    at org.drools.compiler.kie.builder.impl.KieRepositoryImpl.getKieModule(KieRepositoryImpl.java:119)
    at org.drools.compiler.kie.builder.impl.KieServicesImpl.newKieContainer(KieServicesImpl.java:184)
    at org.drools.compiler.kie.builder.impl.KieServicesImpl.newKieContainer(KieServicesImpl.java:172)
    at org.kie.server.integrationtests.jbpm.DeploymentDescriptorIntegrationTest.buildAndDeployArtifacts(DeploymentDescriptorIntegrationTest.java:54)
```
