### PR TITLE
GUVNOR-3482: Assets cannot be open after version of an asset is switched in big repository

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
@@ -206,7 +206,7 @@ public class ProjectClassLoader extends ClassLoader {
         return clazz;
     }
 
-    public synchronized Class<?> defineClass(String name, byte[] bytecode) {
+    public Class<?> defineClass(String name, byte[] bytecode) {
         return defineClass(name, convertClassToResourcePath(name), bytecode);
     }
 

--- a/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
@@ -136,12 +136,10 @@ public class ProjectClassLoader extends ClassLoader {
         if (cls != null) {
             return cls;
         }
-        synchronized (this) {
-            try {
-                cls = internalLoadClass(name, resolve);
-            } catch (ClassNotFoundException e2) {
-                cls = loadType(name, resolve);
-            }
+        try {
+            cls = internalLoadClass(name, resolve);
+        } catch (ClassNotFoundException e2) {
+            cls = loadType(name, resolve);
         }
         loadedClasses.put(name, cls);
         return cls;
@@ -189,7 +187,7 @@ public class ProjectClassLoader extends ClassLoader {
         return defineType(name, bytecode);
     }
 
-    private Class<?> defineType(String name, byte[] bytecode) {
+    private synchronized Class<?> defineType(String name, byte[] bytecode) {
         if (definedTypes == null) {
             definedTypes = new HashMap<String, ClassBytecode>();
         } else {
@@ -208,7 +206,7 @@ public class ProjectClassLoader extends ClassLoader {
         return clazz;
     }
 
-    public Class<?> defineClass(String name, byte[] bytecode) {
+    public synchronized Class<?> defineClass(String name, byte[] bytecode) {
         return defineClass(name, convertClassToResourcePath(name), bytecode);
     }
 
@@ -217,7 +215,7 @@ public class ProjectClassLoader extends ClassLoader {
         return defineType(name, bytecode);
     }
 
-    public void undefineClass(String name) {
+    public synchronized void undefineClass(String name) {
         String resourceName = convertClassToResourcePath(name);
         if (store.remove(resourceName) != null) {
             if (CACHE_NON_EXISTING_CLASSES) {
@@ -414,12 +412,10 @@ public class ProjectClassLoader extends ClassLoader {
             try {
                 return loadType( name, resolve );
             } catch (ClassNotFoundException cnfe) {
-                synchronized (projectClassLoader) {
-                    try {
-                        return projectClassLoader.internalLoadClass( name, resolve );
-                    } catch (ClassNotFoundException cnfe2) {
-                        return projectClassLoader.tryDefineType( name, cnfe );
-                    }
+                try {
+                    return projectClassLoader.internalLoadClass( name, resolve );
+                } catch (ClassNotFoundException cnfe2) {
+                    return projectClassLoader.tryDefineType( name, cnfe );
                 }
             }
         }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3482

@mariofusco Would you mind taking a look please?

I've moved synchronisation to the _mutating_ methods and not the accessors.

It seems to fix the reported problem.. but IDK a great deal about custom class loaders.