### PR TITLE
DROOLS-1706 Allow marshalling of DMN Extension Elements

### DIFF
--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/ExtensionElementsConverter.java
@@ -22,6 +22,7 @@ import org.kie.dmn.model.v1_1.DMNModelInstrumentedBase;
 import org.kie.dmn.model.v1_1.DMNElement.ExtensionElements;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
@@ -29,9 +30,6 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Currently ignoring all extensionElements
- */
 public class ExtensionElementsConverter extends DMNModelInstrumentedBaseConverter {
 
     private List<DMNExtensionRegister> extensionRegisters = new ArrayList<>();
@@ -71,6 +69,22 @@ public class ExtensionElementsConverter extends DMNModelInstrumentedBaseConverte
     protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
         super.writeAttributes(writer, parent);
         // no attributes.
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        
+        if(extensionRegisters.size() == 0) {
+            return;
+        }
+
+        ExtensionElements ee = (ExtensionElements) parent;
+        if ( ee.getAny() != null ) {
+            for ( Object a : ee.getAny() ) {
+                writeItem(a, context, writer);
+            }
+        }
     }
 
     public ExtensionElementsConverter(XStream xstream) {

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/XStreamMarshaller.java
@@ -162,6 +162,7 @@ public class XStreamMarshaller
                 String dmnPrefix = base.getNsContext().entrySet().stream().filter( kv -> DMNModelInstrumentedBase.URI_DMN.equals( kv.getValue() ) ).findFirst().map(Map.Entry::getKey).orElse("");
                 hsWriter.getQNameMap().setDefaultPrefix( dmnPrefix );
             }
+            extensionRegisters.forEach( r -> r.beforeMarshal(o, hsWriter.getQNameMap()) );
             xStream.marshal(o, hsWriter);
             hsWriter.flush();
             return writer.toString();
@@ -371,12 +372,9 @@ public class XStreamMarshaller
         
         xStream.ignoreUnknownElements();
 
-        if(extensionRegisters != null && !extensionRegisters.isEmpty()) {
-            for(DMNExtensionRegister extensionRegister : extensionRegisters) {
-                extensionRegister.registerExtensionConverters(xStream);
-            }
+        for(DMNExtensionRegister extensionRegister : extensionRegisters) {
+            extensionRegister.registerExtensionConverters(xStream);
         }
-
 
         return xStream;
     }

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/UnmarshalMarshalTest.java
@@ -34,6 +34,8 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.kie.dmn.api.marshalling.v1_1.DMNMarshaller;
+import org.kie.dmn.backend.marshalling.v1_1.extensions.MyTestRegister;
 import org.kie.dmn.backend.marshalling.v1_1.xstream.XStreamMarshaller;
 import org.kie.dmn.model.v1_1.DMNModelInstrumentedBase;
 import org.kie.dmn.model.v1_1.Definitions;
@@ -98,6 +100,12 @@ public class UnmarshalMarshalTest {
     }
     
     @Test
+    public void testHello_World_semantic_namespace_with_extensions() throws Exception {
+        DMNMarshaller marshaller = DMNMarshallerFactory.newMarshallerWithExtensions(Arrays.asList( new MyTestRegister() ));
+        testRoundTrip("", "Hello_World_semantic_namespace_with_extensions.dmn", marshaller);
+    }
+    
+    @Test
     public void testSemanticNamespace() throws Exception {
         testRoundTrip("", "semantic-namespace.xml");
     }
@@ -113,9 +121,13 @@ public class UnmarshalMarshalTest {
     public void testFAILforMissingNamespaces() {
         fail("PERFORM A MANUAL CHECK: does now the Stax driver do output the namespace for 'feel:' ?? ");
     }
-
+    
     public void testRoundTrip(String subdir, String xmlfile) throws Exception {
-        XStreamMarshaller marshaller = new XStreamMarshaller();
+        DMNMarshaller marshaller = DMNMarshallerFactory.newDefaultMarshaller();
+        testRoundTrip(subdir, xmlfile, marshaller);
+    }
+
+    public void testRoundTrip(String subdir, String xmlfile, DMNMarshaller marshaller) throws Exception {
         
         File baseOutputDir = new File("target/test-xmlunit/");
         File testClassesBaseDir = new File("target/test-classes/");

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyDroolsExt.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyDroolsExt.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_1.extensions;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
+
+@XStreamAlias("mydroolsext")
+@XStreamConverter(value = ToAttributedValueConverter.class, strings = { "content" })
+public class MyDroolsExt {
+
+    @XStreamAsAttribute
+    private String b1;
+    
+    private String content;
+
+    public String getContent() {
+        return content;
+    }
+
+    
+    public String getB1() {
+        return b1;
+    }
+
+    
+    
+}

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyKieExt.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyKieExt.java
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-package org.kie.dmn.api.marshalling.v1_1;
+package org.kie.dmn.backend.marshalling.v1_1.extensions;
 
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.io.xml.QNameMap;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
+@XStreamAlias("mykieext")
+public class MyKieExt {
 
-public interface DMNExtensionRegister {
+    @XStreamAsAttribute
+    private String a1;
+    
+    @XStreamAlias("mydroolsext")
+    private MyDroolsExt content;
 
-    public void registerExtensionConverters(XStream xstream);
-
-    default void beforeMarshal(Object o, QNameMap qmap) {
-        // do nothing.
+    public MyDroolsExt getContent() {
+        return content;
     }
+    
+    public void setContent(MyDroolsExt content) {
+        this.content = content;
+    }
+    
 }

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyTestRegister.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/extensions/MyTestRegister.java
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-package org.kie.dmn.api.marshalling.v1_1;
+package org.kie.dmn.backend.marshalling.v1_1.extensions;
+
+import javax.xml.namespace.QName;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.QNameMap;
+import org.kie.dmn.api.marshalling.v1_1.DMNExtensionRegister;
 
+public class MyTestRegister implements DMNExtensionRegister {
 
-public interface DMNExtensionRegister {
-
-    public void registerExtensionConverters(XStream xstream);
-
-    default void beforeMarshal(Object o, QNameMap qmap) {
-        // do nothing.
+    @Override
+    public void registerExtensionConverters(XStream xStream) {
+        xStream.processAnnotations(MyKieExt.class);
+        xStream.processAnnotations(MyDroolsExt.class);
     }
+
+    @Override
+    public void beforeMarshal(Object o, QNameMap qmap) {
+        qmap.registerMapping(new QName("https://github.com/kiegroup/drools", "mykieext", "kie"), "mykieext");
+        qmap.registerMapping(new QName("http://drools.org", "mydroolsext", "drools"), "mydroolsext");
+    }
+    
 }

--- a/kie-dmn/kie-dmn-backend/src/test/resources/Hello_World_semantic_namespace_with_extensions.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/Hello_World_semantic_namespace_with_extensions.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+					  xmlns="http://www.trisotech.com/definitions/_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+					  xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+					  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+					  xmlns:trisofeed="http://trisotech.com/feed"
+                      xmlns:drools="http://drools.org"
+                      xmlns:kie="https://github.com/kiegroup/drools"
+					  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					  exporter="DMN Modeler" exporterVersion="5.2.2"
+					  id="_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+					  name="Hello World semantic namespace"
+					  namespace="http://www.trisotech.com/definitions/_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+					  triso:logoChoice="Default">
+  <semantic:extensionElements>
+    <kie:mykieext a1="value_a1">
+      <drools:mydroolsext b1="value_b1">Hello Extensions</drools:mydroolsext>
+    </kie:mykieext> 
+  </semantic:extensionElements>
+  <semantic:itemDefinition label="tName" name="tName">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+  </semantic:itemDefinition>
+  <semantic:inputData id="_e34ee32e-ebe8-40e4-9ed6-477ad50951a9" name="My Name" triso:displayName="My Name">
+    <semantic:variable id="_a0a3d084-e6e7-4bb8-8b52-c557ef0f43cb" name="My Name" typeRef="feel:string"/>
+  </semantic:inputData>
+  <semantic:decision id="_70b66b6b-931a-46bb-b9f0-e3e727322896" name="Hello Name" triso:displayName="Hello Name">
+    <semantic:variable id="_f2640616-bbba-4bbc-ac7e-2d3376e1c3de" name="Hello Name" typeRef="tName"/>
+    <semantic:informationRequirement>
+      <semantic:requiredInput href="#_e34ee32e-ebe8-40e4-9ed6-477ad50951a9"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression id="_95ae7282-553f-4f29-9432-2e1d323d43b7">
+      <semantic:text>"Hello " + My Name</semantic:text>
+    </semantic:literalExpression>
+  </semantic:decision>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/DMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/DMNModelInstrumentedBase.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
@@ -78,6 +79,16 @@ public abstract class DMNModelInstrumentedBase {
             return parent.getNamespaceURI( prefix );
         }
         return null;
+    }
+    
+    public Optional<String> getPrefixForNamespaceURI( String namespaceURI ) {
+        if( this.nsContext != null && this.nsContext.containsValue(namespaceURI) ) {
+            return this.nsContext.entrySet().stream().filter(kv -> kv.getValue().equals(namespaceURI)).findFirst().map(Map.Entry::getKey);
+        }
+        if( this.parent != null ) {
+            return parent.getPrefixForNamespaceURI( namespaceURI );
+        }
+        return Optional.empty();
     }
     
     public void setAdditionalAttributes(Map<QName, String> additionalAttributes) {


### PR DESCRIPTION
Please note it is necessary for the marshaller to know (at runtime) the composition of the namespaces, which is stored in the in-memory object Definitions, in order to assign the namespaces and prefixes correctly.