### PR TITLE
[DROOLS-1582] fix cast to avoid exception in the kie maven plugin

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -325,7 +325,7 @@ public class ClasspathKieProject extends AbstractKieProject {
 
                 KieBuilderImpl.validatePomModel( pomModel ); // throws an exception if invalid
 
-                ReleaseIdImpl gav = (ReleaseIdImpl) pomModel.getReleaseId();
+                org.appformer.maven.support.ReleaseId gav = pomModel.getReleaseId();
 
                 String str =  KieBuilderImpl.generatePomProperties( gav );
                 log.info( "Recursed up folders, found and used pom.xml " + file );


### PR DESCRIPTION
Fix to avoid the Exception
"org.appformer.maven.support.ReleaseIdImpl cannot be cast to org.drools.compiler.kproject.ReleaseIdImpl" in the tests of Kie Maven Plugin