### PR TITLE
DROOLS-1351 Calling KieRepository.getKieModule() for a GAV of a non K…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -173,8 +173,9 @@ public class KieRepositoryImpl
                                          pomPropertiesUrl.getPort(),
                                          pathToJar + "!/" + KieModuleModelImpl.KMODULE_JAR_PATH );
                 
-                // length -1 if the content length is not known, unable to locate and read from the kmodule
-                if ( pathToKmodule.openConnection().getContentLength() < 0 ) {
+                // URLConnection.getContentLength() returns -1 if the content length is not known, unable to locate and read from the kmodule
+                // if URL backed by 'file:' then FileURLConnection.getContentLength() returns 0, as per java.io.File.length() returns 0L if the file does not exist. (the same also for WildFly's VFS FileURLConnection) 
+                if ( pathToKmodule.openConnection().getContentLength() <= 0 ) {
                     return null;
                 }
             } catch (MalformedURLException e) {


### PR DESCRIPTION
…Jar throws Exception instead of returning null as per API contract.

URLConnection.getContentLength() returns -1 if the content length is not
 known, unable to locate and read from the kmodule.
if URL backed by 'file:' then FileURLConnection.getContentLength()
returns 0, as per java.io.File.length() returns 0L if the file does not 
exist. (the same also for WildFly's VFS FileURLConnection).

Aligned condition to check if kmodule.xml actually exists
to pathToKmodule.openConnection().getContentLength() <= 0