### PR TITLE
DROOLS-1599 Support Signavio Multi Instance Decision node (GAV align)

### DIFF
--- a/kie-dmn/kie-dmn-signavio/pom.xml
+++ b/kie-dmn/kie-dmn-signavio/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-signavio</artifactId>
   


### PR DESCRIPTION
Aligned parent coordinate version.
The kiegroup/drools#1348 PR was originally raised before a version bump on master.
Hence it bringed the orgiinal 7.1.0-SNAPSHOT
Meanwhile master bumped to 7.2.0-SNAPSHOT
Fixing with this commit for version alignment.