### PR TITLE
DROOLS-1404 Alpha node not shared with static function evaluation

### DIFF
--- a/drools-core/src/main/java/org/drools/core/rule/constraint/MvelConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/rule/constraint/MvelConstraint.java
@@ -561,13 +561,13 @@ public class MvelConstraint extends MutableTypeConstraint implements IndexableCo
 
     public int hashCode() {
         if (isAlphaHashable()) {
-            return 29 * getLeftForEqualExpression().hashCode() + 31 * fieldValue.hashCode();
+            return 29 * getLeftInExpression(IndexUtil.ConstraintType.EQUAL).hashCode() + 31 * fieldValue.hashCode();
         }
         return expression.hashCode();
     }
 
-    private String getLeftForEqualExpression() {
-        return expression.substring(0, expression.indexOf("==")).trim();
+    private String getLeftInExpression(IndexUtil.ConstraintType constraint) {
+        return expression.substring(0, expression.indexOf(constraint.getOperator())).trim();
     }
 
     private boolean isAlphaHashable() {
@@ -584,7 +584,7 @@ public class MvelConstraint extends MutableTypeConstraint implements IndexableCo
         MvelConstraint other = (MvelConstraint) object;
         if (isAlphaHashable()) {
             if ( !other.isAlphaHashable() ||
-                    !getLeftForEqualExpression().equals(other.getLeftForEqualExpression()) ||
+                    !getLeftInExpression(IndexUtil.ConstraintType.EQUAL).equals(other.getLeftInExpression(IndexUtil.ConstraintType.EQUAL)) ||
                     !fieldValue.equals(other.fieldValue) ) {
                 return false;
             }
@@ -617,12 +617,19 @@ public class MvelConstraint extends MutableTypeConstraint implements IndexableCo
         Map<String, Object> thisImports = ((MVELDialectRuntimeData) kbase.getPackage( thisPkg ).getDialectRuntimeRegistry().getDialectData("mvel")).getImports();
         Map<String, Object> otherImports = ((MVELDialectRuntimeData) kbase.getPackage( otherPkg ).getDialectRuntimeRegistry().getDialectData("mvel")).getImports();
 
+        if (fieldValue != null) {
+            return equalsExpressionTokensInBothImports(getLeftInExpression(IndexUtil.ConstraintType.EQUAL), thisImports, otherImports);
+        } else {
+            return equalsExpressionTokensInBothImports(expression, thisImports, otherImports);
+        }
+    }
+    
+    private boolean equalsExpressionTokensInBothImports(String expression, Map<String, Object> thisImports, Map<String, Object> otherImports) {
         for (String token : splitExpression(expression)) {
             if ( !areNullSafeEquals(thisImports.get(token), otherImports.get(token)) ) {
                 return false;
             }
         }
-
         return true;
     }
 

--- a/drools-core/src/main/java/org/drools/core/util/index/IndexUtil.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/IndexUtil.java
@@ -188,19 +188,21 @@ public class IndexUtil {
     }
 
     public enum ConstraintType {
-        EQUAL(true),
-        NOT_EQUAL(false),
-        GREATER_THAN(true),
-        GREATER_OR_EQUAL(true),
-        LESS_THAN(true),
-        LESS_OR_EQUAL(true),
-        RANGE(true),
-        UNKNOWN(false);
+        EQUAL(true, "=="),
+        NOT_EQUAL(false, "!="),
+        GREATER_THAN(true, ">"),
+        GREATER_OR_EQUAL(true, ">="),
+        LESS_THAN(true, "<"),
+        LESS_OR_EQUAL(true, "<="),
+        RANGE(true, null),
+        UNKNOWN(false, null);
 
         private final boolean indexable;
+        private final String operator;
 
-        private ConstraintType(boolean indexable) {
+        private ConstraintType(boolean indexable, String operator) {
             this.indexable = indexable;
+            this.operator = operator;
         }
 
         public boolean isComparison() {
@@ -222,6 +224,14 @@ public class IndexUtil {
         public boolean isIndexable() {
             return indexable;
         }
+        
+        /**
+         * May be null.
+         * @return the operator string representation if does exists, null otherwise.
+         */
+        public String getOperator() {
+            return this.operator;
+        }
 
         public boolean isIndexableForNode(short nodeType) {
             switch (this) {
@@ -236,23 +246,10 @@ public class IndexUtil {
         }
 
         public static ConstraintType decode(String operator) {
-            if (operator.equals("==")) {
-                return EQUAL;
-            }
-            if (operator.equals("!=")) {
-                return NOT_EQUAL;
-            }
-            if (operator.equals(">")) {
-                return GREATER_THAN;
-            }
-            if (operator.equals(">=")) {
-                return GREATER_OR_EQUAL;
-            }
-            if (operator.equals("<")) {
-                return LESS_THAN;
-            }
-            if (operator.equals("<=")) {
-                return LESS_OR_EQUAL;
+            for ( ConstraintType c : ConstraintType.values() ) {
+                if ( c.getOperator() != null && c.getOperator().equals(operator) ) {
+                    return c;
+                }
             }
             return UNKNOWN;
         }


### PR DESCRIPTION
If MVELConstraint hashable (==) 
and MVELConstraint.FieldValue != null
then 
the right part of the expression is constant/memoized,
hence
only the left part of the expression shall be compared.