### PR TITLE
  [DROOLS-1523] defer retraction of tuples generated by expired events if there are setFocus action in the propagation queue

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/WrappedStatefulKnowledgeSessionForRHS.java
+++ b/drools-core/src/main/java/org/drools/core/base/WrappedStatefulKnowledgeSessionForRHS.java
@@ -1,5 +1,16 @@
 package org.drools.core.base;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.locks.Lock;
+
 import org.drools.core.SessionConfiguration;
 import org.drools.core.WorkingMemory;
 import org.drools.core.WorkingMemoryEntryPoint;
@@ -27,6 +38,7 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.StatefulKnowledgeSessionImpl;
 import org.drools.core.marshalling.impl.MarshallerReaderContext;
 import org.drools.core.phreak.PropagationEntry;
+import org.drools.core.phreak.PropagationList;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeConf;
 import org.drools.core.rule.EntryPointId;
@@ -66,17 +78,6 @@ import org.kie.internal.event.rule.RuleEventListener;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.runtime.KnowledgeRuntime;
 import org.kie.internal.runtime.beliefs.Mode;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.locks.Lock;
 
 /**
  * Wrapper of StatefulKnowledgeSessionImpl so to intercept call from RHS internal Drools execution and proxy or delegate method call as appropriate.
@@ -723,6 +724,11 @@ public final class WrappedStatefulKnowledgeSessionForRHS
 
 	public PropagationEntry takeAllPropagations() {
 		return delegate.takeAllPropagations();
+	}
+
+	@Override
+	public PropagationList getPropagationList() {
+		return delegate.getPropagationList();
 	}
 
 	public Iterator<? extends PropagationEntry> getActionsIterator() {

--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -16,6 +16,11 @@
 
 package org.drools.core.common;
 
+import java.io.IOException;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.drools.core.conflict.PhreakConflictResolver;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.marshalling.impl.MarshallerReaderContext;
@@ -25,11 +30,6 @@ import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.spi.Activation;
 import org.drools.core.spi.PropagationContext;
 import org.drools.core.util.BinaryHeapQueue;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * <code>AgendaGroup</code> implementation that uses a <code>PriorityQueue</code> to prioritise the evaluation of added
@@ -143,6 +143,11 @@ public class AgendaGroupQueueImpl
         @Override
         public void execute( InternalWorkingMemory wm ) {
             wm.getAgenda().setFocus(this.name);
+        }
+
+        @Override
+        public boolean defersExpiration() {
+            return true;
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
+++ b/drools-core/src/main/java/org/drools/core/common/DefaultAgenda.java
@@ -33,6 +33,7 @@ import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.phreak.ExecutableEntry;
 import org.drools.core.phreak.PropagationEntry;
+import org.drools.core.phreak.PropagationList;
 import org.drools.core.phreak.RuleAgendaItem;
 import org.drools.core.phreak.RuleExecutor;
 import org.drools.core.reteoo.LeftTuple;
@@ -1321,7 +1322,7 @@ public class DefaultAgenda
                     group = null; // set the group to null in case the fire limit has been reached
                 }
 
-                if ( returnedFireCount == 0 && head == null && ( group == null || !group.isAutoDeactivate() ) && !flushExpirations() ) {
+                if ( returnedFireCount == 0 && head == null && ( group == null || !group.isAutoDeactivate() ) && !flushExpirations(this.workingMemory.getPropagationList()) ) {
                     // if true, the engine is now considered potentially at rest
                     head = restHandler.handleRest( workingMemory, this );
                 }
@@ -1562,8 +1563,8 @@ public class DefaultAgenda
         expirationContexts.add(ectx);
     }
 
-    private boolean flushExpirations() {
-        if (expirationContexts.isEmpty()) {
+    private boolean flushExpirations( PropagationList propagationList ) {
+        if (expirationContexts.isEmpty() || propagationList.hasEntriesDeferringExpiration()) {
             return false;
         }
         for (PropagationContext ectx : expirationContexts) {

--- a/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalWorkingMemory.java
@@ -16,12 +16,18 @@
 
 package org.drools.core.common;
 
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+
 import org.drools.core.SessionConfiguration;
 import org.drools.core.WorkingMemory;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.event.AgendaEventSupport;
 import org.drools.core.event.RuleRuntimeEventSupport;
 import org.drools.core.phreak.PropagationEntry;
+import org.drools.core.phreak.PropagationList;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeConf;
 import org.drools.core.rule.EntryPointId;
@@ -34,11 +40,6 @@ import org.kie.api.runtime.Calendars;
 import org.kie.api.runtime.Channel;
 import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.FactHandle;
-
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.locks.Lock;
 
 public interface InternalWorkingMemory
     extends WorkingMemory, InternalWorkingMemoryEntryPoint {
@@ -213,6 +214,8 @@ public interface InternalWorkingMemory
 
     boolean hasPendingPropagations();
     PropagationEntry takeAllPropagations();
+
+    PropagationList getPropagationList();
 
     Iterator<? extends PropagationEntry> getActionsIterator();
 

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -2116,6 +2116,10 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         return propagationList.takeAll();
     }
 
+    public PropagationList getPropagationList() {
+        return propagationList;
+    }
+
     @Override
     public PropagationEntry handleRestOnFireUntilHalt(DefaultAgenda.ExecutionState currentState) {
         // this must use the same sync target as takeAllPropagations, to ensure this entire block is atomic, up to the point of wait

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -42,8 +42,10 @@ public interface PropagationEntry {
     void setNext(PropagationEntry next);
 
     boolean requiresImmediateFlushing();
-    
+
     boolean isCalledFromRHS();
+
+    boolean defersExpiration();
 
     abstract class AbstractPropagationEntry implements PropagationEntry {
         private PropagationEntry next;
@@ -60,7 +62,7 @@ public interface PropagationEntry {
         public boolean requiresImmediateFlushing() {
             return false;
         }
-        
+
         @Override
         public boolean isCalledFromRHS() {
             return false;
@@ -74,6 +76,11 @@ public interface PropagationEntry {
         @Override
         public void executeForMarshalling(InternalWorkingMemory wm) {
             execute( wm );
+        }
+
+        @Override
+        public boolean defersExpiration() {
+            return false;
         }
     }
 
@@ -157,7 +164,7 @@ public interface PropagationEntry {
 
             WorkingMemoryReteExpireAction action = new WorkingMemoryReteExpireAction( (EventFactHandle) handle, otn );
             if (nextTimestamp < workingMemory.getTimerService().getCurrentTime()) {
-                  workingMemory.addPropagation( action );
+                workingMemory.addPropagation( action );
             } else {
                 JobContext jobctx = new ObjectTypeNode.ExpireJobContext( action, workingMemory );
                 JobHandle jobHandle = workingMemory.getTimerService()

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationList.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationList.java
@@ -29,6 +29,8 @@ public interface PropagationList {
 
     boolean isEmpty();
 
+    boolean hasEntriesDeferringExpiration();
+
     Iterator<PropagationEntry> iterator();
 
     void waitOnRest();

--- a/drools-reteoo/src/main/java/org/drools/reteoo/common/RetePropagationList.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/common/RetePropagationList.java
@@ -16,12 +16,12 @@
 
 package org.drools.reteoo.common;
 
+import java.util.Collections;
+import java.util.Iterator;
+
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.phreak.PropagationEntry;
 import org.drools.core.phreak.PropagationList;
-
-import java.util.Collections;
-import java.util.Iterator;
 
 public class RetePropagationList implements PropagationList {
 
@@ -71,6 +71,11 @@ public class RetePropagationList implements PropagationList {
 
     @Override
     public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public boolean hasEntriesDeferringExpiration() {
         return true;
     }
 

--- a/drools-reteoo/src/main/java/org/drools/reteoo/common/RetePropagationList.java
+++ b/drools-reteoo/src/main/java/org/drools/reteoo/common/RetePropagationList.java
@@ -76,7 +76,7 @@ public class RetePropagationList implements PropagationList {
 
     @Override
     public boolean hasEntriesDeferringExpiration() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
…if there are setFocus action in the propagation queue (#1203)

[DROOLS-1523] defer retraction of tuples generated by expired events if there are setFocus action in the propagation queue
(cherry picked from commit d959f206857b434ff9651bb49196ab43435e335f)