### PR TITLE
GUVNOR-2786 : Guided Decision Tables: Generate source code based on selected hit mode

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/hitpolicy/DecisionTableHitPolicyEnhancer.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/hitpolicy/DecisionTableHitPolicyEnhancer.java
@@ -48,12 +48,9 @@ public class DecisionTableHitPolicyEnhancer {
                 addActivationGroup( "unique-hit-policy-group" );
                 break;
             case FIRST_HIT:
-                addSalienceBasedOnRowOrder();
                 addActivationGroup( "first-hit-policy-group" );
                 break;
             case RULE_ORDER:
-                addSalienceBasedOnRowOrder();
-                break;
             case NONE:
             default:
                 // We do nothing.
@@ -62,30 +59,6 @@ public class DecisionTableHitPolicyEnhancer {
         }
 
         return dtable;
-    }
-
-    private void addSalienceBasedOnRowOrder() {
-        // Add Column
-        final AttributeCol52 attributeCol52 = new AttributeCol52();
-        attributeCol52.setAttribute( GuidedDecisionTable52.SALIENCE_ATTR );
-        dtable.getAttributeCols()
-                .add( attributeCol52 );
-
-        final int columnIndex = dtable.getExpandedColumns()
-                .indexOf( attributeCol52 );
-
-        int salience = 0;
-
-        final int size = dtable.getData()
-                .size();
-
-        // Add salience values
-        for ( int i = ( size - 1 ); i >= 0; i-- ) {
-            dtable.getData()
-                    .get( i )
-                    .add( columnIndex,
-                          new DTCellValue52( salience++ ) );
-        }
     }
 
     private void addActivationGroup( final String activationGroupType ) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceFirstHitPolicyTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceFirstHitPolicyTest.java
@@ -76,21 +76,6 @@ public class GuidedDTDRLPersistenceFirstHitPolicyTest {
     }
 
     @Test
-    public void salienceEqualsOrderOfLinesNumberRunsFromBottomToTop() {
-
-        final String drl = GuidedDTDRLPersistence.getInstance()
-                .marshal( dtable );
-
-        assertContainsLinesInOrder( drl,
-                                    "rule \"Row 1 First hit policy table\"",
-                                    "salience 2",
-                                    "rule \"Row 2 First hit policy table\"",
-                                    "salience 1",
-                                    "rule \"Row 3 First hit policy table\"",
-                                    "salience 0" );
-    }
-
-    @Test
     public void allRulesHaveTheSameActivationGroup() throws
                                                      Exception {
 

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceRuleOrderHitPolicyTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceRuleOrderHitPolicyTest.java
@@ -53,25 +53,4 @@ public class GuidedDTDRLPersistenceRuleOrderHitPolicyTest {
                 .marshal( dtable );
     }
 
-    @Test
-    public void salienceEqualsOrderOfLinesNumberRunsFromBottomToTop() {
-
-        dtable.setData( DataUtilities.makeDataLists(
-                new Object[][]{
-                        new Object[]{1, "desc-row1"},
-                        new Object[]{2, "desc-row2"},
-                        new Object[]{3, "desc-row3"}
-                } ) );
-
-        final String drl = GuidedDTDRLPersistence.getInstance()
-                .marshal( dtable );
-
-        assertContainsLinesInOrder( drl,
-                                    "rule \"Row 1 Rule order table\"",
-                                    "salience 2",
-                                    "rule \"Row 2 Rule order table\"",
-                                    "salience 1",
-                                    "rule \"Row 3 Rule order table\"",
-                                    "salience 0" );
-    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/GUVNOR-2786

Setting the salience is redundant since PHREAK forces the top down order anyway. So removed that from code generation. The code still blocks using salience in First Hit and Rule Order.