### PR TITLE
Fix race condition

### DIFF
--- a/drools-core/src/main/java/org/drools/core/rule/MVELDialectRuntimeData.java
+++ b/drools-core/src/main/java/org/drools/core/rule/MVELDialectRuntimeData.java
@@ -315,10 +315,12 @@ public class MVELDialectRuntimeData
 
             }
 
-            this.parserConfiguration = new ParserConfiguration();
-            this.parserConfiguration.setImports( this.imports );
-            this.parserConfiguration.setPackageImports( this.packageImports );
-            this.parserConfiguration.setClassLoader( packageClassLoader );
+            ParserConfiguration parserConfiguration = new ParserConfiguration();
+            parserConfiguration.setImports( this.imports );
+            parserConfiguration.setPackageImports( this.packageImports );
+            parserConfiguration.setClassLoader( packageClassLoader );
+            
+            this.parserConfiguration = parserConfiguration;
         }
         return this.parserConfiguration;
     }


### PR DESCRIPTION
Fix race condition on assignment of imports to unsafe parserConfiguration field.

[DROOLS-1359](https://issues.jboss.org/browse/DROOLS-1359)