### PR TITLE
Fix exception when Pong GUI window is closed, when originally launched..

### DIFF
--- a/drools-examples/src/main/java/org/drools/games/GameUI.java
+++ b/drools-examples/src/main/java/org/drools/games/GameUI.java
@@ -69,7 +69,14 @@ public class GameUI extends Canvas{
         createBufferStrategy(2);
         bufferStrategy = getBufferStrategy();
     }
-
+    
+    protected void registerWindowListenerOnFrame(WindowListener listener) {
+        frame.addWindowListener(listener);
+    }
+    
+    protected KieSession getKieSession() {
+        return this.ksession;
+    }
 
     public JPanel getCanvas() {
         return panel;

--- a/drools-examples/src/main/java/org/drools/games/pong/PongUI.java
+++ b/drools-examples/src/main/java/org/drools/games/pong/PongUI.java
@@ -20,6 +20,9 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
 import java.awt.image.BufferedImage;
@@ -39,6 +42,17 @@ public class PongUI extends GameUI {
     public PongUI(KieSession ksession, GameConfiguration conf) {
         super(ksession, conf);
         this.pconf = (PongConfiguration) conf;
+    }
+    
+    @Override
+    public void init() {
+        super.init();
+        registerWindowListenerOnFrame(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                getKieSession().halt();
+            }
+        });
     }
 
     public void drawGame(Ball ball, Bat bat1, Bat bat2, Player p1, Player p2) {


### PR DESCRIPTION
...from the main app menu.

This fixes the stacktraces below, albeit slightly differ from original
reporter stacktrace, it manifest the same issue:
attempt to redraw GUI from rules, after CLOSE window button is pressed
from Swing side.

The solution is to let the KieSession aware the GUI is disposed, and
more generally in this case the solution is simply to halt() the
KieSession.

```
Exception executing consequence for rule "Redraw" in org.drools.games.pong: java.lang.RuntimeException: cannot invoke method: drawGame
	at org.drools.core.runtime.rule.impl.DefaultConsequenceExceptionHandler.handleException(DefaultConsequenceExceptionHandler.java:39)
	at org.drools.core.common.DefaultAgenda.handleException(DefaultAgenda.java:1256)
	at org.drools.core.phreak.RuleExecutor.innerFireActivation(RuleExecutor.java:440)
	at org.drools.core.phreak.RuleExecutor.fireActivation(RuleExecutor.java:382)
	at org.drools.core.phreak.RuleExecutor.fire(RuleExecutor.java:136)
	at org.drools.core.phreak.RuleExecutor.evaluateNetworkAndFire(RuleExecutor.java:89)
	at org.drools.core.concurrent.AbstractRuleEvaluator.internalEvaluateAndFire(AbstractRuleEvaluator.java:37)
	at org.drools.core.concurrent.SequentialRuleEvaluator.evaluateAndFire(SequentialRuleEvaluator.java:43)
	at org.drools.core.common.DefaultAgenda.fireLoop(DefaultAgenda.java:1072)
	at org.drools.core.common.DefaultAgenda.internalFireUntilHalt(DefaultAgenda.java:1001)
	at org.drools.core.common.DefaultAgenda.fireUntilHalt(DefaultAgenda.java:994)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.fireUntilHalt(StatefulKnowledgeSessionImpl.java:1360)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.fireUntilHalt(StatefulKnowledgeSessionImpl.java:1339)
	at org.drools.games.pong.PongMain$1.run(PongMain.java:56)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.RuntimeException: cannot invoke method: drawGame
	at org.mvel2.optimizers.impl.refl.nodes.MethodAccessor.getValue(MethodAccessor.java:55)
	at org.mvel2.optimizers.impl.refl.nodes.VariableAccessor.getValue(VariableAccessor.java:37)
	at org.mvel2.ast.ASTNode.getReducedValueAccelerated(ASTNode.java:108)
	at org.mvel2.MVELRuntime.execute(MVELRuntime.java:85)
	at org.mvel2.compiler.CompiledExpression.getDirectValue(CompiledExpression.java:123)
	at org.mvel2.compiler.CompiledExpression.getValue(CompiledExpression.java:119)
	at org.mvel2.MVEL.executeExpression(MVEL.java:929)
	at org.drools.core.base.mvel.MVELConsequence.evaluate(MVELConsequence.java:110)
	at org.drools.core.phreak.RuleExecutor.innerFireActivation(RuleExecutor.java:433)
	... 16 more
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.GeneratedMethodAccessor21.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.mvel2.optimizers.impl.refl.nodes.MethodAccessor.getValue(MethodAccessor.java:40)
	... 24 more
Caused by: java.lang.IllegalStateException: Component must have a valid peer
	at java.awt.Component$FlipBufferStrategy.getBackBuffer(Component.java:4067)
	at java.awt.Component$FlipBufferStrategy.updateInternalBuffers(Component.java:4050)
	at java.awt.Component$FlipBufferStrategy.revalidate(Component.java:4165)
	at java.awt.Component$FlipBufferStrategy.revalidate(Component.java:4147)
	at java.awt.Component$FlipBufferStrategy.getDrawGraphics(Component.java:4139)
	at org.drools.games.GameUI.getGraphics(GameUI.java:87)
	at org.drools.games.pong.PongUI.drawGame(PongUI.java:59)
	... 28 more
```