### PR TITLE
add BuilderResultUtils to drools-compiler to avoid code duplicate

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/ActionError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/ActionError.java
@@ -16,7 +16,6 @@
 
 package org.drools.compiler.compiler;
 
-import org.drools.compiler.commons.jci.problems.CompilationProblem;
 import org.drools.compiler.lang.descr.BaseDescr;
 
 public class ActionError extends DroolsError {
@@ -45,12 +44,12 @@ public class ActionError extends DroolsError {
     public Object getObject() {
         return this.object;
     }
-    
+
     public int[] getLines() {
         return this.errorLines;
     }
 
-    /** 
+    /**
      * This will return the line number of the error, if possible
      * Otherwise it will be -1
      */
@@ -59,37 +58,15 @@ public class ActionError extends DroolsError {
     }
 
     public String getMessage() {
-        String summary = this.message;
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                if (i != 0) {
-                    summary = summary + "\n" + problem[i].getMessage();
-                } else {
-                    summary = summary + " " + problem[i].getMessage();
-                }
-            }
-
-        }
-        return summary;
+        return BuilderResultUtils.getProblemMessage( this.object, this.message, "\n" );
     }
 
     public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append( this.message );
-        buf.append( " : " );
-        buf.append( "\n" );
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                buf.append( "\t" );
-                buf.append( problem[i] );
-                buf.append( "\n" );
-            }
-        } else if ( this.object != null ) {
-            buf.append( this.object );
-        }
-        return buf.toString();
+        final StringBuilder builder = new StringBuilder()
+                .append( this.message )
+                .append( " : " )
+                .append( "\n" );
+        return BuilderResultUtils.appendProblems( this.object, builder ).toString();
     }
-    
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/BuilderResultUtils.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/BuilderResultUtils.java
@@ -1,0 +1,75 @@
+package org.drools.compiler.compiler;
+
+import org.drools.compiler.commons.jci.problems.CompilationProblem;
+
+/**
+ * Utility class for compilation results
+ */
+public final class BuilderResultUtils {
+
+    private static final String DEFAULT_SEPARATOR = " ";
+
+    private BuilderResultUtils() {
+    }
+
+    /**
+     * Appends compilation problems to summary message if object is an array of {@link CompilationProblem}
+     * separated with backspaces
+     *
+     * @param object  object with compilation results
+     * @param summary summary message
+     * @return summary message with changes
+     */
+    public static String getProblemMessage(Object object, String summary) {
+        return getProblemMessage( object, summary, DEFAULT_SEPARATOR );
+    }
+
+    /**
+     * Appends compilation problems to summary message if object is an array of {@link CompilationProblem}
+     * with custom separator
+     *
+     * @param object    object with compilation results
+     * @param summary   summary message
+     * @param separator custom messages separator
+     * @return summary message with changes
+     */
+    public static String getProblemMessage(Object object, String summary, String separator) {
+        if (object instanceof CompilationProblem[]) {
+            return fillSummary( (CompilationProblem[]) object, summary, separator );
+        }
+        return summary;
+    }
+
+    /**
+     * Appends compilation problems to builder if object is an array of {@link CompilationProblem}
+     * or object itself if not
+     *
+     * @param object  object with compilation results
+     * @param builder message builder
+     * @return builder
+     */
+    public static StringBuilder appendProblems(Object object, StringBuilder builder) {
+        if (object instanceof CompilationProblem[]) {
+            final CompilationProblem[] problem = (CompilationProblem[]) object;
+            for (CompilationProblem aProblem : problem) {
+                builder.append("\t")
+                       .append(aProblem)
+                       .append("\n");
+            }
+        } else if (object != null) {
+            builder.append(object);
+        }
+        return builder;
+    }
+
+    private static String fillSummary(CompilationProblem[] problem, String summary, String separator) {
+        StringBuilder builder = new StringBuilder(summary)
+                .append(DEFAULT_SEPARATOR)
+                .append(problem[0].getMessage());
+        for (int i = 1; i < problem.length; i++) {
+            builder.append(separator)
+                   .append(problem[i].getMessage());
+        }
+        return builder.toString();
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildError.java
@@ -16,7 +16,6 @@
 
 package org.drools.compiler.compiler;
 
-import org.drools.compiler.commons.jci.problems.CompilationProblem;
 import org.drools.compiler.lang.descr.BaseDescr;
 
 public class DescrBuildError extends DroolsError {
@@ -59,7 +58,7 @@ public class DescrBuildError extends DroolsError {
         return this.errorLines;
     }
 
-    /** 
+    /**
      * This will return the line number of the error, if possible
      * Otherwise it will be -1
      */
@@ -72,37 +71,15 @@ public class DescrBuildError extends DroolsError {
     }
 
     public String getMessage() {
-        String summary = this.message;
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                if ( i != 0 ) {
-                    summary = summary + "\n" + problem[i].getMessage();
-                } else {
-                    summary = summary + " " + problem[i].getMessage();
-                }
-            }
-
-        }
-        return summary;
+        return BuilderResultUtils.getProblemMessage( this.object, this.message, "\n" );
     }
 
     public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append( this.message );
-        buf.append( " : " );
-        buf.append( this.parentDescr );
-        buf.append( "\n" );
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                buf.append( "\t" );
-                buf.append( problem[i] );
-                buf.append( "\n" );
-            }
-        } else if ( this.object != null ) {
-            buf.append( this.object );
-        }
-        return buf.toString();
+        final StringBuilder builder = new StringBuilder()
+                .append( this.message )
+                .append( " : " )
+                .append( this.parentDescr )
+                .append( "\n" );
+        return BuilderResultUtils.appendProblems( this.object, builder ).toString();
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildWarning.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/DescrBuildWarning.java
@@ -16,7 +16,6 @@
 
 package org.drools.compiler.compiler;
 
-import org.drools.compiler.commons.jci.problems.CompilationProblem;
 import org.drools.compiler.lang.descr.BaseDescr;
 
 public class DescrBuildWarning extends DroolsWarning {
@@ -54,7 +53,7 @@ public class DescrBuildWarning extends DroolsWarning {
         return this.errorLines;
     }
 
-    /** 
+    /**
      * This will return the line number of the error, if possible
      * Otherwise it will be -1
      */
@@ -67,37 +66,15 @@ public class DescrBuildWarning extends DroolsWarning {
     }
 
     public String getMessage() {
-        String summary = this.message;
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                if ( i != 0 ) {
-                    summary = summary + "\n" + problem[i].getMessage();
-                } else {
-                    summary = summary + " " + problem[i].getMessage();
-                }
-            }
-
-        }
-        return summary;
+        return BuilderResultUtils.getProblemMessage( this.object, this.message, "\n" );
     }
 
     public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append( this.message );
-        buf.append( " : " );
-        buf.append( this.parentDescr );
-        buf.append( "\n" );
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                buf.append( "\t" );
-                buf.append( problem[i] );
-                buf.append( "\n" );
-            }
-        } else if ( this.object != null ) {
-            buf.append( this.object );
-        }
-        return buf.toString();
+        final StringBuilder builder = new StringBuilder()
+                .append( this.message )
+                .append( " : " )
+                .append( this.parentDescr )
+                .append( "\n" );
+        return BuilderResultUtils.appendProblems( this.object, builder ).toString();
     }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/FactTemplateError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/FactTemplateError.java
@@ -70,15 +70,7 @@ public class FactTemplateError extends DroolsError {
     }
 
     public String getMessage() {
-        String summary = this.message;
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                summary = summary + " " + problem[i].getMessage();
-            }
-
-        }
-        return summary;
+        return BuilderResultUtils.getProblemMessage( this.object, this.message );
     }
 
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/FieldTemplateError.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/FieldTemplateError.java
@@ -70,15 +70,7 @@ public class FieldTemplateError extends DroolsError {
     }
 
     public String getMessage() {
-        String summary = this.message;
-        if ( this.object instanceof CompilationProblem[] ) {
-            final CompilationProblem[] problem = (CompilationProblem[]) this.object;
-            for ( int i = 0; i < problem.length; i++ ) {
-                summary = summary + " " + problem[i].getMessage();
-            }
-
-        }
-        return summary;
+        return BuilderResultUtils.getProblemMessage( this.object, this.message );
     }
 
 }


### PR DESCRIPTION
add BuilderResultUtils to drools-compiler to avoid code duplicate with static methods.

Rework of pull-request https://github.com/droolsjbpm/drools/pull/986