### PR TITLE
DROOLS-1618: fix sort function to accept a null "precedes" parameter

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SortFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SortFunction.java
@@ -39,7 +39,7 @@ public class SortFunction
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         } else if ( function == null ){
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "precedes", "cannot be null"));
+            return invoke( list );
         }
         List<Object> newList = new ArrayList<Object>( list );
         AtomicBoolean hasError = new AtomicBoolean( false );


### PR DESCRIPTION
 When the "precedes" parameter is not available on a sort() call, just use natural order, delegating to the second method.