### PR TITLE
GUVNOR-2786 : Guided Decision Tables: Generate source code based on selected hit mode

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
@@ -53,6 +53,7 @@ import org.drools.workbench.models.guided.dtable.backend.util.GuidedDTDRLOtherwi
 import org.drools.workbench.models.guided.dtable.backend.util.GuidedDTDRLUtilities;
 import org.drools.workbench.models.guided.dtable.backend.util.GuidedDTTemplateDataProvider;
 import org.drools.workbench.models.guided.dtable.backend.util.TemplateDataProvider;
+import org.drools.workbench.models.guided.dtable.shared.hitpolicy.DecisionTableHitPolicyEnhancer;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
@@ -86,7 +87,9 @@ public class GuidedDTDRLPersistence {
         return new GuidedDTDRLPersistence();
     }
 
-    public String marshal( GuidedDecisionTable52 dt ) {
+    public String marshal( final GuidedDecisionTable52 originalDTable ) {
+
+        final GuidedDecisionTable52 dt = DecisionTableHitPolicyEnhancer.enhance( originalDTable );
 
         StringBuilder sb = new StringBuilder();
 
@@ -490,7 +493,7 @@ public class GuidedDTDRLPersistence {
         }
     }
 
-    //Labelled Actions are used to group actions on the same bound Fact. Only 
+    //Labelled Actions are used to group actions on the same bound Fact. Only
     //ActionSetField and ActionUpdateField need to be grouped in this manner.
     private LabelledAction findByLabelledAction( List<LabelledAction> actions,
                                                  String boundName ) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/hitpolicy/DTableValidationException.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/hitpolicy/DTableValidationException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.hitpolicy;
+
+public class DTableValidationException
+        extends IllegalArgumentException {
+
+    public DTableValidationException() {
+    }
+
+    public DTableValidationException( final String message ) {
+        super( message );
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/hitpolicy/DecisionTableHitPolicyEnhancer.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/hitpolicy/DecisionTableHitPolicyEnhancer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.hitpolicy;
+
+import java.util.List;
+
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.validation.DecisionTableValidator;
+
+/**
+ * Validates and extends the model based on selected HitPolicy
+ * @see org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.HitPolicy
+ */
+public class DecisionTableHitPolicyEnhancer {
+
+    private final GuidedDecisionTable52 dtable;
+
+    private DecisionTableHitPolicyEnhancer( final GuidedDecisionTable52 originalDTable ) {
+        this.dtable = originalDTable;
+    }
+
+    public static GuidedDecisionTable52 enhance( final GuidedDecisionTable52 originalDTable ) {
+        return new DecisionTableHitPolicyEnhancer( originalDTable ).enhance();
+    }
+
+    private GuidedDecisionTable52 enhance() {
+
+        new DecisionTableValidator( dtable ).validate();
+
+        switch ( dtable.getHitPolicy() ) {
+
+            case UNIQUE_HIT:
+                addActivationGroup( "unique-hit-policy-group" );
+                break;
+            case FIRST_HIT:
+                addSalienceBasedOnRowOrder();
+                addActivationGroup( "first-hit-policy-group" );
+                break;
+            case RULE_ORDER:
+                addSalienceBasedOnRowOrder();
+                break;
+            case NONE:
+            default:
+                // We do nothing.
+                break;
+
+        }
+
+        return dtable;
+    }
+
+    private void addSalienceBasedOnRowOrder() {
+        // Add Column
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( GuidedDecisionTable52.SALIENCE_ATTR );
+        dtable.getAttributeCols()
+                .add( attributeCol52 );
+
+        final int columnIndex = dtable.getExpandedColumns()
+                .indexOf( attributeCol52 );
+
+        int salience = 0;
+
+        final int size = dtable.getData()
+                .size();
+
+        // Add salience values
+        for ( int i = ( size - 1 ); i >= 0; i-- ) {
+            dtable.getData()
+                    .get( i )
+                    .add( columnIndex,
+                          new DTCellValue52( salience++ ) );
+        }
+    }
+
+    private void addActivationGroup( final String activationGroupType ) {
+        // Add Column
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( GuidedDecisionTable52.ACTIVATION_GROUP_ATTR );
+        dtable.getAttributeCols()
+                .add( attributeCol52 );
+
+        final int columnIndex = dtable.getExpandedColumns()
+                .indexOf( attributeCol52 );
+
+        for ( final List<DTCellValue52> row : dtable.getData() ) {
+            row.add( columnIndex,
+                     new DTCellValue52( activationGroupType + " " + dtable.getTableName() ) );
+        }
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/GuidedDecisionTable52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/GuidedDecisionTable52.java
@@ -91,7 +91,28 @@ public class GuidedDecisionTable52 implements HasImports,
         LIMITED_ENTRY
     }
 
+    /**
+     * Lists available dtable hit policies.
+     * <br>
+     * <br>
+     * Source code is genarated based on the selection.
+     * NONE is the default, setting no limitations for the table setup
+     * and generating nothing that the user does not add himself.
+     */
+    public enum HitPolicy {
+        NONE,
+        UNIQUE_HIT,
+        FIRST_HIT,
+        RULE_ORDER;
+
+        public static HitPolicy getDefault() {
+            return NONE;
+        }
+    }
+
     private TableFormat tableFormat = TableFormat.EXTENDED_ENTRY;
+
+    private HitPolicy hitPolicy = HitPolicy.getDefault();
 
     /**
      * First column is always row number. Second column is description.
@@ -331,6 +352,14 @@ public class GuidedDecisionTable52 implements HasImports,
 
     public void setTableFormat( final TableFormat tableFormat ) {
         this.tableFormat = tableFormat;
+    }
+
+    public HitPolicy getHitPolicy() {
+        return hitPolicy == null ? HitPolicy.getDefault(): hitPolicy;
+    }
+
+    public void setHitPolicy( final HitPolicy hitPolicy ) {
+        this.hitPolicy = hitPolicy;
     }
 
     /**

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/DecisionTableValidator.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/DecisionTableValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.validation;
+
+import java.util.Set;
+
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+
+public class DecisionTableValidator {
+
+    private final GuidedDecisionTable52 dtable;
+
+    private final Set<String> illegalAttributes;
+
+    public DecisionTableValidator( final GuidedDecisionTable52 dtable ) {
+        this.dtable = dtable;
+        this.illegalAttributes = HitPolicyValidation.getReservedAttributes( dtable.getHitPolicy() );
+    }
+
+    public void validate() {
+        validateAttributes();
+    }
+
+    public void isValidToAdd( final AttributeCol52 attributeCol52 ) {
+
+        isValid( attributeCol52 );
+
+        for ( final AttributeCol52 existingAttributeCol52 : dtable.getAttributeCols() ) {
+            if ( attributeCol52.getAttribute()
+                    .equals( existingAttributeCol52.getAttribute() ) ) {
+                throw new DuplicateAttributeException( existingAttributeCol52.getAttribute() );
+            }
+        }
+    }
+
+    private void isValid( final AttributeCol52 attributeCol52 ) {
+        if ( illegalAttributes.contains( attributeCol52.getAttribute() ) ) {
+            throw new InvalidAttributeColumnForHitPolicyException( attributeCol52.getAttribute(),
+                                                                   dtable.getHitPolicy() );
+        }
+    }
+
+    private void validateAttributes() {
+        for ( final AttributeCol52 attributeCol52 : dtable.getAttributeCols() ) {
+            isValid( attributeCol52 );
+        }
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/DuplicateAttributeException.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/DuplicateAttributeException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.validation;
+
+import org.drools.workbench.models.guided.dtable.shared.hitpolicy.DTableValidationException;
+
+public class DuplicateAttributeException
+        extends DTableValidationException {
+
+    private final String attribute;
+
+
+    public DuplicateAttributeException( final String attribute ) {
+        super( "A decision table can only have each attribute once, found " + attribute + " twice." );
+
+        this.attribute = attribute;
+    }
+
+    private DuplicateAttributeException() {
+        this.attribute = null;
+    }
+
+    public String getAttribute() {
+        return attribute;
+    }
+
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/HitPolicyValidation.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/HitPolicyValidation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.validation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+
+public class HitPolicyValidation {
+
+    public static Set<String> getReservedAttributes( GuidedDecisionTable52.HitPolicy hitPolicy ) {
+        switch ( hitPolicy ) {
+            case UNIQUE_HIT:
+                return new HashSet<>( Arrays.asList( GuidedDecisionTable52.ACTIVATION_GROUP_ATTR ) );
+            case FIRST_HIT:
+                return new HashSet<>( Arrays.asList( GuidedDecisionTable52.SALIENCE_ATTR,
+                                                     GuidedDecisionTable52.ACTIVATION_GROUP_ATTR ) );
+            case RULE_ORDER:
+                return new HashSet<>( Arrays.asList( GuidedDecisionTable52.SALIENCE_ATTR ) );
+            case NONE:
+            default:
+                return Collections.EMPTY_SET;
+        }
+    }
+
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/InvalidAttributeColumnForHitPolicyException.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/validation/InvalidAttributeColumnForHitPolicyException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.validation;
+
+import org.drools.workbench.models.guided.dtable.shared.hitpolicy.DTableValidationException;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+
+public class InvalidAttributeColumnForHitPolicyException
+        extends DTableValidationException {
+
+    private final String attribute;
+    private final GuidedDecisionTable52.HitPolicy hitPolicy;
+
+
+    public InvalidAttributeColumnForHitPolicyException( final String attribute,
+                                                        final GuidedDecisionTable52.HitPolicy hitPolicy ) {
+        super( "A decision table can not have both. Attribute: " + attribute + " and hit policy: " + hitPolicy.toString() );
+
+        this.attribute = attribute;
+        this.hitPolicy = hitPolicy;
+    }
+
+    private InvalidAttributeColumnForHitPolicyException() {
+        this.attribute = null;
+        this.hitPolicy = null;
+    }
+
+    public String getAttribute() {
+        return attribute;
+    }
+
+    public GuidedDecisionTable52.HitPolicy getHitPolicy() {
+        return hitPolicy;
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceFirstHitPolicyTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceFirstHitPolicyTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.backend;
+
+import org.drools.workbench.models.guided.dtable.backend.util.DataUtilities;
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.drools.workbench.models.guided.dtable.backend.TestUtil.*;
+
+public class GuidedDTDRLPersistenceFirstHitPolicyTest {
+
+
+    private GuidedDecisionTable52 dtable;
+
+    @Before
+    public void setUp() throws
+                        Exception {
+        dtable = new GuidedDecisionTable52();
+        dtable.setTableName( "First hit policy table" );
+
+        dtable.setHitPolicy( GuidedDecisionTable52.HitPolicy.FIRST_HIT );
+
+        dtable.setData( DataUtilities.makeDataLists(
+                new Object[][]{
+                        new Object[]{1, "desc-row1"},
+                        new Object[]{2, "desc-row2"},
+                        new Object[]{3, "desc-row3"}
+                } ) );
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blockUseOfSalience() {
+
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( "salience" );
+        attributeCol52.setDefaultValue( new DTCellValue52( "123" ) );
+
+        dtable.getAttributeCols()
+                .add( attributeCol52 );
+
+        GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blockUseOfActivationGroup() {
+
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( "activation-group" );
+        attributeCol52.setDefaultValue( new DTCellValue52( "test" ) );
+
+        dtable.getAttributeCols()
+                .add( attributeCol52 );
+
+        GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+    }
+
+    @Test
+    public void salienceEqualsOrderOfLinesNumberRunsFromBottomToTop() {
+
+        final String drl = GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+
+        assertContainsLinesInOrder( drl,
+                                    "rule \"Row 1 First hit policy table\"",
+                                    "salience 2",
+                                    "rule \"Row 2 First hit policy table\"",
+                                    "salience 1",
+                                    "rule \"Row 3 First hit policy table\"",
+                                    "salience 0" );
+    }
+
+    @Test
+    public void allRulesHaveTheSameActivationGroup() throws
+                                                     Exception {
+
+        final String drl = GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+
+        assertContainsLinesInOrder( drl,
+                                    "rule \"Row 1 First hit policy table\"",
+                                    "activation-group \"first-hit-policy-group First hit policy table\"",
+                                    "rule \"Row 2 First hit policy table\"",
+                                    "activation-group \"first-hit-policy-group First hit policy table\"",
+                                    "rule \"Row 3 First hit policy table\"",
+                                    "activation-group \"first-hit-policy-group First hit policy table\"" );
+
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceRuleOrderHitPolicyTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceRuleOrderHitPolicyTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.backend;
+
+import org.drools.workbench.models.guided.dtable.backend.util.DataUtilities;
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.drools.workbench.models.guided.dtable.backend.TestUtil.*;
+
+public class GuidedDTDRLPersistenceRuleOrderHitPolicyTest {
+
+
+    private GuidedDecisionTable52 dtable;
+
+    @Before
+    public void setUp() throws
+                        Exception {
+        dtable = new GuidedDecisionTable52();
+        dtable.setTableName( "Rule order table" );
+
+        dtable.setHitPolicy( GuidedDecisionTable52.HitPolicy.RULE_ORDER );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blockUseOfSalience() {
+
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( "salience" );
+        attributeCol52.setDefaultValue( new DTCellValue52( "123" ) );
+
+        dtable.getAttributeCols()
+                .add( attributeCol52 );
+
+        GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+    }
+
+    @Test
+    public void salienceEqualsOrderOfLinesNumberRunsFromBottomToTop() {
+
+        dtable.setData( DataUtilities.makeDataLists(
+                new Object[][]{
+                        new Object[]{1, "desc-row1"},
+                        new Object[]{2, "desc-row2"},
+                        new Object[]{3, "desc-row3"}
+                } ) );
+
+        final String drl = GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+
+        assertContainsLinesInOrder( drl,
+                                    "rule \"Row 1 Rule order table\"",
+                                    "salience 2",
+                                    "rule \"Row 2 Rule order table\"",
+                                    "salience 1",
+                                    "rule \"Row 3 Rule order table\"",
+                                    "salience 0" );
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceUniqueHitPolicyTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceUniqueHitPolicyTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.backend;
+
+import org.drools.workbench.models.guided.dtable.backend.util.DataUtilities;
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.drools.workbench.models.guided.dtable.backend.TestUtil.*;
+
+public class GuidedDTDRLPersistenceUniqueHitPolicyTest {
+
+    private GuidedDecisionTable52 dtable;
+
+    @Before
+    public void setUp() throws
+                        Exception {
+        dtable = new GuidedDecisionTable52();
+        dtable.setTableName( "Unique hit policy table" );
+
+        dtable.setHitPolicy( GuidedDecisionTable52.HitPolicy.UNIQUE_HIT );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blockUseOfActivationGroup() {
+
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( "activation-group" );
+        attributeCol52.setDefaultValue( new DTCellValue52( "test" ) );
+
+        dtable.getAttributeCols()
+                .add( attributeCol52 );
+
+        GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+    }
+
+    @Test
+    public void allRulesHaveTheSameActivationGroup() throws
+                                                     Exception {
+
+        dtable.setData( DataUtilities.makeDataLists(
+                new Object[][]{
+                        new Object[]{1, "desc-row1"},
+                        new Object[]{2, "desc-row2"},
+                        new Object[]{3, "desc-row3"}
+                } ) );
+
+        final String drl = GuidedDTDRLPersistence.getInstance()
+                .marshal( dtable );
+
+        assertContainsLinesInOrder( drl,
+                                    "rule \"Row 1 Unique hit policy table\"",
+                                    "activation-group \"unique-hit-policy-group Unique hit policy table\"",
+                                    "rule \"Row 2 Unique hit policy table\"",
+                                    "activation-group \"unique-hit-policy-group Unique hit policy table\"",
+                                    "rule \"Row 3 Unique hit policy table\"",
+                                    "activation-group \"unique-hit-policy-group Unique hit policy table\"" );
+
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTXMLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTXMLPersistenceTest.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.List;
 
+import static org.drools.workbench.models.guided.dtable.backend.TestUtil.loadResource;
 import static org.junit.Assert.*;
 
 public class GuidedDTXMLPersistenceTest {
@@ -153,19 +154,4 @@ public class GuidedDTXMLPersistenceTest {
         Assertions.assertThat(cellValueList.get(0).getDataType()).isEqualTo(DataType.DataTypes.NUMERIC_INTEGER);
         Assertions.assertThat(cellValueList.get(0).getNumericValue().intValue()).isEqualTo(1);
     }
-
-    public static String loadResource( final String name ) throws Exception {
-        final InputStream in = GuidedDTXMLPersistenceTest.class.getResourceAsStream( name );
-        final Reader reader = new InputStreamReader( in );
-        final StringBuilder text = new StringBuilder();
-        final char[] buf = new char[ 1024 ];
-        int len = 0;
-        while ( ( len = reader.read( buf ) ) >= 0 ) {
-            text.append( buf,
-                         0,
-                         len );
-        }
-        return text.toString();
-    }
-
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/HitPolicyPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/HitPolicyPersistenceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.backend;
+
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Test;
+
+import static org.drools.workbench.models.guided.dtable.backend.TestUtil.*;
+import static org.junit.Assert.*;
+
+public class HitPolicyPersistenceTest {
+
+    @Test
+    public void testDefault() throws
+                              Exception {
+        assertEquals( GuidedDecisionTable52.HitPolicy.NONE,
+                      new GuidedDecisionTable52().getHitPolicy() );
+    }
+
+    @Test
+    public void testRoundTrip() {
+
+        final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+
+        dt.setHitPolicy( GuidedDecisionTable52.HitPolicy.FIRST_HIT );
+
+        final String xml = GuidedDTXMLPersistence.getInstance()
+                .marshal( dt );
+
+        assertNotNull( xml );
+        assertTrue( xml.contains( "<hitPolicy>FIRST_HIT</hitPolicy>" ) );
+
+        final GuidedDecisionTable52 dt_ = GuidedDTXMLPersistence.getInstance()
+                .unmarshal( xml );
+
+        assertEquals( GuidedDecisionTable52.HitPolicy.FIRST_HIT,
+                      dt_.getHitPolicy() );
+    }
+
+    @Test
+    public void testBackwardsCompatibility() throws
+                                             Exception {
+        final String xml = loadResource( "ExistingDecisionTable.xml" );
+        final GuidedDecisionTable52 dt_ = GuidedDTXMLPersistence.getInstance()
+                .unmarshal( xml );
+        assertNotNull( dt_ );
+
+        assertEquals( GuidedDecisionTable52.HitPolicy.NONE,
+                      dt_.getHitPolicy() );
+    }
+
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/TestUtil.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/TestUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.models.guided.dtable.backend;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class TestUtil {
+
+    public static void assertContainsLinesInOrder( final String text,
+                                                   final String... strings ) {
+
+        final Iterator<String> theseAreTheLinesYouAreLookingFor = Arrays.asList( strings )
+                .iterator();
+
+        String thisIsTheLineYouAreLookingFor = theseAreTheLinesYouAreLookingFor.next();
+
+        for ( final String line : text.split( "\n" ) ) {
+
+            if ( line.trim()
+                    .equals( thisIsTheLineYouAreLookingFor ) ) {
+                if ( theseAreTheLinesYouAreLookingFor.hasNext() ) {
+                    thisIsTheLineYouAreLookingFor = theseAreTheLinesYouAreLookingFor.next();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        assertFalse( "Could not find " + thisIsTheLineYouAreLookingFor,
+                     theseAreTheLinesYouAreLookingFor.hasNext() );
+    }
+
+    public static String loadResource( final String name ) throws
+                                                           Exception {
+        final InputStream in = TestUtil.class.getResourceAsStream( name );
+        final Reader reader = new InputStreamReader( in );
+        final StringBuilder text = new StringBuilder();
+        final char[] buf = new char[1024];
+        int len = 0;
+        while ( ( len = reader.read( buf ) ) >= 0 ) {
+            text.append( buf,
+                         0,
+                         len );
+        }
+        return text.toString();
+    }
+
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/validation/DecisionTableValidatorAttributesTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/validation/DecisionTableValidatorAttributesTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.validation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class DecisionTableValidatorAttributesTest {
+
+    private final String attributeName;
+    private GuidedDecisionTable52 table;
+
+    public DecisionTableValidatorAttributesTest( final String attributeName ) {
+        this.attributeName = attributeName;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<String> attributes() {
+        return Arrays.asList( GuidedDecisionTable52.SALIENCE_ATTR,
+                              GuidedDecisionTable52.ENABLED_ATTR,
+                              GuidedDecisionTable52.DATE_EFFECTIVE_ATTR,
+                              GuidedDecisionTable52.DATE_EXPIRES_ATTR,
+                              GuidedDecisionTable52.NO_LOOP_ATTR,
+                              GuidedDecisionTable52.AGENDA_GROUP_ATTR,
+                              GuidedDecisionTable52.ACTIVATION_GROUP_ATTR,
+                              GuidedDecisionTable52.DURATION_ATTR,
+                              GuidedDecisionTable52.TIMER_ATTR,
+                              GuidedDecisionTable52.CALENDARS_ATTR,
+                              GuidedDecisionTable52.AUTO_FOCUS_ATTR,
+                              GuidedDecisionTable52.LOCK_ON_ACTIVE_ATTR,
+                              GuidedDecisionTable52.RULEFLOW_GROUP_ATTR,
+                              GuidedDecisionTable52.DIALECT_ATTR,
+                              GuidedDecisionTable52.NEGATE_RULE_ATTR );
+    }
+
+    @Test(expected = DuplicateAttributeException.class)
+    public void addAttributeColumn() throws
+                                     Exception {
+        final DecisionTableValidator validator = getDecisionTableValidator();
+
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( attributeName );
+
+        try {
+            validator.isValidToAdd( attributeCol52 );
+        } catch ( final Exception e ) {
+            fail( "First addition should be valid." );
+        }
+
+        addAttributeCol( attributeCol52 );
+
+        validator.isValidToAdd( attributeCol52 );
+    }
+
+    private DecisionTableValidator getDecisionTableValidator() {
+        table = mock( GuidedDecisionTable52.class );
+        when( table.getHitPolicy() ).thenReturn( GuidedDecisionTable52.HitPolicy.NONE );
+        return new DecisionTableValidator( table );
+    }
+
+    private void addAttributeCol( final AttributeCol52 attributeCol52 ) {
+        final ArrayList<AttributeCol52> attributeCol52s = new ArrayList<>();
+        when( table.getAttributeCols() ).thenReturn( attributeCol52s );
+        attributeCol52s.add( attributeCol52 );
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/validation/DecisionTableValidatorHitPolicyAttributeLimitationsTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/validation/DecisionTableValidatorHitPolicyAttributeLimitationsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.validation;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class DecisionTableValidatorHitPolicyAttributeLimitationsTest {
+
+    private final GuidedDecisionTable52.HitPolicy hitPolicy;
+    private final String attributeName;
+    private final boolean isAllowed;
+
+    public DecisionTableValidatorHitPolicyAttributeLimitationsTest( final GuidedDecisionTable52.HitPolicy hitPolicy,
+                                                                    final String attributeName,
+                                                                    final boolean isAllowed ) {
+        this.hitPolicy = hitPolicy;
+        this.attributeName = attributeName;
+        this.isAllowed = isAllowed;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> attributes() {
+        return Arrays.asList( new Object[][]{
+                {GuidedDecisionTable52.HitPolicy.NONE, GuidedDecisionTable52.SALIENCE_ATTR, true},
+                {GuidedDecisionTable52.HitPolicy.FIRST_HIT, GuidedDecisionTable52.SALIENCE_ATTR, false},
+                {GuidedDecisionTable52.HitPolicy.RULE_ORDER, GuidedDecisionTable52.SALIENCE_ATTR, false},
+                {GuidedDecisionTable52.HitPolicy.UNIQUE_HIT, GuidedDecisionTable52.SALIENCE_ATTR, true},
+                {GuidedDecisionTable52.HitPolicy.NONE, GuidedDecisionTable52.ACTIVATION_GROUP_ATTR, true},
+                {GuidedDecisionTable52.HitPolicy.FIRST_HIT, GuidedDecisionTable52.ACTIVATION_GROUP_ATTR, false},
+                {GuidedDecisionTable52.HitPolicy.RULE_ORDER, GuidedDecisionTable52.ACTIVATION_GROUP_ATTR, true},
+                {GuidedDecisionTable52.HitPolicy.UNIQUE_HIT, GuidedDecisionTable52.ACTIVATION_GROUP_ATTR, false}
+        } );
+    }
+
+    @Test
+    public void addAttributeColumn() throws
+                                     Exception {
+        final GuidedDecisionTable52 table = mock( GuidedDecisionTable52.class );
+        when( table.getHitPolicy() ).thenReturn( hitPolicy );
+        final DecisionTableValidator validator = new DecisionTableValidator( table );
+
+        final AttributeCol52 attributeCol52 = new AttributeCol52();
+        attributeCol52.setAttribute( attributeName );
+
+        boolean wasAllowed = true;
+        try {
+            validator.isValidToAdd( attributeCol52 );
+        } catch ( final Exception e ) {
+            wasAllowed = false;
+        }
+
+        assertEquals( wasAllowed,
+                      isAllowed );
+
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/GUVNOR-2619

This closes tickets:
GUVNOR-2786 : Guided Decision Tables: Generate source code based on selected hit mode
GUVNOR-2766 : Guided Decision Tables: Add hit policy into dtable model

And completes the code generation for:
GUVNOR-2792 : Guided Decision Table V&V - Hit policy: Rule Order
GUVNOR-2746 : Guided Decision Table V&V - Hit policy: First hit
GUVNOR-2794 : Guided Decision Table V&V - Hit policy: Unique

@manstis and @jomarko 
Throwing this out for review. This could even be merged in. It defaults the hit policies to NONE and there is currently no way in the workbench to create anything else than NONE. I chose not to use the name "Any", at least in the code since there is also the Any hit mode that we are not implementing and is a bit different than our default free editing mode.