### PR TITLE
DROOLS-1443 implemented hashCode and equals to ensure that caches for…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/MemoryKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/MemoryKieModule.java
@@ -170,6 +170,20 @@ public class MemoryKieModule extends AbstractKieModule
                 return null;
             }
         }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof MemoryKieModuleResourceProvider)) return false;
+
+            MemoryKieModuleResourceProvider that =
+                    (MemoryKieModuleResourceProvider) o;
+
+            return mfs != null ? mfs.equals(that.mfs) : that.mfs == null;
+        }
+
+        @Override public int hashCode() {
+            return mfs != null ? mfs.hashCode() : 0;
+        }
     }
 
     private static class MemoryFileURLStreamHandler extends URLStreamHandler {

--- a/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
@@ -351,6 +351,36 @@ public class ProjectClassLoader extends ClassLoader {
                 new DefaultInternalTypesClassLoader( this );
     }
 
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProjectClassLoader)) return false;
+
+        ProjectClassLoader that = (ProjectClassLoader) o;
+
+        if (droolsClassLoader != null ? !droolsClassLoader.equals(
+                that.droolsClassLoader) : that.droolsClassLoader != null)
+            return false;
+        if (typesClassLoader != null ? !typesClassLoader.equals(
+                that.typesClassLoader) : that.typesClassLoader != null)
+            return false;
+        if (getParent() != null ? !getParent().equals(
+                that.getParent()) : that.getParent() != null)
+            return false;
+        return resourceProvider != null ? resourceProvider.equals(
+                that.resourceProvider) : that.resourceProvider == null;
+    }
+
+    @Override public int hashCode() {
+        int result =
+                droolsClassLoader != null ? droolsClassLoader.hashCode() : 0;
+        result = 31 * result + (
+                typesClassLoader != null ? typesClassLoader.hashCode() : 0);
+        result = 31 * result + (
+                resourceProvider != null ? resourceProvider.hashCode() : 0);
+        result = 31 * result +(getParent() != null ? getParent().hashCode() : 0);
+        return result;
+    }
+
     interface InternalTypesClassLoader {
         Class<?> defineClass(String name, byte[] bytecode);
         Class<?> loadType(String name, boolean resolve) throws ClassNotFoundException;


### PR DESCRIPTION
… resource loading can cache on classloaders that will return the same resources regardless of instance

This pull request is requirement for:
https://github.com/droolsjbpm/droolsjbpm-knowledge/pull/209