### PR TITLE
Cherry-pick of DROOLS-1513 (#1196) for porting to 70x branch

### DIFF
--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNType.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/DMNType.java
@@ -37,4 +37,6 @@ public interface DMNType
 
     DMNType clone();
 
+    boolean isInstanceOf(Object o);
+    
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -175,7 +175,8 @@ public class DMNEvaluatorCompiler {
                     ctxEval.addEntry(
                             entryName,
                             entryType,
-                            evaluator );
+                            evaluator,
+                            ce );
 
                     // add context entry to the list of available variables for the following entries
                     ctx.setVariable( entryName, entryType );
@@ -194,7 +195,8 @@ public class DMNEvaluatorCompiler {
                     ctxEval.addEntry(
                             DMNContextEvaluator.RESULT_ENTRY,
                             type,
-                            compileExpression( ctx, model, node, contextName, ce.getExpression() ) );
+                            compileExpression( ctx, model, node, contextName, ce.getExpression() ),
+                            ce );
                 }
             }
         } finally {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistry.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistry.java
@@ -33,7 +33,7 @@ public class DMNTypeRegistry {
                     // already added, skip it
                     continue;
                 } else if( type == BuiltInType.LIST ) {
-                    feelPrimitiveType = new SimpleTypeImpl( feelNamespace, name, null, true, null, UNKNOWN, type );
+                    feelPrimitiveType = new SimpleTypeImpl( feelNamespace, name, null, false, null, UNKNOWN, type );
                 } else if( type == BuiltInType.CONTEXT ) {
                     feelPrimitiveType = new CompositeTypeImpl( feelNamespace, name, null, false, Collections.emptyMap(), null, type );
                 } else {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesComparator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesComparator.java
@@ -22,6 +22,10 @@ import javax.xml.namespace.QName;
 
 import org.kie.dmn.model.v1_1.ItemDefinition;
 
+/**
+ * Note: this comparator imposes orderings that are inconsistent with equals.
+ *
+ */
 public class ItemDefinitionDependenciesComparator implements Comparator<ItemDefinition> {
     
     private final String modelNamespace;
@@ -29,7 +33,10 @@ public class ItemDefinitionDependenciesComparator implements Comparator<ItemDefi
     public ItemDefinitionDependenciesComparator(String modelNamespace) {
         this.modelNamespace = modelNamespace;
     }
-
+    
+    /**
+     * Note: this comparator imposes orderings that are inconsistent with equals.
+     */
     @Override
     public int compare(ItemDefinition o1, ItemDefinition o2) {
         QName qname1 = new QName(modelNamespace, o1.getName());
@@ -39,9 +46,7 @@ public class ItemDefinitionDependenciesComparator implements Comparator<ItemDefi
         } else if ( recurseFind(o2, qname1) ) {
             return -1;
         } else { 
-            // although 0 would be correct, in order to have this comparison stable across several potential context
-            // in the case the two ItemDefinition are not dependent on one-another, order them alphabetically by name. (also helps for testing)
-            return o1.getName().compareTo(o2.getName());
+            return 0;
         }
     }
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BaseDMNTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BaseDMNTypeImpl.java
@@ -16,6 +16,7 @@
 
 package org.kie.dmn.core.impl;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -123,4 +124,25 @@ public abstract class BaseDMNTypeImpl
     public String toString() {
         return "DMNType{ "+getNamespace()+" : "+getName()+" }";
     }
+
+    @Override
+    public boolean isInstanceOf(Object o) {
+        if ( o == null ) {
+            return true; // null is instance of any type
+        }
+        // try first to recurse in case of Collection..
+        if ( isCollection() && o instanceof Collection ) {
+            Collection<Object> elements = (Collection) o;
+            for ( Object e : elements ) {
+                if ( !internalIsInstanceOf(e) ) {
+                    return false;
+                }
+            }
+            return true;
+        } 
+        // .. normal case, or collection of 1 element:
+        return internalIsInstanceOf(o);
+    }
+    
+    protected abstract boolean internalIsInstanceOf(Object o);
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/CompositeTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/CompositeTypeImpl.java
@@ -16,9 +16,11 @@
 
 package org.kie.dmn.core.impl;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.kie.dmn.api.core.DMNType;
 import org.kie.dmn.feel.lang.Type;
@@ -76,5 +78,25 @@ public class CompositeTypeImpl
     @Override
     public CompositeTypeImpl clone() {
         return new CompositeTypeImpl( getNamespace(), getName(), getId(), isCollection(), new LinkedHashMap<>( fields), getBaseType(), getFeelType() );
+    }
+    
+    @Override
+    protected boolean internalIsInstanceOf(Object o) {
+        Map<String, Object> instance = null;
+        try {
+            instance = (Map<String, Object>) o;
+        } catch ( Exception e ) {
+            return false;
+        }
+        for ( Entry<String, DMNType> f : fields.entrySet() ) {
+            if ( !instance.containsKey(f.getKey()) ) {
+                return false;
+            } else {
+                if ( !f.getValue().isInstanceOf(instance.get(f.getKey())) ) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/SimpleTypeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/SimpleTypeImpl.java
@@ -20,6 +20,7 @@ import org.kie.dmn.api.core.DMNType;
 import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.feel.runtime.UnaryTest;
 
+import java.util.Collection;
 import java.util.List;
 
 public class SimpleTypeImpl
@@ -47,4 +48,8 @@ public class SimpleTypeImpl
         return new SimpleTypeImpl( getNamespace(), getName(), getId(), isCollection(), getAllowedValues(), getBaseType(), getFeelType() );
     }
 
+    @Override
+    protected boolean internalIsInstanceOf(Object o) {
+        return getFeelType().isInstanceOf(o);
+    }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -55,6 +55,7 @@ public class Msg {
     public static final Message2 ERROR_EVAL_BKM_NODE                                 = new Message2( DMNMessageType.ERROR_EVAL_NODE, "Error evaluating Business Knowledge Model node '%s': %s" );
     public static final Message2 ERROR_EVAL_DECISION_NODE                            = new Message2( DMNMessageType.ERROR_EVAL_NODE, "Error evaluating Decision node '%s': %s" );
     public static final Message3 ERROR_EVAL_NODE_DEP_WRONG_TYPE                      = new Message3( DMNMessageType.ERROR_EVAL_NODE, "Error while evaluating node '%s' for dependency '%s': the dependency value '%s' is not allowed by the declared type" );
+    public static final Message3 ERROR_EVAL_NODE_RESULT_WRONG_TYPE                   = new Message3( DMNMessageType.ERROR_EVAL_NODE, "Error while evaluating node '%s': the declared result type is '%s' but the actual value '%s' is not an instance of that type" );
     public static final Message2 EXPR_TYPE_NOT_SUPPORTED_IN_NODE                     = new Message2( DMNMessageType.EXPR_TYPE_NOT_SUPPORTED_IN_NODE, "Expression type '%s' not supported in node '%s'" );
     public static final Message3 ERR_COMPILING_FEEL_EXPR_ON_DT_INPUT_CLAUSE_IDX      = new Message3( DMNMessageType.ERR_COMPILING_FEEL, "Error compiling FEEL expression '%s' on decision table '%s', input clause #%s" );
     public static final Message3 ERR_COMPILING_FEEL_EXPR_ON_DT_OUTPUT_CLAUSE_IDX     = new Message3( DMNMessageType.ERR_COMPILING_FEEL, "Error compiling FEEL expression '%s' on decision table '%s', output clause #%s" );

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
@@ -96,12 +96,16 @@ public class DMNRuntimeTest {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "trisotech_namespace.dmn", this.getClass() );
         DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/dmn/definitions/_b8feec86-dadf-4051-9feb-8e6093bbb530", "Solution 3" );
         assertThat( dmnModel, notNullValue() );
-
+        assertThat( formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        
         DMNContext context = DMNFactory.newContext();
         context.set( "IsDoubleHulled", true );
         context.set( "Residual Cargo Size", new BigDecimal( 0.1 ) );
         context.set( "Ship Size", new BigDecimal( 50 ) );
+        
         DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
+        assertThat( formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
+        
         DMNContext result = dmnResult.getContext();
         assertThat( result.get( "Ship can enter a Dutch port" ), is( true ) );
     }
@@ -1053,6 +1057,31 @@ public class DMNRuntimeTest {
         assertThat( formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( false ) );
         DMNContext result = dmnResult.getContext();
         assertThat( result.get( "My Decision" ), is( "The person John Doe is located at 100 East Davie Street" ) );
+    }
+    
+    @Test
+    public void testDecisionResultTypeCheck() {
+        // DROOLS-1513
+        DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "LoanRecommendationWrongOutputType.dmn", this.getClass() );
+        DMNModel dmnModel = runtime.getModel(
+                "http://www.trisotech.com/dmn/definitions/_591d49d0-26e1-4a1c-9f72-b65bec09964a",
+                "Loan Recommendation Multi-step" );
+        assertThat( dmnModel, notNullValue() );
+        System.out.println(formatMessages( dmnModel.getMessages() ));
+        assertThat( formatMessages( dmnModel.getMessages() ), dmnModel.hasErrors(), is( false ) );
+        
+        DMNContext context = runtime.newContext();
+        Map<String, Number> loan = new HashMap<>();
+        loan.put("Amount", 100);
+        loan.put("Rate", 12);
+        loan.put("Term", 1);
+        context.set("Loan", loan);
+
+        DMNResult dmnResult = runtime.evaluateDecisionByName( dmnModel, "Loan Payment", context );
+        assertThat( formatMessages( dmnResult.getMessages() ), dmnResult.hasErrors(), is( true ) );
+        assertThat( dmnResult.getMessages().size(), is( 1 ) );
+        assertThat( dmnResult.getMessages().get( 0 ).getSourceId(), is("_93062144-ebc7-4ef7-a156-c342aeffac49") );
+        assertThat( dmnResult.getMessages().get( 0 ).getMessageType(), is( DMNMessageType.ERROR_EVAL_NODE ) );
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/FlightRebookingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/FlightRebookingTest.java
@@ -59,27 +59,6 @@ public class FlightRebookingTest {
 
         assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
     }
-    
-    @Test
-    public void testSolution1_usingFEELdateTime() {
-        DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0019-flight-rebooking.dmn", this.getClass() );
-        DMNModel dmnModel = runtime.getModel( "https://www.drools.org/kie-dmn", "0019-flight-rebooking" );
-        assertThat( dmnModel, notNullValue() );
-
-        DMNContext context = DMNFactory.newContext();
-
-        List passengerList = loadPassengerList();
-        List flightList = loadFlightListFEEL();
-
-        context.set( "Passenger List", passengerList );
-        context.set( "Flight List", flightList );
-
-        DMNResult dmnResult = runtime.evaluateAll( dmnModel, context );
-
-        DMNContext result = dmnResult.getContext();
-        
-        assertThat( result.get( "Rebooked Passengers" ), is( loadExpectedResult() ) );
-    }
 
     @Test
     public void testSolutionAlternate() {
@@ -193,10 +172,6 @@ public class FlightRebookingTest {
                 {"UA1111", "SFO", "LAX", date("2017-01-01T23:00:00"), date("2017-01-02T05:00:00"), 2, "scheduled"}
         };
 
-        return flightDataToFlightList(flightData);
-    }
-
-    private List flightDataToFlightList(Object[][] flightData) {
         List<Map<String,Object>> flightList = new ArrayList<>(  );
         for( Object[] pd : flightData ) {
             Map<String, Object> p = new HashMap<>(  );
@@ -210,21 +185,6 @@ public class FlightRebookingTest {
             flightList.add( p );
         }
         return flightList;
-    }
-    
-    /**
-     * Same as {@link #loadFlightList()} but instead of using Java LocalDateTime, using FEEL "date and time" datatype.
-     */
-    private List loadFlightListFEEL() {
-        Object[][] flightData = new Object[][] {
-                {"UA123", "SFO", "SNA", "date and time(\"2017-01-01T18:00:00\")", "date and time(\"2017-01-01T19:00:00\")", 5, "cancelled"},
-                {"UA456", "SFO", "SNA", "date and time(\"2017-01-01T19:00:00\")", "date and time(\"2017-01-01T20:00:00\")", 2, "scheduled"},
-                {"UA789", "SFO", "SNA", "date and time(\"2017-01-01T21:00:00\")", "date and time(\"2017-01-01T23:00:00\")", 2, "scheduled"},
-                {"UA1001", "SFO", "SNA", "date and time(\"2017-01-01T23:00:00\")", "date and time(\"2017-01-02T05:00:00\")", 0, "scheduled"},
-                {"UA1111", "SFO", "LAX", "date and time(\"2017-01-01T23:00:00\")", "date and time(\"2017-01-02T05:00:00\")", 2, "scheduled"}
-        };
-
-        return flightDataToFlightList(flightData);
     }
 
     private List loadExpectedResult() {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesComparatorTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesComparatorTest.java
@@ -27,7 +27,7 @@ import org.kie.dmn.api.marshalling.v1_1.DMNMarshaller;
 import org.kie.dmn.backend.marshalling.v1_1.DMNMarshallerFactory;
 import org.kie.dmn.model.v1_1.ItemDefinition;
 
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 
@@ -63,7 +63,8 @@ public class ItemDefinitionDependenciesComparatorTest {
         List<ItemDefinition> orderedList = new ArrayList<>(originalList);
         orderedList.sort(new ItemDefinitionDependenciesComparator(TEST_NS));
 
-        assertThat(orderedList, contains(a,b,c,d));
+        assertThat(orderedList.subList(0, 2), containsInAnyOrder(a,b));
+        assertThat(orderedList.subList(2, 4), contains(c,d));
     }
     
     

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0007-date-time.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0007-date-time.dmn
@@ -22,13 +22,13 @@
 	</itemDefinition>
 	<itemDefinition id="tDateVariants" name="tDateVariants">
 		<itemComponent id="_02d44cc2-24ac-4f64-a61f-7044684dc438" name="fromString">
-			<typeRef>feel:string</typeRef>
+			<typeRef>feel:date</typeRef>
 		</itemComponent>
 		<itemComponent id="_13da5f5e-8fdd-4a33-9500-ceeaaeaccc91" name="fromDateTime">
-			<typeRef>feel:string</typeRef>
+			<typeRef>feel:date</typeRef>
 		</itemComponent>
 		<itemComponent id="_c4e03aa1-d8f3-4ffa-aab2-42a17a4fb707" name="fromYearMonthDay">
-			<typeRef>feel:string</typeRef>
+			<typeRef>feel:date</typeRef>
 		</itemComponent>
 	</itemDefinition>
 	<inputData id="_74a9c3ad-a813-444e-88ee-8a91096ee233" name="dateString">

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Dinner.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/Dinner.dmn
@@ -165,8 +165,11 @@
   <semantic:inputData id="_1480f7e8-1c39-4781-9684-9a0e784044ce" name="Number of guests">
     <semantic:variable id="_db14818f-bd6b-4481-a797-7602d6f15c0e" name="Number of guests"/>
   </semantic:inputData>
+    <itemDefinition id="tDrinks" name="tDrinks" isCollection="true">
+            <typeRef>feel:string</typeRef>
+    </itemDefinition>
   <semantic:decision id="_7e01ac6d-56b2-4ddf-aa0e-9242db09cfe5" name="Drinks">
-    <semantic:variable id="_4ea2078c-8107-4df9-b4d5-876462bcc728" name="Drinks" typeRef="feel:string"/>
+    <semantic:variable id="_4ea2078c-8107-4df9-b4d5-876462bcc728" name="Drinks" typeRef="tDrinks"/>
     <semantic:informationRequirement>
       <semantic:requiredDecision href="#_b9dc3d65-6aa4-4ff9-9baf-f4ed04fdf8fd"/>
     </semantic:informationRequirement>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/LoanRecommendationWrongOutputType.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/LoanRecommendationWrongOutputType.dmn
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+xmlns="http://www.trisotech.com/dmn/definitions/_591d49d0-26e1-4a1c-9f72-b65bec09964a" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" 
+xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+exporter="DMN Modeler" exporterVersion="5.1.9.201704041157" id="_c636dddb-121f-4ec6-8356-182904dd2779" name="Loan Recommendation Multi-step"
+namespace="http://www.trisotech.com/dmn/definitions/_591d49d0-26e1-4a1c-9f72-b65bec09964a" triso:logoChoice="Default">
+  <semantic:extensionElements/>
+  <semantic:itemDefinition isCollection="false" label="tCollateralRisk" name="tCollateralRiskCategory">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"Very low","Low","Medium","High"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tCreditRisk" name="tCreditRiskCategory">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"A","B","C","D","E"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tAffordability" name="tAffordabilityCategory">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"Affordable","Marginal","Not affordable"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tLoanRecommendation" name="tLoanRecommendation">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"Approve","Decline"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tLoan" name="tLoan">
+    <semantic:itemComponent id="_559a9874-6acf-4ce7-be7c-3f64cbc90dc3" name="Amount">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_faf3ed69-3f1d-4aaa-bd23-881632425d74" name="Rate">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_ae467e15-d8b4-4f77-ac0d-1c4138a1b675" name="Term">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tAge" name="tAge">
+    <semantic:typeRef>feel:number</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="simple">
+      <semantic:text>&gt;=18</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tEmploymentStatus" name="temploementStatus">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"Employed","Self-employed","Retired","Unemployed"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tCreditScore" name="tCreditScore">
+    <semantic:typeRef>feel:number</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="simple">
+      <semantic:text>[300..850]</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tRiskCategory" name="tRiskCategory">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"High","Medium","Low"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tIncomeRisk" name="tIncomeRisk">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"Low","Medium","High"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tBorrower" name="tBorrowe">
+    <semantic:itemComponent id="_9dd862e1-05d1-4563-b361-49daf1dadcb1" name="Age">
+      <semantic:typeRef>tAge</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_308e0a0f-c6f0-42cc-9940-207cf04b1666" name="EmploymentStatus">
+      <semantic:typeRef>temploementStatus</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_abf6732d-dbc8-4a1b-ad5e-a68c2882ed32" name="YearsAtCurrentEmployer">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_7c41c419-fe3d-4a8b-ae22-04235acd3ec5" name="TotalAnnualIncome">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_cfea2f20-fe02-43c2-96d9-69d3e0376da8" name="NonSalaryIncome">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_ce957999-301f-4ae5-a28d-65b6be962d25" name="MonthlyDebtPmtAmt">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_08108b3d-3656-4d38-b4d2-269e45e25113" name="LiquidAssetsAmt">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition isCollection="false" label="tPrequalification" name="tPrequalification">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+    <semantic:allowedValues triso:constraintsType="enumeration">
+      <semantic:text>"Decline","Need credit score"</semantic:text>
+    </semantic:allowedValues>
+  </semantic:itemDefinition>
+  <semantic:decision id="_5c05c833-cbd8-4346-864a-54aec7b66f8a" name="Reserves Months" triso:displayName="Reserves Months">
+    <semantic:variable id="_812594d7-799e-405e-a7e8-40f40268ecc3" name="Reserves Months" typeRef="feel:number"/>
+    <semantic:informationRequirement>
+      <semantic:requiredInput href="#_19af4d40-1aaf-4615-8038-b2470b6c014b"/>
+    </semantic:informationRequirement>
+    <semantic:informationRequirement>
+      <semantic:requiredDecision href="#_93062144-ebc7-4ef7-a156-c342aeffac49"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression id="_7a828a6c-ff23-44e0-91c8-898a33587a28">
+      <semantic:text>Borrower.LiquidAssetsAmt / Loan Payment</semantic:text>
+    </semantic:literalExpression>
+  </semantic:decision>
+  <semantic:inputData id="_19af4d40-1aaf-4615-8038-b2470b6c014b" name="Borrower" triso:displayName="Borrower">
+    <semantic:variable id="_c452ee2f-283d-43a3-b70c-cd5ba13274ab" name="Borrower" typeRef="tBorrowe"/>
+  </semantic:inputData>
+  <semantic:decision id="_93062144-ebc7-4ef7-a156-c342aeffac49" name="Loan Payment" triso:displayName="Loan Payment">
+    <semantic:variable id="_1b058750-0c2d-46cf-8d6a-06e0acd6b262" name="Loan Payment" typeRef="tLoan"/>
+    <semantic:informationRequirement>
+      <semantic:requiredInput href="#_d8c8d124-7069-4d66-9015-282e857b72fc"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression expressionLanguage="http://www.omg.org/spec/FEEL/20140401" id="_229c1eda-11e7-4310-8555-6e4eb6f38b78" triso:unparsed="false">
+      <semantic:text>Loan.Amount * Loan.Rate/12/(1 - (1 + Loan.Rate/12) ** - Loan.Term)</semantic:text>
+    </semantic:literalExpression>
+  </semantic:decision>
+  <semantic:inputData id="_d8c8d124-7069-4d66-9015-282e857b72fc" name="Loan" triso:displayName="Loan">
+    <semantic:variable id="_a24c2e72-a4c4-443d-9fd8-375b813eb893" name="Loan" typeRef="tLoan"/>
+  </semantic:inputData>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/trisotech_namespace.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/trisotech_namespace.dmn
@@ -10,7 +10,7 @@
                       namespace="http://www.trisotech.com/dmn/definitions/_b8feec86-dadf-4051-9feb-8e6093bbb530"
                       triso:logoChoice="Default">
   <semantic:decision id="_42806504-8ed5-488f-b274-de98c1bc67b9" name="Ship can enter a Dutch port">
-    <semantic:variable id="_5e5f1d3a-2476-4688-82c6-796f23ab1b38" name="Ship can enter a Dutch port" typeRef="feel:string"/>
+    <semantic:variable id="_5e5f1d3a-2476-4688-82c6-796f23ab1b38" name="Ship can enter a Dutch port" typeRef="feel:boolean"/>
     <semantic:informationRequirement>
       <semantic:requiredInput href="#_b932dcf4-5462-42bb-8c6b-9280ec229d7a"/>
     </semantic:informationRequirement>

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/Type.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/Type.java
@@ -22,5 +22,6 @@ package org.kie.dmn.feel.lang;
 public interface Type {
 
     String getName();
-
+    
+    boolean isInstanceOf(Object o);
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
@@ -86,4 +86,9 @@ public class JavaBackedType implements CompositeType {
             this.type = type;
         }
     }
+
+    @Override
+    public boolean isInstanceOf(Object o) {
+        return wrapped.getClass().isAssignableFrom(o.getClass());
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/MapBackedType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/MapBackedType.java
@@ -5,6 +5,7 @@ import org.kie.dmn.feel.lang.Type;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * A map-based type descriptor
@@ -42,5 +43,25 @@ public class MapBackedType
     @Override
     public Map<String, Type> getFields() {
         return fields;
+    }
+
+    @Override
+    public boolean isInstanceOf(Object o) {
+        Map<String, Object> instance = null;
+        try {
+            instance = (Map<String, Object>) o;
+        } catch ( Exception e ) {
+            return false;
+        }
+        for ( Entry<String, Type> f : fields.entrySet() ) {
+            if ( instance.get(f.getKey()) == null ) {
+                return false;
+            } else {
+                if ( !f.getValue().isInstanceOf(instance.get(f.getKey())) ) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BuiltInType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BuiltInType.java
@@ -146,11 +146,19 @@ public enum BuiltInType implements SimpleType {
     }
 
     public static boolean isInstanceOf( Object o, Type t ) {
+        if ( t == UNKNOWN ) {
+            return true;
+        }
         return determineTypeFromInstance( o ) == t;
     }
 
     public static boolean isInstanceOf( Object o, String name ) {
         return determineTypeFromInstance( o ) == determineTypeFromName( name );
+    }
+
+    @Override
+    public boolean isInstanceOf(Object o) {
+        return isInstanceOf(o, this);
     }
 
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BuiltInTypeSymbol.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/types/BuiltInTypeSymbol.java
@@ -35,4 +35,9 @@ public class BuiltInTypeSymbol
         return getId();
     }
 
+    @Override
+    public boolean isInstanceOf(Object o) {
+        return getType().isInstanceOf(o);
+    }
+
 }


### PR DESCRIPTION
DROOLS-1513 Evaluation result Type error check and reporting (#1196)

* WIP - still failing tests

* Fix 0007-date-time.dmn

* Fix dinner.dmn

* Fix trisotech_namespace.dmn

* Reimplementation of DMNType isInstanceOf

* latent bug FIX: the DMNType on DMN layer wrapping FEEL's BuiltInType.LIST

is NOT a DMN Collection.

* .

* Resolve merge conflict.

* FIX 0009-invocation-arithmetic.dmn

* Revert "FIX 0009-invocation-arithmetic.dmn"

This reverts commit 6961c88f4c10725ad5dd1c8dc8666c0cfdb96e2e.

* Revert "Augment flight test using FEEL "date and time" datatype in input context (#72)"

This reverts commit d0c712c20b2212c84d34144cb4e490ed1f448c10.

* Add ContentEntry return type check, BKM not possible yet.

* Check output type for DMNRelationEvaluator

* .

* .

* Check output type for DMNListEvaluator, analogous to DMNRelationEvaluator

* Reverting DMNRelationEvaluator and DMNListEvaluator mods

This reverts commit 5ade8012c77caae4f83e9f2dcb4cab1dfdb9fcd9.
This reverts commit 2ee7571538f70aa3a41552565db319236e85b72e.
This reverts commit b45dc151a04615ddb511573f29795fadf491f627.