### PR TITLE
[DROOLS-1542] Root cause Exception is hidden in MVELExprAnalyzer.anal…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/mvel/MVELExprAnalyzer.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/mvel/MVELExprAnalyzer.java
@@ -135,6 +135,9 @@ public class MVELExprAnalyzer {
                                                    context.getParentDescr(),
                                                    null,
                                                    "Unable to Analyse Expression " + expr + ":\n" + e.getMessage() ) );
+            if (e.getCause() != null) {
+                log.error("Exception was thrown in Mvel", e);
+            }
             return null;
         }
 


### PR DESCRIPTION
…yzeExpression()

- unit test and candidate fix

The test method is marked as @Ignore because it's not actually a failing test (no assertion) and it pollutes stdout. Just to explain the use case.

Please have a look, thanks!