### PR TITLE
GUVNOR-2745: [Guided Rule Template] RTE when generating Template for Pattern with multiple non-template constraints

### DIFF
--- a/drools-templates/src/main/java/org/drools/template/parser/TemplateDataListener.java
+++ b/drools-templates/src/main/java/org/drools/template/parser/TemplateDataListener.java
@@ -16,10 +16,10 @@
 
 package org.drools.template.parser;
 
+import java.io.InputStream;
+
 import org.drools.template.model.DRLOutput;
 import org.kie.api.runtime.KieSession;
-
-import java.io.InputStream;
 
 /**
  * SheetListener for creating rules from a template
@@ -44,121 +44,162 @@ public class TemplateDataListener
 
     private Generator generator;
 
+    private boolean checkEmptyRows = true;
+
     // private WorkingMemoryFileLogger logger;
 
-    public TemplateDataListener(final TemplateContainer tc) {
-        this(1,
-             1,
-             tc);
+    public TemplateDataListener( final TemplateContainer tc ) {
+        this( 1,
+              1,
+              tc,
+              true );
     }
 
-    public TemplateDataListener(final int startRow,
-                                final int startCol,
-                                final String template) {
-        this(startRow,
-             startCol,
-             new DefaultTemplateContainer(template));
+    public TemplateDataListener( final TemplateContainer tc,
+                                 final boolean checkEmptyRows ) {
+        this( 1,
+              1,
+              tc,
+              checkEmptyRows );
     }
 
-    public TemplateDataListener(final int startRow,
-                                final int startCol,
-                                final InputStream templateStream) {
-        this(startRow,
-             startCol,
-             new DefaultTemplateContainer(templateStream));
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final String template ) {
+        this( startRow,
+              startCol,
+              new DefaultTemplateContainer( template ) );
     }
 
-    public TemplateDataListener(final int startRow,
-                                final int startCol,
-                                final TemplateContainer tc) {
-        this(startRow,
-             startCol,
-             tc,
-             new DefaultTemplateRuleBase(tc));
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final InputStream templateStream ) {
+        this( startRow,
+              startCol,
+              new DefaultTemplateContainer( templateStream ) );
     }
 
-    public TemplateDataListener(final int startRow,
-                                final int startCol,
-                                final TemplateContainer tc,
-                                final TemplateRuleBase rb) {
-        this(startRow,
-             startCol,
-             tc,
-             rb,
-             new DefaultGenerator(tc.getTemplates()));
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final TemplateContainer tc ) {
+        this( startRow,
+              startCol,
+              tc,
+              true );
     }
 
-    public TemplateDataListener(final int startRow,
-                                final int startCol,
-                                final TemplateContainer tc,
-                                final TemplateRuleBase ruleBase,
-                                final Generator generator) {
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final TemplateContainer tc,
+                                 final boolean checkEmptyRows ) {
+        this( startRow,
+              startCol,
+              tc,
+              new DefaultTemplateRuleBase( tc ),
+              checkEmptyRows );
+    }
+
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final TemplateContainer tc,
+                                 final TemplateRuleBase rb,
+                                 final boolean checkEmptyRows ) {
+        this( startRow,
+              startCol,
+              tc,
+              rb,
+              new DefaultGenerator( tc.getTemplates() ),
+              checkEmptyRows );
+    }
+
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final TemplateContainer tc,
+                                 final TemplateRuleBase ruleBase,
+                                 final Generator generator ) {
+        this( startRow,
+              startCol,
+              tc,
+              ruleBase,
+              generator,
+              true );
+    }
+
+    public TemplateDataListener( final int startRow,
+                                 final int startCol,
+                                 final TemplateContainer tc,
+                                 final TemplateRuleBase ruleBase,
+                                 final Generator generator,
+                                 final boolean checkEmptyRows ) {
         this.startRow = startRow - 1;
         this.startCol = startCol - 1;
-        columns = tc.getColumns();
+        this.columns = tc.getColumns();
         this.templateContainer = tc;
-        session = ruleBase.newStatefulSession();
+        this.session = ruleBase.newStatefulSession();
         // logger = new WorkingMemoryFileLogger(session);
         // logger.setFileName("log/event");
         this.generator = generator;
-        session.setGlobal("generator",
-                          generator);
+        this.session.setGlobal( "generator",
+                                generator );
+        this.checkEmptyRows = checkEmptyRows;
         assertColumns();
     }
 
     private void assertColumns() {
-        for (int i = 0; i < columns.length; i++) {
-            session.insert(columns[i]);
+        for ( int i = 0; i < columns.length; i++ ) {
+            session.insert( columns[ i ] );
         }
     }
 
     public void finishSheet() {
-        if (currentRow != null) {
-            session.insert(currentRow);
+        if ( currentRow != null ) {
+            session.insert( currentRow );
         }
         session.fireAllRules();
         // logger.writeToDisk();
         session.dispose();
     }
 
-    public void newCell(int row,
-                        int column,
-                        String value,
-                        int mergedColStart) {
-        if (currentRow != null && column >= startCol && value != null && value.trim().length() > 0) {
+    public void newCell( int row,
+                         int column,
+                         String value,
+                         int mergedColStart ) {
+        if ( currentRow != null && column >= startCol && value != null && value.trim().length() > 0 ) {
 
             int columnIndex = column - startCol;
-            if (columnIndex < columns.length) {
-                Cell cell = currentRow.getCell(columnIndex);
-                cell.setValue(value);
-                cell.insert(session);
+            if ( columnIndex < columns.length ) {
+                Cell cell = currentRow.getCell( columnIndex );
+                cell.setValue( value );
+                cell.insert( session );
             }
         }
     }
 
-    public void newRow(int rowNumber,
-                       int columnCount) {
-        if (!tableFinished && rowNumber >= startRow) {
-            if (currentRow != null && currentRow.isEmpty()) {
+    public void newRow( int rowNumber,
+                        int columnCount ) {
+        if ( !tableFinished && rowNumber >= startRow ) {
+            if ( currentRow != null && ( checkEmptyRows && currentRow.isEmpty() ) ) {
                 currentRow = null;
                 tableFinished = true;
             } else {
-                if (currentRow != null) { session.insert(currentRow); }
-                currentRow = new Row(rowNumber,
-                                     columns);
+                if ( currentRow != null ) {
+                    session.insert( currentRow );
+                }
+                currentRow = new Row( rowNumber,
+                                      columns );
             }
         }
     }
 
-    public void startSheet(String name) {
+    public void startSheet( String name ) {
 
     }
 
     public String renderDRL() {
         DRLOutput out = new DRLOutput();
-        out.writeLine(templateContainer.getHeader());
+        out.writeLine( templateContainer.getHeader() );
 
-        out.writeLine(generator.getDrl());
+        out.writeLine( generator.getDrl() );
         // System.err.println(out.getDRL());
         return out.getDRL();
     }

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceImpl.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.models.guided.template.backend;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +30,8 @@ import org.drools.core.util.IoUtils;
 import org.drools.template.DataProvider;
 import org.drools.template.DataProviderCompiler;
 import org.drools.template.objects.ArrayDataProvider;
+import org.drools.template.parser.DefaultTemplateContainer;
+import org.drools.template.parser.TemplateDataListener;
 import org.drools.workbench.models.commons.backend.rule.RuleModelDRLPersistenceImpl;
 import org.drools.workbench.models.commons.backend.rule.RuleModelPersistence;
 import org.drools.workbench.models.commons.backend.rule.context.LHSGeneratorContext;
@@ -543,9 +546,11 @@ public class RuleTemplateModelDRLPersistenceImpl
 
         final DataProvider dataProvider = chooseDataProvider( model );
         final DataProviderCompiler tplCompiler = new DataProviderCompiler();
+        final InputStream templateStream = new ByteArrayInputStream( ruleTemplate.getBytes( IoUtils.UTF8_CHARSET ) );
+        final DefaultTemplateContainer tc = new DefaultTemplateContainer( templateStream, false );
+        final TemplateDataListener listener = new TemplateDataListener( tc, false );
         final String generatedDrl = tplCompiler.compile( dataProvider,
-                                                         new ByteArrayInputStream( ruleTemplate.getBytes( IoUtils.UTF8_CHARSET ) ),
-                                                         false );
+                                                         listener );
 
         log.debug( "generated drl:\n{}", generatedDrl );
 


### PR DESCRIPTION
See [here](https://issues.jboss.org/browse/GUVNOR-2745?focusedCommentId=13333045&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13333045).

TemplateDataListener assumes empty rows represent an end to the data; which is likely when processing XLS files as the exact row count is undetermined. However Guided Rule Templates can generate DRL for empty template data rows. This fix adds support for processing empty rows.