### PR TITLE
RHBPMS-4737: XLS DT conversion does not handle BigDecimal or BigInteger fields

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -135,7 +135,7 @@ import static org.drools.workbench.models.commons.backend.rule.RuleModelPersiste
 import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.findMethodInfo;
 import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.getMethodInfosForType;
 import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.getSimpleFactType;
-import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.inferDataType;
+import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.inferDataTypeFromAction;
 import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.inferFieldNature;
 import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.parseExpressionParameters;
 import static org.drools.workbench.models.commons.backend.rule.RuleModelPersistenceHelper.removeNumericSuffix;
@@ -3272,16 +3272,14 @@ public class RuleModelDRLPersistenceImpl
                                       boundParams.get(variable),
                                       dmo);
         String value = unwrapParenthesis(statement);
-        String dataType = inferDataType(action,
-                                        field,
-                                        boundParams,
-                                        dmo,
-                                        model.getImports());
-        if (dataType == null) {
-            dataType = inferDataType(value,
-                                     boundParams,
-                                     isJavaDialect);
-        }
+        String dataType = inferDataTypeFromAction(action,
+                                                  field,
+                                                  value,
+                                                  isJavaDialect,
+                                                  boundParams,
+                                                  dmo,
+                                                  model.getImports());
+
         action.addFieldValue(buildFieldValue(isJavaDialect,
                                              field,
                                              value,
@@ -3815,8 +3813,9 @@ public class RuleModelDRLPersistenceImpl
                                                    m,
                                                    con,
                                                    boundParams);
-            String classType = getFQFactType(m,
-                                             factPattern.getFactType());
+            String classType = RuleModelPersistenceHelper.getFQFactType(m,
+                                                                        factPattern.getFactType(),
+                                                                        dmo);
             con.getExpressionLeftSide().appendPart(new ExpressionUnboundFact(factPattern.getFactType()));
 
             parseExpression(m,
@@ -3841,8 +3840,9 @@ public class RuleModelDRLPersistenceImpl
 
             boolean isBoundParam = false;
             if (factType == null) {
-                factType = getFQFactType(m,
-                                         boundParams.get(splits[0].trim()));
+                factType = RuleModelPersistenceHelper.getFQFactType(m,
+                                                                    boundParams.get(splits[0].trim()),
+                                                                    dmo);
                 isBoundParam = true;
             }
 
@@ -3860,8 +3860,9 @@ public class RuleModelDRLPersistenceImpl
 
                 //The first part of the expression may be a bound variable
                 if (boundParams.containsKey(expressionPart)) {
-                    factType = getFQFactType(m,
-                                             boundParams.get(expressionPart));
+                    factType = RuleModelPersistenceHelper.getFQFactType(m,
+                                                                        boundParams.get(expressionPart),
+                                                                        dmo);
                     isBoundParam = true;
 
                     typeFields = findFields(m,
@@ -3992,30 +3993,6 @@ public class RuleModelDRLPersistenceImpl
                                                           isJavaDialect);
         }
 
-        private String getFQFactType(final RuleModel ruleModel,
-                                     final String factType) {
-
-            Set<String> factTypes = dmo.getProjectModelFields().keySet();
-
-            if (factTypes.contains(ruleModel.getPackageName() + "." + factType)) {
-                return ruleModel.getPackageName() + "." + factType;
-            }
-
-            for (String item : ruleModel.getImports().getImportStrings()) {
-                if (item.endsWith("." + factType)) {
-                    return item;
-                }
-            }
-
-            for (String type : factTypes) {
-                if (type.endsWith("." + factType)) {
-                    return type;
-                }
-            }
-
-            return factType;
-        }
-
         private ModelField findFact(final Map<String, ModelField[]> modelFields,
                                     final String factType) {
             final ModelField[] typeFields = modelFields.get(factType);
@@ -4119,21 +4096,17 @@ public class RuleModelDRLPersistenceImpl
                                             final FactPattern factPattern,
                                             final BaseSingleFieldConstraint con,
                                             String value) {
-            String type = null;
             if (value.contains("@{")) {
                 con.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
                 con.setValue(unwrapTemplateKey(value));
             } else if (value.startsWith("\"")) {
-                type = DataType.TYPE_STRING;
                 con.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
                 con.setValue(value.substring(1,
                                              value.length() - 1));
             } else if (value.startsWith("(")) {
                 if (operator != null && operator.contains("in")) {
-                    value = unwrapParenthesis(value);
-                    type = value.startsWith("\"") ? DataType.TYPE_STRING : DataType.TYPE_NUMERIC_INTEGER;
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
-                    con.setValue(value);
+                    con.setValue(unwrapParenthesis(value));
                 } else {
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_RET_VALUE);
                     con.setValue(unwrapParenthesis(value));
@@ -4141,12 +4114,11 @@ public class RuleModelDRLPersistenceImpl
             } else {
                 if (!Character.isDigit(value.charAt(0))) {
                     if (value.equals("true") || value.equals("false")) {
-                        type = DataType.TYPE_BOOLEAN;
                         con.setConstraintValueType(BaseSingleFieldConstraint.TYPE_ENUM);
-                    } else if (isEnumerationValue(m,
-                                                  factPattern,
-                                                  con)) {
-                        type = DataType.TYPE_COMPARABLE;
+                    } else if (RuleModelPersistenceHelper.isEnumerationValue(m,
+                                                                             factPattern,
+                                                                             con,
+                                                                             dmo)) {
                         con.setConstraintValueType(SingleFieldConstraint.TYPE_ENUM);
                     } else if (value.indexOf('.') > 0 && boundParams.containsKey(value.substring(0,
                                                                                                  value.indexOf('.')).trim())) {
@@ -4162,61 +4134,24 @@ public class RuleModelDRLPersistenceImpl
                         con.setConstraintValueType(SingleFieldConstraint.TYPE_RET_VALUE);
                     }
                 } else {
-                    if (value.endsWith("I")) {
-                        type = DataType.TYPE_NUMERIC_BIGINTEGER;
-                        value = value.substring(0,
-                                                value.length() - 1);
-                    } else if (value.endsWith("B")) {
-                        type = DataType.TYPE_NUMERIC_BIGDECIMAL;
-                        value = value.substring(0,
-                                                value.length() - 1);
-                    } else if (value.endsWith("f")) {
-                        type = DataType.TYPE_NUMERIC_FLOAT;
-                    } else if (value.endsWith("d")) {
-                        type = DataType.TYPE_NUMERIC_DOUBLE;
-                    } else {
-                        type = DataType.TYPE_NUMERIC_INTEGER;
-                    }
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
                 }
                 con.setValue(value);
             }
+
+            final String type = RuleModelPersistenceHelper.inferDataTypeFromConstraint(m,
+                                                                                       factPattern,
+                                                                                       con,
+                                                                                       value,
+                                                                                       dmo,
+                                                                                       m.getImports());
+
             if (con instanceof SingleFieldConstraint) {
                 ((SingleFieldConstraint) con).setFieldType(type);
             } else if (con instanceof ConnectiveConstraint) {
                 ((ConnectiveConstraint) con).setFieldType(type);
             }
             return type;
-        }
-
-        private boolean isEnumerationValue(final RuleModel ruleModel,
-                                           final FactPattern factPattern,
-                                           final BaseSingleFieldConstraint con) {
-            String factType = null;
-            String fieldName = null;
-            if (con instanceof SingleFieldConstraintEBLeftSide) {
-                SingleFieldConstraintEBLeftSide sfcex = (SingleFieldConstraintEBLeftSide) con;
-                List<ExpressionPart> sfcexParts = sfcex.getExpressionLeftSide().getParts();
-                factType = sfcexParts.get(sfcexParts.size() - 1).getPrevious().getClassType();
-                fieldName = sfcex.getFieldName();
-            } else if (con instanceof SingleFieldConstraint) {
-                factType = factPattern.getFactType();
-                fieldName = ((SingleFieldConstraint) con).getFieldName();
-            } else if (con instanceof ConnectiveConstraint) {
-                factType = factPattern.getFactType();
-                fieldName = ((ConnectiveConstraint) con).getFieldName();
-            }
-
-            if (factType == null || fieldName == null) {
-                return false;
-            }
-
-            final String fullyQualifiedFactType = getFQFactType(ruleModel,
-                                                                factType);
-            final String key = fullyQualifiedFactType + "#" + fieldName;
-            final Map<String, String[]> projectJavaEnumDefinitions = dmo.getProjectJavaEnumDefinitions();
-
-            return projectJavaEnumDefinitions.containsKey(key);
         }
     }
 

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistenceHelper.java
@@ -15,6 +15,17 @@
 
 package org.drools.workbench.models.commons.backend.rule;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.drools.core.util.DateUtils;
@@ -27,199 +38,182 @@ import org.drools.workbench.models.datamodel.oracle.PackageDataModelOracle;
 import org.drools.workbench.models.datamodel.rule.ActionFieldList;
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
 import org.drools.workbench.models.datamodel.rule.ActionSetField;
+import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.datamodel.rule.ConnectiveConstraint;
+import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.FieldNatureType;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
+import org.drools.workbench.models.datamodel.rule.SingleFieldConstraintEBLeftSide;
 
 class RuleModelPersistenceHelper {
 
-    static String unwrapParenthesis( final String s ) {
-        int start = s.indexOf( '(' );
-        int end = s.lastIndexOf( ')' );
-        if ( start < 0 || end < 0 ) {
+    static String unwrapParenthesis(final String s) {
+        int start = s.indexOf('(');
+        int end = s.lastIndexOf(')');
+        if (start < 0 || end < 0) {
             return s;
         }
-        return s.substring( start + 1,
-                            end ).trim();
+        return s.substring(start + 1,
+                           end).trim();
     }
 
-    static String unwrapTemplateKey( final String s ) {
-        int start = s.indexOf( "@{" );
-        if ( start < 0 ) {
+    static String unwrapTemplateKey(final String s) {
+        int start = s.indexOf("@{");
+        if (start < 0) {
             return s;
         }
-        int end = s.indexOf( "}",
-                             start );
-        if ( end < 0 ) {
+        int end = s.indexOf("}",
+                            start);
+        if (end < 0) {
             return s;
         }
-        return s.substring( start + 2,
-                            end ).trim();
+        return s.substring(start + 2,
+                           end).trim();
     }
 
-    static String getSimpleFactType( final String className,
-                                     final PackageDataModelOracle dmo ) {
-        for ( String type : dmo.getProjectModelFields().keySet() ) {
-            if ( type.equals( className ) ) {
-                return type.substring( type.lastIndexOf( "." ) + 1 );
+    static String getSimpleFactType(final String className,
+                                    final PackageDataModelOracle dmo) {
+        for (String type : dmo.getProjectModelFields().keySet()) {
+            if (type.equals(className)) {
+                return type.substring(type.lastIndexOf(".") + 1);
             }
         }
         return className;
     }
 
-    static int inferFieldNature( final String dataType,
-                                 final String value,
-                                 final Map<String, String> boundParams,
-                                 final boolean isJavaDialect ) {
-        if ( boundParams.containsKey( value ) ) {
+    static int inferFieldNature(final String dataType,
+                                final String value,
+                                final Map<String, String> boundParams,
+                                final boolean isJavaDialect) {
+        if (boundParams.containsKey(value)) {
             return FieldNatureType.TYPE_VARIABLE;
         }
-        if ( value.contains( "@{" ) ) {
+        if (value.contains("@{")) {
             return FieldNatureType.TYPE_TEMPLATE;
         }
 
-        return inferFieldNature( dataType,
-                                 value,
-                                 isJavaDialect );
+        return inferFieldNature(dataType,
+                                value,
+                                isJavaDialect);
     }
 
-    static int inferFieldNature( final String dataType,
-                                 final String value,
-                                 final boolean isJavaDialect ) {
-        int nature = ( StringUtils.isEmpty( value ) ? FieldNatureType.TYPE_UNDEFINED : FieldNatureType.TYPE_LITERAL );
+    static int inferFieldNature(final String dataType,
+                                final String value,
+                                final boolean isJavaDialect) {
+        int nature = (StringUtils.isEmpty(value) ? FieldNatureType.TYPE_UNDEFINED : FieldNatureType.TYPE_LITERAL);
 
-        if ( dataType == DataType.TYPE_COLLECTION ) {
+        if (dataType == DataType.TYPE_COLLECTION) {
             return FieldNatureType.TYPE_FORMULA;
-
-        } else if ( DataType.TYPE_BOOLEAN.equals( dataType ) ) {
-            if ( !( Boolean.TRUE.equals( Boolean.parseBoolean( value ) ) || Boolean.FALSE.equals( Boolean.parseBoolean( value ) ) ) ) {
+        } else if (DataType.TYPE_BOOLEAN.equals(dataType)) {
+            if (!(Boolean.TRUE.equals(Boolean.parseBoolean(value)) || Boolean.FALSE.equals(Boolean.parseBoolean(value)))) {
                 return FieldNatureType.TYPE_FORMULA;
             } else {
                 return FieldNatureType.TYPE_LITERAL;
             }
-
-        } else if ( DataType.TYPE_DATE.equals( dataType ) ) {
+        } else if (DataType.TYPE_DATE.equals(dataType)) {
             try {
-                new SimpleDateFormat( DateUtils.getDateFormatMask(), Locale.ENGLISH ).parse( adjustParam( dataType,
-                                                                                                          value,
-                                                                                                          Collections.EMPTY_MAP,
-                                                                                                          isJavaDialect ) );
+                new SimpleDateFormat(DateUtils.getDateFormatMask(),
+                                     Locale.ENGLISH).parse(adjustParam(dataType,
+                                                                       value,
+                                                                       Collections.EMPTY_MAP,
+                                                                       isJavaDialect));
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( ParseException e ) {
+            } catch (ParseException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_STRING.equals( dataType ) ) {
-            if ( isStringLiteral( value ) ) {
+        } else if (DataType.TYPE_STRING.equals(dataType)) {
+            if (isStringLiteral(value)) {
                 return FieldNatureType.TYPE_LITERAL;
             } else {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC.equals( dataType ) ) {
-            if ( !NumberUtils.isNumber( value ) ) {
+        } else if (DataType.TYPE_NUMERIC.equals(dataType)) {
+            if (!NumberUtils.isNumber(value)) {
                 return FieldNatureType.TYPE_FORMULA;
             }
             return FieldNatureType.TYPE_LITERAL;
-
-        } else if ( DataType.TYPE_NUMERIC_BIGDECIMAL.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_BIGDECIMAL.equals(dataType)) {
             try {
-                new BigDecimal( adjustParam( dataType,
-                                             value,
-                                             Collections.EMPTY_MAP,
-                                             isJavaDialect ) );
+                new BigDecimal(adjustParam(dataType,
+                                           value,
+                                           Collections.EMPTY_MAP,
+                                           isJavaDialect));
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_BIGINTEGER.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_BIGINTEGER.equals(dataType)) {
             try {
-                new BigInteger( adjustParam( dataType,
-                                             value,
-                                             Collections.EMPTY_MAP,
-                                             isJavaDialect ) );
+                new BigInteger(adjustParam(dataType,
+                                           value,
+                                           Collections.EMPTY_MAP,
+                                           isJavaDialect));
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_BYTE.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_BYTE.equals(dataType)) {
             try {
-                new Byte( value );
+                new Byte(value);
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_DOUBLE.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_DOUBLE.equals(dataType)) {
             try {
-                new Double( value );
+                new Double(value);
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_FLOAT.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_FLOAT.equals(dataType)) {
             try {
-                new Float( value );
+                new Float(value);
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_INTEGER.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_INTEGER.equals(dataType)) {
             try {
-                new Integer( value );
+                new Integer(value);
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_LONG.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_LONG.equals(dataType)) {
             try {
-                new Long( value );
+                new Long(value);
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
-        } else if ( DataType.TYPE_NUMERIC_SHORT.equals( dataType ) ) {
+        } else if (DataType.TYPE_NUMERIC_SHORT.equals(dataType)) {
             try {
-                new Short( value );
+                new Short(value);
                 return FieldNatureType.TYPE_LITERAL;
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 return FieldNatureType.TYPE_FORMULA;
             }
-
         }
 
         return nature;
     }
 
-    private static boolean isStringLiteral( final String value ) {
+    private static boolean isStringLiteral(final String value) {
         boolean escape = false;
         boolean inString = false;
-        for ( char c : value.toCharArray() ) {
-            if ( escape ) {
+        for (char c : value.toCharArray()) {
+            if (escape) {
                 escape = false;
                 continue;
             }
-            if ( !inString ) {
-                if ( !( c == ' ' || c == '\t' || c == '"' ) ) {
+            if (!inString) {
+                if (!(c == ' ' || c == '\t' || c == '"')) {
                     return false;
                 }
             }
-            if ( c == '"' ) {
+            if (c == '"') {
                 inString = !inString;
             } else {
                 escape = c == '\\';
@@ -228,30 +222,30 @@ class RuleModelPersistenceHelper {
         return true;
     }
 
-    static ModelField[] findFields( final RuleModel m,
-                                    final PackageDataModelOracle dmo,
-                                    final String type ) {
-        ModelField[] fields = dmo.getProjectModelFields().get( type );
-        if ( fields != null ) {
+    static ModelField[] findFields(final RuleModel m,
+                                   final PackageDataModelOracle dmo,
+                                   final String type) {
+        ModelField[] fields = dmo.getProjectModelFields().get(type);
+        if (fields != null) {
             return fields;
         }
-        for ( String i : m.getImports().getImportStrings() ) {
-            if ( i.endsWith( "." + type ) ) {
-                fields = dmo.getProjectModelFields().get( i );
-                if ( fields != null ) {
+        for (String i : m.getImports().getImportStrings()) {
+            if (i.endsWith("." + type)) {
+                fields = dmo.getProjectModelFields().get(i);
+                if (fields != null) {
                     return fields;
                 }
             }
         }
 
-        return dmo.getProjectModelFields().get( m.getPackageName() + "." + type );
+        return dmo.getProjectModelFields().get(m.getPackageName() + "." + type);
     }
 
-    static ModelField findField( final ModelField[] typeFields,
-                                 final String fieldName ) {
-        if ( typeFields != null && fieldName != null ) {
-            for ( ModelField typeField : typeFields ) {
-                if ( typeField.getName().equals( fieldName ) ) {
+    static ModelField findField(final ModelField[] typeFields,
+                                final String fieldName) {
+        if (typeFields != null && fieldName != null) {
+            for (ModelField typeField : typeFields) {
+                if (typeField.getName().equals(fieldName)) {
                     return typeField;
                 }
             }
@@ -259,164 +253,283 @@ class RuleModelPersistenceHelper {
         return null;
     }
 
-    static MethodInfo findMethodInfo( final List<MethodInfo> methodInfos,
-                                      final String expressionPart ) {
-        if ( methodInfos != null && expressionPart != null ) {
+    static MethodInfo findMethodInfo(final List<MethodInfo> methodInfos,
+                                     final String expressionPart) {
+        if (methodInfos != null && expressionPart != null) {
             //Find a MethodInfo that matches name and parameter count
-            final int expressionParameterCount = parseExpressionParameters( expressionPart ).size();
-            final String normalizedExpressionPart = normalizeExpressionPart( expressionPart );
-            for ( MethodInfo methodInfo : methodInfos ) {
-                if ( methodInfo.getName().equals( normalizedExpressionPart ) && methodInfo.getParams().size() == expressionParameterCount ) {
+            final int expressionParameterCount = parseExpressionParameters(expressionPart).size();
+            final String normalizedExpressionPart = normalizeExpressionPart(expressionPart);
+            for (MethodInfo methodInfo : methodInfos) {
+                if (methodInfo.getName().equals(normalizedExpressionPart) && methodInfo.getParams().size() == expressionParameterCount) {
                     return methodInfo;
                 }
             }
         }
         return null;
-
     }
 
     //TODO This is a naive implementation that won't handle parameter values containing ","
     //TODO for example callMyMethod("Anstis, Michael", 41). This would parse as 3 parameters
-    static List<String> parseExpressionParameters( String expressionPart ) {
-        int parenthesisOpenPos = expressionPart.indexOf( '(' );
-        int parenthesisClosePos = expressionPart.lastIndexOf( ')' );
-        if ( parenthesisOpenPos > 0 && parenthesisClosePos > 0 ) {
-            expressionPart = expressionPart.substring( parenthesisOpenPos + 1,
-                                                       parenthesisClosePos );
+    static List<String> parseExpressionParameters(String expressionPart) {
+        int parenthesisOpenPos = expressionPart.indexOf('(');
+        int parenthesisClosePos = expressionPart.lastIndexOf(')');
+        if (parenthesisOpenPos > 0 && parenthesisClosePos > 0) {
+            expressionPart = expressionPart.substring(parenthesisOpenPos + 1,
+                                                      parenthesisClosePos);
         }
-        if ( expressionPart.isEmpty() ) {
+        if (expressionPart.isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.asList( expressionPart.split( "," ) );
+        return Arrays.asList(expressionPart.split(","));
     }
 
-    private static String normalizeExpressionPart( String expressionPart ) {
-        int parenthesisPos = expressionPart.indexOf( '(' );
-        if ( parenthesisPos > 0 ) {
-            expressionPart = expressionPart.substring( 0,
-                                                       parenthesisPos );
+    private static String normalizeExpressionPart(String expressionPart) {
+        int parenthesisPos = expressionPart.indexOf('(');
+        if (parenthesisPos > 0) {
+            expressionPart = expressionPart.substring(0,
+                                                      parenthesisPos);
         }
         return expressionPart.trim();
     }
 
-    static String inferDataType( final ActionFieldList action,
-                                 final String field,
-                                 final Map<String, String> boundParams,
-                                 final PackageDataModelOracle dmo,
-                                 final Imports imports ) {
-        String factType = null;
-        if ( action instanceof ActionInsertFact ) {
-            factType = ( (ActionInsertFact) action ).getFactType();
+    static String inferDataTypeFromModelFields(final String factType,
+                                               final String field,
+                                               final PackageDataModelOracle dmo,
+                                               final Imports imports) {
 
-        } else if ( action instanceof ActionSetField ) {
-            String boundParam = ( (ActionSetField) action ).getVariable();
-            factType = boundParams.get( boundParam );
-        }
-        if ( factType == null ) {
+        if (factType == null) {
             return null;
         }
+        if (field == null) {
+            return null;
+        }
+
         //Lookup without package prefix or imports
-        ModelField[] modelFields = dmo.getProjectModelFields().get( factType );
+        ModelField[] modelFields = dmo.getProjectModelFields().get(factType);
 
         //Lookup with package prefix
-        if ( modelFields == null ) {
+        if (modelFields == null) {
             String fqcn = dmo.getPackageName() + "." + factType;
-            modelFields = dmo.getProjectModelFields().get( fqcn );
+            modelFields = dmo.getProjectModelFields().get(fqcn);
         }
 
         //Lookup from imports
-        if ( modelFields == null ) {
-            for ( Import item : imports.getImports() ) {
-                if ( item.getType().endsWith( factType ) ) {
-                    modelFields = dmo.getProjectModelFields().get( item.getType() );
-                    if ( modelFields != null ) {
+        if (modelFields == null) {
+            for (Import item : imports.getImports()) {
+                if (item.getType().endsWith(factType)) {
+                    modelFields = dmo.getProjectModelFields().get(item.getType());
+                    if (modelFields != null) {
                         break;
                     }
                 }
             }
         }
 
-        if ( modelFields == null ) {
+        if (modelFields == null) {
             return null;
         }
-        for ( ModelField modelField : modelFields ) {
-            if ( modelField.getName().equals( field ) ) {
-                return getSimpleFactType( modelField.getType(),
-                                          dmo );
+        for (ModelField modelField : modelFields) {
+            if (modelField.getName().equals(field)) {
+                return getSimpleFactType(modelField.getType(),
+                                         dmo);
             }
         }
         return null;
     }
 
-    static String inferDataType( final String param,
-                                 final Map<String, String> boundParams,
-                                 final boolean isJavaDialect ) {
-        if ( param.startsWith( "sdf.parse(\"" ) ) {
-            return DataType.TYPE_DATE;
-        } else if ( param.startsWith( "\"" ) ) {
+    static String inferDataTypeFromConstraint(final RuleModel m,
+                                              final FactPattern factPattern,
+                                              final BaseSingleFieldConstraint con,
+                                              final String value,
+                                              final PackageDataModelOracle dmo,
+                                              final Imports imports) {
+        final String factType = extractFactType(factPattern,
+                                                con);
+        final String fieldName = extractFieldName(con);
+        final String type = inferDataTypeFromModelFields(factType,
+                                                         fieldName,
+                                                         dmo,
+                                                         imports);
+
+        if (type != null) {
+            return type;
+        }
+
+        final String operator = con.getOperator();
+
+        return RuleModelPersistenceHelper.inferDataTypeFromConstraintValue(m,
+                                                                           operator,
+                                                                           factPattern,
+                                                                           con,
+                                                                           dmo,
+                                                                           value);
+    }
+
+    static String extractFactType(final FactPattern factPattern,
+                                  final BaseSingleFieldConstraint con) {
+        if (con instanceof SingleFieldConstraintEBLeftSide) {
+            return ((SingleFieldConstraintEBLeftSide) con).getExpressionLeftSide().getPreviousClassType();
+        }
+        return factPattern.getFactType();
+    }
+
+    static String extractFieldName(final BaseSingleFieldConstraint con) {
+        if (con instanceof SingleFieldConstraintEBLeftSide) {
+            return ((SingleFieldConstraintEBLeftSide) con).getExpressionLeftSide().getFieldName();
+        } else if (con instanceof SingleFieldConstraint) {
+            return ((SingleFieldConstraint) con).getFieldName();
+        } else if (con instanceof ConnectiveConstraint) {
+            return ((ConnectiveConstraint) con).getFieldName();
+        }
+        return null;
+    }
+
+    static String inferDataTypeFromConstraintValue(final RuleModel m,
+                                                   final String operator,
+                                                   final FactPattern factPattern,
+                                                   final BaseSingleFieldConstraint con,
+                                                   final PackageDataModelOracle dmo,
+                                                   final String value) {
+        //Infer from value
+        if (value.startsWith("\"")) {
             return DataType.TYPE_STRING;
-        } else if ( param.equals( "true" ) || param.equals( "false" ) ) {
+        } else if (value.startsWith("(")) {
+            if (operator != null && operator.contains("in")) {
+                return unwrapParenthesis(value).startsWith("\"") ? DataType.TYPE_STRING : DataType.TYPE_NUMERIC_INTEGER;
+            }
+        } else {
+            if (!Character.isDigit(value.charAt(0))) {
+                if (value.equals("true") || value.equals("false")) {
+                    return DataType.TYPE_BOOLEAN;
+                } else if (isEnumerationValue(m,
+                                              factPattern,
+                                              con,
+                                              dmo)) {
+                    return DataType.TYPE_COMPARABLE;
+                }
+            }
+        }
+        return null;
+    }
+
+    static boolean isEnumerationValue(final RuleModel ruleModel,
+                                      final FactPattern factPattern,
+                                      final BaseSingleFieldConstraint con,
+                                      final PackageDataModelOracle dmo) {
+        final String factType = extractFactType(factPattern,
+                                                con);
+        final String fieldName = extractFieldName(con);
+        if (factType == null || fieldName == null) {
+            return false;
+        }
+
+        final String fullyQualifiedFactType = getFQFactType(ruleModel,
+                                                            factType,
+                                                            dmo);
+        final String key = fullyQualifiedFactType + "#" + fieldName;
+        final Map<String, String[]> projectJavaEnumDefinitions = dmo.getProjectJavaEnumDefinitions();
+
+        return projectJavaEnumDefinitions.containsKey(key);
+    }
+
+    static String inferDataTypeFromAction(final ActionFieldList action,
+                                          final String field,
+                                          final String value,
+                                          final boolean isJavaDialect,
+                                          final Map<String, String> boundParams,
+                                          final PackageDataModelOracle dmo,
+                                          final Imports imports) {
+        String factType = null;
+        if (action instanceof ActionInsertFact) {
+            factType = ((ActionInsertFact) action).getFactType();
+        } else if (action instanceof ActionSetField) {
+            String boundParam = ((ActionSetField) action).getVariable();
+            factType = boundParams.get(boundParam);
+        }
+
+        final String type = inferDataTypeFromModelFields(factType,
+                                                         field,
+                                                         dmo,
+                                                         imports);
+        if (type != null) {
+            return type;
+        }
+
+        return RuleModelPersistenceHelper.inferDataTypeFromActionValue(value,
+                                                                       boundParams,
+                                                                       isJavaDialect);
+    }
+
+    static String inferDataTypeFromActionValue(final String param,
+                                               final Map<String, String> boundParams,
+                                               final boolean isJavaDialect) {
+        if (param.startsWith("sdf.parse(\"")) {
+            return DataType.TYPE_DATE;
+        } else if (param.startsWith("\"")) {
+            return DataType.TYPE_STRING;
+        } else if (param.equals("true") || param.equals("false")) {
             return DataType.TYPE_BOOLEAN;
-        } else if ( param.endsWith( "B" ) || ( isJavaDialect && param.startsWith( "new java.math.BigDecimal" ) ) ) {
+        } else if (param.endsWith("B") || (isJavaDialect && param.startsWith("new java.math.BigDecimal"))) {
             return DataType.TYPE_NUMERIC_BIGDECIMAL;
-        } else if ( param.endsWith( "I" ) || ( isJavaDialect && param.startsWith( "new java.math.BigInteger" ) ) ) {
+        } else if (param.endsWith("I") || (isJavaDialect && param.startsWith("new java.math.BigInteger"))) {
             return DataType.TYPE_NUMERIC_BIGINTEGER;
-        } else if ( param.startsWith( "[" ) && param.endsWith( "]" ) ) {
+        } else if (param.startsWith("[") && param.endsWith("]")) {
             return DataType.TYPE_COLLECTION;
-        } else if ( boundParams.containsKey( param ) ) {
+        } else if (boundParams.containsKey(param)) {
             return DataType.TYPE_OBJECT;
         }
         return DataType.TYPE_NUMERIC;
     }
 
-    static String adjustParam( final String dataType,
-                               final String param,
-                               final Map<String, String> boundParams,
-                               final boolean isJavaDialect ) {
-        if ( DataType.TYPE_DATE.equals( dataType ) ) {
-            if ( param.contains( "sdf.parse(\"" ) ) {
-                return param.substring( "sdf.parse(\"".length(),
-                                        param.length() - 2 );
+    static String adjustParam(final String dataType,
+                              final String param,
+                              final Map<String, String> boundParams,
+                              final boolean isJavaDialect) {
+        if (DataType.TYPE_DATE.equals(dataType)) {
+            if (param.contains("sdf.parse(\"")) {
+                return param.substring("sdf.parse(\"".length(),
+                                       param.length() - 2);
             } else {
                 return param;
             }
-        } else if ( DataType.TYPE_STRING.equals( dataType ) ) {
-            if ( param.startsWith( "\"" ) && param.endsWith( "\"" ) ) {
-                return param.substring( 1,
-                                        param.length() - 1 );
+        } else if (DataType.TYPE_STRING.equals(dataType)) {
+            if (param.startsWith("\"") && param.endsWith("\"")) {
+                return param.substring(1,
+                                       param.length() - 1);
             } else {
                 return param;
             }
-        } else if ( DataType.TYPE_NUMERIC_BIGDECIMAL.equals( dataType ) ) {
-            if ( isJavaDialect ) {
-                return param.substring( "new java.math.BigDecimal(\"".length(),
-                                        param.length() - 2 );
+        } else if (DataType.TYPE_NUMERIC_BIGDECIMAL.equals(dataType)) {
+            if (isJavaDialect) {
+                return param.substring("new java.math.BigDecimal(\"".length(),
+                                       param.length() - 2);
             } else {
-                return param.substring( 0, param.length() - 1 );
+                return param.substring(0,
+                                       param.length() - 1);
             }
-        } else if ( DataType.TYPE_NUMERIC_BIGINTEGER.equals( dataType ) ) {
-            if ( isJavaDialect ) {
-                return param.substring( "new java.math.BigInteger(\"".length(),
-                                        param.length() - 2 );
+        } else if (DataType.TYPE_NUMERIC_BIGINTEGER.equals(dataType)) {
+            if (isJavaDialect) {
+                return param.substring("new java.math.BigInteger(\"".length(),
+                                       param.length() - 2);
             } else {
-                return param.substring( 0,
-                                        param.length() - 1 );
+                return param.substring(0,
+                                       param.length() - 1);
             }
-        } else if ( boundParams.containsKey( param ) ) {
+        } else if (boundParams.containsKey(param)) {
             return "=" + param;
         }
         return param;
     }
 
-    static List<MethodInfo> getMethodInfosForType( final RuleModel model,
-                                                   final PackageDataModelOracle dmo,
-                                                   final String variableType ) {
-        List<MethodInfo> methods = dmo.getProjectMethodInformation().get( variableType );
-        if ( methods == null ) {
-            for ( String imp : model.getImports().getImportStrings() ) {
-                if ( imp.endsWith( "." + variableType ) ) {
-                    methods = dmo.getProjectMethodInformation().get( imp );
-                    if ( methods != null ) {
+    static List<MethodInfo> getMethodInfosForType(final RuleModel model,
+                                                  final PackageDataModelOracle dmo,
+                                                  final String variableType) {
+        List<MethodInfo> methods = dmo.getProjectMethodInformation().get(variableType);
+        if (methods == null) {
+            for (String imp : model.getImports().getImportStrings()) {
+                if (imp.endsWith("." + variableType)) {
+                    methods = dmo.getProjectMethodInformation().get(imp);
+                    if (methods != null) {
                         break;
                     }
                 }
@@ -425,27 +538,48 @@ class RuleModelPersistenceHelper {
         return methods;
     }
 
-    static String removeNumericSuffix( final String value,
-                                       final String dataType ) {
-        if ( DataType.TYPE_NUMERIC_DOUBLE.equals( dataType ) ) {
-            if ( value.endsWith( "d" ) ) {
-                return value.substring( 0,
-                                        value.indexOf( "d" ) );
+    static String removeNumericSuffix(final String value,
+                                      final String dataType) {
+        if (DataType.TYPE_NUMERIC_DOUBLE.equals(dataType)) {
+            if (value.endsWith("d")) {
+                return value.substring(0,
+                                       value.indexOf("d"));
             }
-        } else if ( DataType.TYPE_NUMERIC_FLOAT.equals( dataType ) ) {
-            if ( value.endsWith( "f" ) ) {
-                return value.substring( 0,
-                                        value.indexOf( "f" ) );
+        } else if (DataType.TYPE_NUMERIC_FLOAT.equals(dataType)) {
+            if (value.endsWith("f")) {
+                return value.substring(0,
+                                       value.indexOf("f"));
             }
-
-        } else if ( DataType.TYPE_NUMERIC_LONG.equals( dataType ) ) {
-            if ( value.endsWith( "L" ) ) {
-                return value.substring( 0,
-                                        value.indexOf( "L" ) );
-
+        } else if (DataType.TYPE_NUMERIC_LONG.equals(dataType)) {
+            if (value.endsWith("L")) {
+                return value.substring(0,
+                                       value.indexOf("L"));
             }
         }
         return value;
     }
 
+    static String getFQFactType(final RuleModel ruleModel,
+                                final String factType,
+                                final PackageDataModelOracle dmo) {
+        Set<String> factTypes = dmo.getProjectModelFields().keySet();
+
+        if (factTypes.contains(ruleModel.getPackageName() + "." + factType)) {
+            return ruleModel.getPackageName() + "." + factType;
+        }
+
+        for (String item : ruleModel.getImports().getImportStrings()) {
+            if (item.endsWith("." + factType)) {
+                return item;
+            }
+        }
+
+        for (String type : factTypes) {
+            if (type.endsWith("." + factType)) {
+                return type;
+            }
+        }
+
+        return factType;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/BaseRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/BaseRuleModelTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.commons.backend.rule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
+import org.drools.workbench.models.datamodel.oracle.MethodInfo;
+import org.drools.workbench.models.datamodel.oracle.ModelField;
+import org.drools.workbench.models.datamodel.oracle.PackageDataModelOracle;
+import org.junit.After;
+import org.junit.Before;
+
+import static org.mockito.Mockito.*;
+
+public abstract class BaseRuleModelTest {
+
+    protected PackageDataModelOracle dmo;
+    protected Map<String, ModelField[]> packageModelFields = new HashMap<>();
+    protected Map<String, String[]> projectJavaEnumDefinitions = new HashMap<>();
+    protected Map<String, List<MethodInfo>> projectMethodInformation = new HashMap<>();
+
+    @Before
+    public void setUp() throws Exception {
+        dmo = mock(PackageDataModelOracle.class);
+        when(dmo.getProjectModelFields()).thenReturn(packageModelFields);
+        when(dmo.getProjectJavaEnumDefinitions()).thenReturn(projectJavaEnumDefinitions);
+        when(dmo.getProjectMethodInformation()).thenReturn(projectMethodInformation);
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        packageModelFields.clear();
+        projectJavaEnumDefinitions.clear();
+        projectMethodInformation.clear();
+    }
+
+    protected void addModelField(final String factName,
+                                 final String fieldName,
+                                 final String clazz,
+                                 final String type) {
+        ModelField[] modelFields = new ModelField[1];
+        modelFields[0] = new ModelField(fieldName,
+                                        clazz,
+                                        ModelField.FIELD_CLASS_TYPE.TYPE_DECLARATION_CLASS,
+                                        ModelField.FIELD_ORIGIN.DECLARED,
+                                        FieldAccessorsAndMutators.BOTH,
+                                        type);
+        if (packageModelFields.containsKey(factName)) {
+            final List<ModelField> existingModelFields = new ArrayList<>(Arrays.asList(packageModelFields.get(factName)));
+            existingModelFields.add(modelFields[0]);
+            modelFields = existingModelFields.toArray(modelFields);
+        }
+        packageModelFields.put(factName,
+                               modelFields);
+    }
+
+    protected void addJavaEnumDefinition(final String factName,
+                                         final String fieldName,
+                                         final String[] values) {
+        final String key = factName + "#" + fieldName;
+        projectJavaEnumDefinitions.put(key,
+                                       values);
+    }
+
+    protected void addMethodInformation(final String factName,
+                                        final String name,
+                                        final List<String> params,
+                                        final String returnType,
+                                        final String parametricReturnType,
+                                        final String genericType) {
+        MethodInfo mi = new MethodInfo(name,
+                                       params,
+                                       returnType,
+                                       parametricReturnType,
+                                       genericType);
+
+        List<MethodInfo> existingMethodInfo = projectMethodInformation.get(factName);
+        if (existingMethodInfo == null) {
+            existingMethodInfo = new ArrayList<>();
+            projectMethodInformation.put(factName,
+                                         existingMethodInfo);
+        }
+        existingMethodInfo.add(mi);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-public class RuleModelDRLPersistenceTest {
+public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
 
     private static final Logger logger = LoggerFactory.getLogger(RuleModelDRLPersistenceTest.class);
 
@@ -81,6 +81,7 @@ public class RuleModelDRLPersistenceTest {
 
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         ruleModelPersistence = RuleModelDRLPersistenceImpl.getInstance();
     }
 
@@ -516,7 +517,8 @@ public class RuleModelDRLPersistenceTest {
     @Test
     public void testMoreComplexRendering() {
         final RuleModel m = getComplexModel(false);
-        String expected = "rule \"Complex Rule\"\n" +
+        String expected = "package org.test;\n" +
+                "rule \"Complex Rule\"\n" +
                 "no-loop true\n" +
                 "salience -10\n" +
                 "agenda-group \"aGroup\"\n" +
@@ -539,7 +541,8 @@ public class RuleModelDRLPersistenceTest {
     @Test
     public void testMoreComplexRenderingWithDsl() {
         final RuleModel m = getComplexModel(true);
-        String expected = "rule \"Complex Rule\"\n" +
+        String expected = "package org.test;\n" +
+                "rule \"Complex Rule\"\n" +
                 "no-loop true\n" +
                 "salience -10\n" +
                 "agenda-group \"aGroup\"\n" +
@@ -567,7 +570,7 @@ public class RuleModelDRLPersistenceTest {
 
         RuleModel unmarshalledModel = ruleModelPersistence.unmarshalUsingDSL(drl,
                                                                              null,
-                                                                             mock(PackageDataModelOracle.class),
+                                                                             dmo,
                                                                              dslFile);
 
         IAction[] actions = unmarshalledModel.rhs;
@@ -740,6 +743,7 @@ public class RuleModelDRLPersistenceTest {
     private RuleModel getComplexModel(boolean useDsl) {
         final RuleModel m = new RuleModel();
         m.name = "Complex Rule";
+        m.setPackageName("org.test");
 
         m.addAttribute(new RuleAttribute("no-loop",
                                          "true"));
@@ -781,6 +785,19 @@ public class RuleModelDRLPersistenceTest {
             sen.setDefinition("Send an email to {administrator}");
             m.addRhsItem(sen);
         }
+
+        addModelField("org.test.Person",
+                      "this",
+                      "org.test.Person",
+                      DataType.TYPE_THIS);
+        addModelField("org.test.Person",
+                      "age",
+                      Integer.class.getName(),
+                      DataType.TYPE_NUMERIC_INTEGER);
+        addModelField("org.test.Person",
+                      "status",
+                      String.class.getName(),
+                      DataType.TYPE_STRING);
 
         return m;
     }
@@ -3593,7 +3610,6 @@ public class RuleModelDRLPersistenceTest {
         final RuleModel m = getComplexModel();
         final String drl = RuleModelDRLPersistenceImpl.getInstance().marshal(m);
 
-        PackageDataModelOracle dmo = mock(PackageDataModelOracle.class);
         final RuleModel m2 = RuleModelDRLPersistenceImpl.getInstance().unmarshalUsingDSL(drl,
                                                                                          Collections.EMPTY_LIST,
                                                                                          dmo);
@@ -3736,6 +3752,7 @@ public class RuleModelDRLPersistenceTest {
     private RuleModel getComplexModel() {
         final RuleModel m = new RuleModel();
         m.name = "complex";
+        m.setPackageName("org.test");
 
         m.addAttribute(new RuleAttribute("no-loop",
                                          "true"));
@@ -3768,8 +3785,21 @@ public class RuleModelDRLPersistenceTest {
 
         final DSLSentence sen = new DSLSentence();
         sen.setDefinition("Send an email to {administrator}");
-
         m.addRhsItem(sen);
+
+        addModelField("org.test.Person",
+                      "this",
+                      "org.test.Person",
+                      DataType.TYPE_THIS);
+        addModelField("org.test.Person",
+                      "age",
+                      Integer.class.getName(),
+                      DataType.TYPE_NUMERIC_INTEGER);
+        addModelField("org.test.Person",
+                      "status",
+                      String.class.getName(),
+                      DataType.TYPE_STRING);
+
         return m;
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4737

This PR refactors identification of fields' data-types to primarily use the ```DataModelOracle``` (that contains meta-data relating to classes and fields in a project) and fallback to infer the type from the fields' value if no information is found in the ```DataModelOracle```. A few tests needed refactoring; but on the whole the function remains unchanged. This is required to ensure the fields' data-type is correct on the XLS->Guided Decision Table conversion. 