### PR TITLE
[JBPM-6038] OptimisticLockRetryInterceptor doesn't retry 3 times

### DIFF
--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/OptimisticLockRetryInterceptor.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/OptimisticLockRetryInterceptor.java
@@ -89,11 +89,11 @@ public class OptimisticLockRetryInterceptor extends AbstractInterceptor {
     }
 
     protected RequestContext internalExecute( Executable executable, RequestContext ctx ) {
-        int attempt = 1;
+        int attempt = 0;
         long sleepTime = delay;
         RuntimeException originException = null;
 
-        while (attempt <= retries) {
+        while (true) {
             if (attempt > 1) {
                 logger.trace("retrying (attempt {})...", attempt);
             }
@@ -113,11 +113,14 @@ public class OptimisticLockRetryInterceptor extends AbstractInterceptor {
                     throw ex;
                 }
                 attempt++;
-                logger.trace("Command failed due to optimistic locking {} waiting {} millis before retry", ex, sleepTime);
                 // save origin exception in case it needs to be rethrown
                 if (originException == null) {
                     originException = ex;
                 }
+                if (attempt > retries) {
+                    break;
+                }
+                logger.trace("Command failed due to optimistic locking {} waiting {} millis before retry", ex, sleepTime);
                 try {
                     Thread.sleep(sleepTime);
                 } catch (InterruptedException e1) {


### PR DESCRIPTION
This PR doesn't contain a unit test because JpaOptLockPersistentStatefulSessionTest in master doesn't seem to work now (DROOLS-1393). Instead, I attached a unit test diff for branch 6.5.x to https://issues.jboss.org/browse/JBPM-6038

If you think this PR should contain the unit test (even though I cannot verify), please let me know, I will add it and revise this commit.