### PR TITLE
Fix drools-example GameUI keylistener

### DIFF
--- a/drools-examples/src/main/java/org/drools/games/GameUI.java
+++ b/drools-examples/src/main/java/org/drools/games/GameUI.java
@@ -56,8 +56,10 @@ public class GameUI extends Canvas{
         panel.add(this);
         setIgnoreRepaint(true);
 
+        panel.setFocusable(false); // GameUI is used in Canvas-based games only (Invaders, Pong) and only need keylistener on the external Swing JFrame 
+        setFocusable(false);
         KeyListener klistener = new GameKeyListener( ksession.getEntryPoint( "KeyPressedStream" ), ksession.getEntryPoint( "KeyReleasedStream" ) );
-        addKeyListener(klistener);
+        frame.addKeyListener(klistener);
 
         frame.setLocationRelativeTo(null); // Center in screen
         frame.pack();


### PR DESCRIPTION
Avoid to Pong, Invaders end users the need to click the Canvas in order
to actually produce the key pressed events.
This way, the external JFrame registers the keylistener.
The internal JPanel and Canvas are not responsive to the user hence are
set as non-focusable.
When the external JFrame becomes visible, the keylistener is immediately
active to create the key pressed events necessary for the game/rules.

Please notice GameUI is only used by Canvas-based games: Pong, Invaders.