### PR TITLE
1. To use extension elements inside inputData elements in order to pr…

### DIFF
--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -32,6 +32,11 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-model</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/marshalling/v1_1/DMNExtensionElementRegister.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/marshalling/v1_1/DMNExtensionElementRegister.java
@@ -14,23 +14,13 @@
  * limitations under the License.
  */
 
-package org.kie.dmn.api.core;
+package org.kie.dmn.api.marshalling.v1_1;
 
-import org.kie.api.io.Resource;
-import org.kie.dmn.api.marshalling.v1_1.DMNExtensionElementRegister;
-import org.kie.dmn.model.v1_1.Definitions;
+import com.thoughtworks.xstream.XStream;
 
-import java.io.Reader;
 
-public interface DMNCompiler {
+public interface DMNExtensionElementRegister {
 
-    DMNModel compile( Resource resource );
+    public void registerExtensionConverters(XStream xstream);
 
-    DMNModel compile( Resource resource, DMNExtensionElementRegister extensionElementRegister );
-
-    DMNModel compile( Reader source );
-
-    DMNModel compile( Reader source, DMNExtensionElementRegister extensionElementRegister );
-
-    DMNModel compile(Definitions dmndefs);
 }

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/DMNMarshallerFactory.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/DMNMarshallerFactory.java
@@ -16,6 +16,7 @@
 
 package org.kie.dmn.backend.marshalling.v1_1;
 
+import org.kie.dmn.api.marshalling.v1_1.DMNExtensionElementRegister;
 import org.kie.dmn.backend.marshalling.v1_1.xstream.XStreamMarshaller;
 import org.kie.dmn.api.marshalling.v1_1.DMNMarshaller;
 
@@ -24,5 +25,10 @@ public class DMNMarshallerFactory {
     public static DMNMarshaller newDefaultMarshaller() {
         return new XStreamMarshaller();
     }
+
+    public static DMNMarshaller newMarshallerWithExtensions(DMNExtensionElementRegister extensionElementRegister) {
+        return new XStreamMarshaller(extensionElementRegister);
+    }
+
 
 }

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
@@ -40,6 +40,7 @@ import com.thoughtworks.xstream.io.xml.AbstractPullReader;
 import com.thoughtworks.xstream.io.xml.QNameMap;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
 import com.thoughtworks.xstream.io.xml.StaxWriter;
+import org.kie.dmn.api.marshalling.v1_1.DMNExtensionElementRegister;
 import org.kie.dmn.api.marshalling.v1_1.DMNMarshaller;
 import org.kie.dmn.backend.marshalling.CustomStaxReader;
 import org.kie.dmn.backend.marshalling.CustomStaxWriter;
@@ -87,6 +88,8 @@ public class XStreamMarshaller
         implements DMNMarshaller {
 
     private static Logger logger = LoggerFactory.getLogger( XStreamMarshaller.class );
+    private DMNExtensionElementRegister extensionElementRegister;
+
 
     private static StaxDriver staxDriver;
     static {
@@ -107,6 +110,15 @@ public class XStreamMarshaller
         staxDriver.setQnameMap(qmap);
         staxDriver.setRepairingNamespace(false);
     }
+
+    public XStreamMarshaller() {
+
+    }
+
+    public XStreamMarshaller (DMNExtensionElementRegister extensionElementRegister) {
+        this.extensionElementRegister = extensionElementRegister;
+    }
+
 
     @Override
     public Definitions unmarshal(String xml) {
@@ -338,7 +350,12 @@ public class XStreamMarshaller
         xStream.registerConverter(new ExtensionElementsConverter( xStream ) );
         
         xStream.ignoreUnknownElements();
-        
+
+        if(extensionElementRegister != null) {
+            extensionElementRegister.registerExtensionConverters(xStream);
+        }
+
+
         return xStream;
     }
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -25,6 +25,7 @@ import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
 import org.kie.dmn.api.core.DMNCompiler;
 import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.marshalling.v1_1.DMNExtensionElementRegister;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.impl.DMNKnowledgeBuilderError;
 import org.kie.dmn.core.impl.DMNPackageImpl;
@@ -41,6 +42,8 @@ import java.util.Map;
 public class DMNAssemblerService implements KieAssemblerService {
 
     private static final Logger logger = LoggerFactory.getLogger( DMNAssemblerService.class );
+    private static final String DMN_EXTENSION_REGISTER = "ork.kie.dmn.extension.element.register";
+
 
     @Override
     public ResourceType getResourceType() {
@@ -52,7 +55,19 @@ public class DMNAssemblerService implements KieAssemblerService {
             throws Exception {
 
         DMNCompiler dmnCompiler = DMNFactory.newCompiler();
-        DMNModel model = dmnCompiler.compile( resource );
+        String extensionRegisterClassName = ( (KnowledgeBuilderImpl) kbuilder ).getBuilderConfiguration().getChainedProperties().getProperty(DMN_EXTENSION_REGISTER,
+                null);
+
+        DMNModel model = null;
+
+        if(extensionRegisterClassName != null && !extensionRegisterClassName.isEmpty()) {
+            DMNExtensionElementRegister extensionElementRegister =
+                    (DMNExtensionElementRegister)Class.forName(extensionRegisterClassName).newInstance();
+            model = dmnCompiler.compile(resource, extensionElementRegister);
+        } else {
+            model = dmnCompiler.compile(resource);
+        }
+
         if( model != null ) {
             String namespace = model.getNamespace();
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -23,6 +23,7 @@ import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNType;
 import org.kie.dmn.api.core.ast.BusinessKnowledgeModelNode;
+import org.kie.dmn.api.marshalling.v1_1.DMNExtensionElementRegister;
 import org.kie.dmn.core.api.DMNExpressionEvaluator;
 import org.kie.dmn.api.core.ast.DMNNode;
 import org.kie.dmn.api.core.ast.DecisionNode;
@@ -69,9 +70,31 @@ public class DMNCompilerImpl
     }
 
     @Override
+    public DMNModel compile(Resource resource, DMNExtensionElementRegister extensionElementRegister) {
+        try {
+            return compile( resource.getReader(), extensionElementRegister );
+        } catch ( IOException e ) {
+            logger.error( "Error retrieving reader for resource: " + resource.getSourcePath(), e );
+        }
+        return null;
+    }
+
+    @Override
     public DMNModel compile(Reader source) {
         try {
             Definitions dmndefs = DMNMarshallerFactory.newDefaultMarshaller().unmarshal( source );
+            DMNModel model = compile( dmndefs );
+            return model;
+        } catch ( Exception e ) {
+            logger.error( "Error compiling model from source.", e );
+        }
+        return null;
+    }
+
+    @Override
+    public DMNModel compile(Reader source, DMNExtensionElementRegister extensionElementRegister) {
+        try {
+            Definitions dmndefs = DMNMarshallerFactory.newMarshallerWithExtensions(extensionElementRegister).unmarshal( source );
             DMNModel model = compile( dmndefs );
             return model;
         } catch ( Exception e ) {


### PR DESCRIPTION
**_Please, review the following code._**
1. To use extension elements inside inputData elements in order to provide “external” information: GEO location, time and location tracking of a decision making (when and were specific decision was taken). This is the primary scope of the use.

2. In case extension element represents a complex type customer prefers to get back an instance of the complex type, assuming the complex type is defined as a class by the development team on the customer side. However, the customer also understands that it can be more complex and considers the possibility to get the complex type as an XML snippet. The parsing and turning the XML snippet into the complex type, defined by the customer.
3. The possibility of getting the list of extension elements is expected from other DMN elements, which extend from DMNElement, according to the DMN specification and meta model diagram by OMG. In other words, the usage of extension elements is not limited to be a part of input data elements only.
4. The client is not expecting “authoring” of the extension elements.
Since extension elements are a part of DMN specification, this is an attempt to make it possible for drools to register custom extension elements in a generic way.