### PR TITLE
[DROOLS-936] fix dependency issues introducing duplicated classes

### DIFF
--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -63,9 +63,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>provided</scope><!-- HACK for OSGi: should be <optional>true</optional> instead -->
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope> <!-- HACK for OSGi: should be <optional>true</optional> instead-->
     </dependency>
 
     <!-- Logging -->

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -90,12 +90,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.codemodel</groupId>
-      <artifactId>codemodel</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-xjc</artifactId>
       <scope>provided</scope>
@@ -157,6 +151,16 @@
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope><!-- HACK for OSGi: should be <optional>true</optional> instead -->
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency><!-- It works in any CDI container, but the weld CDI container is used for testing -->

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -97,12 +97,12 @@
       <artifactId>activation</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
       <scope>provided</scope><!-- HACK for OSGi: should be <optional>true</optional> instead -->
-    </dependency>    
+    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -54,6 +54,17 @@
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for stax:stax-api excluded from org.apache.poi:poi-ooxml -->
+    <dependency>
+      <groupId>javax.xml.stream</groupId>
+      <artifactId>stax-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -18,6 +18,40 @@
   </description>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>ban-duplicated-classes</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <banDuplicateClasses>
+                    <dependencies>
+                      <!-- kie-ci-osgi is an uberjar intended for OSGi environment. It is being excluded from the check
+                           as it contains hundreds of other classes, but that is expected. -->
+                      <dependency>
+                        <groupId>org.kie</groupId>
+                        <artifactId>kie-ci-osgi</artifactId>
+                        <ignoreClasses>
+                          <ignoreClass>*</ignoreClass>
+                        </ignoreClasses>
+                      </dependency>
+                    </dependencies>
+                  </banDuplicateClasses>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/drools-examples-cdi/cdi-example-scopes/pom.xml
+++ b/drools-examples-cdi/cdi-example-scopes/pom.xml
@@ -13,18 +13,6 @@
 
   <name>cdi-example-scopes</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>1.1.11.Final</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>
@@ -42,6 +30,16 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
@@ -20,6 +20,16 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/drools-examples-cdi/cdi-example/pom.xml
+++ b/drools-examples-cdi/cdi-example/pom.xml
@@ -20,6 +20,16 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/drools-persistence-jpa/pom.xml
+++ b/drools-persistence-jpa/pom.xml
@@ -133,10 +133,6 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
-      <artifactId>dom4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>
@@ -157,10 +153,22 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-jta_1.1_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-jta_1.1_spec</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 
@@ -206,6 +214,16 @@
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -128,6 +128,12 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   </description>
 
   <properties>
+    <enforcer.failOnDuplicatedClasses>true</enforcer.failOnDuplicatedClasses>
     <surefire.forkCount>1</surefire.forkCount>
   </properties>
 


### PR DESCRIPTION
 * remove com.sun.codemodel as it contains same classes as jaxb-xjc.
   jaxb-xjc is basically uberjar as it bundles other classes as well. However,
   there does not seem to be a way to get rid of it, as there is no proper
   replacement. Drools code itself should get rid of that dependency
   alltogether and use just public jaxb APIs

 * exclude commons-logging as the jars should not depend on any
   logging impl

 * remove javax.stream:stax-api as the same classes are provided by
   stax-api:stax-api (and other as well)

 * ignoring check for kie-ci-osg in drools-distribution as it is
   uberjar and the duplicated classes are expected there

Should be merged together with https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/363