### PR TITLE
DROOLS-1379 #1034 fix PatternBuilder NPE if oopath has no binding

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
@@ -180,13 +180,15 @@ public class PatternBuilder
 
                 Declaration declaration = xpathConstraint.getDeclaration();
 
-                Pattern clonedPattern = new Pattern( pattern.getIndex(),
-                                                     context.getCurrentPatternOffset(),
-                                                     new ClassObjectType( xpathConstraint.getResultClass() ),
-                                                     declaration.getIdentifier(),
-                                                     declaration.isInternalFact() );
-
-                declaration.setPattern( clonedPattern );
+                if ( declaration != null ) { // oopath actually have the binding
+                    Pattern clonedPattern = new Pattern( pattern.getIndex(),
+                                                         context.getCurrentPatternOffset(),
+                                                         new ClassObjectType( xpathConstraint.getResultClass() ),
+                                                         declaration.getIdentifier(),
+                                                         declaration.isInternalFact() );
+    
+                    declaration.setPattern( clonedPattern );
+                }
             }
 
             context.popRuleComponent();

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathSmokeTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathSmokeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.oopath;
+
+import org.assertj.core.api.Assertions;
+import org.drools.testcoverage.common.model.Address;
+import org.drools.testcoverage.common.model.Person;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+
+/**
+ * Tests basic usage of OOPath expressions.
+ */
+public class OOPathSmokeTest {
+
+    private KieSession kieSession;
+
+    @After
+    public void disposeKieSession() {
+        if (this.kieSession != null) {
+            this.kieSession.dispose();
+            this.kieSession = null;
+        }
+    }
+
+    @Test
+    public void testBuildKieBase() {
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), true, "oopath.drl");
+        Assertions.assertThat(kieBase).isNotNull();
+    }
+
+    @Test
+    public void testFireRule() {
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), true, "oopath.drl");
+        this.kieSession = kieBase.newKieSession();
+
+        final Person person = new Person("Bruno", 21);
+        person.setAddress(new Address("Some Street", 10, "Beautiful City"));
+        this.kieSession.insert(person);
+        Assertions.assertThat(this.kieSession.fireAllRules()).isEqualTo(1);
+    }
+
+}

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
@@ -20,9 +20,8 @@ import org.drools.testcoverage.common.model.Address
 import org.drools.testcoverage.common.model.Person
 
 rule "Basic expression"
-	when
-        person: Person( /address{ street == "Some Street" } )
-	then
-		//consequences
+when
+    person: Person( /address{ street == "Some Street" } )
+then
+    //consequences
 end
-

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/oopath/oopath.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.bre.functional.oopath
+
+import org.drools.testcoverage.common.model.Address
+import org.drools.testcoverage.common.model.Person
+
+rule "Basic expression"
+	when
+        person: Person( /address{ street == "Some Street" } )
+	then
+		//consequences
+end
+


### PR DESCRIPTION
fix PatternBuilder.buildXpathConstraints() NPE if oopath has no binding

e.g.:
this worked:
when person: Person( $MYBIND: /address{ street == "Some Street" } ) then ..
this NPE'd:
when person: Person( /address{ street == "Some Street" } ) then ..

Demonstrated with droolsjbpm/drools#1034 .