### PR TITLE
Fixed imports - the class didn't compile on jdk7.

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBuilderTest.java
@@ -18,7 +18,6 @@ package org.drools.compiler.integrationtests;
 import org.drools.compiler.CommonTestMethodBase;
 import org.drools.compiler.Message;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -36,7 +35,6 @@ import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.internal.io.ResourceFactory;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 public class KieBuilderTest extends CommonTestMethodBase {
 


### PR DESCRIPTION
- This is needed for running tests with jdk7. 