### PR TITLE
RHBPMS-4435 Fixes behaviour when interval scanning is stopped when kieScanner.scanNow() is called

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -282,11 +282,13 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
         if (getStatus() == Status.SHUTDOWN ) {
             throw new IllegalStateException("The scanner was already shut down and can no longer be used.");
         }
+        // Polling can be started so remember the original state.
+        final Status originalStatus = status;
         try {
             status = Status.SCANNING;
             Map<DependencyDescriptor, Artifact> updatedArtifacts = scanForUpdates();
             if (updatedArtifacts.isEmpty()) {
-                status = Status.STOPPED;
+                status = originalStatus;
                 return;
             }
             status = Status.UPDATING;
@@ -309,7 +311,7 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
             // show we catch exceptions here and shutdown the scanner if one happens?
             
         } finally {
-            status = Status.STOPPED;
+            status = originalStatus;
         }
     }
 

--- a/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
@@ -334,4 +334,22 @@ public class AbstractKieCiTest {
                         list.contains( result ) );
         }
     }
+
+    protected boolean producesResults(KieSession ksession, Object... results) {
+        List<String> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+        ksession.fireAllRules();
+        ksession.dispose();
+
+        if (results.length != list.size()) {
+            return false;
+        }
+
+        for (Object result : results) {
+            if (!list.contains(result)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -804,7 +804,7 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         testKScannerWithKJarContainingClassLoadedFromClassLoader(true);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testKScannerStartScanNow() throws Exception {
         KieServices ks = KieServices.Factory.get();
         ReleaseId releaseId = ks.newReleaseId("org.kie", "scanner-test", "1.0-SNAPSHOT");
@@ -823,21 +823,32 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
 
         // Starting scanner with 200ms interval.
         scanner.start(100);
-        // Manual scan, should continue interval scanning afterwards.
-        scanner.scanNow();
+        try {
+            // Manual scan, should continue interval scanning afterwards.
+            scanner.scanNow();
 
-        // create a new kjar
-        InternalKieModule kJar2 = createKieJar(ks, releaseId, "rule2", "rule3");
-        // deploy it on maven
-        repository.installArtifact(releaseId, kJar2, createKPom(fileManager, releaseId));
+            // create a new kjar
+            InternalKieModule kJar2 = createKieJar(ks, releaseId, "rule2", "rule3");
+            // deploy it on maven
+            repository.installArtifact(releaseId, kJar2, createKPom(fileManager, releaseId));
 
-        Thread.sleep(300);
-
-        // create a ksesion and check it works as expected
-        KieSession ksession2 = kieContainer.newKieSession("KSession1");
-        checkKSession(ksession2, "rule2", "rule3");
-
-        ks.getRepository().removeKieModule(releaseId);
+            // Check each 100ms until scanner finds the new kjar.
+            AssertionError assertionError = new AssertionError();
+            while (assertionError != null) {
+                try {
+                    assertionError = null;
+                    Thread.sleep(100);
+                    // create a ksesion and check it works as expected
+                    KieSession ksession2 = kieContainer.newKieSession("KSession1");
+                    checkKSession(ksession2, "rule2", "rule3");
+                } catch (AssertionError ex) {
+                    assertionError = ex;
+                }
+            }
+        } finally {
+            scanner.stop();
+            ks.getRepository().removeKieModule(releaseId);
+        }
     }
 
     private void testKScannerWithKJarContainingClassLoadedFromClassLoader(boolean differentKbases) throws Exception {


### PR DESCRIPTION
When scanNow() was called after interval scanning was started with kieScanner.start(),
the interval scanning was stopped, because "status" of kieScanner was set to STOPPED.
Adds reproducer for mentioned issue and proposed fix.