### PR TITLE
RHBRMS-2809 [DROOLS-1243] allow from pattern to match a subclass of t…

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FromTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FromTest.java
@@ -34,9 +34,11 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.utils.KieHelper;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -216,6 +218,128 @@ public class FromTest {
         KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
         Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
+        assertFalse( results.getMessages().isEmpty() );
+    }
+    
+    public static class Container2 {
+        private Number wrapped;
+        public Container2(Number wrapped) {
+            this.wrapped = wrapped;
+        }
+        public Number getSingleValue() {
+            return this.wrapped;
+        }
+    }
+    @Test
+    public void testFromWithInterfaceAndAbstractClass() {
+        String drl =
+                "import " + Container2.class.getCanonicalName() + "\n" +
+                "import " + Comparable.class.getCanonicalName() + "\n" +
+                "global java.util.List out;\n" +
+                "rule R1 when\n" +
+                "    $c2 : Container2( )\n" +
+                "    $s : Comparable() from $c2.singleValue\n" +
+                "then\n" +
+                "    out.add($s);\n" +
+                "end\n";
+
+        KieBase kbase = new KieHelper().addContent( drl, ResourceType.DRL ).build();
+        KieSession ksession = kbase.newKieSession();
+
+        List<Integer> out = new ArrayList<Integer>();
+        ksession.setGlobal( "out", out );
+
+        ksession.insert( new Container2( new Integer(1) ) );
+        ksession.fireAllRules();
+
+        assertEquals( 1, out.size() );
+        assertEquals( 1, (int)out.get(0) );
+        
+        
+        out.clear();
+        
+        ksession.insert( new Container2( new AtomicInteger(1) ) );
+        ksession.fireAllRules();
+        
+        assertEquals( 0, out.size() );
+    }
+    
+    public static class Container2b {
+        private AtomicInteger wrapped;
+        public Container2b(AtomicInteger wrapped) {
+            this.wrapped = wrapped;
+        }
+        public AtomicInteger getSingleValue() {
+            return this.wrapped;
+        }
+    }
+    public static interface CustomIntegerMarker {}
+    public static class CustomInteger extends AtomicInteger implements CustomIntegerMarker {
+        public CustomInteger(int initialValue) {
+            super(initialValue);
+        }
+    }
+    @Test
+    public void testFromWithInterfaceAndConcreteClass() {
+        String drl =
+                "import " + Container2b.class.getCanonicalName() + "\n" +
+                "import " + CustomIntegerMarker.class.getCanonicalName() + "\n" +
+                "global java.util.List out;\n" +
+                "rule R1 when\n" +
+                "    $c2 : Container2b( )\n" +
+                "    $s : CustomIntegerMarker() from $c2.singleValue\n" +
+                "then\n" +
+                "    out.add($s);\n" +
+                "end\n";
+
+        KieBase kbase = new KieHelper().addContent( drl, ResourceType.DRL ).build();
+        KieSession ksession = kbase.newKieSession();
+
+        List<AtomicInteger> out = new ArrayList<>();
+        ksession.setGlobal( "out", out );
+
+        ksession.insert( new Container2b( new CustomInteger(1) ) );
+        ksession.fireAllRules();
+
+        assertEquals( 1, out.size() );
+        assertEquals( 1, ((CustomInteger)out.get(0)).get() );
+        
+        
+        out.clear();
+        
+        ksession.insert( new Container2b( new AtomicInteger(1) ) );
+        ksession.fireAllRules();
+        
+        assertEquals( 0, out.size() );
+    }
+    
+    public static class Container3 {
+        private Integer wrapped;
+        public Container3(Integer wrapped) {
+            this.wrapped = wrapped;
+        }
+        public Integer getSingleValue() {
+            return this.wrapped;
+        }
+    }
+    @Test
+    public void testFromWithInterfaceAndFinalClass() {
+        String drl =
+                "import " + Container3.class.getCanonicalName() + "\n" +
+                "import " + CustomIntegerMarker.class.getCanonicalName() + "\n" +
+                "global java.util.List out;\n" +
+                "rule R1 when\n" +
+                "    $c3 : Container3( )\n" +
+                "    $s : CustomIntegerMarker() from $c3.singleValue\n" +
+                "then\n" +
+                "    out.add($s);\n" +
+                "end\n";
+        
+        KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
+        Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
+        
+        // Integer is final class, so there cannot be ever the case of pattern matching in the `from` on a non-extended interface to ever match.
         assertFalse( results.getMessages().isEmpty() );
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
@@ -8728,5 +8728,48 @@ public class Misc2Test extends CommonTestMethodBase {
         }
 
     }
+
+    public static class ElementOperation {
+        private AbstractElement element;
+        public ElementOperation(AbstractElement element) {
+            this.element = element;
+        }
+        public AbstractElement getElement() {
+            return element;
+        }
+    }
+    public static abstract class AbstractElement {
+    }
+    public static interface MyInterface {
+        public void nothing();
+    }
+    public static class MyElement extends AbstractElement implements MyInterface {
+        @Override
+        public void nothing() {}
+    }
     
+    @Test
+    public void test01841522() {
+        String str = "package com.sample\n" +
+                "import " + ElementOperation.class.getCanonicalName() + ";\n" +
+                "import " + AbstractElement.class.getCanonicalName() + ";\n" +
+                "import " + MyInterface.class.getCanonicalName() + ";\n" +
+                "global java.util.List list\n" +
+                "rule R when\n" +
+                "  ElementOperation( $e : element )      \n" +
+                "  $my: MyInterface( ) from $e           \n" +
+                "then\n" +
+                "  list.add(\"\" );" +
+                "end\n";
+
+        KieSession ksession = new KieHelper().addContent(str, ResourceType.DRL).build().newKieSession();
+
+        List<String> list = new ArrayList<String>();
+        ksession.setGlobal( "list", list );
+                
+        ksession.insert( new ElementOperation(new MyElement()) );
+        ksession.fireAllRules();
+
+        assertEquals(1, list.size());
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/rule/Pattern.java
+++ b/drools-core/src/main/java/org/drools/core/rule/Pattern.java
@@ -33,6 +33,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,6 +46,8 @@ import java.util.Set;
 
 import static org.drools.core.util.ClassUtils.convertFromPrimitiveType;
 import static org.drools.core.util.ClassUtils.isIterable;
+import static org.drools.core.util.ClassUtils.isFinal;
+import static org.drools.core.util.ClassUtils.isInterface;;
 
 public class Pattern
     implements
@@ -545,6 +548,9 @@ public class Pattern
     public boolean isCompatibleWithFromReturnType( Class<?> returnType ) {
         return isCompatibleWithAccumulateReturnType( returnType ) ||
                isIterable( returnType ) ||
-               ( objectType instanceof ClassObjectType && returnType.isAssignableFrom(((ClassObjectType)objectType).getClassType()) );
+               ( objectType instanceof ClassObjectType && 
+                       ( returnType.isAssignableFrom( ((ClassObjectType)objectType).getClassType()) || 
+                         ( !isFinal( returnType ) && isInterface(((ClassObjectType)objectType).getClassType()))   
+                         ) );
     }
 }

--- a/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
@@ -535,6 +535,14 @@ public final class ClassUtils {
     public static boolean isIterable(Class<?> clazz) {
         return Iterable.class.isAssignableFrom( clazz ) || clazz.isArray();
     }
+    
+    public static boolean isFinal(Class<?> clazz) {
+        return Modifier.isFinal( clazz.getModifiers() );
+    }
+    
+    public static boolean isInterface(Class<?> clazz) {
+        return Modifier.isInterface( clazz.getModifiers() );
+    }
 
     private static class SetterInClass implements Comparable {
         private final String setter;


### PR DESCRIPTION
…he type of the source (#1238)

* [DROOLS-1243] allow from pattern to match a subclass of the type of the source

Specific case when `from` is returning an Abstract class
and the pattern is matching on an Interface

* Refined case using Interface in `from` pattern against non-final class

(cherry picked from commit 06e97fa599ffd18b2f14d1c1799d9ea5d1d82cfb)

Conflicts:
	drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
	drools-core/src/main/java/org/drools/core/rule/Pattern.java