### PR TITLE
DROOLS-1379: Add tests for NPE in OOPath marshalling

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathSmokeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathSmokeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.oopath;
+
+import org.assertj.core.api.Assertions;
+import org.drools.testcoverage.common.model.Address;
+import org.drools.testcoverage.common.model.Person;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+
+/**
+ * Tests basic usage of OOPath expressions.
+ */
+public class OOPathSmokeTest {
+
+    private KieSession kieSession;
+
+    @After
+    public void disposeKieSession() {
+        if (this.kieSession != null) {
+            this.kieSession.dispose();
+            this.kieSession = null;
+        }
+    }
+
+    @Test
+    public void testBuildKieBase() {
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), true, "oopath.drl");
+        Assertions.assertThat(kieBase).isNotNull();
+    }
+
+    @Test
+    public void testFireRule() {
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), true, "oopath.drl");
+        this.kieSession = kieBase.newKieSession();
+
+        final Person person = new Person("Bruno", 21);
+        person.setAddress(new Address("Some Street", 10, "Beautiful City"));
+        this.kieSession.insert(person);
+        Assertions.assertThat(this.kieSession.fireAllRules()).isEqualTo(1);
+    }
+
+}

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
@@ -20,9 +20,8 @@ import org.drools.testcoverage.common.model.Address
 import org.drools.testcoverage.common.model.Person
 
 rule "Basic expression"
-	when
-        person: Person( /address{ street == "Some Street" } )
-	then
-		//consequences
+when
+    person: Person( /address{ street == "Some Street" } )
+then
+    //consequences
 end
-

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.bre.functional.oopath
+
+import org.drools.testcoverage.common.model.Address
+import org.drools.testcoverage.common.model.Person
+
+rule "Basic expression"
+	when
+        person: Person( /address{ street == "Some Street" } )
+	then
+		//consequences
+end
+


### PR DESCRIPTION
Add new tests for OOPath illustrating NPE when building KieBase - probably because XpathConstraint#writeExternal() is not implemented [1].

[1] https://github.com/droolsjbpm/drools/blob/master/drools-core/src/main/java/org/drools/core/rule/constraint/XpathConstraint.java#L138