### PR TITLE
[6.5.x] RHBRMS-2572: Guided Rule Templates: Generates incorrect DRL when literal constraint follows templated constraints

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/LHSGeneratorContextFactory.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/LHSGeneratorContextFactory.java
@@ -39,7 +39,7 @@ public class LHSGeneratorContextFactory {
         final LHSGeneratorContext gc = new LHSGeneratorContext( parent,
                                                                 pattern,
                                                                 getMaximumDepth() + 1,
-                                                                parent.getOffset() );
+                                                                0 );
         contexts.add( gc );
         return gc;
     }
@@ -49,7 +49,7 @@ public class LHSGeneratorContextFactory {
         final LHSGeneratorContext gc = new LHSGeneratorContext( parent,
                                                                 fieldConstraint,
                                                                 getMaximumDepth() + 1,
-                                                                parent.getOffset() );
+                                                                0 );
         contexts.add( gc );
         return gc;
     }

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/RHSGeneratorContextFactory.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/RHSGeneratorContextFactory.java
@@ -39,7 +39,7 @@ public class RHSGeneratorContextFactory {
         final RHSGeneratorContext gc = new RHSGeneratorContext( parent,
                                                                 action,
                                                                 getMaximumDepth() + 1,
-                                                                parent.getOffset() );
+                                                                0 );
         contexts.add( gc );
         return gc;
     }
@@ -49,7 +49,7 @@ public class RHSGeneratorContextFactory {
         final RHSGeneratorContext gc = new RHSGeneratorContext( parent,
                                                                 afv,
                                                                 getMaximumDepth() + 1,
-                                                                parent.getOffset() );
+                                                                0 );
         contexts.add( gc );
         return gc;
     }

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceImpl.java
@@ -162,20 +162,29 @@ public class RuleTemplateModelDRLPersistenceImpl
                         buf.delete( buf.length() - 4, buf.length() );
                     }
                 }
-                buf.append( ") || hasLHSNonTemplateOutput" ).append( gctx.getDepth() + "_" + gctx.getOffset() ).append( "}" );
-            } else {
-                LHSGeneratorContext parentContext = gctx.getParent();
-                if ( parentContext != null ) {
-                    Set<String> parentVarsInScope = new HashSet<String>( parentContext.getVarsInScope() );
-                    parentVarsInScope.removeAll( gctx.getVarsInScope() );
-                    if ( parentVarsInScope.size() > 0 ) {
-                        buf.append( "@if{!(" );
-                        for ( String var : parentVarsInScope ) {
-                            buf.append( var + " == empty && " );
-                        }
-                        buf.delete( buf.length() - 4, buf.length() );
-                        buf.append( ")}" );
+                int ctxOffset = gctx.getOffset();
+                if ( ctxOffset > 0 ) {
+                    buf.append( ") || (" );
+                    do {
+                        ctxOffset--;
+                        buf.append( "hasLHSNonTemplateOutput" + gctx.getDepth() + "_" + ctxOffset + " || " );
                     }
+                    while ( ctxOffset > 0 );
+                    buf.delete( buf.length() - 4, buf.length() );
+                    buf.append( ")}" );
+                }
+
+            } else {
+                int ctxOffset = gctx.getOffset();
+                if ( ctxOffset > 0 ) {
+                    buf.append( "@if{" );
+                    do {
+                        ctxOffset--;
+                        buf.append( "hasLHSOutput" + gctx.getDepth() + "_" + ctxOffset + " || " );
+                    }
+                    while ( ctxOffset > 0 );
+                    buf.delete( buf.length() - 4, buf.length() );
+                    buf.append( "}" );
                 }
             }
         }

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceTest.java
@@ -4323,6 +4323,108 @@ public class RuleTemplateModelDRLPersistenceTest {
                        m4 );
     }
 
+    @Test
+    public void checkLHSConstraintSeparatorWithEmptyTemplateKeyAndLiteralAndNonEmptyTemplateKey() {
+        FactPattern fp = new FactPattern( "Smurf" );
+        fp.setBoundName( "p1" );
+
+        SingleFieldConstraint sfc1 = new SingleFieldConstraint();
+        sfc1.setOperator( "==" );
+        sfc1.setFactType( "Smurf" );
+        sfc1.setFieldName( "field1" );
+        sfc1.setFieldType( DataType.TYPE_STRING );
+        sfc1.setConstraintValueType( SingleFieldConstraint.TYPE_TEMPLATE );
+        sfc1.setValue( "$f1" );
+
+        SingleFieldConstraint sfc2 = new SingleFieldConstraint();
+        sfc2.setOperator( "==" );
+        sfc2.setFactType( "Smurf" );
+        sfc2.setFieldName( "field1" );
+        sfc2.setFieldType( DataType.TYPE_STRING );
+        sfc2.setConstraintValueType( SingleFieldConstraint.TYPE_LITERAL );
+        sfc2.setValue( "value" );
+
+        SingleFieldConstraint sfc3 = new SingleFieldConstraint();
+        sfc3.setOperator( "==" );
+        sfc3.setFactType( "Smurf" );
+        sfc3.setFieldName( "field1" );
+        sfc3.setFieldType( DataType.TYPE_STRING );
+        sfc3.setConstraintValueType( SingleFieldConstraint.TYPE_TEMPLATE );
+        sfc3.setValue( "$f2" );
+
+        fp.addConstraint( sfc1 );
+        fp.addConstraint( sfc2 );
+        fp.addConstraint( sfc3 );
+
+        //Test 1
+        TemplateModel m1 = new TemplateModel();
+        m1.addLhsItem( fp );
+        m1.name = "r1";
+
+        m1.addRow( new String[]{ null, null } );
+
+        final String expected1 = "rule \"r1_0\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "    p1 : Smurf( field1 == \"value\" )\n" +
+                "  then\n" +
+                "end";
+
+        checkMarshall( expected1,
+                       m1 );
+
+        //Test 2
+        TemplateModel m2 = new TemplateModel();
+        m2.addLhsItem( fp );
+        m2.name = "r2";
+
+        m2.addRow( new String[]{ "t1", "t2" } );
+
+        final String expected2 = "rule \"r2_0\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "    p1 : Smurf( field1 == \"t1\", field1 == \"value\", field1 == \"t2\" )\n" +
+                "  then\n" +
+                "end";
+
+        checkMarshall( expected2,
+                       m2 );
+
+        //Test 3
+        TemplateModel m3 = new TemplateModel();
+        m3.addLhsItem( fp );
+        m3.name = "r3";
+
+        m3.addRow( new String[]{ "t1", null } );
+
+        final String expected3 = "rule \"r3_0\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "    p1 : Smurf( field1 == \"t1\", field1 == \"value\" )\n" +
+                "  then\n" +
+                "end";
+
+        checkMarshall( expected3,
+                       m3 );
+
+        //Test 4
+        TemplateModel m4 = new TemplateModel();
+        m4.addLhsItem( fp );
+        m4.name = "r4";
+
+        m4.addRow( new String[]{ null, "t2" } );
+
+        final String expected4 = "rule \"r4_0\"\n" +
+                "  dialect \"mvel\"\n" +
+                "  when\n" +
+                "    p1 : Smurf( field1 == \"value\", field1 == \"t2\" )\n" +
+                "  then\n" +
+                "end";
+
+        checkMarshall( expected4,
+                       m4 );
+    }
+
     private void assertEqualsIgnoreWhitespace( final String expected,
                                                final String actual ) {
         final String cleanExpected = expected.replaceAll( "\\s+",


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2572 (this is on @etirelli BxMS 6.4.x hit list)

This is the corollary of https://github.com/droolsjbpm/drools/pull/990 for 6.5.x

(cherry picked from commit a9cdfb77cfb3b4294f789a531d12d69bacda6e4d)