### PR TITLE
JBPM-5492 - Timer does not retry after failure in another node

### DIFF
--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JDKCallableJobCommand.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/JDKCallableJobCommand.java
@@ -34,9 +34,8 @@ public class JDKCallableJobCommand
         try {
             return job.internalCall();
         } catch ( Exception e ) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
 }


### PR DESCRIPTION
tests are in jbpm, the change here is to propagate the exception thrown after timer expiration back to caller