### PR TITLE
[6.5.x] RHBRMS-2854 (GUVNOR-3260): [GSS] (6.4.z) Guided Rule Editor doesn't render RDRL with abbreviated combined relation condition correctly

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -3472,9 +3472,9 @@ public class RuleModelDRLPersistenceImpl
                 case OR:
                 case AND:
                     if (ch == '=' || ch == '!' || ch == '<' || ch == '>') {
-                        status = SplitterState.EXPR;
                         sb.append(status == SplitterState.AND ? "&& " : "|| ");
                         sb.append(ch);
+                        status = SplitterState.EXPR;
                     } else if (Character.isJavaIdentifierStart(ch)) {
                         String currentExpr = sb.toString().trim();
                         if (currentExpr.length() > 0) {
@@ -3560,13 +3560,13 @@ public class RuleModelDRLPersistenceImpl
                                            opPos).trim();
             } else {
                 operator = findOperator(expr);
-                if (operator != null) {
-                    int opPos = expr.indexOf(operator);
-                    fieldName = expr.substring(0,
-                                               opPos).trim();
-                    value = expr.substring(opPos + operator.length(),
-                                           expr.length()).trim();
-                }
+            }
+            if (operator != null) {
+                int opPos = expr.indexOf(operator);
+                fieldName = expr.substring(0,
+                                           opPos).trim();
+                value = expr.substring(opPos + operator.length(),
+                                       expr.length()).trim();
             }
 
             boolean isExpression = fieldName.contains(".") || fieldName.endsWith("()");
@@ -3960,14 +3960,16 @@ public class RuleModelDRLPersistenceImpl
             String type = null;
             boolean isAnd = false;
             String[] splittedValue = new String[0];
-            if (value != null) {
+            if (!(value == null || value.isEmpty())) {
                 isAnd = value.contains("&&");
                 splittedValue = isAnd ? value.split("\\&\\&") : value.split("\\|\\|");
-                type = setValueOnConstraint(m,
-                                            operator,
-                                            factPattern,
-                                            con,
-                                            splittedValue[0].trim());
+                if (!splittedValue[0].trim().isEmpty()) {
+                    type = setValueOnConstraint(m,
+                                                operator,
+                                                factPattern,
+                                                con,
+                                                splittedValue[0].trim());
+                }
             }
 
             if (splittedValue.length > 1) {
@@ -4053,6 +4055,7 @@ public class RuleModelDRLPersistenceImpl
             } else if (con instanceof ConnectiveConstraint) {
                 ((ConnectiveConstraint) con).setFieldType(type);
             }
+
             return type;
         }
     }

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -6452,6 +6452,187 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
     }
 
     @Test
+    //https://issues.jboss.org/browse/RHBRMS-2854
+    public void testSingleFieldConstraintConnectives3() {
+        String drl = "package org.test;\n" +
+                "rule \"rule1\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "    Applicant(age != 1 && < 10 && > 5)\n" +
+                "then\n" +
+                "end";
+
+        addModelField("org.test.Applicant",
+                      "this",
+                      "org.test.Applicant",
+                      DataType.TYPE_THIS);
+        addModelField("org.test.Applicant",
+                      "age",
+                      Integer.class.getName(),
+                      DataType.TYPE_NUMERIC_INTEGER);
+
+        when(dmo.getPackageName()).thenReturn("org.test");
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                          Collections.EMPTY_LIST,
+                                                                          dmo);
+
+        assertNotNull(m);
+        assertEquals("rule1",
+                     m.name);
+
+        assertEquals(1,
+                     m.lhs.length);
+        IPattern p = m.lhs[0];
+        assertTrue(p instanceof FactPattern);
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals("Applicant",
+                     fp.getFactType());
+
+        assertEquals(1,
+                     fp.getConstraintList().getConstraints().length);
+        assertTrue(fp.getConstraint(0) instanceof SingleFieldConstraint);
+
+        SingleFieldConstraint sfp = (SingleFieldConstraint) fp.getConstraint(0);
+        assertEquals("Applicant",
+                     sfp.getFactType());
+        assertEquals("age",
+                     sfp.getFieldName());
+        assertEquals("!=",
+                     sfp.getOperator());
+        assertEquals("1",
+                     sfp.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     sfp.getConstraintValueType());
+
+        assertEquals(2,
+                     sfp.getConnectives().length);
+        ConnectiveConstraint cc1 = sfp.getConnectives()[0];
+        assertEquals("Applicant",
+                     cc1.getFactType());
+        assertEquals("age",
+                     cc1.getFieldName());
+        assertEquals("&& <",
+                     cc1.getOperator());
+        assertEquals("10",
+                     cc1.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     cc1.getConstraintValueType());
+
+        ConnectiveConstraint cc2 = sfp.getConnectives()[1];
+        assertEquals("Applicant",
+                     cc2.getFactType());
+        assertEquals("age",
+                     cc2.getFieldName());
+        assertEquals("&& >",
+                     cc2.getOperator());
+        assertEquals("5",
+                     cc2.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     cc2.getConstraintValueType());
+
+        assertEqualsIgnoreWhitespace(drl,
+                                     RuleModelDRLPersistenceImpl.getInstance().marshal(m));
+    }
+
+    @Test
+    //https://issues.jboss.org/browse/RHBRMS-2854
+    public void testSingleFieldConstraintConnectives4() {
+        String drl = "package org.test;\n" +
+                "rule \"rule1\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "    Applicant(age != null && != 1 && < 10 && > 5)\n" +
+                "then\n" +
+                "end";
+
+        addModelField("org.test.Applicant",
+                      "this",
+                      "org.test.Applicant",
+                      DataType.TYPE_THIS);
+        addModelField("org.test.Applicant",
+                      "age",
+                      Integer.class.getName(),
+                      DataType.TYPE_NUMERIC_INTEGER);
+
+        when(dmo.getPackageName()).thenReturn("org.test");
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                          Collections.EMPTY_LIST,
+                                                                          dmo);
+
+        assertNotNull(m);
+        assertEquals("rule1",
+                     m.name);
+
+        assertEquals(1,
+                     m.lhs.length);
+        IPattern p = m.lhs[0];
+        assertTrue(p instanceof FactPattern);
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals("Applicant",
+                     fp.getFactType());
+
+        assertEquals(1,
+                     fp.getConstraintList().getConstraints().length);
+        assertTrue(fp.getConstraint(0) instanceof SingleFieldConstraint);
+
+        SingleFieldConstraint sfp = (SingleFieldConstraint) fp.getConstraint(0);
+        assertEquals("Applicant",
+                     sfp.getFactType());
+        assertEquals("age",
+                     sfp.getFieldName());
+        assertEquals("!= null",
+                     sfp.getOperator());
+        assertNull(sfp.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_UNDEFINED,
+                     sfp.getConstraintValueType());
+
+        assertEquals(3,
+                     sfp.getConnectives().length);
+        ConnectiveConstraint cc1 = sfp.getConnectives()[0];
+        assertEquals("Applicant",
+                     cc1.getFactType());
+        assertEquals("age",
+                     cc1.getFieldName());
+        assertEquals("&& !=",
+                     cc1.getOperator());
+        assertEquals("1",
+                     cc1.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     cc1.getConstraintValueType());
+
+        ConnectiveConstraint cc2 = sfp.getConnectives()[1];
+        assertEquals("Applicant",
+                     cc2.getFactType());
+        assertEquals("age",
+                     cc2.getFieldName());
+        assertEquals("&& <",
+                     cc2.getOperator());
+        assertEquals("10",
+                     cc2.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     cc2.getConstraintValueType());
+
+        ConnectiveConstraint cc3 = sfp.getConnectives()[2];
+        assertEquals("Applicant",
+                     cc3.getFactType());
+        assertEquals("age",
+                     cc3.getFieldName());
+        assertEquals("&& >",
+                     cc3.getOperator());
+        assertEquals("5",
+                     cc3.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     cc3.getConstraintValueType());
+
+        assertEqualsIgnoreWhitespace(drl,
+                                     RuleModelDRLPersistenceImpl.getInstance().marshal(m));
+    }
+
+    @Test
     //https://issues.jboss.org/browse/GUVNOR-2143
     public void testNewKeywordVariableNamePrefix1() {
         String oldValue = System.getProperty("drools.dateformat");


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2854

This is the corollary of https://github.com/kiegroup/drools/pull/1362 for 6.5.x.

(cherry picked from commit 73fc9690f6524ac2279d5bd05e637af6203be4c8)