### PR TITLE
RHBPMS-4413: DRL file with spaces in name fails first validation

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
@@ -29,7 +29,9 @@ import org.kie.api.io.Resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -178,7 +180,7 @@ public class KieBuilderSetImpl implements KieBuilderSet {
 
     public static class DummyResource extends BaseResource {
         public DummyResource(String resourceName) {
-            setSourcePath(resourceName);
+            setSourcePath( decode( resourceName ) );
         }
 
         @Override
@@ -224,6 +226,14 @@ public class KieBuilderSetImpl implements KieBuilderSet {
         @Override
         public Reader getReader() throws IOException {
             throw new UnsupportedOperationException();
+        }
+
+        private String decode( final String resourceName ) {
+            try {
+                return URLDecoder.decode( resourceName, "UTF-8" );
+            } catch ( UnsupportedEncodingException e ) {
+                return resourceName;
+            }
         }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImplTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImplTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.kie.builder.impl;
+
+import org.drools.compiler.CommonTestMethodBase;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.io.Resource;
+import org.kie.internal.builder.IncrementalResults;
+
+public class KieBuilderSetImplTest extends CommonTestMethodBase {
+
+    @Test
+    public void testBuild() throws Exception {
+        final KieServices ks = KieServices.Factory.get();
+        final KieFileSystem kfs = ks.newKieFileSystem();
+
+        kfs.write( "src/main/resources/rule%201.drl", ruleContent() );
+
+        final KieBuilderSetImpl kieBuilderSet = new KieBuilderSetImpl( kieBuilder( ks, kfs ) );
+
+        kieBuilderSet.setFiles( new String[]{ "src/main/resources/rule%201.drl" } );
+
+        final IncrementalResults build = kieBuilderSet.build();
+
+        assertEquals( 0, build.getAddedMessages().size() );
+        assertEquals( 0, build.getRemovedMessages().size() );
+    }
+
+    @Test
+    public void testDummyResourceWithAnEncodedFileName() {
+        final Resource dummyResource = new KieBuilderSetImpl.DummyResource( "Dummy%20Resource" );
+        final Resource testResource = new KieBuilderSetImpl.DummyResource( "Dummy Resource" );
+
+        assertEquals( testResource, dummyResource );
+    }
+
+    private KieBuilderImpl kieBuilder( final KieServices ks,
+                                       final KieFileSystem kfs ) {
+        final KieBuilder kieBuilder = ks.newKieBuilder( kfs );
+
+        kieBuilder.buildAll();
+
+        return (KieBuilderImpl) kieBuilder;
+    }
+
+    private String ruleContent() {
+        return "package org.kie.test\n"
+                + "import java.util.concurrent.atomic.AtomicInteger\n"
+                + "global java.util.List list\n"
+                + "rule 'rule 1'\n"
+                + "when\n"
+                + " $i: AtomicInteger(intValue > 0)\n"
+                + "then\n"
+                + " list.add( $i );\n"
+                + "end\n"
+                + "\n";
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4413
- Before:
  ![a](https://cloud.githubusercontent.com/assets/1079279/19841953/63963ee6-9efa-11e6-9a72-3e8b3687b1bb.gif)
- After:
  ![b](https://cloud.githubusercontent.com/assets/1079279/19841955/69319102-9efa-11e6-94f4-3f3ae333fcf3.gif)

The `buildChanges` method from the `KieBuilderSetImpl` was failing because [this validation](https://github.com/droolsjbpm/drools/blob/master/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java#L988) had a false negative due to [this comparison](https://github.com/droolsjbpm/drools/blob/master/drools-core/src/main/java/org/drools/core/definitions/impl/KnowledgePackageImpl.java#L715-L715).
