### PR TITLE
DROOLS-1666: changing return value for decision tables with hit policy C and C#

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
@@ -214,22 +214,33 @@ public class DMNDecisionTableHitPolicyTest {
 
     @Test
     public void testSimpleDecisionTableHitPolicyCollect() {
-        final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("0004-simpletable-C.dmn", this.getClass());
-        final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-C");
-        assertThat(dmnModel, notNullValue());
-
-        final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true);
-        final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
-
-        final List<BigDecimal> decisionResults = (List<BigDecimal>) result.get("Status number");
+        List<BigDecimal> decisionResults = executeTestDecisionTableHitPolicyCollect(getSimpleTableContext( BigDecimal.valueOf( 70 ), "Medium", true));
         assertThat(decisionResults, hasSize(3));
         assertThat(decisionResults, contains(BigDecimal.valueOf(10), BigDecimal.valueOf(25), BigDecimal.valueOf(13)));
     }
 
     @Test
+    public void testSimpleDecisionTableHitPolicyCollectNoHits() {
+        List<BigDecimal> decisionResults = executeTestDecisionTableHitPolicyCollect(getSimpleTableContext( BigDecimal.valueOf( 5 ), "Medium", true));
+        assertThat(decisionResults, hasSize(0));
+    }
+
+    private List<BigDecimal> executeTestDecisionTableHitPolicyCollect(DMNContext context) {
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "0004-simpletable-C.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel( "https://github.com/kiegroup/kie-dmn", "0004-simpletable-C");
+        assertThat(dmnModel, notNullValue());
+
+        final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
+
+        final List<BigDecimal> decisionResults = (List<BigDecimal>) result.get( "Status number");
+        return decisionResults;
+    }
+
+    @Test
     public void testSimpleDecisionTableHitPolicyCollectSum() {
         testSimpleDecisionTableHitPolicyCollectAggregateFunction(
-                "0004-simpletable-C-sum.dmn", "0004-simpletable-C-sum", BigDecimal.valueOf(48));
+                "0004-simpletable-C-sum.dmn", "0004-simpletable-C-sum", BigDecimal.valueOf(48),
+                getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true));
     }
 
     @Test
@@ -252,28 +263,37 @@ public class DMNDecisionTableHitPolicyTest {
     @Test
     public void testSimpleDecisionTableHitPolicyCollectMin() {
         testSimpleDecisionTableHitPolicyCollectAggregateFunction(
-                "0004-simpletable-C-min.dmn", "0004-simpletable-C-min", BigDecimal.valueOf(10));
+                "0004-simpletable-C-min.dmn", "0004-simpletable-C-min", BigDecimal.valueOf(10),
+                getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true));
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyCollectMax() {
         testSimpleDecisionTableHitPolicyCollectAggregateFunction(
-                "0004-simpletable-C-max.dmn", "0004-simpletable-C-max", BigDecimal.valueOf(25));
+                "0004-simpletable-C-max.dmn", "0004-simpletable-C-max", BigDecimal.valueOf(25),
+                getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true));
     }
 
     @Test
     public void testSimpleDecisionTableHitPolicyCollectCount() {
         testSimpleDecisionTableHitPolicyCollectAggregateFunction(
-                "0004-simpletable-C-count.dmn", "0004-simpletable-C-count", BigDecimal.valueOf(3));
+                "0004-simpletable-C-count.dmn", "0004-simpletable-C-count", BigDecimal.valueOf(3),
+                getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true));
+    }
+
+    @Test
+    public void testSimpleDecisionTableHitPolicyCollectCountNoHits() {
+        testSimpleDecisionTableHitPolicyCollectAggregateFunction(
+                "0004-simpletable-C-count.dmn", "0004-simpletable-C-count", BigDecimal.valueOf(0),
+                getSimpleTableContext(BigDecimal.valueOf(5), "Medium", true));
     }
 
     private void testSimpleDecisionTableHitPolicyCollectAggregateFunction(
-            final String resourceName, final String modelName, final BigDecimal expectedResult) {
+            final String resourceName, final String modelName, final BigDecimal expectedResult, final DMNContext context) {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(resourceName, this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", modelName);
         assertThat(dmnModel, notNullValue());
 
-        final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(70), "Medium", true);
         final DMNContext result = evaluateSimpleTableWithContext(dmnModel, runtime, context);
         assertThat(result.get("Status number"), is(expectedResult));
     }
@@ -306,4 +326,5 @@ public class DMNDecisionTableHitPolicyTest {
         final DMNContext result = dmnResult.getContext();
         assertThat(result.get("Collect"), is(BigDecimal.valueOf(50)));
     }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
@@ -105,6 +105,9 @@ public class DecisionTableImpl {
                 Object result = defaultToOutput( ctx, feel );
                 return FEELFnResult.ofResult( result );
             } else {
+                if( hitPolicy.getDefaultValue() != null ) {
+                    return FEELFnResult.ofResult( hitPolicy.getDefaultValue() );
+                }
                 return FEELFnResult.ofError( new HitPolicyViolationEvent(
                                                     Severity.WARN,
                                                     "No rule matched for decision table '" + name + "' and no default values were defined. Setting result to null.",

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/HitPolicy.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/HitPolicy.java
@@ -35,30 +35,32 @@ import static java.util.stream.Collectors.*;
 import static java.util.stream.IntStream.range;
 
 public enum HitPolicy {
-    UNIQUE( "U", "UNIQUE", HitPolicy::unique ),
-    FIRST( "F", "FIRST", HitPolicy::first ),
-    PRIORITY( "P", "PRIORITY", HitPolicy::priority ),
-    ANY( "A", "ANY", HitPolicy::any ),
-    COLLECT( "C", "COLLECT", HitPolicy::ruleOrder ),    // Collect – return a list of the outputs in arbitrary order 
-    COLLECT_SUM( "C+", "COLLECT SUM", HitPolicy::sumCollect ),
-    COLLECT_COUNT( "C#", "COLLECT COUNT", HitPolicy::countCollect ),
-    COLLECT_MIN( "C<", "COLLECT MIN", HitPolicy::minCollect ),
-    COLLECT_MAX( "C>", "COLLECT MAX", HitPolicy::maxCollect ),
-    RULE_ORDER( "R", "RULE ORDER", HitPolicy::ruleOrder ),
-    OUTPUT_ORDER( "O", "OUTPUT ORDER", HitPolicy::outputOrder );
+    UNIQUE( "U", "UNIQUE", HitPolicy::unique, null ),
+    FIRST( "F", "FIRST", HitPolicy::first, null ),
+    PRIORITY( "P", "PRIORITY", HitPolicy::priority, null ),
+    ANY( "A", "ANY", HitPolicy::any, null ),
+    COLLECT( "C", "COLLECT", HitPolicy::ruleOrder, Collections.EMPTY_LIST ),    // Collect – return a list of the outputs in arbitrary order
+    COLLECT_SUM( "C+", "COLLECT SUM", HitPolicy::sumCollect, null ),
+    COLLECT_COUNT( "C#", "COLLECT COUNT", HitPolicy::countCollect, BigDecimal.ZERO ),
+    COLLECT_MIN( "C<", "COLLECT MIN", HitPolicy::minCollect, null ),
+    COLLECT_MAX( "C>", "COLLECT MAX", HitPolicy::maxCollect, null ),
+    RULE_ORDER( "R", "RULE ORDER", HitPolicy::ruleOrder, null ),
+    OUTPUT_ORDER( "O", "OUTPUT ORDER", HitPolicy::outputOrder, null );
 
     private final String       shortName;
     private final String       longName;
     private final HitPolicyDTI dti;
+    private final Object       defaultValue;
 
     HitPolicy(final String shortName, final String longName) {
-        this( shortName, longName, HitPolicy::notImplemented );
+        this( shortName, longName, HitPolicy::notImplemented, null );
     }
 
-    HitPolicy(final String shortName, final String longName, final HitPolicyDTI dti) {
+    HitPolicy(final String shortName, final String longName, final HitPolicyDTI dti, Object defaultValue ) {
         this.shortName = shortName;
         this.longName = longName;
         this.dti = dti;
+        this.defaultValue = defaultValue;
     }
 
     public String getShortName() {
@@ -72,6 +74,8 @@ public enum HitPolicy {
     public HitPolicyDTI getDti() {
         return dti;
     }
+
+    public Object getDefaultValue() { return defaultValue; }
 
     public static HitPolicy fromString(String policy) {
         policy = policy.toUpperCase();


### PR DESCRIPTION
changing return value for decision tables with hit policy C and C# when no rule matches are found