### PR TITLE
[DROOLS-1523] defer retraction of tuples generated by expired events …

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -59,7 +59,6 @@ import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.rule.EntryPointId;
 import org.drools.core.rule.TypeDeclaration;
 import org.drools.core.spi.ObjectType;
-import org.kie.api.time.SessionPseudoClock;
 import org.drools.core.time.impl.DurationTimer;
 import org.drools.core.time.impl.PseudoClockScheduler;
 import org.drools.core.util.DateUtils;
@@ -81,7 +80,9 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.definition.type.Role;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.AgendaGroupPoppedEvent;
 import org.kie.api.event.rule.DebugAgendaEventListener;
+import org.kie.api.event.rule.DefaultAgendaEventListener;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
@@ -93,6 +94,7 @@ import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.Match;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.time.SessionClock;
+import org.kie.api.time.SessionPseudoClock;
 import org.kie.internal.KnowledgeBase;
 import org.kie.internal.KnowledgeBaseFactory;
 import org.kie.internal.builder.KnowledgeBuilder;
@@ -6610,5 +6612,71 @@ public class CepEspTest extends CommonTestMethodBase {
         ksession.fireAllRules();
 
         assertEquals(0, ksession.getFactCount());
+    }
+
+    @Test
+    public void testFireExpiredEventOnInactiveGroup() throws Exception {
+        // DROOLS-1523
+        String DRL = "global java.util.List list;\n" +
+                     "declare String  @role(event) @expires( 6d ) end\n" +
+                     "declare Integer @role(event) @expires( 3d ) end\n" +
+                     "\n" +
+                     "rule \"RG_1\"\n" +
+                     "    agenda-group \"rf-grp1\"\n" +
+                     "    when\n" +
+                     "        $event: Integer()\n" +
+                     "        not String(this after [1ms, 48h] $event)\n" +
+                     "    then\n" +
+                     "      System.out.println(\"RG_1 fired\");\n" +
+                     "      retract($event);\n" +
+                     "      list.add(\"RG_1\");\n" +
+                     "end\n" +
+                     "\n" +
+                     "rule \"RG_2\"\n" +
+                     "    agenda-group \"rf-grp1\"\n" +
+                     "    when\n" +
+                     "        $event: String()\n" +
+                     "        not Integer(this after [1ms, 144h] $event)\n" +
+                     "    then\n" +
+                     "      System.out.println(\"RG_2 fired\");\n" +
+                     "      list.add(\"RG_2\");\n" +
+                     "end\n";
+
+        KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+
+        KieHelper helper = new KieHelper();
+        helper.addContent( DRL, ResourceType.DRL );
+        KieBase kbase = helper.build( EventProcessingOption.STREAM );
+        KieSession kieSession = kbase.newKieSession( sessionConfig, null );
+
+        kieSession.addEventListener(new DefaultAgendaEventListener() {
+            public void agendaGroupPopped(AgendaGroupPoppedEvent event ) {
+                if (event.getAgendaGroup().getName().equals("rf-grp0")) {
+                    event.getKieRuntime().getAgenda().getAgendaGroup("rf-grp1").setFocus();
+                }
+            }
+        });
+
+        List<String> list = new ArrayList<>();
+        kieSession.setGlobal("list", list);
+
+        PseudoClockScheduler sessionClock = kieSession.getSessionClock();
+
+        kieSession.insert("DummyEvent");
+        kieSession.insert(1); //<- OtherDummyEvent
+        kieSession.getAgenda().getAgendaGroup( "rf-grp0" ).setFocus();
+        kieSession.fireAllRules(); // OK nothing happens
+
+        assertEquals(2, kieSession.getFactCount());
+
+        sessionClock.advanceTime(145, TimeUnit.HOURS);
+        kieSession.getAgenda().getAgendaGroup( "rf-grp0" ).setFocus();
+        kieSession.fireAllRules();
+
+        assertEquals("Expiration occured => no more fact in WM", 0, kieSession.getFactCount());
+
+        assertEquals("RG_1 should fire once", 1, list.stream().filter(r->r.equals("RG_1")).count());
+        assertEquals("RG_2 should fire once", 1, list.stream().filter(r->r.equals("RG_2")).count());
     }
 }

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -16,6 +16,11 @@
 
 package org.drools.core.common;
 
+import java.io.IOException;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.drools.core.conflict.PhreakConflictResolver;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.marshalling.impl.MarshallerReaderContext;
@@ -25,11 +30,6 @@ import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.spi.Activation;
 import org.drools.core.spi.PropagationContext;
 import org.drools.core.util.BinaryHeapQueue;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * <code>AgendaGroup</code> implementation that uses a <code>PriorityQueue</code> to prioritise the evaluation of added
@@ -143,6 +143,11 @@ public class AgendaGroupQueueImpl
         @Override
         public void execute( InternalWorkingMemory wm ) {
             wm.getAgenda().setFocus(this.name);
+        }
+
+        @Override
+        public boolean defersExpiration() {
+            return true;
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
@@ -1489,7 +1489,7 @@ public class DefaultAgenda
     }
 
     private boolean flushExpirations() {
-        if (expirationContexts.isEmpty()) {
+        if (expirationContexts.isEmpty() || propagationList.hasEntriesDeferringExpiration()) {
             return false;
         }
         for (PropagationContext ectx : expirationContexts) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -51,6 +51,8 @@ public interface PropagationEntry {
     boolean isPartitionSplittable();
     PropagationEntry getSplitForPartition(int partitionNr);
 
+    boolean defersExpiration();
+
     abstract class AbstractPropagationEntry implements PropagationEntry {
         private PropagationEntry next;
 
@@ -79,6 +81,11 @@ public interface PropagationEntry {
 
         @Override
         public boolean isPartitionSplittable() {
+            return false;
+        }
+
+        @Override
+        public boolean defersExpiration() {
             return false;
         }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationList.java
@@ -29,6 +29,8 @@ public interface PropagationList {
 
     boolean isEmpty();
 
+    boolean hasEntriesDeferringExpiration();
+
     Iterator<PropagationEntry> iterator();
 
     void waitOnRest();


### PR DESCRIPTION
…if there are setFocus action in the propagation queue (#1203)

[DROOLS-1523] defer retraction of tuples generated by expired events if there are setFocus action in the propagation queue
(cherry picked from commit d959f206857b434ff9651bb49196ab43435e335f)