### PR TITLE
Process variable is a Hibernate Proxy object

### DIFF
--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/JPAPlaceholderResolverStrategy.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/JPAPlaceholderResolverStrategy.java
@@ -172,7 +172,10 @@ public class JPAPlaceholderResolverStrategy implements ObjectMarshallingStrategy
 
         DroolsObjectInputStream is = new DroolsObjectInputStream( new ByteArrayInputStream( object ), clToUse );
         String canonicalName = is.readUTF();
-        Object id = is.readObject();
+        if(canonicalName.contains("_$$_jvst")){
+		canonicalName = canonicalName.substring(0, canonicalName.indexOf("_$$_jvst"));
+	}	
+	Object id = is.readObject();
 
         EntityManager em = getEntityManager();
         return em.find(Class.forName(canonicalName, true, (clToUse==null?this.getClass().getClassLoader():clToUse)), id);


### PR DESCRIPTION
For some cases my process variables were marshalled by the `Javassistlazyinitializer'` names which ends with **"_$$_jvst91a_55"**, thus when searching for the `canonicalName `it will throw a `org.hibernate.MappingException`: Unknown entity.