### PR TITLE
OOPath tests - logical operators

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Employee.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Employee.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Employee.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.common.model;
+
+import java.io.Serializable;
+
+public class Employee extends Person implements Serializable {
+
+    private static final long serialVersionUID = -5411807328989112199L;
+
+    private String position = "";
+
+    public Employee() {
+        super();
+    }
+
+    public Employee(final String name) {
+        super(name);
+    }
+
+    public Employee(final String name, final int age) {
+        super(name, age);
+    }
+
+    public Employee(final String name, final String likes, final int age) {
+        super(name, likes, age);
+    }
+
+    public Employee(final String name, final String likes, final int age, final String position) {
+        super(name, likes, age);
+        this.position = position;
+    }
+
+    public String getPosition() {
+        return this.position;
+    }
+
+    public void setPosition(final String position) {
+        this.position = position;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s[id='%s', name='%s', position='%s']", getClass().getName(), getId(), getName(), position);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        Employee employee = (Employee) o;
+
+        return position != null ? position.equals(employee.position) : employee.position == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (position != null ? position.hashCode() : 0);
+        return result;
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InternationalAddress.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InternationalAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InternationalAddress.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/InternationalAddress.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.common.model;
+
+import java.io.Serializable;
+
+public class InternationalAddress extends Address implements Serializable {
+
+    private static final long serialVersionUID = -4500788294548913271L;
+
+    private String state;
+
+    public InternationalAddress() {
+        super();
+    }
+
+    public InternationalAddress(final String street, final int number, final String city, final String state) {
+        super(street, number, city);
+        this.state = state;
+    }
+
+    public String getState() {
+        return this.state;
+    }
+
+    public void setState(final String state) {
+        this.state = state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        InternationalAddress that = (InternationalAddress) o;
+
+        return state != null ? state.equals(that.state) : that.state == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (state != null ? state.hashCode() : 0);
+        return result;
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
@@ -66,6 +66,18 @@ public final class KieBaseUtil {
         return getDefaultKieBaseFromKieBuilder(kieBuilder);
     }
 
+    public static KieBase getKieBaseFromDRLResources(final boolean failIfBuildError, final Resource... resources) {
+        generateDRLResourceTargetPath(resources);
+        final KieBuilder kieBuilder = getKieBuilderFromResources(failIfBuildError, resources);
+        return getDefaultKieBaseFromKieBuilder(kieBuilder);
+    }
+
+    private static void generateDRLResourceTargetPath(final Resource[] resources) {
+        for (int index = 0; index < resources.length; index++) {
+            resources[index].setTargetPath(String.format("rule-%d.drl", index));
+        }
+    }
+
     public static KieBase getKieBaseFromReleaseIdByName(final ReleaseId id, final String name) {
         final KieContainer container = KieServices.Factory.get().newKieContainer(id);
         if (name == null) {

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
@@ -38,12 +38,14 @@ public class OOPathLogicalBranchesTest {
     private static final KieServices KIE_SERVICES = KieServices.Factory.get();
 
     private KieSession kieSession;
+    private List<String> results;
 
     @After
     public void disposeKieSession() {
         if (this.kieSession != null) {
             this.kieSession.dispose();
             this.kieSession = null;
+            this.results = null;
         }
     }
 
@@ -61,24 +63,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City", "Small City");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Big City", "Small City");
     }
 
     @Test
@@ -96,24 +84,31 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Big City", "Small City");
+    }
 
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City", "Small City");
+    @Test
+    public void testOrConstraintWithJoin() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  $emp: Employee( $address: /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                "        Employee( this != $emp, /address{ street == $address.street || city == 'Big City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.initKieSession(kieBase);
+
+        this.kieSession.fireAllRules();
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Big City", "Small City");
     }
 
     @Test
@@ -131,24 +126,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Bruno", "Alice");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Bruno", "Alice");
     }
 
     @Test
@@ -167,24 +148,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City", "Small City");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Big City", "Small City");
     }
 
     @Test
@@ -205,24 +172,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Bruno", "Alice");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Bruno", "Alice");
     }
 
     @Test
@@ -239,24 +192,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactly("Big City");
+        Assertions.assertThat(this.results).containsExactly("Big City");
     }
 
     @Test
@@ -274,24 +213,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Big City");
     }
 
     @Test
@@ -309,24 +234,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Alice");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Alice");
     }
 
     @Test
@@ -345,24 +256,10 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.initKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
-        this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
         this.kieSession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City");
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Big City");
     }
 
     @Test
@@ -381,29 +278,45 @@ public class OOPathLogicalBranchesTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
-        this.kieSession =  kieBase.newKieSession();
+        this.createKieSession(kieBase);
 
-        final List<String> list = new ArrayList<String>();
-        this.kieSession.setGlobal("list", list);
-
-        final Address addressOfBruno = new Address("Elm", 10, "Small City");
-        final Employee bruno = new Employee("Bruno");
-        bruno.setAddress(addressOfBruno);
-
-        final Address addressOfAlice = new Address("Elm", 10, "Big City");
-        final Employee alice = new Employee("Alice");
-        alice.setAddress(addressOfAlice);
-
+        final Employee bruno = this.createEmployee("Bruno", new Address("Elm", 10, "Small City"));
         final FactHandle brunoFactHandle = this.kieSession.insert(bruno);
-        this.kieSession.insert(alice);
-        this.kieSession.fireAllRules();
 
-        Assertions.assertThat(list).isEmpty();
+        final Employee alice = this.createEmployee("Alice", new Address("Elm", 10, "Big City"));
+        this.kieSession.insert(alice);
+
+        this.kieSession.fireAllRules();
+        Assertions.assertThat(this.results).isEmpty();
 
         this.kieSession.delete(brunoFactHandle);
         this.kieSession.fireAllRules();
+        Assertions.assertThat(this.results).containsExactlyInAnyOrder("Alice");
+    }
 
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Alice");
+    private void initKieSession(final KieBase kieBase) {
+        this.createKieSession(kieBase);
+        this.populateKieSession();
+    }
+
+    private void createKieSession(final KieBase kieBase) {
+        this.kieSession = kieBase.newKieSession();
+        this.results = new ArrayList<String>();
+        this.kieSession.setGlobal("list", results);
+    }
+
+    private void populateKieSession() {
+        final Employee bruno = this.createEmployee("Bruno", new Address("Elm", 10, "Small City"));
+        this.kieSession.insert(bruno);
+
+        final Employee alice = this.createEmployee("Alice", new Address("Elm", 10, "Big City"));
+        this.kieSession.insert(alice);
+    }
+
+    private Employee createEmployee(final String name, final Address address) {
+        final Employee employee = new Employee(name);
+        employee.setAddress(address);
+        return employee;
     }
 
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
@@ -82,7 +82,7 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testConstraintOr() {
+    public void testOrConstraint() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
                 "import org.drools.testcoverage.common.model.Address;\n" +
@@ -117,18 +117,18 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testConstraintOrNoBinding() {
+    public void testOrConstraintNoBinding() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  $emp: Employee( /address{ street == 'Elm' || city == 'Big City' } )\n" +
-                        "        Employee( this != $emp, /address{ street == 'Elm' || city == 'Big City' } )\n" +
-                        "then\n" +
-                        "  list.add( $emp.getName() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  $emp: Employee( /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                "        Employee( this != $emp, /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                "then\n" +
+                "  list.add( $emp.getName() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();
@@ -152,7 +152,7 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testCEOr() {
+    public void testOrConditionalElement() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
                 "import org.drools.testcoverage.common.model.Address;\n" +
@@ -188,21 +188,21 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testCEOrNoBinding() {
+    public void testOrConditionalElementNoBinding() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        " $employee: (\n" +
-                        "  Employee( /address{ street == 'Elm', city == 'Big City' } )\n" +
-                        " or " +
-                        "  Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
-                        " )\n" +
-                        "then\n" +
-                        "  list.add( $employee.getName() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                " $employee: (\n" +
+                "  Employee( /address{ street == 'Elm', city == 'Big City' } )\n" +
+                " or " +
+                "  Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
+                " )\n" +
+                "then\n" +
+                "  list.add( $employee.getName() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();
@@ -229,14 +229,14 @@ public class OOPathLogicalBranchesTest {
     public void testBasicAndCondition() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  Employee( $address: /address{ street == 'Elm' && city == 'Big City' } )\n" +
-                        "then\n" +
-                        "  list.add( $address.getCity() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  Employee( $address: /address{ street == 'Elm' && city == 'Big City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();
@@ -260,18 +260,18 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testConstraintAnd() {
+    public void testAndConstraint() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  $emp: Employee( $address: /address{ street == 'Elm' && city == 'Big City' } )\n" +
-                        "        Employee( this != $emp, /address{ street == 'Elm' && city == 'Small City' } )\n" +
-                        "then\n" +
-                        "  list.add( $address.getCity() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  $emp: Employee( $address: /address{ street == 'Elm' && city == 'Big City' } )\n" +
+                "        Employee( this != $emp, /address{ street == 'Elm' && city == 'Small City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();
@@ -295,18 +295,18 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testConstraintAndNoBinding() {
+    public void testAndConstraintNoBinding() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  $emp: Employee( /address{ street == 'Elm' && city == 'Big City' } )\n" +
-                        "        Employee( this != $emp, /address{ street == 'Elm' && city == 'Small City' } )\n" +
-                        "then\n" +
-                        "  list.add( $emp.getName() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  $emp: Employee( /address{ street == 'Elm' && city == 'Big City' } )\n" +
+                "        Employee( this != $emp, /address{ street == 'Elm' && city == 'Small City' } )\n" +
+                "then\n" +
+                "  list.add( $emp.getName() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();
@@ -330,19 +330,19 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testCEAnd() {
+    public void testAndConditionalElement() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  Employee( $address: /address{ street == 'Elm', city == 'Big City' } )\n" +
-                        " and " +
-                        "  Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
-                        "then\n" +
-                        "  list.add( $address.getCity() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  Employee( $address: /address{ street == 'Elm', city == 'Big City' } )\n" +
+                " and " +
+                "  Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();
@@ -366,19 +366,19 @@ public class OOPathLogicalBranchesTest {
     }
 
     @Test
-    public void testCEAndWithNot() {
+    public void testAndConditionalElementWithNot() {
         final String drl =
                 "import org.drools.testcoverage.common.model.Employee;\n" +
-                        "import org.drools.testcoverage.common.model.Address;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  $employee: Employee( /address{ street == 'Elm', city == 'Big City' } )\n" +
-                        " and " +
-                        "  not Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
-                        "then\n" +
-                        "  list.add( $employee.getName() );\n" +
-                        "end\n";
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  $employee: Employee( /address{ street == 'Elm', city == 'Big City' } )\n" +
+                " and " +
+                "  not Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
+                "then\n" +
+                "  list.add( $employee.getName() );\n" +
+                "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
         this.kieSession =  kieBase.newKieSession();

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.functional.oopath;
+
+import org.assertj.core.api.Assertions;
+import org.drools.testcoverage.common.model.Address;
+import org.drools.testcoverage.common.model.Employee;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests usage of OOPath expressions resulting in multiple conditional branches (e.g. OR operator).
+ */
+public class OOPathLogicalBranchesTest {
+
+    private static final KieServices KIE_SERVICES = KieServices.Factory.get();
+
+    private KieSession kieSession;
+
+    @After
+    public void disposeKieSession() {
+        if (this.kieSession != null) {
+            this.kieSession.dispose();
+            this.kieSession = null;
+        }
+    }
+
+    @Test
+    public void testBasicOrCondition() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  Employee( $address: /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City", "Small City");
+    }
+
+    @Test
+    public void testConstraintOr() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  $emp: Employee( $address: /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                "        Employee( this != $emp, /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City", "Small City");
+    }
+
+    @Test
+    public void testConstraintOrNoBinding() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        "  $emp: Employee( /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                        "        Employee( this != $emp, /address{ street == 'Elm' || city == 'Big City' } )\n" +
+                        "then\n" +
+                        "  list.add( $emp.getName() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Bruno", "Alice");
+    }
+
+    @Test
+    public void testCEOr() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                "import org.drools.testcoverage.common.model.Address;\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  Employee( $address: /address{ street == 'Elm', city == 'Big City' } )\n" +
+                " or " +
+                "  Employee( $address: /address{ street == 'Elm', city == 'Small City' } )\n" +
+                "then\n" +
+                "  list.add( $address.getCity() );\n" +
+                "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City", "Small City");
+    }
+
+    @Test
+    public void testCEOrNoBinding() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        " $employee: (\n" +
+                        "  Employee( /address{ street == 'Elm', city == 'Big City' } )\n" +
+                        " or " +
+                        "  Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
+                        " )\n" +
+                        "then\n" +
+                        "  list.add( $employee.getName() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Bruno", "Alice");
+    }
+
+    @Test
+    public void testBasicAndCondition() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        "  Employee( $address: /address{ street == 'Elm' && city == 'Big City' } )\n" +
+                        "then\n" +
+                        "  list.add( $address.getCity() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactly("Big City");
+    }
+
+    @Test
+    public void testConstraintAnd() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        "  $emp: Employee( $address: /address{ street == 'Elm' && city == 'Big City' } )\n" +
+                        "        Employee( this != $emp, /address{ street == 'Elm' && city == 'Small City' } )\n" +
+                        "then\n" +
+                        "  list.add( $address.getCity() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City");
+    }
+
+    @Test
+    public void testConstraintAndNoBinding() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        "  $emp: Employee( /address{ street == 'Elm' && city == 'Big City' } )\n" +
+                        "        Employee( this != $emp, /address{ street == 'Elm' && city == 'Small City' } )\n" +
+                        "then\n" +
+                        "  list.add( $emp.getName() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Alice");
+    }
+
+    @Test
+    public void testCEAnd() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        "  Employee( $address: /address{ street == 'Elm', city == 'Big City' } )\n" +
+                        " and " +
+                        "  Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
+                        "then\n" +
+                        "  list.add( $address.getCity() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Big City");
+    }
+
+    @Test
+    public void testCEAndWithNot() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Employee;\n" +
+                        "import org.drools.testcoverage.common.model.Address;\n" +
+                        "global java.util.List list\n" +
+                        "\n" +
+                        "rule R when\n" +
+                        "  $employee: Employee( /address{ street == 'Elm', city == 'Big City' } )\n" +
+                        " and " +
+                        "  not Employee( /address{ street == 'Elm', city == 'Small City' } )\n" +
+                        "then\n" +
+                        "  list.add( $employee.getName() );\n" +
+                        "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromDRLResources(true, KIE_SERVICES.getResources().newByteArrayResource(drl.getBytes()));
+        this.kieSession =  kieBase.newKieSession();
+
+        final List<String> list = new ArrayList<String>();
+        this.kieSession.setGlobal("list", list);
+
+        final Address addressOfBruno = new Address("Elm", 10, "Small City");
+        final Employee bruno = new Employee("Bruno");
+        bruno.setAddress(addressOfBruno);
+
+        final Address addressOfAlice = new Address("Elm", 10, "Big City");
+        final Employee alice = new Employee("Alice");
+        alice.setAddress(addressOfAlice);
+
+        final FactHandle brunoFactHandle = this.kieSession.insert(bruno);
+        this.kieSession.insert(alice);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).isEmpty();
+
+        this.kieSession.delete(brunoFactHandle);
+        this.kieSession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Alice");
+    }
+
+}


### PR DESCRIPTION
Adding a few OOPath tests for rules containing multiple logical branches to test (originally intended to check that the UnsupportedOperationException thrown at [1] does not cause problems).

More PRs for different aspects will follow (OOPath with CEP, OOPath with persistence, ...).

[1] https://github.com/droolsjbpm/drools/blob/master/drools-core/src/main/java/org/drools/core/rule/constraint/XpathConstraint.java#L91