### PR TITLE
DROOLS-1677 - not /someOoPath not supported

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/DRL6Parser.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/DRL6Parser.java
@@ -2408,9 +2408,9 @@ public class DRL6Parser extends AbstractDRLParser implements DRLParser {
             if (helper.validateIdentifierKey(DroolsSoftKeywords.DO)) {
                 namedConsequence(ce, null);
             }
-        } else if (input.LA(1) == DRL6Lexer.ID || input.LA(1) == DRL6Lexer.QUESTION) {
+        } else if (input.LA(1) == DRL6Lexer.ID || input.LA(1) == DRL6Lexer.QUESTION || input.LA( 1) == DRL6Lexer.DIV) {
             result = lhsPatternBind(ce,
-                    allowOr);
+                                    allowOr);
             for (BaseDescr i = consequenceInvocation(ce); i != null; i = consequenceInvocation(ce))
                 ;
         } else {
@@ -3296,13 +3296,16 @@ public class DRL6Parser extends AbstractDRLParser implements DRLParser {
                      String label,
                      boolean isUnification ) throws RecognitionException {
 
-        if (label != null && input.LA(1) == DRL6Lexer.DIV) {
+        if (input.LA(1) == DRL6Lexer.DIV) {
             int first = input.index();
             exprParser.xpathPrimary();
             if (state.failed) return;
             int last = input.LT(-1).getTokenIndex();
             String expr = toExpression("", first, last);
-            pattern.id( label, isUnification ).constraint( expr );
+            pattern.constraint(expr);
+            if ( label != null ) {
+                pattern.id(label, isUnification);
+            }
             return;
         }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleUnitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleUnitTest.java
@@ -613,6 +613,52 @@ public class RuleUnitTest {
     }
 
     @Test
+    public void testWithOOPathAndNot() throws Exception {
+        String drl1 =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                        "import " + AdultUnit.class.getCanonicalName() + "\n" +
+                        "rule Adult @Unit( AdultUnit.class ) when\n" +
+                        "    not /persons[age >= 18]\n" +
+                        "then\n" +
+                        "    System.out.println(\"No adults\");\n" +
+                        "end";
+
+        KieBase kbase = new KieHelper().addContent( drl1, ResourceType.DRL ).build();
+        RuleUnitExecutor executor = RuleUnitExecutor.create().bind( kbase );
+
+        DataSource<Person> persons = executor.newDataSource( "persons",
+                                                             new Person( "Mario", 4 ),
+                                                             new Person( "Marilena", 17 ),
+                                                             new Person( "Sofia", 4 ) );
+
+        RuleUnit adultUnit = new AdultUnit(persons);
+        assertEquals(1, executor.run( adultUnit ) );
+    }
+
+    @Test
+    public void testWithOOPathAndNotNoMatch() throws Exception {
+        String drl1 =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                        "import " + AdultUnit.class.getCanonicalName() + "\n" +
+                        "rule Adult @Unit( AdultUnit.class ) when\n" +
+                        "    not /persons[age >= 18]\n" +
+                        "then\n" +
+                        "    System.out.println(\"No adults\");\n" +
+                        "end";
+
+        KieBase kbase = new KieHelper().addContent( drl1, ResourceType.DRL ).build();
+        RuleUnitExecutor executor = RuleUnitExecutor.create().bind( kbase );
+
+        DataSource<Person> persons = executor.newDataSource( "persons",
+                                                             new Person( "Mario", 44 ),
+                                                             new Person( "Marilena", 170 ),
+                                                             new Person( "Sofia", 18 ) );
+
+        RuleUnit adultUnit = new AdultUnit(persons);
+        assertEquals(0, executor.run( adultUnit ) );
+    }
+
+    @Test
     public void testVarResolution() throws Exception {
         String drl1 =
                 "import " + Person.class.getCanonicalName() + "\n" +


### PR DESCRIPTION
Adjust parser for appropriate look-ahead around DIV and un-labeled
OOPath constraints.