### PR TITLE
RHBRMS-2853 [DROOLS-1619] Compile error on a multibyte-name variable …

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java
@@ -268,4 +268,34 @@ public class I18nTest extends CommonTestMethodBase {
         int fired = kieSession.fireAllRules();
         Assertions.assertThat( fired ).isEqualTo( 1 );
     }
+    
+    @Test
+    public void testMultibytePositonalQueryParam() {
+        // DROOLS-1619
+        String drl = "package org.drools.compiler.i18ntest;\n" +
+                "import org.drools.compiler.Person;\n" +
+                "\n" +
+                "query testquery(int $a, Person $t)\n" +
+                "    $t := Person(age > $a)\n" +
+                "end\n" +
+                "\n" +
+                "rule \"hoge\"\n" +
+                "    when\n" +
+                "        testquery(30, $あああ;)\n" +
+                "    then\n" +
+                "        System.out.println($あああ.getName());\n" +
+                "end";
+
+        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL ).build().newKieSession();
+
+        Person p1 = new Person("John", 25);
+        Person p2 = new Person("Paul", 35);
+        ksession.insert(p1);
+        ksession.insert(p2);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
+
+        ksession.dispose();
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/util/StringUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/StringUtils.java
@@ -1146,12 +1146,12 @@ public class StringUtils {
 
     public static boolean isIdentifier(String expr) {
         return !expr.equals("true") && !expr.equals("false") &&
-               !expr.equals("null") && expr.matches("[a-zA-Z_\\$][a-zA-Z_\\$0-9]*");
+               !expr.equals("null") && expr.matches("[\\p{L}_\\$][\\p{L}_\\$\\p{N}]*");
     }
 
     public static boolean isDereferencingIdentifier(String expr) {
         return !expr.equals("true") && !expr.equals("false") &&
-               !expr.equals("null") && expr.matches("[a-zA-Z_\\$][a-zA-Z_\\$0-9\\.]*");
+               !expr.equals("null") && expr.matches("[\\p{L}_\\$][\\p{L}_\\$\\p{N}\\.]*");
     }
 
     // To be extended in the future with more comparison strategies


### PR DESCRIPTION
…as a positional query parameter

Cherry pick of 936603a7

* [DROOLS-1619] Compile error on a multibyte-name variable as a positional query parameter

Conflicts:
	drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java