### PR TITLE
PLANNER-828: Workbench: ScoreHolder support in GuidedRuleEditor shows error in server log

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -1809,51 +1809,25 @@ public class RuleModelDRLPersistenceImpl
         }
     }
 
-    public static class RHSClassDependencyVisitor extends ReflectiveVisitor {
+    public static class RHSClassDependencyVisitor {
 
-        private Map<String, List<ActionFieldValue>> classes = new HashMap<String, List<ActionFieldValue>>();
+        private Map<String, List<ActionFieldValue>> classes = new HashMap<>();
 
-        public void visitFreeFormLine(FreeFormLine ffl) {
-            //Do nothing other than preventing ReflectiveVisitor recording an error
+        public void visit(final IAction iAction) {
+            if (iAction instanceof ActionFieldList) {
+                visit((ActionFieldList) iAction);
+            }
         }
 
-        public void visitActionGlobalCollectionAdd(final ActionGlobalCollectionAdd add) {
-            //Do nothing other than preventing ReflectiveVisitor recording an error
-        }
-
-        public void visitActionRetractFact(final ActionRetractFact action) {
-            //Do nothing other than preventing ReflectiveVisitor recording an error
-        }
-
-        public void visitDSLSentence(final DSLSentence sentence) {
-            //Do nothing other than preventing ReflectiveVisitor recording an error
-        }
-
-        public void visitActionInsertFact(final ActionInsertFact action) {
-            getClasses(action.getFieldValues());
-        }
-
-        public void visitActionInsertLogicalFact(final ActionInsertLogicalFact action) {
-            getClasses(action.getFieldValues());
-        }
-
-        public void visitActionUpdateField(final ActionUpdateField action) {
-            getClasses(action.getFieldValues());
-        }
-
-        public void visitActionSetField(final ActionSetField action) {
-            getClasses(action.getFieldValues());
-        }
-
-        public void visitActionExecuteWorkItem(final ActionExecuteWorkItem action) {
-            //Do nothing other than preventing ReflectiveVisitor recording an error
+        private void visit(final ActionFieldList actionFieldList) {
+            addClasses(actionFieldList.getFieldValues());
         }
 
         public Map<String, List<ActionFieldValue>> getRHSClasses() {
             return classes;
         }
 
-        private void getClasses(ActionFieldValue[] fieldValues) {
+        private void addClasses(ActionFieldValue[] fieldValues) {
             for (ActionFieldValue afv : fieldValues) {
                 String type = afv.getType();
                 List<ActionFieldValue> afvs = classes.get(type);

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RHSClassDependencyVisitorTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RHSClassDependencyVisitorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.commons.backend.rule;
+
+import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
+import org.drools.workbench.models.datamodel.rule.ActionInsertLogicalFact;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RHSClassDependencyVisitorTest {
+
+    private RuleModelDRLPersistenceImpl.RHSClassDependencyVisitor visitor;
+
+    @Before
+    public void setUp() {
+        visitor = new RuleModelDRLPersistenceImpl.RHSClassDependencyVisitor();
+    }
+
+    @Test
+    public void visitActionInsertLogicalFact() {
+        ActionInsertLogicalFact iAction = new ActionInsertLogicalFact();
+        iAction.setFieldValues(new ActionFieldValue[]{new ActionFieldValue("field",
+                                                                           "value",
+                                                                           "type")});
+
+        visitor.visit(iAction);
+
+        assertTrue(visitor.getRHSClasses().containsKey("type"));
+    }
+
+    @Test
+    public void visitFreeFormLine() {
+        visitor.visit(new FreeFormLine());
+
+        assertTrue(visitor.getRHSClasses().isEmpty());
+    }
+}


### PR DESCRIPTION
All the accepted types are subclasses of ActionFieldList, refactor the code accordingly. Get rid of stinky ReflectiveVisitor.

@manstis Sounds good to you?