### PR TITLE
RHBRMS-2842 [DROOLS-1051] KieScanner does not initialize if missing t…

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -398,10 +398,14 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
     private Map<ReleaseId, DependencyDescriptor> indexAtifacts(ArtifactResolver artifactResolver) {
         Map<ReleaseId, DependencyDescriptor> depsMap = new HashMap<ReleaseId, DependencyDescriptor>();
         for (DependencyDescriptor dep : artifactResolver.getAllDependecies()) {
-            Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
-            log.debug( artifact + " resolved to  " + artifact.getFile() );
-            if (isKJar(artifact.getFile())) {
-                depsMap.put(dep.getReleaseIdWithoutVersion(), new DependencyDescriptor(artifact));
+            if ( !"test".equals(dep.getScope()) && !"provided".equals(dep.getScope()) && !"system".equals(dep.getScope()) ) {
+                Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
+                log.debug( artifact + " resolved to  " + artifact.getFile() );
+                if (isKJar(artifact.getFile())) {
+                    depsMap.put(dep.getReleaseIdWithoutVersion(), new DependencyDescriptor(artifact));
+                }
+            } else {
+                log.debug("{} does not need to be resolved because in scope {}", dep, dep.getScope());
             }
         }
         return depsMap;

--- a/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/AbstractKieCiTest.java
@@ -24,6 +24,7 @@ import org.kie.api.builder.KieModule;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.builder.ReleaseId;
+import org.apache.maven.model.Dependency;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
@@ -66,6 +67,27 @@ public class AbstractKieCiTest {
         KieBuilder kieBuilder = ks.newKieBuilder(kfs);
         assertTrue(kieBuilder.buildAll().getResults().getMessages().isEmpty());
         return (InternalKieModule) kieBuilder.getKieModule();
+    }
+    
+    protected InternalKieModule createKieJarWithDependencies(KieServices ks, ReleaseId releaseId, boolean isdefault, String rule, Dependency... dependencies) {
+        KieFileSystem kfs = createKieFileSystemWithKProject(ks, isdefault);
+        kfs.writePomXML(pomWithMvnDeps(dependencyWithScope(releaseId.getGroupId(), releaseId.getArtifactId(), releaseId.getVersion(), ""), dependencies));
+
+        String file = "org/test/" + rule + ".drl";
+        kfs.write("src/main/resources/KBase1/" + file, createDRL(rule));
+
+        KieBuilder kieBuilder = ks.newKieBuilder(kfs);
+        assertTrue(kieBuilder.buildAll().getResults().getMessages().isEmpty());
+        return (InternalKieModule) kieBuilder.getKieModule();
+    }
+    
+    protected Dependency dependencyWithScope(String groupId, String artifactId, String version, String scope) {
+        Dependency dep1 = new Dependency();
+        dep1.setGroupId(groupId);
+        dep1.setArtifactId(artifactId);
+        dep1.setVersion(version);
+        dep1.setScope(scope);
+        return dep1;
     }
 
     protected InternalKieModule createKieJar(KieServices ks, ReleaseId releaseId, String pomXml, boolean isdefault,  String... rules) throws IOException {
@@ -145,6 +167,38 @@ public class AbstractKieCiTest {
                 pom += "  <groupId>" + dep.getGroupId() + "</groupId>\n";
                 pom += "  <artifactId>" + dep.getArtifactId() + "</artifactId>\n";
                 pom += "  <version>" + dep.getVersion() + "</version>\n";
+                pom += "</dependency>\n";
+            }
+            pom += "</dependencies>\n";
+        }
+        pom += "</project>";
+        return pom;
+    }
+    
+    private String pomWithMvnDeps(Dependency releaseId, Dependency... dependencies) {
+        String pom =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                        "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n" +
+                        "  <modelVersion>4.0.0</modelVersion>\n" +
+                        "\n" +
+                        "  <groupId>" + releaseId.getGroupId() + "</groupId>\n" +
+                        "  <artifactId>" + releaseId.getArtifactId() + "</artifactId>\n" +
+                        "  <version>" + releaseId.getVersion() + "</version>\n" +
+                        "\n";
+        if (dependencies != null && dependencies.length > 0) {
+            pom += "<dependencies>\n";
+            for (Dependency dep : dependencies) {
+                pom += "<dependency>\n";
+                pom += "  <groupId>" + dep.getGroupId() + "</groupId>\n";
+                pom += "  <artifactId>" + dep.getArtifactId() + "</artifactId>\n";
+                pom += "  <version>" + dep.getVersion() + "</version>\n";
+                if ( !"".equals(dep.getScope()) && !"compile".equals(dep.getScope()) ) {
+                    pom += "  <scope>" + dep.getScope() + "</scope>\n";
+                }
+                if ( "system".equals(dep.getScope()) ) {
+                    pom += "  <systemPath>" + dep.getSystemPath() + "</systemPath>\n";
+                }
                 pom += "</dependency>\n";
             }
             pom += "</dependencies>\n";

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Dependency;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.InternalKieScanner;
 import org.drools.compiler.kie.builder.impl.KieFileSystemImpl;
@@ -151,6 +152,27 @@ public class KieRepositoryScannerTest extends AbstractKieCiTest {
         InternalKieModule kJar2 = createKieJarWithDependencies( ks, releaseIdWithDep, false, "rule1", dep1, dep2, dep3);
         KieContainer kieContainer2 = ks.newKieContainer( releaseIdWithDep );
         System.out.println("done in " + (System.nanoTime() - start));
+    }
+    
+    @Test
+    public void testKieScannerScopesNotRequired() throws Exception {
+        MavenRepository repository = getMavenRepository();
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseIdWithDep = ks.newReleaseId( "org.kie", "test-with-dep", "1.0-SNAPSHOT" );
+
+        Dependency dep1 = dependencyWithScope( "org.kie", "test-dep1-in-test-scope"    , "1.0-SNAPSHOT", "test"     );
+        Dependency dep2 = dependencyWithScope( "org.kie", "test-dep2-in-provided-scope", "1.0-SNAPSHOT", "provided" );
+        Dependency dep3 = dependencyWithScope( "org.kie", "test-dep3-in-system-scope"  , "1.0-SNAPSHOT", "system"   );
+        dep3.setSystemPath(fileManager.getRootDirectory().getAbsolutePath());
+        // to ensure KieBuilder is able to build correctly:
+        repository.installArtifact(ks.newReleaseId("org.kie", "test-dep3-in-system-scope", "1.0-SNAPSHOT"), new byte[]{}, new byte[]{});
+        
+        InternalKieModule kJar2 = createKieJarWithDependencies( ks, releaseIdWithDep, false, "rule1", dep1, dep2, dep3);
+        KieContainer kieContainer = ks.newKieContainer( releaseIdWithDep );
+        
+        // DROOLS-1051 following should not throw NPE because dependencies are not in scope of scanner
+        KieScanner scanner = ks.newKieScanner(kieContainer);
+        assertNotNull(scanner);
     }
 
     @Test


### PR DESCRIPTION
…o locate a kjar dependency of test scope.

[ Cherry picked 80a06ea4b to 6.5.x branch ]

See Jboss JIRA https://issues.jboss.org/browse/DROOLS-1051

Suppose a kjar has a "test" scope dependency which may not be resolvable
at runtime; the KieContainer will be created correctly (warning raised
in log) but the initialization of the KieScanner fail with NPE.
Expected behavior: also the KieScanner shall be able to initialize if
the KieContainer is working correctly.

Description of proposed patch.
Problem is that if the dependency "dep" is not resolvable at runtime,
the method artifactResolver.resolveArtifact(...) will return a null, and
in turn a NPE, and in turn will fail the initialization of the
KieScanner.
Actually the following scopes:
"test", "provided", and "system" are not required to be resolved to be
updated by the KieScanner, as these actual artifacts are needed only
during test or they need to be manually specified by the
container/runtime environment.

Thanks in advance for your feedback.

P.s.: this is a squashed commit to update the original proposal to
reflect PR's comment: "check the scope of the dependency (
DependencyDescriptor.getScope() ) and make the KieScanner to fail fast
if the dependency is not optional."
Missed that method as I originally developed this change against the
6.2.x branch, and modified the commit just before submitting the PR to
have it against master... Thanks for pointing it out ! =)

Resolved Conflicts:
	kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerTest.java