### PR TITLE
GUVNOR-2900: [Guided Decision Table] User is not prompted to save or discard changes

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableBooleanParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableBooleanParameterDefinition.java
@@ -72,4 +72,34 @@ public class PortableBooleanParameterDefinition
         return ( this.getBinding() != null && !"".equals( this.getBinding() ) );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PortableBooleanParameterDefinition that = (PortableBooleanParameterDefinition) o;
+
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        return binding != null ? binding.equals(that.binding) : that.binding == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (binding != null ? binding.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableEnumParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableEnumParameterDefinition.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.models.datamodel.workitems;
 
+import java.util.Arrays;
+
 /**
  * An Enum parameter
  */
@@ -57,4 +59,36 @@ public class PortableEnumParameterDefinition
         return this.getClassName() + "." + this.value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PortableEnumParameterDefinition that = (PortableEnumParameterDefinition) o;
+
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(values,
+                           that.values)) {
+            return false;
+        }
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + Arrays.hashCode(values);
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableFloatParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableFloatParameterDefinition.java
@@ -68,4 +68,34 @@ public class PortableFloatParameterDefinition extends PortableParameterDefinitio
         return ( this.getBinding() != null && !"".equals( this.getBinding() ) );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PortableFloatParameterDefinition that = (PortableFloatParameterDefinition) o;
+
+        if (binding != null ? !binding.equals(that.binding) : that.binding != null) {
+            return false;
+        }
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (binding != null ? binding.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableIntegerParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableIntegerParameterDefinition.java
@@ -67,4 +67,34 @@ public class PortableIntegerParameterDefinition
         return ( this.getBinding() != null && !"".equals( this.getBinding() ) );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PortableIntegerParameterDefinition that = (PortableIntegerParameterDefinition) o;
+
+        if (binding != null ? !binding.equals(that.binding) : that.binding != null) {
+            return false;
+        }
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (binding != null ? binding.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableObjectParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableObjectParameterDefinition.java
@@ -58,4 +58,34 @@ public class PortableObjectParameterDefinition
         return ( this.getBinding() != null && !"".equals( this.getBinding() ) );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PortableObjectParameterDefinition that = (PortableObjectParameterDefinition) o;
+
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        return binding != null ? binding.equals(that.binding) : that.binding == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (binding != null ? binding.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableParameterDefinition.java
@@ -57,4 +57,22 @@ public abstract class PortableParameterDefinition {
         return className;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PortableParameterDefinition that = (PortableParameterDefinition) o;
+
+        return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableStringParameterDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableStringParameterDefinition.java
@@ -67,4 +67,34 @@ public class PortableStringParameterDefinition
         return ( this.getBinding() != null && !"".equals( this.getBinding() ) );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PortableStringParameterDefinition that = (PortableStringParameterDefinition) o;
+
+        if (binding != null ? !binding.equals(that.binding) : that.binding != null) {
+            return false;
+        }
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (binding != null ? binding.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableWorkDefinition.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/workitems/PortableWorkDefinition.java
@@ -108,4 +108,39 @@ public class PortableWorkDefinition {
         return results.get( name );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PortableWorkDefinition that = (PortableWorkDefinition) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (displayName != null ? !displayName.equals(that.displayName) : that.displayName != null) {
+            return false;
+        }
+        if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) {
+            return false;
+        }
+        return results != null ? results.equals(that.results) : that.results == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (displayName != null ? displayName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (results != null ? results.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionInsertFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionInsertFactCol52.java
@@ -172,4 +172,49 @@ public class ActionInsertFactCol52 extends ActionCol52 {
         this.isInsertLogical = isInsertLogical;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionInsertFactCol52 that = (ActionInsertFactCol52) o;
+
+        if (isInsertLogical != that.isInsertLogical) {
+            return false;
+        }
+        if (factType != null ? !factType.equals(that.factType) : that.factType != null) {
+            return false;
+        }
+        if (boundName != null ? !boundName.equals(that.boundName) : that.boundName != null) {
+            return false;
+        }
+        if (factField != null ? !factField.equals(that.factField) : that.factField != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        return valueList != null ? valueList.equals(that.valueList) : that.valueList == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = factType != null ? factType.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (boundName != null ? boundName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (factField != null ? factField.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (valueList != null ? valueList.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (isInsertLogical ? 1 : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionInsertFactFieldsPattern.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionInsertFactFieldsPattern.java
@@ -70,4 +70,23 @@ public class ActionInsertFactFieldsPattern extends Pattern52 {
         super.update( other );
         setInsertedLogically( ( (ActionInsertFactFieldsPattern) other ).isInsertedLogically );
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionInsertFactFieldsPattern that = (ActionInsertFactFieldsPattern) o;
+
+        return isInsertedLogically == that.isInsertedLogically;
+    }
+
+    @Override
+    public int hashCode() {
+        return (isInsertedLogically ? 1 : 0);
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionSetFieldCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionSetFieldCol52.java
@@ -154,4 +154,44 @@ public class ActionSetFieldCol52 extends ActionCol52 {
         return update;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionSetFieldCol52 that = (ActionSetFieldCol52) o;
+
+        if (update != that.update) {
+            return false;
+        }
+        if (boundName != null ? !boundName.equals(that.boundName) : that.boundName != null) {
+            return false;
+        }
+        if (factField != null ? !factField.equals(that.factField) : that.factField != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        return valueList != null ? valueList.equals(that.valueList) : that.valueList == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = boundName != null ? boundName.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (factField != null ? factField.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (valueList != null ? valueList.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (update ? 1 : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemCol52.java
@@ -158,4 +158,22 @@ public class ActionWorkItemCol52 extends ActionCol52 {
         this.workItemDefinition = workItemDefinition;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionWorkItemCol52 that = (ActionWorkItemCol52) o;
+
+        return workItemDefinition != null ? workItemDefinition.equals(that.workItemDefinition) : that.workItemDefinition == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return workItemDefinition != null ? workItemDefinition.hashCode() : 0;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemInsertFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemInsertFactCol52.java
@@ -100,4 +100,39 @@ public class ActionWorkItemInsertFactCol52 extends ActionInsertFactCol52 {
         this.parameterClassName = parameterClassName;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ActionWorkItemInsertFactCol52 that = (ActionWorkItemInsertFactCol52) o;
+
+        if (workItemName != null ? !workItemName.equals(that.workItemName) : that.workItemName != null) {
+            return false;
+        }
+        if (workItemResultParameterName != null ? !workItemResultParameterName.equals(that.workItemResultParameterName) : that.workItemResultParameterName != null) {
+            return false;
+        }
+        return parameterClassName != null ? parameterClassName.equals(that.parameterClassName) : that.parameterClassName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (workItemName != null ? workItemName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (workItemResultParameterName != null ? workItemResultParameterName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (parameterClassName != null ? parameterClassName.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemSetFieldCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemSetFieldCol52.java
@@ -94,4 +94,39 @@ public class ActionWorkItemSetFieldCol52 extends ActionSetFieldCol52 {
         this.parameterClassName = parameterClassName;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ActionWorkItemSetFieldCol52 that = (ActionWorkItemSetFieldCol52) o;
+
+        if (workItemName != null ? !workItemName.equals(that.workItemName) : that.workItemName != null) {
+            return false;
+        }
+        if (workItemResultParameterName != null ? !workItemResultParameterName.equals(that.workItemResultParameterName) : that.workItemResultParameterName != null) {
+            return false;
+        }
+        return parameterClassName != null ? parameterClassName.equals(that.parameterClassName) : that.parameterClassName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (workItemName != null ? workItemName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (workItemResultParameterName != null ? workItemResultParameterName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (parameterClassName != null ? parameterClassName.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/AttributeCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/AttributeCol52.java
@@ -111,4 +111,34 @@ public class AttributeCol52 extends DTColumnConfig52 {
         this.reverseOrder = reverseOrder;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AttributeCol52 that = (AttributeCol52) o;
+
+        if (reverseOrder != that.reverseOrder) {
+            return false;
+        }
+        if (useRowNumber != that.useRowNumber) {
+            return false;
+        }
+        return attribute != null ? attribute.equals(that.attribute) : that.attribute == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = attribute != null ? attribute.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (reverseOrder ? 1 : 0);
+        result=~~result;
+        result = 31 * result + (useRowNumber ? 1 : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
@@ -117,4 +117,29 @@ public class BRLActionColumn extends ActionCol52
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BRLActionColumn that = (BRLActionColumn) o;
+
+        if (definition != null ? !definition.equals(that.definition) : that.definition != null) {
+            return false;
+        }
+        return childColumns != null ? childColumns.equals(that.childColumns) : that.childColumns == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = definition != null ? definition.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (childColumns != null ? childColumns.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionVariableColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionVariableColumn.java
@@ -122,4 +122,39 @@ public class BRLActionVariableColumn extends ActionCol52
         return factField;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BRLActionVariableColumn that = (BRLActionVariableColumn) o;
+
+        if (varName != null ? !varName.equals(that.varName) : that.varName != null) {
+            return false;
+        }
+        if (fieldType != null ? !fieldType.equals(that.fieldType) : that.fieldType != null) {
+            return false;
+        }
+        if (factType != null ? !factType.equals(that.factType) : that.factType != null) {
+            return false;
+        }
+        return factField != null ? factField.equals(that.factField) : that.factField == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = varName != null ? varName.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (fieldType != null ? fieldType.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (factType != null ? factType.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (factField != null ? factField.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
@@ -117,4 +117,29 @@ public class BRLConditionColumn extends ConditionCol52
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BRLConditionColumn that = (BRLConditionColumn) o;
+
+        if (definition != null ? !definition.equals(that.definition) : that.definition != null) {
+            return false;
+        }
+        return childColumns != null ? childColumns.equals(that.childColumns) : that.childColumns == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = definition != null ? definition.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (childColumns != null ? childColumns.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionVariableColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionVariableColumn.java
@@ -91,4 +91,29 @@ public class BRLConditionVariableColumn extends ConditionCol52
         return factType;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BRLConditionVariableColumn that = (BRLConditionVariableColumn) o;
+
+        if (varName != null ? !varName.equals(that.varName) : that.varName != null) {
+            return false;
+        }
+        return factType != null ? factType.equals(that.factType) : that.factType == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = varName != null ? varName.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (factType != null ? factType.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52.java
@@ -237,4 +237,54 @@ public class ConditionCol52 extends DTColumnConfig52
         return ( this.binding != null && !"".equals( this.binding ) );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ConditionCol52 that = (ConditionCol52) o;
+
+        if (constraintValueType != that.constraintValueType) {
+            return false;
+        }
+        if (factField != null ? !factField.equals(that.factField) : that.factField != null) {
+            return false;
+        }
+        if (fieldType != null ? !fieldType.equals(that.fieldType) : that.fieldType != null) {
+            return false;
+        }
+        if (operator != null ? !operator.equals(that.operator) : that.operator != null) {
+            return false;
+        }
+        if (valueList != null ? !valueList.equals(that.valueList) : that.valueList != null) {
+            return false;
+        }
+        if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) {
+            return false;
+        }
+        return binding != null ? binding.equals(that.binding) : that.binding == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = constraintValueType;
+        result=~~result;
+        result = 31 * result + (factField != null ? factField.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (fieldType != null ? fieldType.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (operator != null ? operator.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (valueList != null ? valueList.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (binding != null ? binding.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTCellValue52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTCellValue52.java
@@ -445,9 +445,15 @@ public class DTCellValue52 {
     public int hashCode() {
         int hash = 0;
         hash = hash + 31 * ( valueBoolean == null ? 0 : valueBoolean.hashCode() );
+        hash=~~hash;
         hash = hash + 31 * ( valueDate == null ? 0 : valueDate.hashCode() );
+        hash=~~hash;
         hash = hash + 31 * ( valueNumeric == null ? 0 : valueNumeric.hashCode() );
+        hash=~~hash;
+        hash = hash + 31 * ( valueString == null ? 0 : valueString.hashCode() );
+        hash=~~hash;
         hash = hash + 31 * dataType.hashCode();
+        hash=~~hash;
         return hash;
     }
 

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52.java
@@ -166,4 +166,44 @@ public class DTColumnConfig52
         return header;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DTColumnConfig52 that = (DTColumnConfig52) o;
+
+        if (hideColumn != that.hideColumn) {
+            return false;
+        }
+        if (width != that.width) {
+            return false;
+        }
+        if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that.defaultValue != null) {
+            return false;
+        }
+        if (typedDefaultValue != null ? !typedDefaultValue.equals(that.typedDefaultValue) : that.typedDefaultValue != null) {
+            return false;
+        }
+        return header != null ? header.equals(that.header) : that.header == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = defaultValue != null ? defaultValue.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (typedDefaultValue != null ? typedDefaultValue.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (hideColumn ? 1 : 0);
+        result=~~result;
+        result = 31 * result + width;
+        result=~~result;
+        result = 31 * result + (header != null ? header.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/GuidedDecisionTable52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/GuidedDecisionTable52.java
@@ -422,4 +422,90 @@ public class GuidedDecisionTable52 implements HasImports,
     public void setPackageName(String packageName) {
         this.packageName = packageName;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GuidedDecisionTable52 that = (GuidedDecisionTable52) o;
+
+        if (tableName != null ? !tableName.equals(that.tableName) : that.tableName != null) {
+            return false;
+        }
+        if (parentName != null ? !parentName.equals(that.parentName) : that.parentName != null) {
+            return false;
+        }
+        if (rowNumberCol != null ? !rowNumberCol.equals(that.rowNumberCol) : that.rowNumberCol != null) {
+            return false;
+        }
+        if (descriptionCol != null ? !descriptionCol.equals(that.descriptionCol) : that.descriptionCol != null) {
+            return false;
+        }
+        if (metadataCols != null ? !metadataCols.equals(that.metadataCols) : that.metadataCols != null) {
+            return false;
+        }
+        if (attributeCols != null ? !attributeCols.equals(that.attributeCols) : that.attributeCols != null) {
+            return false;
+        }
+        if (conditionPatterns != null ? !conditionPatterns.equals(that.conditionPatterns) : that.conditionPatterns != null) {
+            return false;
+        }
+        if (actionCols != null ? !actionCols.equals(that.actionCols) : that.actionCols != null) {
+            return false;
+        }
+        if (auditLog != null ? !auditLog.equals(that.auditLog) : that.auditLog != null) {
+            return false;
+        }
+        if (imports != null ? !imports.equals(that.imports) : that.imports != null) {
+            return false;
+        }
+        if (packageName != null ? !packageName.equals(that.packageName) : that.packageName != null) {
+            return false;
+        }
+        if (getTableFormat() != that.getTableFormat()) {
+            return false;
+        }
+        if (getHitPolicy() != that.getHitPolicy()) {
+            return false;
+        }
+        return data != null ? data.equals(that.data) : that.data == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tableName != null ? tableName.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (parentName != null ? parentName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (rowNumberCol != null ? rowNumberCol.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (descriptionCol != null ? descriptionCol.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (metadataCols != null ? metadataCols.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (attributeCols != null ? attributeCols.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (conditionPatterns != null ? conditionPatterns.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (actionCols != null ? actionCols.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (auditLog != null ? auditLog.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (imports != null ? imports.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (getTableFormat() != null ? getTableFormat().hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (getHitPolicy() != null ? getHitPolicy().hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (data != null ? data.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionInsertFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionInsertFactCol52.java
@@ -61,4 +61,29 @@ public class LimitedEntryActionInsertFactCol52 extends ActionInsertFactCol52
         this.value = value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LimitedEntryActionInsertFactCol52 that = (LimitedEntryActionInsertFactCol52) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionRetractFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionRetractFactCol52.java
@@ -63,4 +63,29 @@ public class LimitedEntryActionRetractFactCol52 extends ActionRetractFactCol52
         this.value = value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LimitedEntryActionRetractFactCol52 that = (LimitedEntryActionRetractFactCol52) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionSetFieldCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionSetFieldCol52.java
@@ -61,4 +61,29 @@ public class LimitedEntryActionSetFieldCol52 extends ActionSetFieldCol52
         this.value = value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LimitedEntryActionSetFieldCol52 that = (LimitedEntryActionSetFieldCol52) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryConditionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryConditionCol52.java
@@ -62,4 +62,29 @@ public class LimitedEntryConditionCol52 extends ConditionCol52
         this.value = value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LimitedEntryConditionCol52 that = (LimitedEntryConditionCol52) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/MetadataCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/MetadataCol52.java
@@ -68,4 +68,29 @@ public class MetadataCol52 extends DTColumnConfig52 {
         return cloned;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        MetadataCol52 that = (MetadataCol52) o;
+
+        return metadata != null ? metadata.equals(that.metadata) : that.metadata == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result=~~result;
+        result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52.java
@@ -231,4 +231,49 @@ public class Pattern52
         throw new UnsupportedOperationException( "Operation only supported by child columns" );
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Pattern52 pattern52 = (Pattern52) o;
+
+        if (isNegated != pattern52.isNegated) {
+            return false;
+        }
+        if (factType != null ? !factType.equals(pattern52.factType) : pattern52.factType != null) {
+            return false;
+        }
+        if (boundName != null ? !boundName.equals(pattern52.boundName) : pattern52.boundName != null) {
+            return false;
+        }
+        if (conditions != null ? !conditions.equals(pattern52.conditions) : pattern52.conditions != null) {
+            return false;
+        }
+        if (window != null ? !window.equals(pattern52.window) : pattern52.window != null) {
+            return false;
+        }
+        return entryPointName != null ? entryPointName.equals(pattern52.entryPointName) : pattern52.entryPointName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = factType != null ? factType.hashCode() : 0;
+        result=~~result;
+        result = 31 * result + (boundName != null ? boundName.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (isNegated ? 1 : 0);
+        result=~~result;
+        result = 31 * result + (conditions != null ? conditions.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (window != null ? window.hashCode() : 0);
+        result=~~result;
+        result = 31 * result + (entryPointName != null ? entryPointName.hashCode() : 0);
+        result=~~result;
+        return result;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/WorkItemColumnParameterValueDiffImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/WorkItemColumnParameterValueDiffImpl.java
@@ -43,4 +43,22 @@ public class WorkItemColumnParameterValueDiffImpl extends BaseColumnFieldDiffImp
         this.parameterName = parameterName;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WorkItemColumnParameterValueDiffImpl that = (WorkItemColumnParameterValueDiffImpl) o;
+
+        return parameterName != null ? parameterName.equals(that.parameterName) : that.parameterName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return parameterName != null ? parameterName.hashCode() : 0;
+    }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2900

This PR adds automatically generated ```equals()``` and ```hashCode()``` methods to model classes. I allowed for any ```Object``` descendent field to have a possible ```null``` value (as, to be honest, it's safer to assume any could be ```null``` than fully analyse usage)