### PR TITLE
GUVNOR-2864: [Guided Decision Table] Values are reset during column edit

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/DSLComplexVariableValue.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/DSLComplexVariableValue.java
@@ -26,9 +26,9 @@ public class DSLComplexVariableValue extends DSLVariableValue {
     public DSLComplexVariableValue() {
     }
 
-    public DSLComplexVariableValue( String id,
-                                    String value ) {
-        super( value );
+    public DSLComplexVariableValue(String id,
+                                   String value) {
+        super(value);
         this.id = id;
     }
 
@@ -36,18 +36,24 @@ public class DSLComplexVariableValue extends DSLVariableValue {
         return id;
     }
 
-    public void setId( String id ) {
+    public void setId(String id) {
         this.id = id;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         DSLComplexVariableValue that = (DSLComplexVariableValue) o;
 
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (id != null ? !id.equals(that.id) : that.id != null) {
+            return false;
+        }
 
         return true;
     }
@@ -59,5 +65,11 @@ public class DSLComplexVariableValue extends DSLVariableValue {
         result = 31 * result + (id != null ? id.hashCode() : 0);
         result = ~~result;
         return result;
+    }
+
+    @Override
+    public DSLVariableValue copy() {
+        return new DSLComplexVariableValue(id,
+                                           getValue());
     }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/DSLComplexVariableValueTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/DSLComplexVariableValueTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.datamodel.rule;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DSLComplexVariableValueTest {
+
+    @Test
+    public void testCopy() {
+        final DSLComplexVariableValue original = new DSLComplexVariableValue("id",
+                                                                             "value");
+        final DSLComplexVariableValue copy = (DSLComplexVariableValue) original.copy();
+
+        assertEquals(original.getId(),
+                     copy.getId());
+        assertEquals(original.getValue(),
+                     copy.getValue());
+        assertEquals(original,
+                     copy);
+        assertNotSame(original,
+                      copy);
+    }
+}


### PR DESCRIPTION
Override 'copy' for DSLComplexVariableValue

See https://issues.jboss.org/browse/GUVNOR-2864