### PR TITLE
GUVNOR-2980: Test scenarios do not show correct results

### DIFF
--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/TestingEventListener.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/TestingEventListener.java
@@ -58,7 +58,7 @@ public class TestingEventListener
                 if ( ruleNames.isEmpty() ) {
                     return true;
                 }
-                String ruleName = activation.getRule().getName();
+                String ruleName = getFullyQualifiedRuleName(activation.getRule());
 
                 if ( inclusive ) {
                     return ruleNames.contains( ruleName );
@@ -89,12 +89,17 @@ public class TestingEventListener
     private void record( Rule rule,
                          Map<String, Integer> counts ) {
         this.totalFires++;
-        String name = rule.getName();
+        String name = getFullyQualifiedRuleName(rule);
         if ( !counts.containsKey( name ) ) {
             counts.put( name, 1 );
         } else {
             counts.put( name, counts.get( name ) + 1 );
         }
+    }
+
+    private String getFullyQualifiedRuleName(final Rule rule) {
+        String packageName = rule.getPackageName();
+        return (packageName.isEmpty()?rule.getName():packageName+"."+rule.getName());
     }
 
     /**

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/ScenarioRunnerTest.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/ScenarioRunnerTest.java
@@ -424,8 +424,8 @@ public class ScenarioRunnerTest extends RuleUnit {
 
         ExecutionTrace executionTrace = new ExecutionTrace();
 
-        sc.getRules().add("rule1");
-        sc.getRules().add("rule2");
+        sc.getRules().add("foo.bar.rule1");
+        sc.getRules().add("foo.bar.rule2");
         sc.setInclusive(true);
         sc.getFixtures().add(executionTrace);
 
@@ -448,13 +448,13 @@ public class ScenarioRunnerTest extends RuleUnit {
 
         );
 
-        assertions[2] = new VerifyRuleFired("rule1",
+        assertions[2] = new VerifyRuleFired("foo.bar.rule1",
                 1,
                 null);
-        assertions[3] = new VerifyRuleFired("rule2",
+        assertions[3] = new VerifyRuleFired("foo.bar.rule2",
                 1,
                 null);
-        assertions[4] = new VerifyRuleFired("rule3",
+        assertions[4] = new VerifyRuleFired("foo.bar.rule3",
                 0,
                 null);
 
@@ -502,8 +502,8 @@ public class ScenarioRunnerTest extends RuleUnit {
 
         ExecutionTrace executionTrace = new ExecutionTrace();
 
-        sc.getRules().add("rule1");
-        sc.getRules().add("rule2");
+        sc.getRules().add("foo.bar.rule1");
+        sc.getRules().add("foo.bar.rule2");
         sc.setInclusive(true);
         sc.getFixtures().add(executionTrace);
 
@@ -526,13 +526,13 @@ public class ScenarioRunnerTest extends RuleUnit {
 
         );
 
-        assertions[2] = new VerifyRuleFired("rule1",
+        assertions[2] = new VerifyRuleFired("foo.bar.rule1",
                 1,
                 null);
-        assertions[3] = new VerifyRuleFired("rule2",
+        assertions[3] = new VerifyRuleFired("foo.bar.rule2",
                 1,
                 null);
-        assertions[4] = new VerifyRuleFired("rule3",
+        assertions[4] = new VerifyRuleFired("foo.bar.rule3",
                 0,
                 null);
 
@@ -565,7 +565,7 @@ public class ScenarioRunnerTest extends RuleUnit {
 
         ExecutionTrace executionTrace = new ExecutionTrace();
 
-        scenario.getRules().add("rule1");
+        scenario.getRules().add("foo.bar.rule1");
         scenario.setInclusive(true);
         scenario.getFixtures().add(executionTrace);
 
@@ -578,7 +578,7 @@ public class ScenarioRunnerTest extends RuleUnit {
 
                 ));
 
-        assertions[1] = new VerifyRuleFired("rule1",
+        assertions[1] = new VerifyRuleFired("foo.bar.rule1",
                 1,
                 null);
 
@@ -867,8 +867,8 @@ public class ScenarioRunnerTest extends RuleUnit {
                 false));
 
         ExecutionTrace executionTrace = new ExecutionTrace();
-        sc.getRules().add("rule1");
-        sc.getRules().add("rule2");
+        sc.getRules().add("foo.bar.rule1");
+        sc.getRules().add("foo.bar.rule2");
         sc.setInclusive(true);
         sc.getFixtures().add(executionTrace);
 
@@ -886,18 +886,18 @@ public class ScenarioRunnerTest extends RuleUnit {
                         "XXX",
                         "=="),
                         new VerifyField("status",
-                                "rule2",
+                                "foo.bar.rule2",
                                 "==")
 
                 ));
 
-        assertions[2] = new VerifyRuleFired("rule1",
+        assertions[2] = new VerifyRuleFired("foo.bar.rule1",
                 1,
                 null);
-        assertions[3] = new VerifyRuleFired("rule2",
+        assertions[3] = new VerifyRuleFired("foo.bar.rule2",
                 1,
                 null);
-        assertions[4] = new VerifyRuleFired("rule3",
+        assertions[4] = new VerifyRuleFired("foo.bar.rule3",
                 2,
                 null);
 

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/TestingEventListenerTest.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/TestingEventListenerTest.java
@@ -30,8 +30,8 @@ public class TestingEventListenerTest extends RuleUnit {
     @Test
     public void testInclusive() throws Exception {
         HashSet<String> set = new HashSet<String>();
-        set.add( "rule1" );
-        set.add( "rule2" );
+        set.add( "org.pkg1.rule1" );
+        set.add( "org.pkg1.rule2" );
 
         KieSession session = getKieSession( "test_rules.drl" );
 
@@ -43,18 +43,18 @@ public class TestingEventListenerTest extends RuleUnit {
         session.insert( new Cheese() );
         session.fireAllRules( ls.getAgendaFilter( set, true ) );
 
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule1" ) );
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule2" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule1" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule2" ) );
 
         //assertEquals(new Integer(1), (Integer) ls.firingCounts.get("rule3"));
-        assertFalse( ls.firingCounts.containsKey( "rule3" ) );
-        assertFalse( ls.firingCounts.containsKey( "rule4" ) );
+        assertFalse( ls.firingCounts.containsKey( "org.pkg1.rule3" ) );
+        assertFalse( ls.firingCounts.containsKey( "org.pkg1.rule4" ) );
 
         session.insert( new Cheese() );
         session.fireAllRules( ls.getAgendaFilter( set, true ) );
-        assertEquals( new Integer( 2 ), (Integer) ls.firingCounts.get( "rule1" ) );
-        assertEquals( new Integer( 2 ), (Integer) ls.firingCounts.get( "rule2" ) );
-        assertFalse( ls.firingCounts.containsKey( "rule3" ) );
+        assertEquals( new Integer( 2 ), (Integer) ls.firingCounts.get( "org.pkg1.rule1" ) );
+        assertEquals( new Integer( 2 ), (Integer) ls.firingCounts.get( "org.pkg1.rule2" ) );
+        assertFalse( ls.firingCounts.containsKey( "org.pkg1.rule3" ) );
         assertEquals( 4, ls.totalFires );
 
     }
@@ -62,7 +62,7 @@ public class TestingEventListenerTest extends RuleUnit {
     @Test
     public void testExclusive() throws Exception {
         HashSet<String> set = new HashSet<String>();
-        set.add( "rule3" );
+        set.add( "org.pkg1.rule3" );
 
         KieSession session = getKieSession( "test_rules.drl" );
 
@@ -77,10 +77,10 @@ public class TestingEventListenerTest extends RuleUnit {
         //assertEquals(new Integer(1), (Integer) ls.firingCounts.get("rule1"));
         //assertEquals(new Integer(1), (Integer) ls.firingCounts.get("rule2"));
 
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule2" ) );
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule1" ) );
-        assertFalse( ls.firingCounts.containsKey( "rule3" ) );
-        assertFalse( ls.firingCounts.containsKey( "rule4" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule2" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule1" ) );
+        assertFalse( ls.firingCounts.containsKey( "org.pkg1.rule3" ) );
+        assertFalse( ls.firingCounts.containsKey( "org.pkg1.rule4" ) );
 
     }
 
@@ -101,9 +101,9 @@ public class TestingEventListenerTest extends RuleUnit {
         session.setGlobal( "list", list );
         session.fireAllRules( ls.getAgendaFilter( set, false ) );
 
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule1" ) );
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule2" ) );
-        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "rule3" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule1" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule2" ) );
+        assertEquals( new Integer( 1 ), (Integer) ls.firingCounts.get( "org.pkg1.rule3" ) );
 
         String[] summary = ls.getRulesFiredSummary();
         assertEquals( 3, summary.length );


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2980

As far as I could tell; the issue was that the Rule names _expected_ to fire was "fully qualified names" whereas the information regarding which rules had _actually_ fired was "simple names". I've changed ```TestingEventListener``` to record "fully qualified names". 

I've also tested the rule filtering (see [here](https://github.com/manstis/drools/blob/fc84d7db0fe10cf583100737feb1b619ed8227c2/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/TestingEventListener.java#L58)) and confirm it works as expected with "fully qualified names".