### PR TITLE
[6.5.x] RHBPMS-4527 - [GSS] (6.4.x) kjar deployment fails if artifactId ends with bpmn

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
@@ -15,24 +15,34 @@
 
 package org.drools.compiler.kie.builder.impl;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.Map;
-
-import org.drools.core.util.IoUtils;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.drools.core.util.IoUtils.readBytesFromInputStream;
+
 public class ZipKieModule extends AbstractKieModule implements InternalKieModule {
-    private final File             file;    
+    private final File file;
     private Map<String, byte[]> zipEntries;
+    private List<String> fileNames;
 
     public ZipKieModule(ReleaseId releaseId,
                         KieModuleModel kieProject,
                         File file) {
         super(releaseId, kieProject );
         this.file = file;
-        this.zipEntries = IoUtils.indexZipFile( file );
+        indexZipFile( file );
     }
 
     @Override
@@ -52,7 +62,7 @@ public class ZipKieModule extends AbstractKieModule implements InternalKieModule
 
     @Override
     public Collection<String> getFileNames() {
-        return this.zipEntries.keySet();
+        return fileNames;
     }
 
     @Override
@@ -66,5 +76,59 @@ public class ZipKieModule extends AbstractKieModule implements InternalKieModule
 
     public String toString() {
         return "ZipKieModule[releaseId=" + getReleaseId() + ",file=" + file + "]";
+    }
+
+    private void indexZipFile(java.io.File jarFile) {
+        Map<String, List<String>> folders = new HashMap<String, List<String>>();
+        zipEntries = new HashMap<String, byte[]>();
+        fileNames = new ArrayList<String>();
+
+        ZipFile zipFile = null;
+        try {
+            zipFile = new ZipFile( jarFile );
+            Enumeration< ? extends ZipEntry> entries = zipFile.entries();
+            while ( entries.hasMoreElements() ) {
+                ZipEntry entry = entries.nextElement();
+                if (entry.getName().endsWith(".dex")) {
+                    continue; //avoid out of memory error, it is useless anyway
+                }
+                String entryName = entry.getName();
+                if (entry.isDirectory()) {
+                    if (entryName.endsWith( "/" )) {
+                        entryName = entryName.substring( 0, entryName.length()-1 );
+                    }
+                } else {
+                    byte[] bytes = readBytesFromInputStream( zipFile.getInputStream( entry ) );
+                    zipEntries.put( entryName, bytes );
+                    fileNames.add( entryName );
+                }
+                int lastSlashPos = entryName.lastIndexOf( '/' );
+                String folderName = lastSlashPos < 0 ? "" : entryName.substring( 0, lastSlashPos );
+                List<String> folder = folders.get(folderName);
+                if (folder == null) {
+                    folder = new ArrayList<String>();
+                    folders.put( folderName, folder );
+                }
+                folder.add(lastSlashPos < 0 ? entryName : entryName.substring( lastSlashPos+1 ));
+            }
+        } catch ( IOException e ) {
+            throw new RuntimeException( "Unable to get all ZipFile entries: " + jarFile, e );
+        } finally {
+            if ( zipFile != null ) {
+                try {
+                    zipFile.close();
+                } catch ( IOException e ) {
+                    throw new RuntimeException( "Unable to get all ZipFile entries: " + jarFile, e );
+                }
+            }
+        }
+
+        for (Map.Entry<String, List<String>> folder : folders.entrySet()) {
+            StringBuilder sb = new StringBuilder();
+            for (String child : folder.getValue()) {
+                sb.append( child ).append( "\n" );
+            }
+            zipEntries.put( folder.getKey(), sb.toString().getBytes( StandardCharsets.UTF_8 ) );
+        }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/util/IoUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/IoUtils.java
@@ -32,10 +32,7 @@ import java.net.ServerSocket;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -150,60 +147,6 @@ public class IoUtils {
         tempFile.deleteOnExit();
         copy(input, new FileOutputStream(tempFile));
         return tempFile;
-    }
-
-    public static Map<String, byte[]> indexZipFile(java.io.File jarFile) {
-        Map<String, List<String>> folders = new HashMap<String, List<String>>();
-        Map<String, byte[]> files = new HashMap<String, byte[]>();
-        ZipFile zipFile = null;
-
-        try {
-            zipFile = new ZipFile( jarFile );
-            Enumeration< ? extends ZipEntry> entries = zipFile.entries();
-            while ( entries.hasMoreElements() ) {
-                ZipEntry entry = entries.nextElement();
-                if (entry.getName().endsWith(".dex")) {
-                    continue; //avoid out of memory error, it is useless anyway
-                }
-                String entryName = entry.getName();
-                if (entry.isDirectory()) {
-                    if (entryName.endsWith( "/" )) {
-                        entryName = entryName.substring( 0, entryName.length()-1 );
-                    }
-                } else {
-                    byte[] bytes = readBytesFromInputStream( zipFile.getInputStream( entry ) );
-                    files.put( entryName, bytes );
-                }
-                int lastSlashPos = entryName.lastIndexOf( '/' );
-                String folderName = lastSlashPos < 0 ? "" : entryName.substring( 0, lastSlashPos );
-                List<String> folder = folders.get(folderName);
-                if (folder == null) {
-                    folder = new ArrayList<String>();
-                    folders.put( folderName, folder );
-                }
-                folder.add(lastSlashPos < 0 ? entryName : entryName.substring( lastSlashPos+1 ));
-            }
-        } catch ( IOException e ) {
-            throw new RuntimeException( "Unable to get all ZipFile entries: " + jarFile, e );
-        } finally {
-            if ( zipFile != null ) {
-                try {
-                    zipFile.close();
-                } catch ( IOException e ) {
-                    throw new RuntimeException( "Unable to get all ZipFile entries: " + jarFile, e );
-                }
-            }
-        }
-
-        for (Map.Entry<String, List<String>> folder : folders.entrySet()) {
-            StringBuilder sb = new StringBuilder();
-            for (String child : folder.getValue()) {
-                sb.append( child ).append( "\n" );
-            }
-            files.put( folder.getKey(), sb.toString().getBytes( UTF8_CHARSET ) );
-        }
-
-        return files;
     }
 
     public static List<String> recursiveListFile(File folder) {

--- a/kie-ci/src/test/java/org/kie/scanner/KieModuleMavenTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieModuleMavenTest.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.drools.core.util.DroolsAssert.assertEnumerationSize;
 import static org.drools.core.util.DroolsAssert.assertUrlEnumerationContainsMatch;
 import static org.junit.Assert.*;
 import static org.kie.scanner.MavenRepository.getMavenRepository;
@@ -316,7 +317,10 @@ public class KieModuleMavenTest extends AbstractKieCiTest {
 
         assertEquals("There must be one package built", 1, kieBase.getKiePackages().size());
 
+        ClassLoader classLoader = kieContainer.getClassLoader();
 
+        assertEnumerationSize(1, classLoader.getResources("KBase1/org/test"));
+        assertEnumerationSize(1, classLoader.getResources("META-INF/maven/org.kie/maven-test.drl"));
     }
 
     public static String generatePomXml(ReleaseId releaseId, ReleaseId... dependencies) {


### PR DESCRIPTION
backport for 6.4.1 inclusion as part of https://issues.jboss.org/browse/RHBPMS-4527

@mariofusco do you mind double check?