### PR TITLE
OOPath tests with CEP - second part

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MessageEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/MessageEvent.java
@@ -20,18 +20,24 @@ import java.io.Serializable;
 
 public class MessageEvent implements Serializable {
 
-    private static final long serialVersionUID = 5700427692523132352L;
+    private static final long serialVersionUID = 5700427692523132353L;
 
     private final Message msg;
     private final Type type;
+    private final long duration;
 
     public enum Type {
         received, sent
     }
 
-    public MessageEvent(Type type, Message msg) {
+    public MessageEvent(final Type type, final Message msg) {
+        this(type, msg, 0);
+    }
+
+    public MessageEvent(final Type type, final Message msg, final long duration) {
         this.type = type;
         this.msg = msg;
+        this.duration = duration;
     }
 
     public Message getMsg() {
@@ -42,8 +48,12 @@ public class MessageEvent implements Serializable {
         return type;
     }
 
+    public long getDuration() {
+        return duration;
+    }
+
     @Override
     public String toString() {
-        return String.format("MessageEvent[type=%s, message=%s]", type.toString(), msg.toString());
+        return String.format("MessageEvent[type=%s, message=%s, duration=%d]", type.toString(), msg.toString(), duration);
     }
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathCepTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathCepTest.java
@@ -45,7 +45,7 @@ public class OOPathCepTest {
     private static final String MODULE_GROUP_ID = "oopath-cep-test";
     private static final String ENTRY_POINT_NAME = "test-entry-point";
 
-    private static final long DEFAULT_DURATION = 2000;
+    private static final long DEFAULT_DURATION_IN_SECS = 2000;
 
     private KieSession kieSession;
     private List<MessageEvent> events;
@@ -139,13 +139,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -172,13 +172,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 1);
-        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 1);
+        final Message pongMessage = this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -205,13 +205,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -239,13 +239,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS));
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1500));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS - 1500));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -273,13 +273,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1000));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS - 1000));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -307,13 +307,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION), clock, 1);
-        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS), clock, 1);
+        final Message pongMessage = this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION - 1000));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS - 1000));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -341,13 +341,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1500));
+        final Message pongMessage = this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS), clock, 1);
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS - 1500));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION - 1500));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS - 1500));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -374,13 +374,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -407,13 +407,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -441,14 +441,14 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), 1), clock, 2);
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), 1), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), 1), clock, 2);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), 1), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
+        final Message pongMessage = this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS), clock, 1);
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -476,13 +476,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
-        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS), clock, 1);
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS), clock, 1);
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -510,13 +510,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION));
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1000));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS - 1000));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -544,13 +544,13 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         this.initKieSessionWithPseudoClock(kieBase);
 
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION));
-        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS));
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION_IN_SECS));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION + 1000));
+        final Message pongMessage = this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION_IN_SECS + 1000));
 
         this.kieSession.fireAllRules();
         Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
@@ -623,7 +623,7 @@ public class OOPathCepTest {
                 "  events.add( $messageEvent );\n" +
                 "end\n";
 
-        assertDrlHasCompilationError( drl, 2 );
+        assertDrlHasCompilationError(drl, 2);
     }
 
     private void populateAndVerifyLengthWindowCase(final KieBase kieBase) {
@@ -731,6 +731,40 @@ public class OOPathCepTest {
         Assertions.assertThat(this.events).as("The rule should have fired for ping event only").contains(ping4Event);
     }
 
+    @Test
+    public void testEventExplicitExpirationWithOOPath() {
+        final String drl =
+                "import org.drools.testcoverage.common.model.Message;\n" +
+                "import org.drools.testcoverage.common.model.MessageEvent;\n" +
+                "global java.util.List events\n" +
+                "global java.util.List messages\n" +
+                "\n" +
+                "declare org.drools.testcoverage.common.model.MessageEvent\n" +
+                "  @role( event )\n" +
+                "  @expires( 2s )\n" +
+                "end\n" +
+                "rule R when\n" +
+                "  MessageEvent( /msg{ message == 'Ping' } )\n" +
+                "  MessageEvent( $message: /msg{ message == 'Pong' } )\n" +
+                "then\n" +
+                "  messages.add( $message );\n" +
+                "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
+        final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
+
+        this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 3);
+        final Message pongMessage = this.insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
+
+        this.kieSession.fireAllRules();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
+
+        this.insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
+
+        this.kieSession.fireAllRules();
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+    }
+
     private SessionPseudoClock initKieSessionWithPseudoClock(final KieBase kieBase) {
         final KieSessionConfiguration sessionConfiguration = KieSessionUtil.getKieSessionConfigurationWithClock(ClockTypeOption.get("pseudo"), null);
         this.initKieSession(kieBase, sessionConfiguration);
@@ -751,7 +785,7 @@ public class OOPathCepTest {
     }
 
     private Message insertEventAndAdvanceClock(final MessageEvent messageEvent, final SessionPseudoClock clock, final long timeInSeconds) {
-        final Message result = insertEvent(messageEvent);
+        final Message result = this.insertEvent(messageEvent);
         clock.advanceTime(timeInSeconds, TimeUnit.SECONDS);
         return result;
     }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathCepTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathCepTest.java
@@ -139,23 +139,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"));
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(secondPongEvent);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -179,23 +172,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")), clock, 1);
+        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Ping event before Pong event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final MessageEvent secondPingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(secondPingEvent);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("The rule should fire for the Pong event").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -219,23 +205,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"));
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(2, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -260,22 +239,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(pingEvent);
-
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION - 1500);
-        this.kieSession.insert(secondPongEvent);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1500));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -300,24 +273,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION - 1000);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1000));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -342,24 +307,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION), clock, 1);
+        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final MessageEvent secondPingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION - 1000);
-        this.kieSession.insert(secondPingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION - 1000));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -384,22 +341,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1500);
-        this.kieSession.insert(secondPongEvent);
+        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1500));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION - 1500);
-        this.kieSession.insert(pingEvent);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION - 1500));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -423,23 +374,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"));
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(2, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -463,23 +407,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"));
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(2, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")), clock, 2);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong")));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -504,28 +441,17 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), 1);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(2, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), 1);
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), 1), clock, 2);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), 1), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final MessageEvent secondPingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(secondPingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -550,24 +476,16 @@ public class OOPathCepTest {
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
         final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION), clock, 1);
+        insertEventAndAdvanceClock(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION), clock, 1);
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -590,24 +508,18 @@ public class OOPathCepTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
-        final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
+        this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(pingEvent);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION));
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION - 1000);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION - 1000));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -630,70 +542,18 @@ public class OOPathCepTest {
                 "end\n";
 
         final KieBase kieBase = KieBaseUtil.getKieBaseAndBuildInstallModuleFromDrl(MODULE_GROUP_ID, KieBaseTestConfiguration.STREAM_IDENTITY, drl);
-        final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
+        this.initKieSessionWithPseudoClock(kieBase);
 
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION);
-        this.kieSession.insert(pongEvent);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION);
-        this.kieSession.insert(pingEvent);
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION));
+        insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Ping"), DEFAULT_DURATION));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
+        Assertions.assertThat(this.messages).as("The first sequence of events should NOT make the rule fire").isEmpty();
 
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage, DEFAULT_DURATION + 1000);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
+        final Message pongMessage = insertEvent(new MessageEvent(MessageEvent.Type.sent, new Message("Pong"), DEFAULT_DURATION + 1000));
 
         this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
-    }
-
-    private void populateAndVerifyTemporalOperatorPongPingPongCase(final KieBase kieBase) {
-        final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
-
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Pong"));
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event before Ping event should NOT make the rule fire").isEmpty();
-
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent secondPongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(secondPongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Pong event after Ping event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
-    }
-
-    private void populateAndVerifyTemporalOperatorPingPongPingCase(final KieBase kieBase) {
-        final SessionPseudoClock clock = this.initKieSessionWithPseudoClock(kieBase);
-
-        final MessageEvent pingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(pingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        final Message pongMessage = new Message("Pong");
-        final MessageEvent pongEvent = new MessageEvent(MessageEvent.Type.sent, pongMessage);
-        this.kieSession.insert(pongEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("Ping event before Pong event should NOT make the rule fire").isEmpty();
-
-        final MessageEvent secondPingEvent = new MessageEvent(MessageEvent.Type.sent, new Message("Ping"));
-        this.kieSession.insert(secondPingEvent);
-        clock.advanceTime(1, TimeUnit.SECONDS);
-
-        this.kieSession.fireAllRules();
-        Assertions.assertThat(this.messages).as("The rule should fire for the Pong event").containsExactlyInAnyOrder(pongMessage);
+        Assertions.assertThat(this.messages).as("The last event should make the rule fire").containsExactlyInAnyOrder(pongMessage);
     }
 
     @Test
@@ -888,6 +748,17 @@ public class OOPathCepTest {
 
         this.events = new ArrayList<>();
         this.kieSession.setGlobal("events", events);
+    }
+
+    private Message insertEventAndAdvanceClock(final MessageEvent messageEvent, final SessionPseudoClock clock, final long timeInSeconds) {
+        final Message result = insertEvent(messageEvent);
+        clock.advanceTime(timeInSeconds, TimeUnit.SECONDS);
+        return result;
+    }
+
+    private Message insertEvent(final MessageEvent messageEvent) {
+        this.kieSession.insert(messageEvent);
+        return messageEvent.getMsg();
     }
 
 }


### PR DESCRIPTION
Added more tests for using OOPath with CEP:
- the remaining temporal operators,
- event expiration and duration.