### PR TITLE
GUVNOR-2829: [Guided Decision Table] No access to bound facts from BRL Condition fragment

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModel.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModel.java
@@ -21,16 +21,12 @@ import java.util.List;
 import java.util.Set;
 
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
-import org.drools.workbench.models.datamodel.rule.ActionRetractFact;
-import org.drools.workbench.models.datamodel.rule.ActionSetField;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.FactPattern;
-import org.drools.workbench.models.datamodel.rule.FieldConstraint;
 import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.models.datamodel.rule.IPattern;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
-import org.drools.workbench.models.datamodel.rule.SingleFieldConstraintEBLeftSide;
 import org.drools.workbench.models.datamodel.util.PortablePreconditions;
 import org.drools.workbench.models.guided.dtable.shared.model.adaptors.ActionInsertFactCol52ActionInsertFactAdaptor;
 import org.drools.workbench.models.guided.dtable.shared.model.adaptors.ActionInsertFactCol52ActionInsertLogicalFactAdaptor;
@@ -51,377 +47,301 @@ public class BRLRuleModel extends RuleModel {
     public BRLRuleModel() {
     }
 
-    public BRLRuleModel( final GuidedDecisionTable52 dtable ) {
-        PortablePreconditions.checkNotNull( "dtable",
-                                            dtable );
+    public BRLRuleModel(final GuidedDecisionTable52 dtable) {
+        PortablePreconditions.checkNotNull("dtable",
+                                           dtable);
         this.dtable = dtable;
     }
 
     @Override
     public List<String> getLHSBoundFacts() {
         final Set<String> facts = new HashSet<String>();
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                if ( p.isBound() ) {
-                    facts.add( p.getBoundName() );
+                if (p.isBound()) {
+                    facts.add(p.getBoundName());
                 }
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                for ( IPattern p : brl.getDefinition() ) {
-                    if ( p instanceof FactPattern ) {
-                        final FactPattern fp = (FactPattern) p;
-                        if ( fp.isBound() ) {
-                            facts.add( fp.getBoundName() );
-                        }
-                    }
-                }
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                facts.addAll(rm.getLHSBoundFacts());
             }
         }
-        facts.addAll( super.getLHSBoundFacts() );
-        return new ArrayList<String>( facts );
+        facts.addAll(super.getLHSBoundFacts());
+        return new ArrayList<>(facts);
     }
 
     @Override
-    public FactPattern getLHSBoundFact( final String var ) {
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+    public FactPattern getLHSBoundFact(final String var) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                if ( p.isBound() && p.getBoundName().equals( var ) ) {
-                    return new Pattern52FactPatternAdaptor( p );
+                if (p.isBound() && p.getBoundName().equals(var)) {
+                    return new Pattern52FactPatternAdaptor(p);
                 }
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                for ( IPattern p : brl.getDefinition() ) {
-                    if ( p instanceof FactPattern ) {
-                        final FactPattern fp = (FactPattern) p;
-                        if ( fp.isBound() && fp.getBoundName().equals( var ) ) {
-                            return fp;
-                        }
-                    }
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                final FactPattern fp = rm.getLHSBoundFact(var);
+                if (fp != null) {
+                    return fp;
                 }
             }
         }
-        return super.getLHSBoundFact( var );
+        return super.getLHSBoundFact(var);
     }
 
     @Override
-    public SingleFieldConstraint getLHSBoundField( final String var ) {
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+    public SingleFieldConstraint getLHSBoundField(final String var) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                for ( ConditionCol52 cc : p.getChildColumns() ) {
-                    if ( cc.isBound() && cc.getBinding().equals( var ) ) {
-                        final ConditionCol52FieldConstraintAdaptor sfcAdaptor = new ConditionCol52FieldConstraintAdaptor( cc );
-                        sfcAdaptor.setFactType( p.getFactType() );
+                for (ConditionCol52 cc : p.getChildColumns()) {
+                    if (cc.isBound() && cc.getBinding().equals(var)) {
+                        final ConditionCol52FieldConstraintAdaptor sfcAdaptor = new ConditionCol52FieldConstraintAdaptor(cc);
+                        sfcAdaptor.setFactType(p.getFactType());
                         return sfcAdaptor;
                     }
                 }
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                for ( IPattern p : brl.getDefinition() ) {
-                    if ( p instanceof FactPattern ) {
-                        final FactPattern fp = (FactPattern) p;
-                        for ( FieldConstraint fc : fp.getFieldConstraints() ) {
-                            if ( fc instanceof SingleFieldConstraint ) {
-                                final List<String> fieldBindings = getFieldBinding( fc );
-                                if ( fieldBindings.contains( var ) ) {
-                                    return (SingleFieldConstraint) fc;
-                                }
-                            }
-                        }
-                    }
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                final SingleFieldConstraint sfc = rm.getLHSBoundField(var);
+                if (sfc != null) {
+                    return sfc;
                 }
             }
         }
-        return super.getLHSBoundField( var );
+        return super.getLHSBoundField(var);
     }
 
     @Override
-    public String getLHSBindingType( final String var ) {
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+    public String getLHSBindingType(final String var) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                if ( p.isBound() && p.getBoundName().equals( var ) ) {
+                if (p.isBound() && p.getBoundName().equals(var)) {
                     return p.getFactType();
                 }
-                for ( ConditionCol52 cc : p.getChildColumns() ) {
-                    if ( cc.isBound() && cc.getBinding().equals( var ) ) {
+                for (ConditionCol52 cc : p.getChildColumns()) {
+                    if (cc.isBound() && cc.getBinding().equals(var)) {
                         return cc.getFieldType();
                     }
                 }
-
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                for ( IPattern p : brl.getDefinition() ) {
-                    if ( p instanceof FactPattern ) {
-                        final FactPattern fp = (FactPattern) p;
-                        if ( fp.isBound() && fp.getBoundName().equals( var ) ) {
-                            return fp.getFactType();
-                        }
-                        for ( FieldConstraint fc : fp.getFieldConstraints() ) {
-                            final String type = getFieldBinding( fc,
-                                                                 var );
-                            if ( type != null ) {
-                                return type;
-                            }
-                        }
-
-                    }
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                final String type = rm.getLHSBindingType(var);
+                if (type != null) {
+                    return type;
                 }
             }
         }
-        return super.getLHSBindingType( var );
+        return super.getLHSBindingType(var);
     }
 
     @Override
-    public FactPattern getLHSParentFactPatternForBinding( final String var ) {
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+    public FactPattern getLHSParentFactPatternForBinding(final String var) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                if ( p.isBound() && p.getBoundName().equals( var ) ) {
-                    return new Pattern52FactPatternAdaptor( p );
+                if (p.isBound() && p.getBoundName().equals(var)) {
+                    return new Pattern52FactPatternAdaptor(p);
                 }
-                for ( ConditionCol52 cc : p.getChildColumns() ) {
-                    if ( cc.isBound() && cc.getBinding().equals( var ) ) {
-                        return new Pattern52FactPatternAdaptor( p );
+                for (ConditionCol52 cc : p.getChildColumns()) {
+                    if (cc.isBound() && cc.getBinding().equals(var)) {
+                        return new Pattern52FactPatternAdaptor(p);
                     }
                 }
-
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                for ( IPattern p : brl.getDefinition() ) {
-                    if ( p instanceof FactPattern ) {
-                        final FactPattern fp = (FactPattern) p;
-                        if ( fp.isBound() && var.equals( fp.getBoundName() ) ) {
-                            return fp;
-                        }
-                        for ( FieldConstraint fc : fp.getFieldConstraints() ) {
-                            final List<String> fieldBindings = getFieldBinding( fc );
-                            if ( fieldBindings.contains( var ) ) {
-                                return fp;
-                            }
-                        }
-                    }
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                final FactPattern fp = rm.getLHSParentFactPatternForBinding(var);
+                if (fp != null) {
+                    return fp;
                 }
             }
         }
-        return super.getLHSParentFactPatternForBinding( var );
+        return super.getLHSParentFactPatternForBinding(var);
     }
 
     @Override
     public List<String> getAllVariables() {
         final Set<String> variables = new HashSet<String>();
-        variables.addAll( getAllLHSVariables() );
-        variables.addAll( getAllRHSVariables() );
-        return new ArrayList<String>( variables );
+        variables.addAll(getAllLHSVariables());
+        variables.addAll(getAllRHSVariables());
+        return new ArrayList<String>(variables);
     }
 
     @Override
     public List<String> getAllLHSVariables() {
         final Set<String> variables = new HashSet<String>();
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                if ( p.isBound() ) {
-                    variables.add( p.getBoundName() );
+                if (p.isBound()) {
+                    variables.add(p.getBoundName());
                 }
-                for ( ConditionCol52 cc : p.getChildColumns() ) {
-                    if ( cc.isBound() ) {
-                        variables.add( cc.getBinding() );
+                for (ConditionCol52 cc : p.getChildColumns()) {
+                    if (cc.isBound()) {
+                        variables.add(cc.getBinding());
                     }
                 }
-
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                for ( IPattern p : brl.getDefinition() ) {
-                    if ( p instanceof FactPattern ) {
-                        final FactPattern fp = (FactPattern) p;
-                        if ( fp.isBound() ) {
-                            variables.add( fp.getBoundName() );
-                        }
-
-                        for ( FieldConstraint fc : fp.getFieldConstraints() ) {
-                            if ( fc instanceof SingleFieldConstraintEBLeftSide ) {
-                                final SingleFieldConstraintEBLeftSide exp = (SingleFieldConstraintEBLeftSide) fc;
-                                if ( exp.getExpressionLeftSide() != null && exp.getExpressionLeftSide().isBound() ) {
-                                    variables.add( exp.getExpressionLeftSide().getBinding() );
-                                }
-                            } else if ( fc instanceof SingleFieldConstraint ) {
-                                final SingleFieldConstraint sfc = (SingleFieldConstraint) fc;
-                                if ( sfc.isBound() ) {
-                                    variables.add( sfc.getFieldBinding() );
-                                }
-                                if ( sfc.getExpressionValue() != null && sfc.getExpressionValue().isBound() ) {
-                                    variables.add( sfc.getExpressionValue().getBinding() );
-                                }
-                            }
-                        }
-                    }
-                }
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                variables.addAll(rm.getAllLHSVariables());
             }
         }
-        variables.addAll( super.getAllLHSVariables() );
-        return new ArrayList<String>( variables );
+        variables.addAll(super.getAllLHSVariables());
+        return new ArrayList<String>(variables);
     }
 
     @Override
     public List<String> getAllRHSVariables() {
         final Set<String> variables = new HashSet<String>();
-        for ( ActionCol52 col : dtable.getActionCols() ) {
-            if ( col instanceof ActionInsertFactCol52 ) {
+        for (ActionCol52 col : dtable.getActionCols()) {
+            if (col instanceof ActionInsertFactCol52) {
                 final ActionInsertFactCol52 action = (ActionInsertFactCol52) col;
-                variables.add( action.getBoundName() );
-
-            } else if ( col instanceof BRLActionColumn ) {
+                variables.add(action.getBoundName());
+            } else if (col instanceof BRLActionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLActionColumn brl = (BRLActionColumn) col;
-                for ( IAction a : brl.getDefinition() ) {
-                    if ( a instanceof ActionInsertFact ) {
-                        final ActionInsertFact action = (ActionInsertFact) a;
-                        if ( action.isBound() ) {
-                            variables.add( action.getBoundName() );
-                        }
-                    }
-                }
+                rm.rhs = brl.getDefinition().toArray(new IAction[brl.getDefinition().size()]);
+                variables.addAll(rm.getAllRHSVariables());
             }
         }
-        variables.addAll( super.getAllRHSVariables() );
-        return new ArrayList<String>( variables );
+        variables.addAll(super.getAllRHSVariables());
+        return new ArrayList<String>(variables);
     }
 
     @Override
-    public boolean isBoundFactUsed( final String binding ) {
-        for ( ActionCol52 col : dtable.getActionCols() ) {
-            if ( col instanceof ActionInsertFactCol52 ) {
+    public boolean isBoundFactUsed(final String binding) {
+        for (ActionCol52 col : dtable.getActionCols()) {
+            if (col instanceof ActionInsertFactCol52) {
                 final ActionInsertFactCol52 action = (ActionInsertFactCol52) col;
-                if ( action.getBoundName().equals( binding ) ) {
+                if (action.getBoundName().equals(binding)) {
                     return true;
                 }
-            } else if ( col instanceof ActionRetractFactCol52 ) {
+            } else if (col instanceof ActionRetractFactCol52) {
 
-                if ( col instanceof LimitedEntryActionRetractFactCol52 ) {
+                if (col instanceof LimitedEntryActionRetractFactCol52) {
 
                     //Check whether Limited Entry retraction is bound to Pattern
                     final LimitedEntryActionRetractFactCol52 ler = (LimitedEntryActionRetractFactCol52) col;
-                    if ( ler.getValue().getStringValue().equals( binding ) ) {
+                    if (ler.getValue().getStringValue().equals(binding)) {
                         return false;
                     }
-
                 } else {
 
                     //Check whether data for column contains Pattern binding
-                    final int colIndex = dtable.getExpandedColumns().indexOf( col );
-                    for ( List<DTCellValue52> row : dtable.getData() ) {
-                        DTCellValue52 cell = row.get( colIndex );
-                        if ( cell != null && cell.getStringValue().equals( binding ) ) {
+                    final int colIndex = dtable.getExpandedColumns().indexOf(col);
+                    for (List<DTCellValue52> row : dtable.getData()) {
+                        DTCellValue52 cell = row.get(colIndex);
+                        if (cell != null && cell.getStringValue().equals(binding)) {
                             return true;
                         }
                     }
                 }
-
-            } else if ( col instanceof BRLActionColumn ) {
+            } else if (col instanceof BRLActionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLActionColumn brl = (BRLActionColumn) col;
-                for ( IAction a : brl.getDefinition() ) {
-                    if ( a instanceof ActionSetField ) {
-                        final ActionSetField action = (ActionSetField) a;
-                        if ( action.getVariable().equals( binding ) ) {
-                            return true;
-                        }
-                    } else if ( a instanceof ActionRetractFact ) {
-                        final ActionRetractFact action = (ActionRetractFact) a;
-                        if ( action.getVariableName().equals( binding ) ) {
-                            return true;
-                        }
-                    }
+                rm.rhs = brl.getDefinition().toArray(new IAction[brl.getDefinition().size()]);
+                if (rm.isBoundFactUsed(binding)) {
+                    return true;
                 }
             }
         }
-        return super.isBoundFactUsed( binding );
+        return super.isBoundFactUsed(binding);
     }
 
     @Override
-    public List<String> getBoundVariablesInScope( final BaseSingleFieldConstraint con ) {
+    public List<String> getBoundVariablesInScope(final BaseSingleFieldConstraint con) {
         final Set<String> variables = new HashSet<String>();
-        for ( CompositeColumn<? extends BaseColumn> col : dtable.getConditions() ) {
-            if ( col instanceof Pattern52 ) {
+        for (CompositeColumn<? extends BaseColumn> col : dtable.getConditions()) {
+            if (col instanceof Pattern52) {
                 final Pattern52 p = (Pattern52) col;
-                if ( p.isBound() ) {
-                    variables.add( p.getBoundName() );
+                if (p.isBound()) {
+                    variables.add(p.getBoundName());
                 }
-                for ( ConditionCol52 cc : p.getChildColumns() ) {
-                    if ( cc.isBound() ) {
-                        variables.add( cc.getBinding() );
+                for (ConditionCol52 cc : p.getChildColumns()) {
+                    if (cc.isBound()) {
+                        variables.add(cc.getBinding());
                     }
                 }
-
-            } else if ( col instanceof BRLConditionColumn ) {
+            } else if (col instanceof BRLConditionColumn) {
                 //Delegate to super class's implementation
                 final RuleModel rm = new RuleModel();
                 final BRLConditionColumn brl = (BRLConditionColumn) col;
-                rm.lhs = brl.getDefinition().toArray( new IPattern[ brl.getDefinition().size() ] );
-                variables.addAll( rm.getBoundVariablesInScope( con ) );
+                rm.lhs = brl.getDefinition().toArray(new IPattern[brl.getDefinition().size()]);
+                variables.addAll(rm.getBoundVariablesInScope(con));
             }
         }
-        variables.addAll( super.getBoundVariablesInScope( con ) );
-        return new ArrayList<String>( variables );
+        variables.addAll(super.getBoundVariablesInScope(con));
+        return new ArrayList<String>(variables);
     }
 
     @Override
-    public boolean isVariableNameUsed( String s ) {
-        return super.isVariableNameUsed( s );
+    public boolean isVariableNameUsed(String s) {
+        return super.isVariableNameUsed(s);
     }
 
     @Override
     public List<String> getRHSBoundFacts() {
         final Set<String> variables = new HashSet<String>();
-        for ( ActionCol52 col : dtable.getActionCols() ) {
-            if ( col instanceof ActionInsertFactCol52 ) {
+        for (ActionCol52 col : dtable.getActionCols()) {
+            if (col instanceof ActionInsertFactCol52) {
                 final ActionInsertFactCol52 action = (ActionInsertFactCol52) col;
-                variables.add( action.getBoundName() );
-
-            } else if ( col instanceof BRLActionColumn ) {
+                variables.add(action.getBoundName());
+            } else if (col instanceof BRLActionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLActionColumn brl = (BRLActionColumn) col;
-                for ( IAction a : brl.getDefinition() ) {
-                    if ( a instanceof ActionInsertFact ) {
-                        final ActionInsertFact action = (ActionInsertFact) a;
-                        if ( action.isBound() ) {
-                            variables.add( action.getBoundName() );
-                        }
-                    }
-                }
+                rm.rhs = brl.getDefinition().toArray(new IAction[brl.getDefinition().size()]);
+                variables.addAll(rm.getRHSBoundFacts());
             }
         }
-        variables.addAll( super.getRHSBoundFacts() );
-        return new ArrayList<String>( variables );
+        variables.addAll(super.getRHSBoundFacts());
+        return new ArrayList<String>(variables);
     }
 
     @Override
-    public ActionInsertFact getRHSBoundFact( final String var ) {
-        for ( ActionCol52 col : dtable.getActionCols() ) {
-            if ( col instanceof ActionInsertFactCol52 ) {
+    public ActionInsertFact getRHSBoundFact(final String var) {
+        for (ActionCol52 col : dtable.getActionCols()) {
+            if (col instanceof ActionInsertFactCol52) {
                 final ActionInsertFactCol52 action = (ActionInsertFactCol52) col;
-                if ( action.getBoundName().equals( var ) ) {
-                    if ( action.isInsertLogical() ) {
-                        return new ActionInsertFactCol52ActionInsertLogicalFactAdaptor( action );
+                if (action.getBoundName().equals(var)) {
+                    if (action.isInsertLogical()) {
+                        return new ActionInsertFactCol52ActionInsertLogicalFactAdaptor(action);
                     }
-                    return new ActionInsertFactCol52ActionInsertFactAdaptor( action );
+                    return new ActionInsertFactCol52ActionInsertFactAdaptor(action);
                 }
-
-            } else if ( col instanceof BRLActionColumn ) {
+            } else if (col instanceof BRLActionColumn) {
+                //Delegate to super class's implementation
+                final RuleModel rm = new RuleModel();
                 final BRLActionColumn brl = (BRLActionColumn) col;
-                for ( IAction a : brl.getDefinition() ) {
-                    if ( a instanceof ActionInsertFact ) {
-                        final ActionInsertFact action = (ActionInsertFact) a;
-                        if ( action.isBound() ) {
-                            if ( action.getBoundName().equals( var ) ) {
-                                return action;
-                            }
-                        }
-                    }
+                rm.rhs = brl.getDefinition().toArray(new IAction[brl.getDefinition().size()]);
+                final ActionInsertFact aif = rm.getRHSBoundFact(var);
+                if (aif != null) {
+                    return aif;
                 }
             }
         }
-        return super.getRHSBoundFact( var );
+        return super.getRHSBoundFact(var);
     }
-
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModelTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.drools.workbench.models.datamodel.oracle.DataType;
+import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BRLRuleModelTest extends BaseBRLTest {
+
+    private BRLRuleModel rm;
+
+    @Before
+    public void setup() {
+        super.setup();
+        this.rm = new BRLRuleModel(dtable);
+    }
+
+    @Test
+    public void getLHSBoundFactsWithNoDefinition() {
+        assertThereAreNoBindings();
+    }
+
+    @Test
+    public void getLHSBoundFactsWithPattern() {
+        whenThereIsAPattern("Applicant",
+                            "$a");
+        assertThereIsLHSBindingFor("$a");
+    }
+
+    @Test
+    public void getLHSBoundFactsWithFactPattern() {
+        whenThereIsABRLFactPattern("Applicant",
+                                   "$a");
+        assertThereIsLHSBindingFor("$a");
+    }
+
+    @Test
+    public void getLHSBoundFactsWithFromCompositeFactPattern() {
+        whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                "$a");
+        assertThereIsLHSBindingFor("$a");
+    }
+
+    @Test
+    public void getLHSBoundFactWithPattern() {
+        whenThereIsAPattern("Applicant",
+                            "$a");
+        assertThereIsABoundFactFor("$a");
+    }
+
+    @Test
+    public void getLHSBoundFactWithFactPattern() {
+        whenThereIsABRLFactPattern("Applicant",
+                                   "$a");
+        assertThereIsABoundFactFor("$a");
+    }
+
+    @Test
+    public void getLHSBoundFactWithFromCompositeFactPattern() {
+        whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                "$a");
+        assertThereIsABoundFactFor("$a");
+    }
+
+    @Test
+    public void getLHSBindingTypeWithPattern() {
+        whenThereIsAPattern("Applicant",
+                            "$a");
+        assertLHSBindingTypeFor("Applicant",
+                                "$a");
+    }
+
+    @Test
+    public void getLHSBindingTypeWithFactPattern() {
+        whenThereIsABRLFactPattern("Applicant",
+                                   "$a");
+        assertLHSBindingTypeFor("Applicant",
+                                "$a");
+    }
+
+    @Test
+    public void getLHSBindingTypeWithFromCompositeFactPattern() {
+        whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                "$a");
+        assertLHSBindingTypeFor("Applicant",
+                                "$a");
+    }
+
+    @Test
+    public void getLHSBoundFieldWithPatternField() {
+        final Pattern52 p = whenThereIsAPattern("Applicant",
+                                                "$a");
+        whenPatternHasAField(p,
+                             "field1",
+                             DataType.TYPE_STRING,
+                             "$f");
+        assertThereIsAFieldBindingFor("$f");
+    }
+
+    @Test
+    public void getLHSBoundFieldWithFactPatternField() {
+        final BRLConditionColumn brl = whenThereIsABRLFactPattern("Applicant",
+                                                                  "$a");
+        whenBRLFactPatternHasAField(brl,
+                                    "field1",
+                                    DataType.TYPE_STRING,
+                                    "$f");
+        assertThereIsAFieldBindingFor("$f");
+    }
+
+    @Test
+    public void getLHSBoundFieldWithFromCompositeFactPatternField() {
+        final BRLConditionColumn brl = whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                                               "$a");
+        whenBRLFromCompositeFactPatternHasAField(brl,
+                                                 "field1",
+                                                 DataType.TYPE_STRING,
+                                                 "$f");
+        assertThereIsAFieldBindingFor("$f");
+    }
+
+    @Test
+    public void getLHSBindingTypeWithPatternField() {
+        final Pattern52 p = whenThereIsAPattern("Applicant",
+                                                "$a");
+        whenPatternHasAField(p,
+                             "field1",
+                             DataType.TYPE_STRING,
+                             "$f");
+        assertLHSBindingTypeFor(DataType.TYPE_STRING,
+                                "$f");
+    }
+
+    @Test
+    public void getLHSBindingTypeWithFactPatternField() {
+        final BRLConditionColumn brl = whenThereIsABRLFactPattern("Applicant",
+                                                                  "$a");
+        whenBRLFactPatternHasAField(brl,
+                                    "field1",
+                                    DataType.TYPE_STRING,
+                                    "$f");
+        assertLHSBindingTypeFor(DataType.TYPE_STRING,
+                                "$f");
+    }
+
+    @Test
+    public void getLHSBindingTypeWithFromCompositeFactPatternField() {
+        final BRLConditionColumn brl = whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                                               "$a");
+        whenBRLFromCompositeFactPatternHasAField(brl,
+                                                 "field1",
+                                                 DataType.TYPE_STRING,
+                                                 "$f");
+        assertLHSBindingTypeFor(DataType.TYPE_STRING,
+                                "$f");
+    }
+
+    @Test
+    public void getLHSParentFactPatternForBindingWithPatternField() {
+        final Pattern52 p = whenThereIsAPattern("Applicant",
+                                                "$a");
+        whenPatternHasAField(p,
+                             "field1",
+                             DataType.TYPE_STRING,
+                             "$f");
+        assertLHSParentFactPatternFor("$a",
+                                      "$f");
+    }
+
+    @Test
+    public void getLHSParentFactPatternForBindingWithFactPatternField() {
+        final BRLConditionColumn brl = whenThereIsABRLFactPattern("Applicant",
+                                                                  "$a");
+        whenBRLFactPatternHasAField(brl,
+                                    "field1",
+                                    DataType.TYPE_STRING,
+                                    "$f");
+        assertLHSParentFactPatternFor("$a",
+                                      "$f");
+    }
+
+    @Test
+    public void getLHSParentFactPatternForBindingWithFromCompositeFactPatternField() {
+        final BRLConditionColumn brl = whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                                               "$a");
+        whenBRLFromCompositeFactPatternHasAField(brl,
+                                                 "field1",
+                                                 DataType.TYPE_STRING,
+                                                 "$f");
+        assertLHSParentFactPatternFor("$a",
+                                      "$f");
+    }
+
+    @Test
+    public void getAllLHSVariables() {
+        final Pattern52 p = whenThereIsAPattern("Applicant",
+                                                "$a1");
+        whenPatternHasAField(p,
+                             "field1",
+                             DataType.TYPE_STRING,
+                             "$f1");
+
+        final BRLConditionColumn brl1 = whenThereIsABRLFactPattern("Applicant",
+                                                                   "$a2");
+        whenBRLFactPatternHasAField(brl1,
+                                    "field1",
+                                    DataType.TYPE_STRING,
+                                    "$f2");
+
+        final BRLConditionColumn brl2 = whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                                                "$a3");
+        whenBRLFromCompositeFactPatternHasAField(brl2,
+                                                 "field1",
+                                                 DataType.TYPE_STRING,
+                                                 "$f3");
+
+        assertLHSBindings("$a1",
+                          "$a2",
+                          "$a3",
+                          "$f1",
+                          "$f2",
+                          "$f3");
+    }
+
+    private ConditionCol52 whenPatternHasAField(final Pattern52 p,
+                                                final String fieldName,
+                                                final String fieldType,
+                                                final String fieldBinding) {
+        final ConditionCol52 c = new ConditionCol52();
+        c.setFactField(fieldName);
+        c.setFieldType(fieldType);
+        c.setBinding(fieldBinding);
+        p.getChildColumns().add(c);
+        return c;
+    }
+
+    private void assertThereAreNoBindings() {
+        final List<String> result = rm.getLHSBoundFacts();
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    private void assertThereIsLHSBindingFor(final String binding) {
+        final List<String> result = rm.getLHSBoundFacts();
+        assertNotNull(result);
+        assertEquals(1,
+                     result.size());
+        assertEquals(binding,
+                     result.get(0));
+    }
+
+    private void assertThereIsABoundFactFor(final String binding) {
+        final FactPattern result = rm.getLHSBoundFact(binding);
+        assertNotNull(result);
+        assertEquals(binding,
+                     result.getBoundName());
+    }
+
+    private void assertThereIsAFieldBindingFor(final String fieldBinding) {
+        final SingleFieldConstraint sfc = rm.getLHSBoundField(fieldBinding);
+        assertNotNull(sfc);
+    }
+
+    private void assertLHSBindingTypeFor(final String expectedType,
+                                         final String binding) {
+        final String actualType = rm.getLHSBindingType(binding);
+        assertEquals(expectedType,
+                     actualType);
+    }
+
+    private void assertLHSParentFactPatternFor(final String patternBinding,
+                                               final String fieldBinding) {
+        final FactPattern boundPattern1 = rm.getLHSParentFactPatternForBinding(patternBinding);
+        assertNotNull(boundPattern1);
+        assertEquals(patternBinding,
+                     boundPattern1.getBoundName());
+
+        final FactPattern boundPattern2 = rm.getLHSParentFactPatternForBinding(fieldBinding);
+        assertNotNull(boundPattern2);
+        assertEquals(patternBinding,
+                     boundPattern2.getBoundName());
+    }
+
+    private void assertLHSBindings(final String... expectedBindings) {
+        final List<String> actualBindings = rm.getAllLHSVariables();
+        assertNotNull(actualBindings);
+        assertEquals(expectedBindings.length,
+                     actualBindings.size());
+
+        Arrays.asList(expectedBindings).stream().forEach(actualBindings::contains);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BaseBRLTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BaseBRLTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.rule.FromCompositeFactPattern;
+import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
+import org.junit.Before;
+
+import static org.junit.Assert.*;
+
+public abstract class BaseBRLTest {
+
+    protected GuidedDecisionTable52 dtable;
+
+    @Before
+    public void setup() {
+        this.dtable = new GuidedDecisionTable52();
+    }
+
+    protected Pattern52 whenThereIsAPattern(final String factType,
+                                            final String binding) {
+        final Pattern52 p = new Pattern52();
+        p.setFactType(factType);
+        p.setBoundName(binding);
+        dtable.getConditions().add(p);
+        return p;
+    }
+
+    protected BRLConditionColumn whenThereIsABRLFactPattern(final String factType,
+                                                            final String binding) {
+        final FactPattern fp = new FactPattern(factType);
+        fp.setBoundName(binding);
+        final BRLConditionColumn brl = new BRLConditionColumn();
+        brl.getDefinition().add(fp);
+        dtable.getConditions().add(brl);
+        return brl;
+    }
+
+    protected BRLConditionColumn whenThereIsABRLFromCompositeFactPattern(final String factType,
+                                                                         final String binding) {
+        final FromCompositeFactPattern fcfp = new FromCompositeFactPattern();
+        final FactPattern fp = new FactPattern(factType);
+        fp.setBoundName(binding);
+        fcfp.setFactPattern(fp);
+        final BRLConditionColumn brl = new BRLConditionColumn();
+        brl.getDefinition().add(fcfp);
+        dtable.getConditions().add(brl);
+        return brl;
+    }
+
+    protected SingleFieldConstraint whenBRLFactPatternHasAField(final BRLConditionColumn brl,
+                                                                final String fieldName,
+                                                                final String fieldType,
+                                                                final String fieldBinding) {
+        assertFalse("BRLConditionColumn has not been initialised. Was 'whenThereIsABRLFactPattern' called?",
+                    brl.getDefinition().isEmpty());
+        assertEquals("BRLConditionColumn has not been initialised correctly. Was 'whenThereIsABRLFactPattern' called?",
+                     1,
+                     brl.getDefinition().size());
+        assertTrue("BRLConditionColumn has not been initialised correctly. Was 'whenThereIsABRLFactPattern' called?",
+                   brl.getDefinition().get(0) instanceof FactPattern);
+
+        final FactPattern fp = (FactPattern) brl.getDefinition().get(0);
+        final SingleFieldConstraint sfc = new SingleFieldConstraint();
+        sfc.setFactType(fp.getFactType());
+        sfc.setFieldName(fieldName);
+        sfc.setFieldType(fieldType);
+        sfc.setFieldBinding(fieldBinding);
+        fp.addConstraint(sfc);
+        brl.getDefinition().add(fp);
+        return sfc;
+    }
+
+    protected SingleFieldConstraint whenBRLFromCompositeFactPatternHasAField(final BRLConditionColumn brl,
+                                                                             final String fieldName,
+                                                                             final String fieldType,
+                                                                             final String fieldBinding) {
+        assertFalse("BRLConditionColumn has not been initialised. Was 'whenThereIsABRLFactPattern' called?",
+                    brl.getDefinition().isEmpty());
+        assertEquals("BRLConditionColumn has not been initialised correctly. Was 'whenThereIsABRLFactPattern' called?",
+                     1,
+                     brl.getDefinition().size());
+        assertTrue("BRLConditionColumn has not been initialised correctly. Was 'whenThereIsABRLFactPattern' called?",
+                   brl.getDefinition().get(0) instanceof FromCompositeFactPattern);
+
+        final FromCompositeFactPattern fcfp = (FromCompositeFactPattern) brl.getDefinition().get(0);
+        final FactPattern fp = fcfp.getFactPattern();
+        final SingleFieldConstraint sfc = new SingleFieldConstraint();
+        sfc.setFactType(fp.getFactType());
+        sfc.setFieldName(fieldName);
+        sfc.setFieldType(fieldType);
+        sfc.setFieldBinding(fieldBinding);
+        fp.addConstraint(sfc);
+        brl.getDefinition().add(fp);
+        return sfc;
+    }
+
+    protected void assertThereIsNoPatternFor(final String binding) {
+        final Pattern52 p = dtable.getConditionPattern(binding);
+        assertNull(p);
+    }
+
+    protected void assertThereIsAPatternFor(final String factType,
+                                            final String binding) {
+        final Pattern52 result = dtable.getConditionPattern(binding);
+        assertNotNull(result);
+        assertEquals(factType,
+                     result.getFactType());
+        assertEquals(binding,
+                     result.getBoundName());
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/GuidedDecisionTable52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/GuidedDecisionTable52Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import org.junit.Test;
+
+public class GuidedDecisionTable52Test extends BaseBRLTest {
+
+    @Test
+    public void getConditionPatternWithNonExistentBinding() {
+        whenThereIsAPattern("Applicant",
+                            "$a");
+        assertThereIsNoPatternFor("$nonexistent");
+    }
+
+    @Test
+    public void getConditionPatternWithPattern52() {
+        whenThereIsAPattern("Applicant",
+                            "$a");
+        assertThereIsAPatternFor("Applicant",
+                                 "$a");
+    }
+
+    @Test
+    public void getConditionPatternWithFactPattern() {
+        whenThereIsABRLFactPattern("Applicant",
+                                   "$a");
+        assertThereIsAPatternFor("Applicant",
+                                 "$a");
+    }
+
+    @Test
+    public void getConditionPatternWithFromCompositeFactPattern() {
+        whenThereIsABRLFromCompositeFactPattern("Applicant",
+                                                "$a");
+        assertThereIsAPatternFor("Applicant",
+                                 "$a");
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2829

Bound Facts/Fields for the Guided Decision Table Editor were only checked in ```FactPattern``` and not also ```FromCompositeFactPattern``` as is supported by the Guided Rule Editor.