### PR TITLE
Change revapi-config.json comment to be more general

### DIFF
--- a/drools-core/src/build/revapi-config.json
+++ b/drools-core/src/build/revapi-config.json
@@ -43,7 +43,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.method.parameterTypeChanged",


### PR DESCRIPTION
Hi, @mariofusco,

this is only a minor change to the revapi-config.json file, since these files are no more only on master branch, but on 7.0.x as well.

Marian
