### PR TITLE
[DROOLS-1696] immediately propagate event's expiration when equal to current timestamp

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -15,6 +15,7 @@
 
 package org.drools.compiler.integrationtests;
 
+import org.drools.compiler.util.TimerUtils;
 import org.kie.api.time.SessionPseudoClock;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -208,51 +209,4 @@ public class CepFireUntilHaltTimerTest {
             return String.format("MetadataEvent[name='%s' timestamp='%s', duration='%s']", name, metadataTimestamp, metadataDuration);
         }
     }
-
-    /**
-     * Utility class providing methods for coping with timing issues, such as
-     * {@link java.lang.Thread#sleep(long, int)} inaccuracy, on certain OS.
-     * <p/>
-     * Inspired by http://stackoverflow.com/questions/824110/accurate-sleep-for-java-on-windows
-     * and http://andy-malakov.blogspot.cz/2010/06/alternative-to-threadsleep.html.
-     */
-    public static class TimerUtils {
-
-        private static final long SLEEP_PRECISION = Long.valueOf(System.getProperty("TIMER_SLEEP_PRECISION", "50000"));
-
-        private static final long SPIN_YIELD_PRECISION = Long.valueOf(System.getProperty("TIMER_YIELD_PRECISION", "30000"));
-
-        private TimerUtils() {
-        }
-
-        /**
-         * Sleeps for specified amount of time in milliseconds.
-         *
-         * @param duration the amount of milliseconds to wait
-         * @throws InterruptedException if the current thread gets interrupted
-         */
-        public static void sleepMillis(final long duration) throws InterruptedException {
-            sleepNanos(TimeUnit.MILLISECONDS.toNanos(duration));
-        }
-
-        /**
-         * Sleeps for specified amount of time in nanoseconds.
-         *
-         * @param nanoDuration the amount of nanoseconds to wait
-         * @throws InterruptedException if the current thread gets interrupted
-         */
-        public static void sleepNanos(final long nanoDuration) throws InterruptedException {
-            final long end = System.nanoTime() + nanoDuration;
-            long timeLeft = nanoDuration;
-            do {
-                if (timeLeft > SLEEP_PRECISION) {
-                    Thread.sleep(1);
-                } else if (timeLeft > SPIN_YIELD_PRECISION) {
-                    Thread.yield();
-                }
-                timeLeft = end - System.nanoTime();
-            } while (timeLeft > 0);
-        }
-    }
-
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExpirationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExpirationTest.java
@@ -448,7 +448,7 @@ public class ExpirationTest {
                 " then \n" +
                 " end\n";
 
-        testEventsExpiredInThePast(drl, 2);
+        testEventsExpiredInThePast(drl);
     }
 
     @Test
@@ -469,10 +469,10 @@ public class ExpirationTest {
                         " then \n" +
                         " end\n";
 
-        testEventsExpiredInThePast(drl, 0);
+        testEventsExpiredInThePast(drl);
     }
 
-    private void testEventsExpiredInThePast(final String drl, final int expectedNumOfObjectsInWmAfterFire) {
+    private void testEventsExpiredInThePast(final String drl) {
         final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
@@ -495,6 +495,6 @@ public class ExpirationTest {
 
         Assertions.assertThat(kieSession.fireAllRules()).isEqualTo(1);
         clock.advanceTime(10, TimeUnit.MILLISECONDS);
-        Assertions.assertThat(kieSession.getObjects()).hasSize(expectedNumOfObjectsInWmAfterFire);
+        Assertions.assertThat(kieSession.getObjects()).isEmpty();
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExpirationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExpirationTest.java
@@ -16,9 +16,16 @@
 
 package org.drools.compiler.integrationtests;
 
+import static org.junit.Assert.*;
+import static org.kie.api.definition.type.Expires.Policy.TIME_SOFT;
+
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import org.assertj.core.api.Assertions;
+import org.drools.compiler.integrationtests.facts.BasicEvent;
+import org.drools.compiler.util.TimerUtils;
 import org.drools.core.ClassObjectFilter;
 import org.drools.core.ClockType;
 import org.drools.core.impl.KnowledgeBaseFactory;
@@ -33,9 +40,6 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.internal.utils.KieHelper;
-
-import static org.junit.Assert.assertEquals;
-import static org.kie.api.definition.type.Expires.Policy.TIME_SOFT;
 
 public class ExpirationTest {
 
@@ -425,5 +429,47 @@ public class ExpirationTest {
         assertEquals( 0, ksession.getObjects( new ClassObjectFilter( A.class ) ).size() );
         assertEquals( 0, ksession.getObjects( new ClassObjectFilter( B.class ) ).size() );
         assertEquals( 0, ksession.getObjects( new ClassObjectFilter( C.class ) ).size() );
+    }
+
+    @Test
+    public void testEventsExpiredInThePast() throws InterruptedException {
+        final String drl =
+                " package org.drools.compiler.integrationtests;\n" +
+                " import " + BasicEvent.class.getCanonicalName() + ";\n" +
+                " declare BasicEvent\n" +
+                "     @role( event )\n" +
+                "     @timestamp( eventTimestamp )\n" +
+                "     @duration( eventDuration )\n" +
+                " end\n" +
+                " \n" +
+                " rule R1\n" +
+                " when\n" +
+                "     $A : BasicEvent()\n" +
+                "     $B : BasicEvent( this starts $A )\n" +
+                " then \n" +
+                " end\n";
+
+        final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+//        sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+
+        final KieHelper helper = new KieHelper();
+        helper.addContent( drl, ResourceType.DRL );
+        final KieBase kieBase = helper.build( EventProcessingOption.STREAM );
+        final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
+
+//        PseudoClockScheduler clock = kieSession.getSessionClock();
+
+//        final long currentTime = clock.getCurrentTime();
+        final long currentTime = LocalDateTime.now().getNano();
+
+//        clock.advanceTime(100, TimeUnit.MILLISECONDS);
+        TimerUtils.sleepMillis(100);
+
+        kieSession.insert(new BasicEvent(new Date(currentTime + 20), 10L, "20ms-30ms"));
+        kieSession.insert(new BasicEvent(new Date(currentTime + 20), 20L, "20ms-40ms"));
+
+//        clock.advanceTime(100, TimeUnit.MILLISECONDS);
+//        TimerUtils.sleepMillis(100);
+        Assertions.assertThat(kieSession.fireAllRules()).isEqualTo(1);
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExpirationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExpirationTest.java
@@ -450,26 +450,25 @@ public class ExpirationTest {
                 " end\n";
 
         final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
-//        sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
+        sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         final KieHelper helper = new KieHelper();
         helper.addContent( drl, ResourceType.DRL );
         final KieBase kieBase = helper.build( EventProcessingOption.STREAM );
         final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
 
-//        PseudoClockScheduler clock = kieSession.getSessionClock();
+        PseudoClockScheduler clock = kieSession.getSessionClock();
 
-//        final long currentTime = clock.getCurrentTime();
-        final long currentTime = LocalDateTime.now().getNano();
+        final long currentTime = clock.getCurrentTime();
 
-//        clock.advanceTime(100, TimeUnit.MILLISECONDS);
-        TimerUtils.sleepMillis(100);
+        clock.advanceTime(100, TimeUnit.MILLISECONDS);
 
         kieSession.insert(new BasicEvent(new Date(currentTime + 20), 10L, "20ms-30ms"));
+        clock.advanceTime(1, TimeUnit.MILLISECONDS);
         kieSession.insert(new BasicEvent(new Date(currentTime + 20), 20L, "20ms-40ms"));
 
-//        clock.advanceTime(100, TimeUnit.MILLISECONDS);
-//        TimerUtils.sleepMillis(100);
+        clock.advanceTime(100, TimeUnit.MILLISECONDS);
+
         Assertions.assertThat(kieSession.fireAllRules()).isEqualTo(1);
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/facts/BasicEvent.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/facts/BasicEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests.facts;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class BasicEvent implements Serializable {
+
+    private static final long serialVersionUID = 2172618811749631685L;
+
+    private Date eventTimestamp;
+    private Long eventDuration;
+    private String name;
+
+    public BasicEvent(final Date eventTimestamp, final Long eventDuration, final String name) {
+        this.eventTimestamp = eventTimestamp;
+        this.eventDuration = eventDuration;
+        this.name = name;
+    }
+
+    public BasicEvent() {
+    }
+
+    public Date getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(final Date eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+
+    public Long getEventDuration() {
+        return eventDuration;
+    }
+
+    public void setEventDuration(final Long eventDuration) {
+        this.eventDuration = eventDuration;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/util/TimerUtils.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/util/TimerUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.util;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class providing methods for coping with timing issues, such as
+ * {@link java.lang.Thread#sleep(long, int)} inaccuracy, on certain OS.
+ * <p/>
+ * Inspired by http://stackoverflow.com/questions/824110/accurate-sleep-for-java-on-windows
+ * and http://andy-malakov.blogspot.cz/2010/06/alternative-to-threadsleep.html.
+ */
+public class TimerUtils {
+
+    private static final long SLEEP_PRECISION = Long.valueOf(System.getProperty("TIMER_SLEEP_PRECISION", "50000"));
+
+    private static final long SPIN_YIELD_PRECISION = Long.valueOf(System.getProperty("TIMER_YIELD_PRECISION", "30000"));
+
+    private TimerUtils() {
+    }
+
+    /**
+     * Sleeps for specified amount of time in milliseconds.
+     * @param duration the amount of milliseconds to wait
+     * @throws InterruptedException if the current thread gets interrupted
+     */
+    public static void sleepMillis(final long duration) throws InterruptedException {
+        sleepNanos(TimeUnit.MILLISECONDS.toNanos(duration));
+    }
+
+    /**
+     * Sleeps for specified amount of time in nanoseconds.
+     * @param nanoDuration the amount of nanoseconds to wait
+     * @throws InterruptedException if the current thread gets interrupted
+     */
+    public static void sleepNanos(final long nanoDuration) throws InterruptedException {
+        final long end = System.nanoTime() + nanoDuration;
+        long timeLeft = nanoDuration;
+        do {
+            if (timeLeft > SLEEP_PRECISION) {
+                Thread.sleep(1);
+            } else if (timeLeft > SPIN_YIELD_PRECISION) {
+                Thread.yield();
+            }
+            timeLeft = end - System.nanoTime();
+        } while (timeLeft > 0);
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -185,7 +185,7 @@ public interface PropagationEntry {
             long nextTimestamp = getNextTimestamp( insertionTime, expirationOffset, eventFactHandle );
 
             WorkingMemoryReteExpireAction action = new WorkingMemoryReteExpireAction( (EventFactHandle) handle, otn );
-            if (nextTimestamp < wm.getTimerService().getCurrentTime()) {
+            if (nextTimestamp <= wm.getTimerService().getCurrentTime()) {
                 wm.addPropagation( action );
             } else {
                 JobContext jobctx = new ObjectTypeNode.ExpireJobContext( action, wm );


### PR DESCRIPTION
@winklerm This is the issue, we discussed on Friday.