### PR TITLE
RHBPMS-4435 Fixes behaviour when interval scanning is stopped when kieScanner.scanNow() is called

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -282,11 +282,13 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
         if (getStatus() == Status.SHUTDOWN ) {
             throw new IllegalStateException("The scanner was already shut down and can no longer be used.");
         }
+        // Polling can be started so remember the original state.
+        final Status originalStatus = status;
         try {
             status = Status.SCANNING;
             Map<DependencyDescriptor, Artifact> updatedArtifacts = scanForUpdates();
             if (updatedArtifacts.isEmpty()) {
-                status = Status.STOPPED;
+                status = originalStatus;
                 return;
             }
             status = Status.UPDATING;
@@ -309,7 +311,7 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
             // show we catch exceptions here and shutdown the scanner if one happens?
             
         } finally {
-            status = Status.STOPPED;
+            status = originalStatus;
         }
     }
 

--- a/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
@@ -280,4 +280,22 @@ public class AbstractKieCiTest {
                         list.contains( result ) );
         }
     }
+
+    protected boolean producesResults(KieSession ksession, Object... results) {
+        List<String> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+        ksession.fireAllRules();
+        ksession.dispose();
+
+        if (results.length != list.size()) {
+            return false;
+        }
+
+        for (Object result : results) {
+            if (!list.contains(result)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -783,7 +783,7 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         testKScannerWithKJarContainingClassLoadedFromClassLoader(true);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void testKScannerStartScanNow() throws Exception {
         KieServices ks = KieServices.Factory.get();
         ReleaseId releaseId = ks.newReleaseId("org.kie", "scanner-test", "1.0-SNAPSHOT");
@@ -806,29 +806,28 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
             // Manual scan, should continue interval scanning afterwards.
             scanner.scanNow();
 
-            // create a new kjar
             InternalKieModule kJar2 = createKieJar(ks, releaseId, "rule2", "rule3");
-            // deploy it on maven
+
             repository.installArtifact(releaseId, kJar2, createKPom(fileManager, releaseId));
 
-            // Check each 100ms until scanner finds the new kjar.
-            AssertionError assertionError = new AssertionError();
-            while (assertionError != null) {
-                try {
-                    assertionError = null;
-                    Thread.sleep(100);
-                    // create a ksesion and check it works as expected
-                    KieSession ksession2 = kieContainer.newKieSession("KSession1");
-                    checkKSession(ksession2, "rule2", "rule3");
-                } catch (AssertionError ex) {
-                    assertionError = ex;
+            // Check each 100ms until scanner finds the new kjar (or timeout is reached)
+            long timeSpent = 0;
+            while (timeSpent <= 5000) {
+                // create a ksession and check the ksession produces the expected results
+                KieSession ksession2 = kieContainer.newKieSession("KSession1");
+                if (producesResults(ksession2, "rule2", "rule3")) {
+                    break;
                 }
+                Thread.sleep(100);
+                timeSpent += 100;
             }
         } finally {
             scanner.stop();
             ks.getRepository().removeKieModule(releaseId);
         }
     }
+
+
 
     private void testKScannerWithKJarContainingClassLoadedFromClassLoader(boolean differentKbases) throws Exception {
         // DROOLS-1231


### PR DESCRIPTION
When scanNow() was called after interval scanning was started with kieScanner.start(),
the interval scanning was stopped, because "status" of kieScanner was set to STOPPED.
Adds reproducer for mentioned issue and proposed fix.

(cherry picked from commit cda7563)

Master PR: https://github.com/droolsjbpm/drools/pull/1065