### PR TITLE
RHBRMS-2815: add reproducer

### DIFF
--- a/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
+++ b/drools-persistence/drools-persistence-jpa/src/test/java/org/drools/persistence/session/ReloadSessionTest.java
@@ -25,11 +25,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.kie.api.KieBase;
 import org.kie.api.event.rule.DefaultAgendaEventListener;
 import org.kie.api.event.rule.DefaultRuleRuntimeEventListener;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.KnowledgeBase;
 import org.kie.internal.KnowledgeBaseFactory;
@@ -63,6 +65,8 @@ public class ReloadSessionTest {
     private EntityManagerFactory emf;
     private boolean locking;
 
+    private static final String ENTRY_POINT = "ep1";
+
     private static String simpleRule = "package org.kie.test\n"
             + "global java.util.List list\n" 
             + "rule rule1\n" 
@@ -71,6 +75,16 @@ public class ReloadSessionTest {
             + "then\n" 
             + "  list.add( 1 );\n"
             + "end\n" 
+            + "\n";
+
+    private static final String RULE_WITH_EP = "package org.kie.test\n"
+            + "global java.util.List list\n"
+            + "rule rule1\n"
+            + "when\n"
+            + "  Integer(intValue > 0) from entry-point " + ENTRY_POINT + " \n"
+            + "then\n"
+            + "  list.add( 1 );\n"
+            + "end\n"
             + "\n";
 
 
@@ -194,5 +208,41 @@ public class ReloadSessionTest {
 
         assertEquals(1, ksession.getRuleRuntimeEventListeners().size());
         assertEquals(1, ksession.getAgendaEventListeners().size());
+    }
+
+    @Test
+    public void testInsert() {
+        final Environment env = createEnvironment();
+        final KieBase kbase = initializeKnowledgeBase(RULE_WITH_EP);
+        KieSession kieSession = JPAKnowledgeService.newStatefulKnowledgeSession(kbase, null, env);
+        assertTrue("There should be NO facts present in a new (empty) knowledge session.", kieSession.getFactHandles().isEmpty());
+
+        kieSession.insert(Integer.valueOf(10));
+        kieSession = reloadSession(kieSession, env);
+
+        Collection<? extends Object> objects = kieSession.getObjects();
+        assertEquals("Reloaded working memory should contain the fact.", 1, objects.size());
+    }
+
+    @Test
+    public void testInsertIntoEntryPoint() {
+        // RHBRMS-2815
+        final Environment env = createEnvironment();
+        final KieBase kbase = initializeKnowledgeBase(RULE_WITH_EP);
+        KieSession kieSession = JPAKnowledgeService.newStatefulKnowledgeSession(kbase, null, env);
+        assertTrue("There should be NO facts present in a new (empty) knowledge session.", kieSession.getFactHandles().isEmpty());
+
+        kieSession.getEntryPoint(ENTRY_POINT).insert(Integer.valueOf(10));
+        kieSession = reloadSession(kieSession, env);
+
+        Collection<? extends Object> objects = kieSession.getEntryPoint(ENTRY_POINT).getObjects();
+        assertEquals("Reloaded working memory should contain the fact in the entry point.", 1, objects.size());
+    }
+
+    private KieSession reloadSession(final KieSession kieSession, final Environment environment) {
+        final long sessionId = kieSession.getIdentifier();
+        final KieBase kieBase = kieSession.getKieBase();
+        kieSession.dispose();
+        return JPAKnowledgeService.loadStatefulKnowledgeSession(sessionId, kieBase, null, environment);
     }
 }


### PR DESCRIPTION
Add reproducer for RHBRMS-2815

When a fact is inserted into an entry-point of a persistent KieSession and the session is then disposed and reloaded from the database, the fact is not present in the working memory.

When inserting the fact NOT into an entry-point, but into the KieSession directly, it is present in the working memory after the session is reloaded.