### PR TITLE
Make repository overrideable for KieServives (7.2.x branch)

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
@@ -68,8 +68,14 @@ public class KieServicesImpl implements InternalKieServices {
     
     private final ConcurrentMap<String, KieContainer> kContainers = new ConcurrentHashMap<String, KieContainer>();
 
+    private KieRepository repository;
+
     public KieRepository getRepository() {
-        return KieRepositoryImpl.INSTANCE;
+        return (repository == null) ? KieRepositoryImpl.INSTANCE : repository;
+    }
+
+    public void setRepository(KieRepository repository) {
+        this.repository = repository;
     }
 
     /**


### PR DESCRIPTION
Currently default KieRepositoryImpl is hardcoded within KieServices and there is no way to use custom implementation. This PR makes it possible to set a repository override.