### PR TITLE
DROOLS-1673 Add tests for uncovered areas for AST nodes in kie-dmn-feel module

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FilterExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FilterExpressionNode.java
@@ -16,13 +16,16 @@
 
 package org.kie.dmn.feel.lang.ast;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.util.Msg;
-
-import java.util.*;
 
 public class FilterExpressionNode
         extends BaseNode {
@@ -77,24 +80,22 @@ public class FilterExpressionNode
                         return null;
                     }
                 } else {
-                    List results = new ArrayList(  );
-                    for( Object v : list ) {
-                        evaluateExpressionInContext( ctx, results, v );
-                    }
-                    return results;
+                    return evaluateExpressionsInContext(ctx, list);
                 }
             } else {
-                List results = new ArrayList(  );
-                for( Object v : list ) {
-                    evaluateExpressionInContext( ctx, results, v );
-                }
-                return results;
+                return evaluateExpressionsInContext(ctx, list);
             }
         } catch ( Exception e ) {
             ctx.notifyEvt( astEvent(Severity.ERROR, Msg.createMessage(Msg.ERROR_EXECUTING_LIST_FILTER, getText()), e) );
         }
 
         return null;
+    }
+
+    private List evaluateExpressionsInContext(EvaluationContext ctx, List expressions) {
+        List results = new ArrayList();
+        expressions.forEach(expression -> evaluateExpressionInContext( ctx, results, expression));
+        return results;
     }
 
     private void evaluateExpressionInContext(EvaluationContext ctx, List results, Object v) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -77,7 +77,21 @@ public class EvaluationContextImpl implements EvaluationContext {
 
     @Override
     public Object getValue(String[] name) {
-        throw new UnsupportedOperationException( "needs implementation?" );
+        if (name.length == 1) {
+          return getValue(name[0]);
+        } else if (name.length > 1) {
+            Map actualObject = (Map) peek().getValue(name[0]);
+            // Each sublevel must be a context until the last one.
+            for (int i = 1; i < name.length - 1; i++) {
+                actualObject = (Map) actualObject.get(name[i]);
+                if (actualObject == null) {
+                    return null;
+                }
+            }
+            return actualObject.get(name[name.length - 1]);
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -87,7 +101,21 @@ public class EvaluationContextImpl implements EvaluationContext {
 
     @Override
     public boolean isDefined(String[] name) {
-        throw new UnsupportedOperationException( "needs implementation?" );
+        if (name.length == 1) {
+            return isDefined(name[0]);
+        } else if (name.length > 1) {
+            Map actualObject = (Map) peek().getValue(name[0]);
+            // Each sublevel must be a context until the last one.
+            for (int i = 1; i < name.length - 1; i++) {
+                actualObject = (Map) actualObject.get(name[i]);
+                if (actualObject == null) {
+                    return false;
+                }
+            }
+            return actualObject.get(name[name.length - 1]) != null;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/JavaFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/JavaFunction.java
@@ -99,6 +99,13 @@ public class JavaFunction
                     } else {
                         throw new IllegalArgumentException( "Unable to coerce parameter "+parameters.get( 0 )+". Expected "+paramTypes[i]+" but found "+params[i].getClass() );
                     }
+                } else if ( params[i] instanceof String
+                        && ((String) params[i]).length() == 1
+                        && (paramTypes[i] == char.class || paramTypes[i] == Character.class) ) {
+                    actual[i] = ((String) params[i]).charAt(0);
+                } else if ( params[i] instanceof Boolean && paramTypes[i] == boolean.class ) {
+                    // Because Boolean can be also null, boolean.class is not assignable from Boolean.class. So we must coerce this.
+                    actual[i] = params[i];
                 } else {
                     throw new IllegalArgumentException( "Unable to coerce parameter "+parameters.get( 0 )+". Expected "+paramTypes[i]+" but found "+params[i].getClass() );
                 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/BaseFEELTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
-import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
 import org.kie.dmn.feel.FEEL;
 import org.mockito.ArgumentCaptor;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELExpressionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELExpressionsTest.java
@@ -57,7 +57,7 @@ public class FEELExpressionsTest extends BaseFEELTest {
                 {"{ is minor : < 18, bob is minor : is minor(16) }.bob is minor", Boolean.TRUE , null},
 
                 // negated unary tests
-                {"10 in ( not( <5, >=20, =15 ) )", Boolean.TRUE, null},
+                {"10 in ( not( <5, >=20, =15, !=10 ) )", Boolean.TRUE, null},
                 {"10 in ( not( <5, >=20, =10 ) )", Boolean.FALSE, null},
                 {"10 in ( not( <5 ) )", Boolean.TRUE, null},
                 {"10 in ( not( (10..20] ) )", Boolean.TRUE, null},
@@ -76,6 +76,9 @@ public class FEELExpressionsTest extends BaseFEELTest {
                 // unary tests with context evaluation, i.e., the test is defined before the variable "x"
                 {"{ test : > x, y : 20, x : 10, result : y in ( test ) }.result", Boolean.TRUE , null},
                 {"{ test : > x, y : 20, x : 10, result : test( y ) }.result", Boolean.TRUE , null},
+
+                // TODO - DROOLS-1678
+//                {"{ test : in x, y : 20, x : [10, 20, 30], result : test( y ) }.result", Boolean.TRUE , null},
                 
                 {"2 in 2", Boolean.TRUE , null},
                 {"{ x : 2, result : x in 2 }.result", Boolean.TRUE , null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
@@ -33,7 +33,7 @@ public class FEELFunctionsTest extends BaseFEELTest {
                 { "string(null)", null, null},
                 { "string(date(\"2016-08-14\"))", "2016-08-14" , null},
                 { "string(\"Happy %.0fth birthday, Mr %s!\", 38, \"Doe\")", "Happy 38th birthday, Mr Doe!", null},
-                {"number(null, \",\", \".\")", null , FEELEvent.Severity.ERROR},
+                { "number(null, \",\", \".\")", null , FEELEvent.Severity.ERROR},
                 { "number(\"1,000.05\", \",\", \".\")", new BigDecimal( "1000.05" ) , null},
                 { "number(\"1.000,05\", \".\", \",\")", new BigDecimal( "1000.05" ) , null},
                 { "number(\"1000,05\", null, \",\")", new BigDecimal( "1000.05" ) , null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELListsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELListsTest.java
@@ -68,6 +68,10 @@ public class FEELListsTest extends BaseFEELTest {
                 } ), null },
                 {"[ {x:1, y:2}, {x:2, y:3} ][x = 0]", Collections.emptyList(), null },
 
+                // Other filtering
+                // TODO - DROOLS-1679
+//                {"[\"a\", \"b\", \"c\"][a]", null, FEELEvent.Severity.ERROR }
+
                 // Selection
                 {"[ {x:1, y:2}, {x:2, y:3} ].y", Arrays.asList( BigDecimal.valueOf( 2 ), BigDecimal.valueOf( 3 ) ), null },
                 {"[ {x:1, y:2}, {x:2} ].y", Arrays.asList( BigDecimal.valueOf( 2 ) ), null },

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELOperatorsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELOperatorsTest.java
@@ -35,6 +35,7 @@ public class FEELOperatorsTest extends BaseFEELTest {
                 // between
                 { "10 between 5 and 12", Boolean.TRUE , null},
                 { "10 between 20 and 30", Boolean.FALSE , null},
+                { "10 between 20 and \"foo\"", null , FEELEvent.Severity.ERROR},
                 {"\"foo\" between 5 and 12", null , FEELEvent.Severity.ERROR},
                 { "\"foo\" between \"bar\" and \"zap\"", Boolean.TRUE , null},
                 { "\"foo\" between null and \"zap\"", null , FEELEvent.Severity.ERROR},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELRangesTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELRangesTest.java
@@ -19,11 +19,13 @@ package org.kie.dmn.feel.runtime;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import org.junit.runners.Parameterized;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.ast.RangeNode;
 import org.kie.dmn.feel.runtime.impl.RangeImpl;
 
 public class FEELRangesTest extends BaseFEELTest {
@@ -61,6 +63,12 @@ public class FEELRangesTest extends BaseFEELTest {
                         new RangeImpl(Range.RangeBoundary.OPEN, Duration.parse("P2DT20H14M"), Duration.parse("P3DT20H14M"), Range.RangeBoundary.CLOSED), null},
                 {"(duration(\"P2DT20H14M\")..duration(\"P3DT20H14M\"))",
                         new RangeImpl(Range.RangeBoundary.OPEN, Duration.parse("P2DT20H14M"), Duration.parse("P3DT20H14M"), Range.RangeBoundary.OPEN), null},
+
+                {"(duration(\"P1Y6M\")..duration(\"P2Y6M\"))",
+                        new RangeImpl(Range.RangeBoundary.OPEN,
+                                      new RangeNode.ComparablePeriod(Period.parse("P1Y6M")),
+                                      new RangeNode.ComparablePeriod(Period.parse("P2Y6M")),
+                                      Range.RangeBoundary.OPEN), null},
 
                 {"[1+2..8]", new RangeImpl(Range.RangeBoundary.CLOSED, BigDecimal.valueOf(3), BigDecimal.valueOf(8), Range.RangeBoundary.CLOSED), null},
                 {"[1+2..8)", new RangeImpl(Range.RangeBoundary.CLOSED, BigDecimal.valueOf(3), BigDecimal.valueOf(8), Range.RangeBoundary.OPEN), null},


### PR DESCRIPTION
- Covers uncovered areas in AST node classes with new tests
- Adds reproducers for DROOLS-1675, DROOLS-1678 and DROOLS-1679
- Adds type coercion of char and boolean params of external Java functions
- Enables search by qualified name in evaluation context

@etirelli @tarilabs can you please review this? Especially the new type coercion (JavaFunction class) and the search by qualified name (EvaluationContextImpl)

If this is OK, I will create a backport PR for 7.2