### PR TITLE
DROOLS-1733 Enhance test coverage of FEEL built-in functions

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
@@ -108,7 +108,7 @@ public class DMNRuntimeTest {
 
         DMNContext result = dmnResult.getContext();
 
-        assertThat( result.get( "payment" ), is( new BigDecimal( "2778.693549432766720839844710324306" ) ) );
+        assertThat( result.get( "payment" ), is( new BigDecimal( "2778.693549432766768088520383236299" ) ) );
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
@@ -18,11 +18,9 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.Arrays;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class AllFunction
         extends BaseFEELFunction {
@@ -32,18 +30,18 @@ public class AllFunction
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) List list) {
-        boolean result = true;
-        for ( Object element : list ) {
-            if ( element instanceof Boolean ) {
-                result &= ((Boolean) element);
-                if ( !result ) {
-                    break;
-                }
-            } else {
-                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
+        if ( list == null ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
+        }
+        if (!TypeUtil.isCollectionTypeHomogenous(list, Boolean.class)) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
+        }
+        for ( final Object element : list ) {
+            if (element == null || element == Boolean.FALSE) {
+                return FEELFnResult.ofResult( false );
             }
         }
-        return FEELFnResult.ofResult( result );
+        return FEELFnResult.ofResult( true );
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) Boolean single) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.util.TypeUtil;
 
 public class AllFunction
         extends BaseFEELFunction {
@@ -33,15 +32,15 @@ public class AllFunction
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
-        if (!TypeUtil.isCollectionTypeHomogenous(list, Boolean.class)) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
-        }
+        boolean result = true;
         for ( final Object element : list ) {
-            if (element == null || element == Boolean.FALSE) {
-                return FEELFnResult.ofResult( false );
+            if (element != null && !(element instanceof Boolean)) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
+            } else {
+                result &= element != null && element == Boolean.TRUE;
             }
         }
-        return FEELFnResult.ofResult( true );
+        return FEELFnResult.ofResult( result );
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) Boolean single) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AllFunction.java
@@ -33,14 +33,24 @@ public class AllFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
         boolean result = true;
+        boolean containsNull = false;
+        // Spec. definition: return false if any item is false, else true if all items are true, else null
         for ( final Object element : list ) {
             if (element != null && !(element instanceof Boolean)) {
                 return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
             } else {
-                result &= element != null && element == Boolean.TRUE;
+                if (element != null) {
+                    result &= (Boolean) element;
+                } else if (!containsNull) {
+                    containsNull = true;
+                }
             }
         }
-        return FEELFnResult.ofResult( result );
+        if (containsNull && result) {
+            return FEELFnResult.ofResult( null );
+        } else {
+            return FEELFnResult.ofResult( result );
+        }
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) Boolean single) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
@@ -18,11 +18,9 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.Arrays;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class AnyFunction
         extends BaseFEELFunction {
@@ -32,18 +30,18 @@ public class AnyFunction
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) List list) {
-        boolean result = false;
-        for ( Object element : list ) {
-            if ( element instanceof Boolean ) {
-                result |= ((Boolean) element);
-                if ( result ) {
-                    break;
-                }
-            } else {
-                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
+        if ( list == null ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
+        }
+        if (!TypeUtil.isCollectionTypeHomogenous(list, Boolean.class)) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
+        }
+        for ( final Object element : list ) {
+            if (element != null && element == Boolean.TRUE) {
+                return FEELFnResult.ofResult( true );
             }
         }
-        return FEELFnResult.ofResult( result );
+        return FEELFnResult.ofResult( false );
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) Boolean single) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
@@ -33,15 +33,15 @@ public class AnyFunction
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
-        if (!TypeUtil.isCollectionTypeHomogenous(list, Boolean.class)) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
-        }
+        boolean result = false;
         for ( final Object element : list ) {
-            if (element != null && element == Boolean.TRUE) {
-                return FEELFnResult.ofResult( true );
+            if (element != null && !(element instanceof Boolean)) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
+            } else {
+                result |= element != null && element == Boolean.TRUE;
             }
         }
-        return FEELFnResult.ofResult( false );
+        return FEELFnResult.ofResult( result );
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) Boolean single) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AnyFunction.java
@@ -34,14 +34,24 @@ public class AnyFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
         boolean result = false;
+        boolean containsNull = false;
+        // Spec. definition: return true if any item is true, else false if all items are false, else null
         for ( final Object element : list ) {
             if (element != null && !(element instanceof Boolean)) {
                 return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "an element in the list is not a Boolean"));
             } else {
-                result |= element != null && element == Boolean.TRUE;
+                if (element != null) {
+                    result |= (Boolean) element;
+                } else if (!containsNull) {
+                    containsNull = true;
+                }
             }
         }
-        return FEELFnResult.ofResult( result );
+        if (containsNull && !result) {
+            return FEELFnResult.ofResult( null );
+        } else {
+            return FEELFnResult.ofResult( result );
+        }
     }
 
     public FEELFnResult<Boolean> invoke(@ParameterName( "list" ) Boolean single) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AppendFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AppendFunction.java
@@ -17,15 +17,10 @@
 package org.kie.dmn.feel.runtime.functions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
-import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
-import org.kie.dmn.feel.runtime.events.InvalidInputEvent;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class AppendFunction
         extends BaseFEELFunction {
@@ -42,8 +37,8 @@ public class AppendFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "item", "cannot be null"));
         }
         // spec requires us to return a new list
-        List result = new ArrayList( list );
-        Stream.of( items ).forEach( i -> result.add( i ) );
+        final List<Object> result = new ArrayList<Object>( list );
+        result.addAll(Arrays.asList(items));
         return FEELFnResult.ofResult( result );
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunction.java
@@ -78,16 +78,12 @@ public abstract class BaseFEELFunction
             boolean isNamedParams = params.length > 0 && params[0] instanceof NamedParameter;
             if ( !isCustomFunction() ) {
                 List<String> available = null;
-                Class[] classes = null;
                 if ( isNamedParams ) {
                     available = Stream.of( params ).map( p -> ((NamedParameter) p).getName() ).collect( Collectors.toList() );
-                    classes = Stream.of( params ).map( p -> p != null && ((NamedParameter)p).getValue() != null ? ((NamedParameter) p).getValue().getClass() : null ).toArray( Class[]::new );
-                } else {
-                    classes = Stream.of( params ).map( p -> p != null ? p.getClass() : null ).toArray( Class[]::new );
                 }
 
 
-                CandidateMethod cm = getCandidateMethod( ctx, params, isNamedParams, available, classes );
+                CandidateMethod cm = getCandidateMethod( ctx, params, isNamedParams, available );
 
                 if ( cm != null ) {
                     Object result = cm.apply.invoke( this, cm.actualParams );
@@ -117,12 +113,11 @@ public abstract class BaseFEELFunction
 
                     return result;
                 } else {
-                    String ps = Arrays.toString( classes );
+                    String ps = getClass().toString();
                     logger.error( "Unable to find function '" + getName() + "( " + ps.substring( 1, ps.length() - 1 ) + " )'" );
-                    ctx.notifyEvt( () -> {
-                                                                   return new FEELEventBase( Severity.ERROR, "Unable to find function '" + getName() + "( " + ps.substring( 1, ps.length() - 1 ) + " )'", null );
-                                                               }
-                    );
+                    ctx.notifyEvt(() -> {
+                        return new FEELEventBase(Severity.ERROR, "Unable to find function '" + getName() + "( " + ps.substring(1, ps.length() - 1) + " )'", null);
+                    });
                 }
             } else {
                 if ( isNamedParams ) {
@@ -188,7 +183,7 @@ public abstract class BaseFEELFunction
         return params;
     }
 
-    private CandidateMethod getCandidateMethod(EvaluationContext ctx, Object[] params, boolean isNamedParams, List<String> available, Class[] classes) {
+    private CandidateMethod getCandidateMethod(EvaluationContext ctx, Object[] params, boolean isNamedParams, List<String> available) {
         CandidateMethod candidate = null;
         // first, look for exact matches
         for ( Method m : getClass().getDeclaredMethods() ) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CodeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/CodeFunction.java
@@ -16,20 +16,10 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.feel.runtime.Range;
-
-import java.time.*;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class CodeFunction
         extends BaseFEELFunction {
-
-    private final long SECONDS_IN_A_MINUTE = 60;
-    private final long SECONDS_IN_AN_HOUR = 60 * SECONDS_IN_A_MINUTE;
-    private final long SECONDS_IN_A_DAY = 24 * SECONDS_IN_AN_HOUR;
-    private final long NANOSECONDS_PER_SECOND = 1000000000;
 
     public CodeFunction() {
         super( "code" );
@@ -39,165 +29,7 @@ public class CodeFunction
         if ( val == null ) {
             return FEELFnResult.ofResult( "null" );
         } else {
-            StringBuilder sb = new StringBuilder(  );
-            formatValue( sb, val );
-            return FEELFnResult.ofResult( sb.toString() );
+            return FEELFnResult.ofResult(TypeUtil.formatValue(val, true) );
         }
     }
-
-    private void formatValue(StringBuilder sb, Object val) {
-        if( val instanceof String ) {
-            sb.append( "\"" );
-            sb.append( val.toString() );
-            sb.append( "\"" );
-        } else if( val instanceof LocalDate ) {
-            sb.append( "date( \"" );
-            sb.append( val.toString() );
-            sb.append( "\" )" );
-        } else if( val instanceof LocalTime || val instanceof OffsetTime ) {
-            sb.append( "time( \"" );
-            sb.append( val.toString() );
-            sb.append( "\" )" );
-        } else if( val instanceof LocalDateTime || val instanceof OffsetDateTime || val instanceof ZonedDateTime ) {
-            sb.append( "date and time( \"" );
-            sb.append( val.toString() );
-            sb.append( "\" )" );
-        } else if( val instanceof Duration ) {
-            formatDuration( sb, (Duration) val );
-        } else if( val instanceof Period ) {
-            formatPeriod( sb, (Period) val );
-        } else if( val instanceof List ) {
-            formatList( sb, (List) val );
-        } else if( val instanceof Range ) {
-            formatRange( sb, (Range) val );
-        } else if( val instanceof Map ) {
-            formatContext( sb, (Map) val );
-        } else {
-            sb.append( val.toString() );
-        }
-    }
-
-    private void formatContext(StringBuilder sb, Map context) {
-        sb.append( "{ " );
-        int count = 0;
-        for( Map.Entry<Object, Object> val : (Set<Map.Entry<Object, Object>>) context.entrySet() ) {
-            if( count > 0 ) {
-                sb.append( ", " );
-            }
-            // keys should always be strings, so do not call recursivelly to avoid the "
-            sb.append( val.getKey() );
-            sb.append( " : " );
-            formatValue( sb, val.getValue() );
-            count++;
-        }
-        if( !context.isEmpty() ) {
-            sb.append( " " );
-        }
-        sb.append( "}" );
-    }
-
-    private void formatRange(StringBuilder sb, Range val) {
-        sb.append( val.getLowBoundary() == Range.RangeBoundary.OPEN ? "( " : "[ " );
-        formatValue( sb, val.getLowEndPoint() );
-        sb.append( " .. " );
-        formatValue( sb, val.getHighEndPoint() );
-        sb.append( val.getHighBoundary() == Range.RangeBoundary.OPEN ? " )" : " ]" );
-    }
-
-    private void formatList(StringBuilder sb, List list) {
-        sb.append( "[ " );
-        int count = 0;
-        for( Object val : list ) {
-            if( count > 0 ) {
-                sb.append( ", " );
-            }
-            formatValue( sb, val );
-            count++;
-        }
-        if( !list.isEmpty() ) {
-            sb.append( " " );
-        }
-        sb.append( "]" );
-    }
-
-    private void formatPeriod(StringBuilder sb, Period val) {
-        long totalMonths = val.toTotalMonths();
-        if( totalMonths == 0 ) {
-            sb.append( "duration( \"P0M\" )" );
-            return;
-        }
-        sb.append( "duration( \"" );
-        if( totalMonths < 0 ) {
-            sb.append( "-P" );
-        } else {
-            sb.append('P');
-        }
-        long years = Math.abs( totalMonths / 12 );
-        if ( years != 0) {
-            sb.append(years).append('Y');
-        }
-        long months = Math.abs( totalMonths % 12 );
-        if ( months != 0) {
-            sb.append(months).append('M');
-        }
-        sb.append( "\" )" );
-    }
-
-    private void formatDuration(StringBuilder sb, Duration val) {
-        if( val.getSeconds() == 0 && val.getNano() == 0 ) {
-            sb.append( "duration( \"PT0S\" )" );
-            return;
-        }
-        long days = val.getSeconds() / SECONDS_IN_A_DAY;
-        long hours = ( val.getSeconds() % SECONDS_IN_A_DAY ) / SECONDS_IN_AN_HOUR;
-        long minutes = ( val.getSeconds() % SECONDS_IN_AN_HOUR ) / SECONDS_IN_A_MINUTE;
-        long seconds = val.getSeconds() % SECONDS_IN_A_MINUTE;
-        sb.append( "duration( \"" );
-        if( val.isNegative() ) {
-            sb.append( "-" );
-        }
-        sb.append( "P" );
-        if( days != 0 ) {
-            sb.append( Math.abs( days ) );
-            sb.append( "D" );
-        }
-        if( hours != 0 || minutes != 0 || seconds != 0 || val.getNano() != 0 ) {
-            sb.append( "T" );
-            if( hours != 0 ) {
-                sb.append( Math.abs( hours ) );
-                sb.append( "H" );
-            }
-            if( minutes != 0 ) {
-                sb.append( Math.abs( minutes ) );
-                sb.append( "M" );
-            }
-            if( seconds != 0 || val.getNano() != 0 ) {
-                if ( seconds < 0 && val.getNano() > 0) {
-                    if (seconds == -1) {
-                        sb.append( "0" );
-                    } else {
-                        sb.append( Math.abs( seconds + 1 ) );
-                    }
-                } else {
-                    sb.append( Math.abs( seconds ) );
-                }
-                if (val.getNano() > 0) {
-                    int pos = sb.length();
-                    if (seconds < 0) {
-                        sb.append(2 * NANOSECONDS_PER_SECOND - val.getNano());
-                    } else {
-                        sb.append( val.getNano() + NANOSECONDS_PER_SECOND );
-                    }
-                    while ( sb.charAt( sb.length() - 1 ) == '0') {
-                        // eliminates trailing zeros in the nanoseconds
-                        sb.setLength( sb.length() - 1);
-                    }
-                    sb.setCharAt(pos, '.');
-                }
-                sb.append('S');
-            }
-        }
-        sb.append( "\" )" );
-    }
-
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
@@ -34,7 +34,7 @@ public class ConcatenateFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
         // spec requires us to return a new list
-        List result = new ArrayList();
+        final List<Object> result = new ArrayList<>();
         for ( Object list : lists ) {
             if ( list == null ) {
                 // TODO review accordingly to spec, original behavior was: return null;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class ConcatenateFunction
         extends BaseFEELFunction {
@@ -39,13 +36,13 @@ public class ConcatenateFunction
         // spec requires us to return a new list
         List result = new ArrayList();
         for ( Object list : lists ) {
-            if ( list instanceof Collection ) {
-                result.addAll( (Collection) list );
-            } else if ( list != null ) {
-                result.add( list );
-            } else {
+            if ( list == null ) {
                 // TODO review accordingly to spec, original behavior was: return null;
-                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "on of the element in the list was null"));
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "lists", "one of the elements in the list is null"));
+            } else if ( list instanceof Collection ) {
+                result.addAll( (Collection) list );
+            } else {
+                result.add( list );
             }
         }
         return FEELFnResult.ofResult( result );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContainsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContainsFunction.java
@@ -34,6 +34,6 @@ public class ContainsFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "match", "cannot be null"));
         }
         
-        return FEELFnResult.ofResult( string.indexOf( match ) >= 0 );
+        return FEELFnResult.ofResult(string.contains(match));
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContainsFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ContainsFunction.java
@@ -16,10 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class ContainsFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateTimeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateTimeFunction.java
@@ -16,6 +16,7 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -67,10 +68,14 @@ public class DateTimeFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "time", "must be an instance of LocalTime or OffsetTime"));
         }
 
-        if( time instanceof LocalTime ) {
-            return FEELFnResult.ofResult( LocalDateTime.of( (LocalDate) date, (LocalTime) time ) );
-        } else {
-            return FEELFnResult.ofResult( ZonedDateTime.of( (LocalDate) date, LocalTime.from( time ), ZoneOffset.from( time ) ) );
+        try {
+            if ( time instanceof LocalTime ) {
+                return FEELFnResult.ofResult(LocalDateTime.of((LocalDate) date, (LocalTime) time));
+            } else {
+                return FEELFnResult.ofResult(ZonedDateTime.of((LocalDate) date, LocalTime.from(time), ZoneOffset.from(time)));
+            }
+        } catch ( DateTimeException e ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input parameters date-parsing exception", e));
         }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateTimeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateTimeFunction.java
@@ -16,15 +16,18 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class DateTimeFunction
         extends BaseFEELFunction {
@@ -63,16 +66,11 @@ public class DateTimeFunction
         if ( !(time instanceof LocalTime || time instanceof OffsetTime) ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "time", "must be an instance of LocalTime or OffsetTime"));
         }
-        
-        try {
-            if( date instanceof LocalDate && time instanceof LocalTime ) {
-                return FEELFnResult.ofResult( LocalDateTime.of( (LocalDate) date, (LocalTime) time ) );
-            } else if( date instanceof LocalDate && time instanceof OffsetTime ) {
-                return FEELFnResult.ofResult( ZonedDateTime.of( (LocalDate) date, LocalTime.from( time ), ZoneOffset.from( time ) ) );
-            }
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "cannot invoke function for the input parameters"));
-        } catch (DateTimeException e) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input parameters date-parsing exception", e));
+
+        if( time instanceof LocalTime ) {
+            return FEELFnResult.ofResult( LocalDateTime.of( (LocalDate) date, (LocalTime) time ) );
+        } else {
+            return FEELFnResult.ofResult( ZonedDateTime.of( (LocalDate) date, LocalTime.from( time ), ZoneOffset.from( time ) ) );
         }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class DistinctValuesFunction
         extends BaseFEELFunction {
@@ -37,9 +34,13 @@ public class DistinctValuesFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
         // spec requires us to return a new list
-        List result = new ArrayList();
-        if( list instanceof Collection ) {
-            ((Collection)list).stream().forEach( i -> { if( !result.contains( i ) ) result.add(i); } );
+        final List<Object> result = new ArrayList<>();
+        if ( list instanceof Collection ) {
+            for (Object o : (Collection) list) {
+                if ( !result.contains( o ) ) {
+                    result.add(o);
+                }
+            }
         } else {
             result.add( list );
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/EndsWithFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/EndsWithFunction.java
@@ -16,10 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class EndsWithFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FlattenFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/FlattenFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class FlattenFunction
         extends BaseFEELFunction {
@@ -37,12 +34,12 @@ public class FlattenFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
         // spec requires us to return a new list
-        List result = new ArrayList();
+        final List<Object> result = new ArrayList<>();
         flattenList( list, result );
         return FEELFnResult.ofResult( result );
     }
 
-    private void flattenList(Object list, List result) {
+    private void flattenList(Object list, List<Object> result) {
         if( list instanceof Collection ) {
             for( Object element : ((Collection)list) ) {
                 if( element instanceof Collection ) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/IndexOfFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/IndexOfFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class IndexOfFunction
         extends BaseFEELFunction {
@@ -36,14 +33,24 @@ public class IndexOfFunction
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
-        List result = new ArrayList();
+
+        final List<BigDecimal> result = new ArrayList<>();
         for( int i = 0; i < list.size(); i++ ) {
             Object o = list.get( i );
-            if ( ( o == null && match == null) ||
-                 ( o != null && o.equals( match ) ) ) {
+            if ( o == null && match == null) {
                 result.add( BigDecimal.valueOf( i+1 ) );
+            } else if ( o != null && match != null ) {
+                if ( equalsAsBigDecimals(o, match) || o.equals(match) ) {
+                    result.add( BigDecimal.valueOf( i+1 ) );
+                }
             }
         }
         return FEELFnResult.ofResult( result );
+    }
+
+    private boolean equalsAsBigDecimals(final Object object, final Object match) {
+        return (object instanceof BigDecimal)
+                && (match instanceof BigDecimal)
+                && ((BigDecimal) object).compareTo((BigDecimal) match) == 0;
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class InsertBeforeFunction
         extends BaseFEELFunction {
@@ -47,11 +44,11 @@ public class InsertBeforeFunction
         }
 
         // spec requires us to return a new list
-        List result = new ArrayList( list );
+        final List<Object> result = new ArrayList<Object>( list );
         if( position.intValue() > 0 ) {
-            result.add( position.intValue()-1, newItem );
+            result.add( position.intValue() - 1, newItem );
         } else {
-            result.add( list.size()+position.intValue(), newItem );
+            result.add( list.size() + position.intValue(), newItem );
         }
         return FEELFnResult.ofResult( result );
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
@@ -48,8 +48,8 @@ public class MatchesFunction
             return FEELFnResult.ofResult( m.find() );
         } catch ( PatternSyntaxException e ) {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "pattern", "is invalid and can not be compiled", e ) );
-        } catch ( Throwable t ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "pattern", "is invalid and can not be compiled", t ) );
+        } catch ( IllegalArgumentException t ) {
+            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "flags", "contains unknown flags", t ) );
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
@@ -50,6 +50,8 @@ public class MatchesFunction
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "pattern", "is invalid and can not be compiled", e ) );
         } catch ( IllegalArgumentException t ) {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "flags", "contains unknown flags", t ) );
+        } catch ( Throwable t) {
+            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "pattern", "is invalid and can not be compiled", t ) );
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MaxFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MaxFunction.java
@@ -20,10 +20,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class MaxFunction
         extends BaseFEELFunction {
@@ -33,17 +32,20 @@ public class MaxFunction
     }
 
     public FEELFnResult<Object> invoke(@ParameterName("list") List list) {
-        if ( list == null ) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
+        if ( list == null || list.isEmpty() ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null or empty"));
+        } else if (!TypeUtil.areCollectionItemsComparable(list)) {
+            // TODO - check and max in the same iteration.. same for MinFunction
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "does not contain comparable items"));
         } else {
             return FEELFnResult.ofResult( Collections.max( list ) );
         }
     }
 
     public FEELFnResult<Object> invoke(@ParameterName("c") Object[] list) {
-        if ( list == null ) { 
+        if ( list == null || list.length == 0 ) {
             // Arrays.asList does not accept null as parameter
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "c", "cannot be null"));
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "c", "cannot be null or empty"));
         }
         
         return invoke( Arrays.asList( list ) );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MaxFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MaxFunction.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
@@ -34,11 +35,12 @@ public class MaxFunction
     public FEELFnResult<Object> invoke(@ParameterName("list") List list) {
         if ( list == null || list.isEmpty() ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null or empty"));
-        } else if (!TypeUtil.areCollectionItemsComparable(list)) {
-            // TODO - check and max in the same iteration.. same for MinFunction
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "does not contain comparable items"));
         } else {
-            return FEELFnResult.ofResult( Collections.max( list ) );
+            try {
+                return FEELFnResult.ofResult( Collections.max( list ) );
+            } catch (ClassCastException e) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "contains items that are not comparable"));
+            }
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MeanFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MeanFunction.java
@@ -21,11 +21,9 @@ import java.math.MathContext;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 import org.kie.dmn.feel.util.EvalHelper;
 
 public class MeanFunction
@@ -38,6 +36,10 @@ public class MeanFunction
     }
 
     public FEELFnResult<BigDecimal> invoke(@ParameterName( "list" ) List list) {
+        if ( list == null ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
+        }
+
         FEELFnResult<BigDecimal> s = sum.invoke( list );
         
         Function<FEELEvent, FEELFnResult<BigDecimal>> ifLeft = (event) -> {
@@ -56,11 +58,10 @@ public class MeanFunction
     }
 
     public FEELFnResult<BigDecimal> invoke(@ParameterName( "list" ) Number single) {
-        if ( single == null ) { 
-            // Arrays.asList does not accept null as parameter
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "the single value list cannot be null"));
+        if ( single == null ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "single", "the single value list cannot be null"));
         }
-        
+
         if( single instanceof BigDecimal ) {
             return FEELFnResult.ofResult((BigDecimal) single );
         } 
@@ -68,7 +69,7 @@ public class MeanFunction
         if ( result != null ) {
             return FEELFnResult.ofResult( result );
         } else {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "single element in list not a number"));
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "single element in list is not a number"));
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MinFunction.java
@@ -34,10 +34,12 @@ public class MinFunction
     public FEELFnResult<Object> invoke(@ParameterName("list") List list) {
         if ( list == null || list.isEmpty() ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null or empty"));
-        } else if (!TypeUtil.areCollectionItemsComparable(list)) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "does not contain comparable items"));
         } else {
-            return FEELFnResult.ofResult( Collections.min( list ) );
+            try {
+                return FEELFnResult.ofResult( Collections.min( list ) );
+            } catch (ClassCastException e) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "contains items that are not comparable"));
+            }
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MinFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/MinFunction.java
@@ -20,10 +20,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class MinFunction
         extends BaseFEELFunction {
@@ -33,17 +32,19 @@ public class MinFunction
     }
 
     public FEELFnResult<Object> invoke(@ParameterName("list") List list) {
-        if ( list == null ) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
+        if ( list == null || list.isEmpty() ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null or empty"));
+        } else if (!TypeUtil.areCollectionItemsComparable(list)) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "does not contain comparable items"));
         } else {
             return FEELFnResult.ofResult( Collections.min( list ) );
         }
     }
 
     public FEELFnResult<Object> invoke(@ParameterName("c") Object[] list) {
-        if ( list == null ) { 
+        if ( list == null || list.length == 0 ) {
             // Arrays.asList does not accept null as parameter
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "c", "cannot be null"));
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "c", "cannot be null or empty"));
         }
         
         return invoke( Arrays.asList( list ) );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NotFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NotFunction.java
@@ -35,7 +35,7 @@ public class NotFunction
         if ( negand != null && !(negand instanceof Boolean) ) {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "negand", "must be a boolean value" ) );
         }
-        return FEELFnResult.ofResult( negand == null ? null : !((Boolean) negand).booleanValue() );
+        return FEELFnResult.ofResult( negand == null ? null : !((Boolean) negand) );
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NumberFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/NumberFunction.java
@@ -17,12 +17,8 @@
 package org.kie.dmn.feel.runtime.functions;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 import org.kie.dmn.feel.util.EvalHelper;
 
 public class NumberFunction
@@ -39,8 +35,12 @@ public class NumberFunction
         if ( group != null && !group.equals( " " ) && !group.equals( "." ) && !group.equals( "," ) ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "group", "not a valid one, can only be one of: dot ('.'), comma (','), space (' ') "));
         }
-        if ( decimal != null && ((!decimal.equals( "." ) && !decimal.equals( "," )) || (group != null && decimal.equals( group ))) ) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "decimal", "invalid parameter 'decimal' used in conjuction with specified parameter 'group'"));
+        if ( decimal != null ) {
+            if (!decimal.equals( "." ) && !decimal.equals( "," )) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "decimal", "not a valid one, can only be one of: dot ('.'), comma (',') "));
+            } else if (group != null && decimal.equals( group )) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "decimal", "cannot be the same as parameter 'group' "));
+            }
         }
         
         if ( group != null ) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RemoveFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RemoveFunction.java
@@ -46,7 +46,7 @@ public class RemoveFunction
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "position", "inconsistent with 'list' size"));
         }
         // spec requires us to return a new list
-        List result = new ArrayList( list );
+        List<Object> result = new ArrayList<Object>( list );
         if( position.intValue() > 0 ) {
             result.remove( position.intValue()-1 );
         } else {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReplaceFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReplaceFunction.java
@@ -28,15 +28,7 @@ public class ReplaceFunction
 
     public FEELFnResult<Object> invoke(@ParameterName("input") String input, @ParameterName("pattern") String pattern,
                                        @ParameterName( "replacement" ) String replacement ) {
-        if ( input == null ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "input", "cannot be null" ) );
-        }
-        if ( pattern == null ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "pattern", "cannot be null" ) );
-        }
-
-        // for now, using standard java matches function
-        return FEELFnResult.ofResult( input.replaceAll( pattern, replacement ) );
+        return invoke(input, pattern, replacement, null);
     }
 
     public FEELFnResult<Object> invoke(@ParameterName("input") String input, @ParameterName("pattern") String pattern,
@@ -47,9 +39,18 @@ public class ReplaceFunction
         if ( pattern == null ) {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "pattern", "cannot be null" ) );
         }
+        if ( replacement == null ) {
+            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "replacement", "cannot be null" ) );
+        }
 
-        // for now, using standard java replaceAll function... needs fixing to support flags
-        return FEELFnResult.ofResult( input.replaceAll( pattern, replacement ) );
+        final String flagsString;
+        if (flags != null && !flags.isEmpty()) {
+            flagsString = "(?" + flags + ")";
+        } else {
+            flagsString = "";
+        }
+
+        return FEELFnResult.ofResult( input.replaceAll( flagsString + pattern, replacement ) );
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReverseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReverseFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class ReverseFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StartsWithFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StartsWithFunction.java
@@ -16,10 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class StartsWithFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringFunction.java
@@ -17,22 +17,11 @@
 package org.kie.dmn.feel.runtime.functions;
 
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
-import org.kie.dmn.feel.runtime.Range;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-
-import java.time.Duration;
-import java.time.Period;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class StringFunction
         extends BaseFEELFunction {
-
-    private final long SECONDS_IN_A_MINUTE = 60;
-    private final long SECONDS_IN_AN_HOUR = 60 * SECONDS_IN_A_MINUTE;
-    private final long SECONDS_IN_A_DAY = 24 * SECONDS_IN_AN_HOUR;
-    private final long NANOSECONDS_PER_SECOND = 1000000000;
 
     public StringFunction() {
         super( "string" );
@@ -42,9 +31,7 @@ public class StringFunction
         if ( val == null ) {
             return FEELFnResult.ofResult( null );
         } else {
-            StringBuilder sb = new StringBuilder(  );
-            formatValue( sb, val );
-            return FEELFnResult.ofResult( sb.toString() );
+            return FEELFnResult.ofResult( TypeUtil.formatValue(val, false) );
         }
     }
 
@@ -55,139 +42,4 @@ public class StringFunction
             return FEELFnResult.ofResult( String.format( mask, params ) );
         }
     }
-
-    private void formatValue(StringBuilder sb, Object val) {
-        if( val instanceof Duration ) {
-            formatDuration( sb, (Duration) val );
-        } else if( val instanceof Period ) {
-            formatPeriod( sb, (Period) val );
-        } else if( val instanceof List ) {
-            formatList( sb, (List) val );
-        } else if( val instanceof Range ) {
-            formatRange( sb, (Range) val );
-        } else if( val instanceof Map ) {
-            formatContext( sb, (Map) val );
-        } else {
-            sb.append( val.toString() );
-        }
-    }
-
-    private void formatContext(StringBuilder sb, Map context) {
-        sb.append( "{ " );
-        int count = 0;
-        for( Map.Entry<Object, Object> val : (Set<Map.Entry<Object, Object>>) context.entrySet() ) {
-            if( count > 0 ) {
-                sb.append( ", " );
-            }
-            formatValue( sb, val.getKey() );
-            sb.append( " : " );
-            formatValue( sb, val.getValue() );
-            count++;
-        }
-        if( !context.isEmpty() ) {
-            sb.append( " " );
-        }
-        sb.append( "}" );
-    }
-
-    private void formatRange(StringBuilder sb, Range val) {
-        sb.append( val.getLowBoundary() == Range.RangeBoundary.OPEN ? "( " : "[ " );
-        formatValue( sb, val.getLowEndPoint() );
-        sb.append( " .. " );
-        formatValue( sb, val.getHighEndPoint() );
-        sb.append( val.getHighBoundary() == Range.RangeBoundary.OPEN ? " )" : " ]" );
-    }
-
-    private void formatList(StringBuilder sb, List list) {
-        sb.append( "[ " );
-        int count = 0;
-        for( Object val : list ) {
-            if( count > 0 ) {
-                sb.append( ", " );
-            }
-            formatValue( sb, val );
-            count++;
-        }
-        if( !list.isEmpty() ) {
-            sb.append( " " );
-        }
-        sb.append( "]" );
-    }
-
-    private void formatPeriod(StringBuilder sb, Period val) {
-        long totalMonths = val.toTotalMonths();
-        if( totalMonths == 0 ) {
-            sb.append( "P0M" );
-            return;
-        }
-        if( totalMonths < 0 ) {
-            sb.append( "-P" );
-        } else {
-            sb.append('P');
-        }
-        long years = Math.abs( totalMonths / 12 );
-        if ( years != 0) {
-            sb.append(years).append('Y');
-        }
-        long months = Math.abs( totalMonths % 12 );
-        if ( months != 0) {
-            sb.append(months).append('M');
-        }
-    }
-
-    private void formatDuration(StringBuilder sb, Duration val) {
-        if( val.getSeconds() == 0 && val.getNano() == 0 ) {
-            sb.append( "PT0S" );
-            return;
-        }
-        long days = val.getSeconds() / SECONDS_IN_A_DAY;
-        long hours = ( val.getSeconds() % SECONDS_IN_A_DAY ) / SECONDS_IN_AN_HOUR;
-        long minutes = ( val.getSeconds() % SECONDS_IN_AN_HOUR ) / SECONDS_IN_A_MINUTE;
-        long seconds = val.getSeconds() % SECONDS_IN_A_MINUTE;
-        if( val.isNegative() ) {
-            sb.append( "-" );
-        }
-        sb.append( "P" );
-        if( days != 0 ) {
-            sb.append( Math.abs( days ) );
-            sb.append( "D" );
-        }
-        if( hours != 0 || minutes != 0 || seconds != 0 || val.getNano() != 0 ) {
-            sb.append( "T" );
-            if( hours != 0 ) {
-                sb.append( Math.abs( hours ) );
-                sb.append( "H" );
-            }
-            if( minutes != 0 ) {
-                sb.append( Math.abs( minutes ) );
-                sb.append( "M" );
-            }
-            if( seconds != 0 || val.getNano() != 0 ) {
-                if ( seconds < 0 && val.getNano() > 0) {
-                    if (seconds == -1) {
-                        sb.append( "0" );
-                    } else {
-                        sb.append( Math.abs( seconds + 1 ) );
-                    }
-                } else {
-                    sb.append( Math.abs( seconds ) );
-                }
-                if (val.getNano() > 0) {
-                    int pos = sb.length();
-                    if (seconds < 0) {
-                        sb.append(2 * NANOSECONDS_PER_SECOND - val.getNano());
-                    } else {
-                        sb.append( val.getNano() + NANOSECONDS_PER_SECOND );
-                    }
-                    while ( sb.charAt( sb.length() - 1 ) == '0') {
-                        // eliminates trailing zeros in the nanoseconds
-                        sb.setLength( sb.length() - 1);
-                    }
-                    sb.setCharAt(pos, '.');
-                }
-                sb.append('S');
-            }
-        }
-    }
-
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLengthFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLengthFunction.java
@@ -17,11 +17,8 @@
 package org.kie.dmn.feel.runtime.functions;
 
 import java.math.BigDecimal;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 import org.kie.dmn.feel.util.EvalHelper;
 
 public class StringLengthFunction

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunction.java
@@ -16,10 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class StringLowerCaseFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunction.java
@@ -16,10 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class StringUpperCaseFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SublistFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SublistFunction.java
@@ -18,11 +18,8 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.math.BigDecimal;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class SublistFunction
         extends BaseFEELFunction {
@@ -48,7 +45,10 @@ public class SublistFunction
         if ( start.abs().intValue() > list.size() ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "start", "is inconsistent with 'list' size"));
         }
-        
+        if ( length != null && length.compareTo(BigDecimal.ZERO) <= 0) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "length", "must be a positive number when specified"));
+        }
+
         if ( start.intValue() > 0 ) {
             int end = length != null ? start.intValue() - 1 + length.intValue() : list.size();
             if ( end > list.size() ) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunction.java
@@ -16,10 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class SubstringAfterFunction
         extends BaseFEELFunction {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/impl/RangeImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/impl/RangeImpl.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.runtime.impl;
 
-import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.runtime.Range;
 
 public class RangeImpl

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
@@ -16,11 +16,28 @@
 
 package org.kie.dmn.feel.util;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.kie.dmn.feel.runtime.Range;
 
 public final class TypeUtil {
 
-    public static boolean areCollectionItemsComparable(final Collection collection) {
+    private static final long SECONDS_IN_A_MINUTE = 60;
+    private static final long SECONDS_IN_AN_HOUR = 60 * SECONDS_IN_A_MINUTE;
+    private static final long SECONDS_IN_A_DAY = 24 * SECONDS_IN_AN_HOUR;
+    private static final long NANOSECONDS_PER_SECOND = 1000000000;
+
+    public static boolean isCollectionTypeHomogenous(final Collection collection) {
         if (collection.isEmpty()) {
             return true;
         } else {
@@ -37,6 +54,224 @@ public final class TypeUtil {
             }
         }
         return true;
+    }
+
+    public static String formatValue(final Object val, final boolean wrapForCodeUsage) {
+        if (val instanceof String) {
+            return formatString(val.toString(), wrapForCodeUsage);
+        } else if (val instanceof LocalDate) {
+            return formatDate((LocalDate) val, wrapForCodeUsage);
+        } else if (val instanceof LocalTime || val instanceof OffsetTime) {
+            return formatTimeString(val.toString(), wrapForCodeUsage);
+        } else if (val instanceof LocalDateTime || val instanceof OffsetDateTime || val instanceof ZonedDateTime) {
+            return formatDateTimeString(val.toString(), wrapForCodeUsage);
+        } else if (val instanceof Duration) {
+            return formatDuration((Duration) val, wrapForCodeUsage);
+        } else if (val instanceof Period) {
+            return formatPeriod((Period) val, wrapForCodeUsage);
+        } else if (val instanceof List) {
+            return formatList((List) val, wrapForCodeUsage);
+        } else if (val instanceof Range) {
+            return formatRange((Range) val, wrapForCodeUsage);
+        } else if (val instanceof Map) {
+            return formatContext((Map) val, wrapForCodeUsage);
+        } else {
+            return val.toString();
+        }
+    }
+
+    public static String formatDateTimeString(final String dateTimeString, final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "date and time( \"" + dateTimeString + "\" )";
+        } else {
+            return dateTimeString;
+        }
+    }
+
+    public static String formatTimeString(final String timeString, final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "time( \"" + timeString + "\" )";
+        } else {
+            return timeString;
+        }
+    }
+
+    public static String formatDate(final LocalDate date, final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "date( \"" + date.toString() + "\" )";
+        } else {
+            return date.toString();
+        }
+    }
+
+    public static String formatString(final String value, final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "\"" + value + "\"";
+        } else {
+            return value;
+        }
+    }
+
+    public static String formatList(final List list, final boolean wrapDateTimeValuesInFunctions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("[ ");
+        int count = 0;
+        for (final Object val : list) {
+            if (count > 0) {
+                sb.append(", ");
+            }
+            sb.append(formatValue(val, wrapDateTimeValuesInFunctions));
+            count++;
+        }
+        if (!list.isEmpty()) {
+            sb.append(" ");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    public static String formatContext(final Map context, final boolean wrapDateTimeValuesInFunctions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        int count = 0;
+        for (final Map.Entry<Object, Object> val : (Set<Map.Entry<Object, Object>>) context.entrySet()) {
+            if (count > 0) {
+                sb.append(", ");
+            }
+            // keys should always be strings, so do not call recursivelly to avoid the "
+            sb.append(val.getKey());
+            sb.append(" : ");
+            sb.append(formatValue(val.getValue(), wrapDateTimeValuesInFunctions));
+            count++;
+        }
+        if (!context.isEmpty()) {
+            sb.append(" ");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    public static String formatRange(final Range val, final boolean wrapDateTimeValuesInFunctions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(val.getLowBoundary() == Range.RangeBoundary.OPEN ? "( " : "[ ");
+        sb.append(formatValue(val.getLowEndPoint(), wrapDateTimeValuesInFunctions));
+        sb.append(" .. ");
+        sb.append(formatValue(val.getHighEndPoint(), wrapDateTimeValuesInFunctions));
+        sb.append(val.getHighBoundary() == Range.RangeBoundary.OPEN ? " )" : " ]");
+        return sb.toString();
+    }
+
+    public static String formatPeriod(final Period period, final boolean wrapInDurationFunction) {
+        final long totalMonths = period.toTotalMonths();
+        if (totalMonths == 0) {
+            if (wrapInDurationFunction) {
+                return "duration( \"P0M\" )";
+            } else {
+                return "P0M";
+            }
+        }
+        final StringBuilder sb = new StringBuilder();
+        if (wrapInDurationFunction) {
+            sb.append("duration( \"");
+        }
+        if (totalMonths < 0) {
+            sb.append("-P");
+        } else {
+            sb.append('P');
+        }
+
+        final long years = Math.abs(totalMonths / 12);
+        if (years != 0) {
+            sb.append(years).append('Y');
+        }
+
+        final long months = Math.abs(totalMonths % 12);
+        if (months != 0) {
+            sb.append(months).append('M');
+        }
+
+        if (wrapInDurationFunction) {
+            sb.append("\" )");
+        }
+
+        return sb.toString();
+    }
+
+    public static String formatDuration(final Duration duration, final boolean wrapInDurationFunction) {
+        if (duration.getSeconds() == 0 && duration.getNano() == 0) {
+            if (wrapInDurationFunction) {
+                return "duration( \"PT0S\" )";
+            } else {
+                return "PT0S";
+            }
+        }
+        final long days = duration.getSeconds() / SECONDS_IN_A_DAY;
+        final long hours = (duration.getSeconds() % SECONDS_IN_A_DAY) / SECONDS_IN_AN_HOUR;
+        final long minutes = (duration.getSeconds() % SECONDS_IN_AN_HOUR) / SECONDS_IN_A_MINUTE;
+        final long seconds = duration.getSeconds() % SECONDS_IN_A_MINUTE;
+
+        final StringBuilder sb = new StringBuilder();
+        if (wrapInDurationFunction) {
+            sb.append("duration( \"");
+        }
+        if (duration.isNegative()) {
+            sb.append("-");
+        }
+        sb.append("P");
+        if (days != 0) {
+            appendToDurationString(sb, days, "D");
+        }
+        if (hours != 0 || minutes != 0 || seconds != 0 || duration.getNano() != 0) {
+            sb.append("T");
+            if (hours != 0) {
+                appendToDurationString(sb, hours, "H");
+            }
+            if (minutes != 0) {
+                appendToDurationString(sb, minutes, "M");
+            }
+            if (seconds != 0 || duration.getNano() != 0) {
+                appendSecondsToDurationString(sb, seconds, duration.getNano());
+            }
+        }
+        if (wrapInDurationFunction) {
+            sb.append("\" )");
+        }
+        return sb.toString();
+    }
+
+    private static void appendToDurationString(final StringBuilder sb, final long days, final String timeSegmentChar) {
+        sb.append(Math.abs(days));
+        sb.append(timeSegmentChar);
+    }
+
+    private static void appendSecondsToDurationString(final StringBuilder sb, final long seconds, final long nanoseconds) {
+        if (seconds < 0 && nanoseconds > 0) {
+            if (seconds == -1) {
+                sb.append("0");
+            } else {
+                sb.append(Math.abs(seconds + 1));
+            }
+        } else {
+            sb.append(Math.abs(seconds));
+        }
+        if (nanoseconds > 0) {
+            final int pos = sb.length();
+            if (seconds < 0) {
+                sb.append(2 * NANOSECONDS_PER_SECOND - nanoseconds);
+            } else {
+                sb.append(nanoseconds + NANOSECONDS_PER_SECOND);
+            }
+            eliminateTrailingZeros(sb);
+            sb.setCharAt(pos, '.');
+        }
+        sb.append('S');
+    }
+
+    private static void eliminateTrailingZeros(final StringBuilder sb) {
+        while (sb.charAt(sb.length() - 1) == '0') {
+            // eliminates trailing zeros in the nanoseconds
+            sb.setLength(sb.length() - 1);
+        }
     }
 
     private TypeUtil() {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
@@ -20,11 +20,19 @@ import java.util.Collection;
 
 public final class TypeUtil {
 
+    public static boolean areCollectionItemsComparable(final Collection collection) {
+        if (collection.isEmpty()) {
+            return true;
+        } else {
+            return isCollectionTypeHomogenous(collection, collection.iterator().next().getClass());
+        }
+    }
+
     public static boolean isCollectionTypeHomogenous(final Collection collection, final Class expectedType) {
         for (final Object object : collection) {
             if (object == null) {
                 continue;
-            } else if (!expectedType.isInstance(object)) {
+            } else if (!expectedType.isAssignableFrom(object.getClass())) {
                 return false;
             }
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.util;
+
+import java.util.Collection;
+
+public final class TypeUtil {
+
+    public static boolean isCollectionTypeHomogenous(final Collection collection, final Class expectedType) {
+        for (final Object object : collection) {
+            if (object == null) {
+                continue;
+            } else if (!expectedType.isInstance(object)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private TypeUtil() {
+        // Not allowed for util classes.
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELDateTimeDurationTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELDateTimeDurationTest.java
@@ -106,8 +106,6 @@ public class FEELDateTimeDurationTest extends BaseFEELTest {
 //                { "date and time(\"2016-07-29T05:48:23.765-05:00\") - duration( \"P1Y1M\" ) ", OffsetDateTime.of(2015, 6, 29, 5, 48, 23, 765000000, ZoneOffset.ofHours( -5 )), null},
 //                { "date and time(\"2016-07-29T05:48:23.765-05:00\") - duration( \"P1DT1H1M\" ) ", OffsetDateTime.of(2016, 7, 28, 4, 47, 23, 765000000, ZoneOffset.ofHours( -5 )), null},
 
-                { "date and time(\"2016-07-29T05:48:23" + ZoneId.systemDefault().getRules().getStandardOffset(Instant.now()).getId() + "\") - date and time(\"2016-07-29T05:48:23\")", Duration.parse("PT1H") , null},
-                { "date and time(\"2016-07-29T05:48:23\") - date and time(\"2016-07-29T05:48:23" + ZoneId.systemDefault().getRules().getStandardOffset(Instant.now()).getId() + "\")", Duration.parse("PT-1H") , null},
                 { "duration( \"P2Y2M\" ) - duration( \"P1Y1M\" )", Period.parse("P1Y1M"), null },
                 { "duration( \"P2DT20H14M\" ) - duration( \"P1DT1H1M\" )", Duration.parse( "P1DT19H13M" ) , null},
                 { "date and time(\"2016-07-29T05:48:23Z\") - duration( \"P1Y1M\" )", ZonedDateTime.of(2015, 6, 29, 5, 48, 23, 0, ZoneId.of("Z").normalized()) , null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELExpressionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELExpressionsTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.dmn.feel.runtime;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runners.Parameterized;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
@@ -75,6 +75,19 @@ public class FEELNumberCoercionTest {
         assertThat( evaluate(" x.y ", var("x", new HashMap(){{ put("y", 1.01d); }} )), is( getBigDecimalOrNull( 1.01d ) ) );
         assertThat( evaluate("ceiling( x.y )", var("x", new HashMap(){{ put("y", 1.01d); }} )), is( getBigDecimalOrNull( 2d ) ) );
     }
-    
-    
+
+    @Test
+    public void testMethodGetBigDecimalOrNull() {
+        assertThat( getBigDecimalOrNull((short) 1), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull((byte) 1), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull(1), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull(1L), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull(1f), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull(1.1f), is(BigDecimal.valueOf(1.1)) );
+        assertThat( getBigDecimalOrNull(1d), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull(1.1d), is(BigDecimal.valueOf(1.1)) );
+        assertThat( getBigDecimalOrNull("1"), is(BigDecimal.ONE) );
+        assertThat( getBigDecimalOrNull("1.1"), is(BigDecimal.valueOf(1.1)) );
+        assertThat( getBigDecimalOrNull("1.1000000"), is(BigDecimal.valueOf(1.1).setScale(7, BigDecimal.ROUND_HALF_EVEN)) );
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELNumberCoercionTest.java
@@ -16,6 +16,7 @@
 package org.kie.dmn.feel.runtime;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.kie.dmn.feel.util.EvalHelper.getBigDecimalOrNull;
 
@@ -62,7 +63,7 @@ public class FEELNumberCoercionTest {
     }
     
     private static Map.Entry<String, Object> var(String name, Object value) {
-        return new SimpleEntry<String, Object>(name, value);
+        return new SimpleEntry<>(name, value);
     }
     
     @Test
@@ -89,5 +90,8 @@ public class FEELNumberCoercionTest {
         assertThat( getBigDecimalOrNull("1"), is(BigDecimal.ONE) );
         assertThat( getBigDecimalOrNull("1.1"), is(BigDecimal.valueOf(1.1)) );
         assertThat( getBigDecimalOrNull("1.1000000"), is(BigDecimal.valueOf(1.1).setScale(7, BigDecimal.ROUND_HALF_EVEN)) );
+        assertThat( getBigDecimalOrNull(Double.POSITIVE_INFINITY), is(nullValue()) );
+        assertThat( getBigDecimalOrNull(Double.NEGATIVE_INFINITY), is(nullValue()) );
+        assertThat( getBigDecimalOrNull(Double.NaN), is(nullValue()) );
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class AllFunctionTest {
+
+    private AllFunction allFunction;
+
+    @Before
+    public void setUp() {
+        allFunction = new AllFunction();
+    }
+
+    @Test
+    public void invokeBooleanParamNull() {
+        FunctionTestUtil.assertResultNull(allFunction.invoke((Boolean) null));
+    }
+
+    @Test
+    public void invokeBooleanParamTrue() {
+        FunctionTestUtil.assertResult(allFunction.invoke(true), true);
+    }
+
+    @Test
+    public void invokeBooleanParamFalse() {
+        FunctionTestUtil.assertResult(allFunction.invoke(false), false);
+    }
+
+    @Test
+    public void invokeArrayParamNull() {
+        FunctionTestUtil.assertResultError(allFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayParamEmptyArray() {
+        FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{}), true);
+    }
+
+    @Test
+    public void invokeArrayParamTrue() {
+        FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, Boolean.TRUE}), true);
+    }
+
+    @Test
+    public void invokeArrayParamFalse() {
+        FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, Boolean.FALSE}), false);
+        FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, null, Boolean.TRUE}), false);
+    }
+
+    @Test
+    public void invokeArrayParamTypeHeterogenousArray() {
+        FunctionTestUtil.assertResultError(allFunction.invoke(new Object[]{Boolean.TRUE, 1}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(allFunction.invoke(new Object[]{Boolean.FALSE, 1}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(allFunction.invoke(new Object[]{Boolean.TRUE, null, 1}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListParamNull() {
+        FunctionTestUtil.assertResultError(allFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListParamEmptyList() {
+        FunctionTestUtil.assertResult(allFunction.invoke(new ArrayList()), true);
+    }
+
+    @Test
+    public void invokeListParamTrue() {
+        FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.TRUE)), true);
+    }
+
+    @Test
+    public void invokeListParamFalse() {
+        FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.FALSE)), false);
+        FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, null, Boolean.TRUE)), false);
+    }
+
+    @Test
+    public void invokeListParamTypeHeterogenousArray() {
+        FunctionTestUtil.assertResultError(allFunction.invoke(Arrays.asList(Boolean.TRUE, 1)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(allFunction.invoke(Arrays.asList(Boolean.FALSE, 1)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(allFunction.invoke(Arrays.asList(Boolean.TRUE, null, 1)), InvalidParametersEvent.class);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
@@ -58,14 +58,19 @@ public class AllFunctionTest {
     }
 
     @Test
-    public void invokeArrayParamTrue() {
+    public void invokeArrayParamReturnTrue() {
         FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, Boolean.TRUE}), true);
     }
 
     @Test
-    public void invokeArrayParamFalse() {
+    public void invokeArrayParamReturnFalse() {
         FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, Boolean.FALSE}), false);
-        FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, null, Boolean.TRUE}), false);
+        FunctionTestUtil.assertResult(allFunction.invoke(new Object[]{Boolean.TRUE, null, Boolean.FALSE}), false);
+    }
+
+    @Test
+    public void invokeArrayParamReturnNull() {
+        FunctionTestUtil.assertResultNull(allFunction.invoke(new Object[]{Boolean.TRUE, null, Boolean.TRUE}));
     }
 
     @Test
@@ -86,14 +91,19 @@ public class AllFunctionTest {
     }
 
     @Test
-    public void invokeListParamTrue() {
+    public void invokeListParamReturnTrue() {
         FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.TRUE)), true);
     }
 
     @Test
-    public void invokeListParamFalse() {
+    public void invokeListParamReturnFalse() {
         FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.FALSE)), false);
-        FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, null, Boolean.TRUE)), false);
+        FunctionTestUtil.assertResult(allFunction.invoke(Arrays.asList(Boolean.TRUE, null, Boolean.FALSE)), false);
+    }
+
+    @Test
+    public void invokeListParamReturnNull() {
+        FunctionTestUtil.assertResultNull(allFunction.invoke(Arrays.asList(Boolean.TRUE, null, Boolean.TRUE)));
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,7 +83,7 @@ public class AllFunctionTest {
 
     @Test
     public void invokeListParamEmptyList() {
-        FunctionTestUtil.assertResult(allFunction.invoke(new ArrayList()), true);
+        FunctionTestUtil.assertResult(allFunction.invoke(Collections.emptyList()), true);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AllFunctionTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
@@ -58,7 +58,7 @@ public class AnyFunctionTest {
     }
 
     @Test
-    public void invokeArrayParamTrue() {
+    public void invokeArrayParamReturnTrue() {
         FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, Boolean.TRUE}), true);
         FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, Boolean.FALSE}), true);
         FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, null}), true);
@@ -66,9 +66,13 @@ public class AnyFunctionTest {
     }
 
     @Test
-    public void invokeArrayParamFalse() {
+    public void invokeArrayParamReturnFalse() {
         FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.FALSE, Boolean.FALSE}), false);
-        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.FALSE, null, Boolean.FALSE}), false);
+    }
+
+    @Test
+    public void invokeArrayParamReturnNull() {
+        FunctionTestUtil.assertResultNull(anyFunction.invoke(new Object[]{Boolean.FALSE, null, Boolean.FALSE}));
     }
 
     @Test
@@ -89,7 +93,7 @@ public class AnyFunctionTest {
     }
 
     @Test
-    public void invokeListParamTrue() {
+    public void invokeListParamReturnTrue() {
         FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.TRUE)), true);
         FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.FALSE)), true);
         FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, null)), true);
@@ -97,9 +101,13 @@ public class AnyFunctionTest {
     }
 
     @Test
-    public void invokeListParamFalse() {
+    public void invokeListParamReturnFalse() {
         FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.FALSE, Boolean.FALSE)), false);
-        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.FALSE, null, Boolean.FALSE)), false);
+    }
+
+    @Test
+    public void invokeListParamReturnNull() {
+        FunctionTestUtil.assertResultNull(anyFunction.invoke(Arrays.asList(Boolean.FALSE, null, Boolean.FALSE)));
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,7 +86,7 @@ public class AnyFunctionTest {
 
     @Test
     public void invokeListParamEmptyList() {
-        FunctionTestUtil.assertResult(anyFunction.invoke(new ArrayList()), false);
+        FunctionTestUtil.assertResult(anyFunction.invoke(Collections.emptyList()), false);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class AnyFunctionTest {
+
+    private AnyFunction anyFunction;
+
+    @Before
+    public void setUp() {
+        anyFunction = new AnyFunction();
+    }
+
+    @Test
+    public void invokeBooleanParamNull() {
+        FunctionTestUtil.assertResultNull(anyFunction.invoke((Boolean) null));
+    }
+
+    @Test
+    public void invokeBooleanParamTrue() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(true), true);
+    }
+
+    @Test
+    public void invokeBooleanParamFalse() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(false), false);
+    }
+
+    @Test
+    public void invokeArrayParamNull() {
+        FunctionTestUtil.assertResultError(anyFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayParamEmptyArray() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{}), false);
+    }
+
+    @Test
+    public void invokeArrayParamTrue() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, Boolean.TRUE}), true);
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, Boolean.FALSE}), true);
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, null}), true);
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.TRUE, null, Boolean.FALSE}), true);
+    }
+
+    @Test
+    public void invokeArrayParamFalse() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.FALSE, Boolean.FALSE}), false);
+        FunctionTestUtil.assertResult(anyFunction.invoke(new Object[]{Boolean.FALSE, null, Boolean.FALSE}), false);
+    }
+
+    @Test
+    public void invokeArrayParamTypeHeterogenousArray() {
+        FunctionTestUtil.assertResultError(anyFunction.invoke(new Object[]{Boolean.FALSE, 1}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(anyFunction.invoke(new Object[]{Boolean.TRUE, 1}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(anyFunction.invoke(new Object[]{Boolean.TRUE, null, 1}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListParamNull() {
+        FunctionTestUtil.assertResultError(anyFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListParamEmptyList() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(new ArrayList()), false);
+    }
+
+    @Test
+    public void invokeListParamTrue() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.TRUE)), true);
+        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, Boolean.FALSE)), true);
+        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, null)), true);
+        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.TRUE, null, Boolean.FALSE)), true);
+    }
+
+    @Test
+    public void invokeListParamFalse() {
+        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.FALSE, Boolean.FALSE)), false);
+        FunctionTestUtil.assertResult(anyFunction.invoke(Arrays.asList(Boolean.FALSE, null, Boolean.FALSE)), false);
+    }
+
+    @Test
+    public void invokeListParamTypeHeterogenousArray() {
+        FunctionTestUtil.assertResultError(anyFunction.invoke(Arrays.asList(Boolean.FALSE, 1)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(anyFunction.invoke(Arrays.asList(Boolean.TRUE, 1)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(anyFunction.invoke(Arrays.asList(Boolean.TRUE, null, 1)), InvalidParametersEvent.class);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AnyFunctionTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,12 +37,12 @@ public class AppendFunctionTest {
     public void invokeInvalidParams() {
         FunctionTestUtil.assertResultError(appendFunction.invoke((List) null, null), InvalidParametersEvent.class);
         FunctionTestUtil.assertResultError(appendFunction.invoke((List) null, new Object[]{}), InvalidParametersEvent.class);
-        FunctionTestUtil.assertResultError(appendFunction.invoke(new ArrayList(), null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(appendFunction.invoke(Collections.emptyList(), null), InvalidParametersEvent.class);
     }
 
     @Test
     public void invokeEmptyParams() {
-        FunctionTestUtil.assertResultList(appendFunction.invoke(new ArrayList(), new Object[]{}), new ArrayList<>());
+        FunctionTestUtil.assertResultList(appendFunction.invoke(Collections.emptyList(), new Object[]{}), Collections.emptyList());
     }
 
     @Test
@@ -52,7 +53,7 @@ public class AppendFunctionTest {
 
     @Test
     public void invokeAppendSomething() {
-        FunctionTestUtil.assertResultList(appendFunction.invoke(new ArrayList(), new Object[]{"test"}), Arrays.asList("test"));
+        FunctionTestUtil.assertResultList(appendFunction.invoke(Collections.emptyList(), new Object[]{"test"}), Arrays.asList("test"));
         FunctionTestUtil.assertResultList(appendFunction.invoke(Arrays.asList("test"), new Object[]{"test2"}), Arrays.asList("test", "test2"));
         FunctionTestUtil.assertResultList(appendFunction.invoke(Arrays.asList("test"), new Object[]{"test2", "test3"}), Arrays.asList("test", "test2", "test3"));
     }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/AppendFunctionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class AppendFunctionTest {
+
+    private AppendFunction appendFunction;
+
+    @Before
+    public void setUp() {
+        appendFunction = new AppendFunction();
+    }
+
+    @Test
+    public void invokeInvalidParams() {
+        FunctionTestUtil.assertResultError(appendFunction.invoke((List) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(appendFunction.invoke((List) null, new Object[]{}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(appendFunction.invoke(new ArrayList(), null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyParams() {
+        FunctionTestUtil.assertResultList(appendFunction.invoke(new ArrayList(), new Object[]{}), new ArrayList<>());
+    }
+
+    @Test
+    public void invokeAppendNothing() {
+        FunctionTestUtil.assertResultList(appendFunction.invoke(Arrays.asList("test"), new Object[]{}), Arrays.asList("test"));
+        FunctionTestUtil.assertResultList(appendFunction.invoke(Arrays.asList("test", "test2"), new Object[]{}), Arrays.asList("test", "test2"));
+    }
+
+    @Test
+    public void invokeAppendSomething() {
+        FunctionTestUtil.assertResultList(appendFunction.invoke(new ArrayList(), new Object[]{"test"}), Arrays.asList("test"));
+        FunctionTestUtil.assertResultList(appendFunction.invoke(Arrays.asList("test"), new Object[]{"test2"}), Arrays.asList("test", "test2"));
+        FunctionTestUtil.assertResultList(appendFunction.invoke(Arrays.asList("test"), new Object[]{"test2", "test3"}), Arrays.asList("test", "test2", "test3"));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CeilingFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CeilingFunctionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class CeilingFunctionTest {
+
+    private CeilingFunction ceilingFunction;
+
+    @Before
+    public void setUp() {
+        ceilingFunction = new CeilingFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(ceilingFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeZero() {
+        final BigDecimal value = BigDecimal.ZERO;
+        FunctionTestUtil.assertResultBigDecimal(ceilingFunction.invoke(value), BigDecimal.ZERO);
+    }
+
+    @Test
+    public void invokePositive() {
+        final BigDecimal value = BigDecimal.valueOf(10.2);
+        FunctionTestUtil.assertResultBigDecimal(ceilingFunction.invoke(value), BigDecimal.valueOf(11));
+    }
+
+    @Test
+    public void invokeNegative() {
+        final BigDecimal value = BigDecimal.valueOf(-10.2);
+        FunctionTestUtil.assertResultBigDecimal(ceilingFunction.invoke(value), BigDecimal.valueOf(-10));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CodeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CodeFunctionTest.java
@@ -26,6 +26,7 @@ import java.time.OffsetTime;
 import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -159,7 +160,7 @@ public class CodeFunctionTest {
 
     @Test
     public void invokeListEmpty() {
-        FunctionTestUtil.assertResult(codeFunction.invoke(new ArrayList<>()), "[ ]");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Collections.emptyList()), "[ ]");
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CodeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CodeFunctionTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.runtime.impl.RangeImpl;
+
+public class CodeFunctionTest {
+
+    private CodeFunction codeFunction;
+
+    @Before
+    public void setUp() throws Exception {
+        codeFunction = new CodeFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(null), "null");
+    }
+
+    @Test
+    public void invokeString() {
+        FunctionTestUtil.assertResult(codeFunction.invoke("test"), "\"test\"");
+    }
+
+    @Test
+    public void invokeBigDecimal() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(BigDecimal.valueOf(10.7)), "10.7");
+    }
+
+    @Test
+    public void invokeLocalDate() {
+        final LocalDate localDate = LocalDate.now();
+        FunctionTestUtil.assertResult(codeFunction.invoke(localDate), "date( \"" + localDate.toString() + "\" )");
+    }
+
+    @Test
+    public void invokeLocalTime() {
+        final LocalTime localTime = LocalTime.now();
+        FunctionTestUtil.assertResult(codeFunction.invoke(localTime), "time( \"" + localTime.toString() + "\" )");
+    }
+
+    @Test
+    public void invokeOffsetTime() {
+        final OffsetTime offsetTime = OffsetTime.now();
+        FunctionTestUtil.assertResult(codeFunction.invoke(offsetTime), "time( \"" + offsetTime.toString() + "\" )");
+    }
+
+    @Test
+    public void invokeLocalDateTime() {
+        final LocalDateTime localDateTime = LocalDateTime.now();
+        FunctionTestUtil.assertResult(codeFunction.invoke(localDateTime), "date and time( \"" + localDateTime.toString() + "\" )");
+    }
+
+    @Test
+    public void invokeOffsetDateTime() {
+        final OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        FunctionTestUtil.assertResult(codeFunction.invoke(offsetDateTime), "date and time( \"" + offsetDateTime.toString() + "\" )");
+    }
+
+    @Test
+    public void invokeZonedDateTime() {
+        final ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        FunctionTestUtil.assertResult(codeFunction.invoke(zonedDateTime), "date and time( \"" + zonedDateTime.toString() + "\" )");
+    }
+
+    @Test
+    public void invokeDurationZero() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ZERO), "duration( \"PT0S\" )");
+    }
+
+    @Test
+    public void invokeDurationDays() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofDays(9)), "duration( \"P9D\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofDays(-9)), "duration( \"-P9D\" )");
+    }
+
+    @Test
+    public void invokeDurationHours() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofHours(9)), "duration( \"PT9H\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofHours(200)), "duration( \"P8DT8H\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofHours(-200)), "duration( \"-P8DT8H\" )");
+    }
+
+    @Test
+    public void invokeDurationMinutes() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMinutes(9)), "duration( \"PT9M\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMinutes(200)), "duration( \"PT3H20M\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMinutes(5000)), "duration( \"P3DT11H20M\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMinutes(-5000)), "duration( \"-P3DT11H20M\" )");
+    }
+
+    @Test
+    public void invokeDurationSeconds() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofSeconds(9)), "duration( \"PT9S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofSeconds(200)), "duration( \"PT3M20S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofSeconds(5000)), "duration( \"PT1H23M20S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofSeconds(90061)), "duration( \"P1DT1H1M1S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofSeconds(-90061)), "duration( \"-P1DT1H1M1S\" )");
+    }
+
+    @Test
+    public void invokeDurationNanosMillis() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofNanos(25)), "duration( \"PT0.000000025S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofNanos(10000)), "duration( \"PT0.00001S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofNanos(10025)), "duration( \"PT0.000010025S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMillis(1500)), "duration( \"PT1.5S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMillis(90061025)), "duration( \"P1DT1H1M1.025S\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Duration.ofMillis(-90061025)), "duration( \"-P1DT1H1M1.025S\" )");
+    }
+
+    @Test
+    public void invokePeriodZero() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Period.ZERO), "duration( \"P0M\" )");
+    }
+
+    @Test
+    public void invokePeriodYears() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Period.ofYears(24)), "duration( \"P24Y\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Period.ofYears(-24)), "duration( \"-P24Y\" )");
+    }
+
+    @Test
+    public void invokePeriodMonths() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(Period.ofMonths(2)), "duration( \"P2M\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Period.ofMonths(27)), "duration( \"P2Y3M\" )");
+        FunctionTestUtil.assertResult(codeFunction.invoke(Period.ofMonths(-27)), "duration( \"-P2Y3M\" )");
+    }
+
+    @Test
+    public void invokeListEmpty() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(new ArrayList<>()), "[ ]");
+    }
+
+    @Test
+    public void invokeListNonEmpty() {
+        final List<Object> values = new ArrayList<>();
+        values.add(1);
+        values.add(BigDecimal.valueOf(10.5));
+        values.add("test");
+        FunctionTestUtil.assertResult(codeFunction.invoke(values), "[ 1, 10.5, \"test\" ]");
+    }
+
+    @Test
+    public void invokeRangeOpenOpen() {
+        FunctionTestUtil.assertResult(
+                codeFunction.invoke(new RangeImpl(Range.RangeBoundary.OPEN, 12, 15, Range.RangeBoundary.OPEN)),
+                "( 12 .. 15 )");
+    }
+
+    @Test
+    public void invokeRangeOpenClosed() {
+        FunctionTestUtil.assertResult(
+                codeFunction.invoke(new RangeImpl(Range.RangeBoundary.OPEN, 12, 15, Range.RangeBoundary.CLOSED)),
+                "( 12 .. 15 ]");
+    }
+
+    @Test
+    public void invokeRangeClosedOpen() {
+        FunctionTestUtil.assertResult(
+                codeFunction.invoke(new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.OPEN)),
+                "[ 12 .. 15 )");
+    }
+
+    @Test
+    public void invokeRangeClosedClosed() {
+        FunctionTestUtil.assertResult(
+                codeFunction.invoke(new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED)),
+                "[ 12 .. 15 ]");
+    }
+
+    @Test
+    public void invokeContextEmpty() {
+        FunctionTestUtil.assertResult(codeFunction.invoke(new HashMap<>()), "{ }");
+    }
+
+    @Test
+    public void invokeContextNonEmpty() {
+        final Map<String, Object> childContextMap = new HashMap<>();
+        childContextMap.put("childKey1", "childValue1");
+
+        final Map<String, Object> contextMap = new HashMap<>();
+        contextMap.put("key1", "value1");
+        contextMap.put("key2", childContextMap);
+
+        FunctionTestUtil.assertResult(codeFunction.invoke(contextMap), "{ key1 : \"value1\", key2 : { childKey1 : \"childValue1\" } }");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunctionTest.java
@@ -19,6 +19,7 @@ package org.kie.dmn.feel.runtime.functions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
@@ -39,7 +40,7 @@ public class ConcatenateFunctionTest {
 
     @Test
     public void invokeEmptyArray() {
-        FunctionTestUtil.assertResultList(concatenateFunction.invoke(new Object[]{}), new ArrayList<>());
+        FunctionTestUtil.assertResultList(concatenateFunction.invoke(new Object[]{}), Collections.emptyList());
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunctionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class ConcatenateFunctionTest {
+
+    private ConcatenateFunction concatenateFunction;
+
+    @Before
+    public void setUp() {
+        concatenateFunction = new ConcatenateFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(concatenateFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyArray() {
+        FunctionTestUtil.assertResultList(concatenateFunction.invoke(new Object[]{}), new ArrayList<>());
+    }
+
+    @Test
+    public void invokeArrayWithNull() {
+        FunctionTestUtil.assertResultError(concatenateFunction.invoke(new Object[]{null}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(concatenateFunction.invoke(new Object[]{1, null}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayWithList() {
+        FunctionTestUtil.assertResultList(concatenateFunction.invoke(new Object[]{"test", 2, Arrays.asList(2, 3)}), Arrays.asList("test", 2, 2, 3));
+    }
+
+    @Test
+    public void invokeArrayWithoutList() {
+        FunctionTestUtil.assertResultList(concatenateFunction.invoke(new Object[]{"test", 2, BigDecimal.valueOf(25.3)}), Arrays.asList("test", 2, BigDecimal.valueOf(25.3)));
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ContainsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ContainsFunctionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class ContainsFunctionTest {
+
+    private ContainsFunction containsFunction;
+
+    @Before
+    public void setUp() throws Exception {
+        containsFunction = new ContainsFunction();
+    }
+
+    @Test
+    public void invokeParamsNull() {
+        FunctionTestUtil.assertResultError(containsFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(containsFunction.invoke(null, "test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(containsFunction.invoke("test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeContains() {
+        FunctionTestUtil.assertResult(containsFunction.invoke("test", "es"), true);
+        FunctionTestUtil.assertResult(containsFunction.invoke("test", "t"), true);
+        FunctionTestUtil.assertResult(containsFunction.invoke("testy", "y"), true);
+    }
+
+    @Test
+    public void invokeNotContains() {
+        FunctionTestUtil.assertResult(containsFunction.invoke("test", "ex"), false);
+        FunctionTestUtil.assertResult(containsFunction.invoke("test", "u"), false);
+        FunctionTestUtil.assertResult(containsFunction.invoke("test", "esty"), false);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CountFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CountFunctionTest.java
@@ -19,6 +19,7 @@ package org.kie.dmn.feel.runtime.functions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class CountFunctionTest {
 
     @Test
     public void invokeParamListEmpty() {
-        FunctionTestUtil.assertResult(countFunction.invoke(new ArrayList<>()), BigDecimal.ZERO);
+        FunctionTestUtil.assertResult(countFunction.invoke(Collections.emptyList()), BigDecimal.ZERO);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CountFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/CountFunctionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class CountFunctionTest {
+
+    private CountFunction countFunction;
+
+    @Before
+    public void setUp() {
+        countFunction = new CountFunction();
+    }
+
+    @Test
+    public void invokeParamListNull() {
+        FunctionTestUtil.assertResultError(countFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamListEmpty() {
+        FunctionTestUtil.assertResult(countFunction.invoke(new ArrayList<>()), BigDecimal.ZERO);
+    }
+
+    @Test
+    public void invokeParamListNonEmpty() {
+        FunctionTestUtil.assertResult(countFunction.invoke(Arrays.asList(1, 2, "test")), BigDecimal.valueOf(3));
+    }
+
+    @Test
+    public void invokeParamArrayNull() {
+        FunctionTestUtil.assertResultError(countFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamArrayEmpty() {
+        FunctionTestUtil.assertResult(countFunction.invoke(new Object[]{}), BigDecimal.ZERO);
+    }
+
+    @Test
+    public void invokeParamArrayNonEmpty() {
+        FunctionTestUtil.assertResult(countFunction.invoke(new Object[]{1, 2, "test"}), BigDecimal.valueOf(3));
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateFunctionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAccessor;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DateFunctionTest {
+
+    private DateFunction dateFunction;
+
+    @Before
+    public void setUp() {
+        dateFunction = new DateFunction();
+    }
+
+    @Test
+    public void invokeParamStringNull() {
+        FunctionTestUtil.assertResultError(dateFunction.invoke((String) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamStringNotDateOrTime() {
+        FunctionTestUtil.assertResultError(dateFunction.invoke("test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke("2017-09-test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke("2017-09-89"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamStringDate() {
+        FunctionTestUtil.assertResult(dateFunction.invoke("2017-09-07"), LocalDate.of(2017, 9, 7));
+    }
+
+    @Test
+    public void invokeParamStringDateTime() {
+        FunctionTestUtil.assertResult(dateFunction.invoke("2017-09-07T10:20:30"), LocalDate.of(2017, 9, 7));
+    }
+
+    @Test
+    public void invokeParamYearMonthDayNulls() {
+        FunctionTestUtil.assertResultError(dateFunction.invoke(null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(10, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(null, 10, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(null, null, 10), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(10, 10, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(10, null, 10), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(null, 10, 10), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamYearMonthDayInvalidDate() {
+        FunctionTestUtil.assertResultError(dateFunction.invoke(2017, 6, 59), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(2017, 59, 12), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateFunction.invoke(Integer.MAX_VALUE, 6, 12), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamYearMonthDay() {
+        FunctionTestUtil.assertResult(dateFunction.invoke(2017, 6, 12), LocalDate.of(2017, 6, 12));
+    }
+
+    @Test
+    public void invokeParamTemporalNull() {
+        FunctionTestUtil.assertResultError(dateFunction.invoke((TemporalAccessor) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamTemporalWrongTemporal() {
+        FunctionTestUtil.assertResultError(dateFunction.invoke(DayOfWeek.MONDAY), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamTemporal() {
+        FunctionTestUtil.assertResult(dateFunction.invoke(LocalDate.of(2017, 6, 12)), LocalDate.of(2017, 6, 12));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateTimeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateTimeFunctionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DateTimeFunctionTest {
+
+    private DateTimeFunction dateTimeFunction;
+
+    @Before
+    public void setUp() {
+        dateTimeFunction = new DateTimeFunction();
+    }
+
+    @Test
+    public void invokeParamStringNull() {
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamStringNotDateOrTime() {
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke("test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke("2017-09-test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke("2017-09-T89"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamStringDateTime() {
+        FunctionTestUtil.assertResult(dateTimeFunction.invoke("2017-09-07T10:20:30"), LocalDateTime.of(2017, 9, 7, 10, 20, 30));
+    }
+
+    @Test
+    public void invokeParamStringDate() {
+        FunctionTestUtil.assertResult(dateTimeFunction.invoke("2017-09-07"), LocalDateTime.of(2017, 9, 7, 0, 0, 0));
+    }
+
+    @Test
+    public void invokeParamTemporalNulls() {
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke((Temporal) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke(null, LocalTime.of(10, 6, 20)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(dateTimeFunction.invoke(LocalDate.of(2017, 6, 12), null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamTemporalWrongTemporal() {
+        FunctionTestUtil.assertResultError(
+                dateTimeFunction.invoke(
+                        LocalDateTime.of(2017, 6, 12, 0, 0),
+                        LocalTime.of(10, 6, 20)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(
+                dateTimeFunction.invoke(
+                        LocalDate.of(2017, 6, 12),
+                        LocalDateTime.of(2017, 6, 12, 0, 0)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(
+                dateTimeFunction.invoke(
+                        LocalDateTime.of(2017, 6, 12, 0, 0),
+                        LocalDateTime.of(2017, 6, 12, 0, 0)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamTemporalLocalTime() {
+        FunctionTestUtil.assertResult(
+                dateTimeFunction.invoke(
+                        LocalDate.of(2017, 6, 12),
+                        LocalTime.of(10, 6, 20)),
+                LocalDateTime.of(2017, 6, 12, 10, 6, 20));
+    }
+
+    @Test
+    public void invokeParamTemporalOffsetTime() {
+        FunctionTestUtil.assertResult(
+                dateTimeFunction.invoke(
+                        LocalDate.of(2017, 6, 12),
+                        OffsetTime.of(10, 6, 20, 0, ZoneOffset.UTC)),
+                ZonedDateTime.of(2017, 6, 12, 10, 6, 20, 0, ZoneOffset.UTC));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DecimalFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DecimalFunctionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DecimalFunctionTest {
+
+    private DecimalFunction decimalFunction;
+
+    @Before
+    public void setUp() {
+        decimalFunction = new DecimalFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(decimalFunction.invoke((BigDecimal) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(decimalFunction.invoke(BigDecimal.ONE, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(decimalFunction.invoke(null, BigDecimal.ONE), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeRoundingUp() {
+        FunctionTestUtil.assertResult(decimalFunction.invoke(BigDecimal.valueOf(10.27), BigDecimal.ONE), BigDecimal.valueOf(10.3));
+    }
+
+    @Test
+    public void invokeRoundingDown() {
+        FunctionTestUtil.assertResult(decimalFunction.invoke(BigDecimal.valueOf(10.24), BigDecimal.ONE), BigDecimal.valueOf(10.2));
+    }
+
+    @Test
+    public void invokeRoundingEven() {
+        FunctionTestUtil.assertResult(decimalFunction.invoke(BigDecimal.valueOf(10.25), BigDecimal.ONE), BigDecimal.valueOf(10.2));
+    }
+
+    @Test
+    public void invokeRoundingOdd() {
+        FunctionTestUtil.assertResult(decimalFunction.invoke(BigDecimal.valueOf(10.35), BigDecimal.ONE), BigDecimal.valueOf(10.4));
+    }
+
+    @Test
+    public void invokeLargerScale() {
+        FunctionTestUtil.assertResult(decimalFunction.invoke(BigDecimal.valueOf(10.123456789), BigDecimal.valueOf(6)), BigDecimal.valueOf(10.123457));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunctionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DistinctValuesFunctionTest {
+
+    private DistinctValuesFunction distinctValuesFunction;
+
+    @Before
+    public void setUp() {
+        distinctValuesFunction = new DistinctValuesFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(distinctValuesFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamNotCollection() {
+        FunctionTestUtil.assertResultList(
+                distinctValuesFunction.invoke(BigDecimal.valueOf(10.1)),
+                Collections.singletonList(BigDecimal.valueOf(10.1)));
+    }
+
+    @Test
+    public void invokeParamArray() {
+        FunctionTestUtil.assertResultList(
+                distinctValuesFunction.invoke(new Object[]{BigDecimal.valueOf(10.1)}),
+                Collections.singletonList(new Object[]{BigDecimal.valueOf(10.1)}));
+    }
+
+    @Test
+    public void invokeEmptyList() {
+        FunctionTestUtil.assertResultList(distinctValuesFunction.invoke(Collections.emptyList()), Collections.emptyList());
+    }
+
+    @Test
+    public void invokeList() {
+        final List testValues = Arrays.asList(1, BigDecimal.valueOf(10.1), "test", 1, "test", BigDecimal.valueOf(10.1));
+        FunctionTestUtil.assertResultList(
+                distinctValuesFunction.invoke(testValues),
+                Arrays.asList(1, BigDecimal.valueOf(10.1), "test"));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DurationFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DurationFunctionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DurationFunctionTest {
+
+    private DurationFunction durationFunction;
+
+    @Before
+    public void setUp() {
+        durationFunction = new DurationFunction();
+    }
+
+    @Test
+    public void invokeParamStringNull() {
+        FunctionTestUtil.assertResultError(durationFunction.invoke((String) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamStringInvalid() {
+        FunctionTestUtil.assertResultError(durationFunction.invoke("test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("test HHH"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("testP2Y3D"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("test P2Y3D"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("P2Y3DD"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("P3DD"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("PT3HH"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(durationFunction.invoke("P2Y3M4DT3H"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamStringDuration() {
+        FunctionTestUtil.assertResult(durationFunction.invoke("P2D"), Duration.of(2, ChronoUnit.DAYS));
+        FunctionTestUtil.assertResult(durationFunction.invoke("P2DT3H"), Duration.of(2, ChronoUnit.DAYS).plusHours(3));
+        FunctionTestUtil.assertResult(
+                durationFunction.invoke("P2DT3H28M"),
+                Duration.of(2, ChronoUnit.DAYS).plusHours(3).plusMinutes(28));
+        FunctionTestUtil.assertResult(
+                durationFunction.invoke("P2DT3H28M15S"),
+                Duration.of(2, ChronoUnit.DAYS).plusHours(3).plusMinutes(28).plusSeconds(15));
+    }
+
+    @Test
+    public void invokeParamStringPeriod() {
+        FunctionTestUtil.assertResult(durationFunction.invoke("P2Y3M"), Period.of(2, 3, 0));
+        FunctionTestUtil.assertResult(durationFunction.invoke("P2Y3M4D"), Period.of(2, 3, 4));
+    }
+
+    @Test
+    public void invokeParamTemporalAmountNull() {
+        FunctionTestUtil.assertResultError(durationFunction.invoke((TemporalAmount) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamTemporalDuration() {
+        FunctionTestUtil.assertResult(
+                durationFunction.invoke(Duration.parse("P2DT3H28M15S")),
+                Duration.of(2, ChronoUnit.DAYS).plusHours(3).plusMinutes(28).plusSeconds(15));
+    }
+
+    @Test
+    public void invokeParamTemporalPeriod() {
+        FunctionTestUtil.assertResult(durationFunction.invoke(Period.parse("P2Y3M4D")), Period.of(2, 3, 4));
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/EndsWithFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/EndsWithFunctionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class EndsWithFunctionTest {
+
+    private EndsWithFunction endsWithFunction;
+
+    @Before
+    public void setUp() {
+        endsWithFunction = new EndsWithFunction();
+    }
+
+    @Test
+    public void invokeParamsNull() {
+        FunctionTestUtil.assertResultError(endsWithFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(endsWithFunction.invoke(null, "test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(endsWithFunction.invoke("test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEndsWith() {
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "t"), true);
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "st"), true);
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "est"), true);
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "test"), true);
+    }
+
+    @Test
+    public void invokeNotEndsWith() {
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "es"), false);
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "ttttt"), false);
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "estt"), false);
+        FunctionTestUtil.assertResult(endsWithFunction.invoke("test", "tt"), false);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FlattenFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FlattenFunctionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class FlattenFunctionTest {
+
+    private FlattenFunction flattenFunction;
+
+    @Before
+    public void setUp() {
+        flattenFunction = new FlattenFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(flattenFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeParamNotCollection() {
+        FunctionTestUtil.assertResult(flattenFunction.invoke(BigDecimal.valueOf(10.2)), Collections.singletonList(BigDecimal.valueOf(10.2)));
+        FunctionTestUtil.assertResult(flattenFunction.invoke("test"), Collections.singletonList("test"));
+    }
+
+    @Test
+    public void invokeParamCollection() {
+        FunctionTestUtil.assertResult(flattenFunction.invoke(Arrays.asList("test", 1, 2)), Arrays.asList("test", 1, 2));
+        FunctionTestUtil.assertResult(flattenFunction.invoke(Arrays.asList("test", 1, 2, Arrays.asList(3, 4))), Arrays.asList("test", 1, 2, 3, 4));
+        FunctionTestUtil.assertResult(flattenFunction.invoke(Arrays.asList("test", 1, 2, Arrays.asList(1, 2))), Arrays.asList("test", 1, 2, 1, 2));
+        FunctionTestUtil.assertResult(
+                flattenFunction.invoke(
+                        Arrays.asList("test", 1, Arrays.asList(BigDecimal.ZERO, 3), 2, Arrays.asList(1, 2))),
+                        Arrays.asList("test", 1, BigDecimal.ZERO, 3, 2, 1, 2));
+
+        FunctionTestUtil.assertResult(
+                flattenFunction.invoke(
+                        Arrays.asList("test", 1, Arrays.asList(Arrays.asList(10, 15), BigDecimal.ZERO, 3), 2, Arrays.asList(1, 2))),
+                Arrays.asList("test", 1, 10, 15, BigDecimal.ZERO, 3, 2, 1, 2));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FloorFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FloorFunctionTest.java
@@ -21,32 +21,33 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
 
-public class CeilingFunctionTest {
+public class FloorFunctionTest {
 
-    private CeilingFunction ceilingFunction;
+    private FloorFunction floorFunction;
 
     @Before
     public void setUp() {
-        ceilingFunction = new CeilingFunction();
+        floorFunction = new FloorFunction();
     }
 
     @Test
     public void invokeNull() {
-        FunctionTestUtil.assertResultError(ceilingFunction.invoke(null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(floorFunction.invoke(null), InvalidParametersEvent.class);
     }
 
     @Test
     public void invokeZero() {
-        FunctionTestUtil.assertResultBigDecimal(ceilingFunction.invoke(BigDecimal.ZERO), BigDecimal.ZERO);
+        FunctionTestUtil.assertResultBigDecimal(floorFunction.invoke(BigDecimal.ZERO), BigDecimal.ZERO);
     }
 
     @Test
     public void invokePositive() {
-        FunctionTestUtil.assertResultBigDecimal(ceilingFunction.invoke(BigDecimal.valueOf(10.2)), BigDecimal.valueOf(11));
+        FunctionTestUtil.assertResultBigDecimal(floorFunction.invoke(BigDecimal.valueOf(10.2)), BigDecimal.valueOf(10));
     }
 
     @Test
     public void invokeNegative() {
-        FunctionTestUtil.assertResultBigDecimal(ceilingFunction.invoke(BigDecimal.valueOf(-10.2)), BigDecimal.valueOf(-10));
+        FunctionTestUtil.assertResultBigDecimal(floorFunction.invoke(BigDecimal.valueOf(-10.2)), BigDecimal.valueOf(-11));
     }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -25,10 +25,14 @@ import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 public final class FunctionTestUtil {
 
     public static <T> void assertResult(final FEELFnResult<T> result, final T expectedResult) {
-        assertResultNotError(result);
-        final T resultValue = result.cata(left -> null, right -> right);
-        Assert.assertThat(resultValue, Matchers.notNullValue());
-        Assert.assertThat(resultValue, Matchers.equalTo(expectedResult));
+        if (expectedResult == null) {
+            assertResultNull(result);
+        } else {
+            assertResultNotError(result);
+            final T resultValue = result.cata(left -> null, right -> right);
+            Assert.assertThat(resultValue, Matchers.notNullValue());
+            Assert.assertThat(resultValue, Matchers.equalTo(expectedResult));
+        }
     }
 
     public static void assertResultBigDecimal(final FEELFnResult<BigDecimal> result, final BigDecimal expectedResult) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+
+public final class FunctionTestUtil {
+
+    public static <T> void assertResult(final FEELFnResult<T> result, final T expectedResult) {
+        assertResultNotError(result);
+        final T resultValue = result.cata(left -> null, right -> right);
+        Assert.assertThat(resultValue, Matchers.notNullValue());
+        Assert.assertThat(resultValue, Matchers.equalTo(expectedResult));
+    }
+
+    public static void assertResultBigDecimal(final FEELFnResult<BigDecimal> result, final BigDecimal expectedResult) {
+        assertResultNotError(result);
+        final BigDecimal resultValue = result.cata(left -> null, right -> right);
+        Assert.assertThat(resultValue, Matchers.notNullValue());
+        Assert.assertThat(resultValue, Matchers.comparesEqualTo(expectedResult));
+    }
+
+    public static void assertResultList(final FEELFnResult<List> result, final List<Object> expectedResult) {
+        assertResultNotError(result);
+        final List<Object> resultList = result.cata(left -> null, right -> right);
+        Assert.assertThat(resultList, Matchers.hasSize(expectedResult.size()));
+        if (expectedResult.isEmpty()) {
+            Assert.assertThat(resultList, Matchers.empty());
+        } else {
+            Assert.assertThat(resultList, Matchers.contains(expectedResult.toArray(new Object[]{})));
+        }
+    }
+
+    public static <T> void assertResultNull(final FEELFnResult<T> result) {
+        assertResultNotError(result);
+        Assert.assertThat(result.cata(left -> false, right -> right), Matchers.nullValue());
+    }
+
+    public static <T> void assertResultNotError(final FEELFnResult<T> result) {
+        Assert.assertThat(result, Matchers.notNullValue());
+        Assert.assertThat(result.isRight(), Matchers.is(true));
+    }
+
+    public static <T> void assertResultError(final FEELFnResult<T> result, final Class expectedErrorEventClass) {
+        Assert.assertThat(result, Matchers.notNullValue());
+        Assert.assertThat(result.isLeft(), Matchers.is(true));
+        final FEELEvent resultEvent = result.cata(left -> left, right -> null);
+        checkErrorEvent(resultEvent, expectedErrorEventClass);
+    }
+
+    public static void checkErrorEvent(final FEELEvent errorEvent, final Class errorEventClass) {
+        Assert.assertThat(errorEvent, Matchers.notNullValue());
+        Assert.assertThat(errorEvent.getSeverity(), Matchers.is(FEELEvent.Severity.ERROR));
+        Assert.assertThat(errorEvent, Matchers.instanceOf(errorEventClass));
+    }
+
+    private FunctionTestUtil() {
+        // Not allowed for util classes.
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/IndexOfFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/IndexOfFunctionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class IndexOfFunctionTest {
+
+    private IndexOfFunction indexOfFunction;
+
+    @Before
+    public void setUp() {
+        indexOfFunction = new IndexOfFunction();
+    }
+
+    @Test
+    public void invokeListNull() {
+        FunctionTestUtil.assertResultError(indexOfFunction.invoke((List) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(indexOfFunction.invoke(null, new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeMatchNull() {
+        FunctionTestUtil.assertResultList(indexOfFunction.invoke(Collections.emptyList(), null), Collections.emptyList());
+        FunctionTestUtil.assertResultList(indexOfFunction.invoke(Collections.singletonList("test"), null), Collections.emptyList());
+        FunctionTestUtil.assertResultList(
+                indexOfFunction.invoke(Arrays.asList("test", null), null),
+                Collections.singletonList(BigDecimal.valueOf(2)));
+        FunctionTestUtil.assertResultList(
+                indexOfFunction.invoke(Arrays.asList(null, "test"), null),
+                Collections.singletonList(BigDecimal.ONE));
+        FunctionTestUtil.assertResultList(
+                indexOfFunction.invoke(Arrays.asList("test", null, BigDecimal.ZERO), null),
+                Collections.singletonList(BigDecimal.valueOf(2)));
+        FunctionTestUtil.assertResultList(
+                indexOfFunction.invoke(Arrays.asList("test", null, null, BigDecimal.ZERO), null),
+                Arrays.asList(BigDecimal.valueOf(2), BigDecimal.valueOf(3)));
+    }
+
+    @Test
+    public void invokeBigDecimal() {
+        FunctionTestUtil.assertResult(indexOfFunction.invoke(Arrays.asList("test", null, 12), BigDecimal.valueOf(12)), Collections.emptyList());
+        FunctionTestUtil.assertResult(
+                indexOfFunction.invoke(Arrays.asList("test", null, BigDecimal.valueOf(12)), BigDecimal.valueOf(12)),
+                Collections.singletonList(BigDecimal.valueOf(3)));
+        FunctionTestUtil.assertResult(
+                indexOfFunction.invoke(
+                        Arrays.asList("test", null, BigDecimal.valueOf(12)),
+                        BigDecimal.valueOf(12).setScale(4, BigDecimal.ROUND_HALF_UP)),
+                Collections.singletonList(BigDecimal.valueOf(3)));
+        FunctionTestUtil.assertResult(
+                indexOfFunction.invoke(
+                        Arrays.asList(BigDecimal.valueOf(12.00), "test", null, BigDecimal.valueOf(12)),
+                        BigDecimal.valueOf(12)),
+                Arrays.asList(BigDecimal.valueOf(1), BigDecimal.valueOf(4)));
+    }
+
+    @Test
+    public void invokeMatchNotNull() {
+        FunctionTestUtil.assertResult(indexOfFunction.invoke(Arrays.asList("test", null, 12), "testttt"), Collections.emptyList());
+        FunctionTestUtil.assertResult(
+                indexOfFunction.invoke(Arrays.asList("test", null, BigDecimal.valueOf(12)), "test"),
+                Collections.singletonList(BigDecimal.valueOf(1)));
+        FunctionTestUtil.assertResult(
+                indexOfFunction.invoke(Arrays.asList("test", null, "test"),"test"),
+                Arrays.asList(BigDecimal.valueOf(1), BigDecimal.valueOf(3)));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/InsertBeforeFunctionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class InsertBeforeFunctionTest {
+
+    private InsertBeforeFunction insertBeforeFunction;
+
+    @Before
+    public void setUp() {
+        insertBeforeFunction = new InsertBeforeFunction();
+    }
+
+    @Test
+    public void invokeListNull() {
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(null, BigDecimal.ZERO, new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionNull() {
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(Collections.emptyList(), null, new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListPositionNull() {
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(null, null, new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionZero() {
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(Collections.emptyList(), BigDecimal.ZERO, new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionOutsideListBounds() {
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(Collections.emptyList(), BigDecimal.ONE, new Object()), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(Collections.emptyList(), BigDecimal.valueOf(-1), new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeInsertIntoEmptyList() {
+        // According to spec, inserting into empty list shouldn't be possible. For inserting into empty list, user should use append() function.
+        FunctionTestUtil.assertResultError(insertBeforeFunction.invoke(Collections.emptyList(), BigDecimal.ONE, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionPositive() {
+        FunctionTestUtil.assertResult(insertBeforeFunction.invoke(Collections.singletonList("test"), BigDecimal.ONE, null), Arrays.asList(null, "test"));
+        FunctionTestUtil.assertResult(
+                insertBeforeFunction.invoke(Arrays.asList("test", null, BigDecimal.ZERO), BigDecimal.valueOf(2), "testtt"),
+                Arrays.asList("test", "testtt", null, BigDecimal.ZERO));
+        FunctionTestUtil.assertResult(
+                insertBeforeFunction.invoke(Arrays.asList("test", null, BigDecimal.ZERO), BigDecimal.valueOf(3), "testtt"),
+                Arrays.asList("test", null, "testtt", BigDecimal.ZERO));
+    }
+
+    @Test
+    public void invokePositionNegative() {
+        FunctionTestUtil.assertResult(insertBeforeFunction.invoke(Collections.singletonList("test"), BigDecimal.valueOf(-1), null), Arrays.asList(null, "test"));
+        FunctionTestUtil.assertResult(
+                insertBeforeFunction.invoke(Arrays.asList("test", null, BigDecimal.ZERO), BigDecimal.valueOf(-2), "testtt"),
+                Arrays.asList("test", "testtt", null, BigDecimal.ZERO));
+        FunctionTestUtil.assertResult(
+                insertBeforeFunction.invoke(Arrays.asList("test", null, BigDecimal.ZERO), BigDecimal.valueOf(-3), "testtt"),
+                Arrays.asList("testtt", "test", null, BigDecimal.ZERO));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ListContainsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ListContainsFunctionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class ListContainsFunctionTest {
+
+    private ListContainsFunction listContainsFunction;
+
+    @Before
+    public void setUp() {
+        listContainsFunction = new ListContainsFunction();
+    }
+
+    @Test
+    public void invokeListNull() {
+        FunctionTestUtil.assertResultError(listContainsFunction.invoke((List) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(listContainsFunction.invoke(null, new Object()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeContainsNull() {
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Collections.singletonList(null), null), true);
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(1, null), null), true);
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(null, 1), null), true);
+    }
+
+    @Test
+    public void invokeNotContainsNull() {
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Collections.emptyList(), null), false);
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Collections.singletonList(1), null), false);
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(1, 2), null), false);
+    }
+
+    @Test
+    public void invokeContains() {
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(1, 2, "test", BigDecimal.ONE), "test"), true);
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(1, 2, "test", BigDecimal.ONE), BigDecimal.ONE), true);
+    }
+
+    @Test
+    public void invokeNotContains() {
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(1, 2, "test", BigDecimal.ONE), "testtt"), false);
+        FunctionTestUtil.assertResult(listContainsFunction.invoke(Arrays.asList(1, 2, "test", BigDecimal.ONE), BigDecimal.valueOf(2)), false);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class MatchesFunctionTest {
+
+    private MatchesFunction matchesFunction;
+
+    @Before
+    public void setUp() {
+        matchesFunction = new MatchesFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(matchesFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(matchesFunction.invoke(null, "test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(matchesFunction.invoke("test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeWithoutFlagsMatch() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("test", "test"), true);
+        FunctionTestUtil.assertResult(matchesFunction.invoke("foobar", "^fo*b"), true);
+    }
+
+    @Test
+    public void invokeWithoutFlagsNotMatch() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("test", "testt"), false);
+        FunctionTestUtil.assertResult(matchesFunction.invoke("foobar", "^fo*bb"), false);
+        FunctionTestUtil.assertResult(matchesFunction.invoke("fo\nbar", "fo.bar"), false);
+    }
+
+    @Test
+    public void invokeWithFlagDotAll() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("fo\nbar", "fo.bar", "s"), true);
+    }
+
+    @Test
+    public void invokeWithFlagMultiline() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("fo\nbar", "^bar", "m"), true);
+    }
+
+    @Test
+    public void invokeWithFlagCaseInsensitive() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("foobar", "^Fo*bar", "i"), true);
+    }
+
+    @Test
+    public void invokeWithAllFlags() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("fo\nbar", "Fo.^bar", "smi"), true);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MaxFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MaxFunctionTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class MaxFunctionTest {
+
+    private MaxFunction maxFunction;
+
+    @Before
+    public void setUp() {
+        maxFunction = new MaxFunction();
+    }
+
+    @Test
+    public void invokeNullList() {
+        FunctionTestUtil.assertResultError(maxFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyList() {
+        FunctionTestUtil.assertResultError(maxFunction.invoke(Collections.emptyList()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListWithHeterogenousTypes() {
+        FunctionTestUtil.assertResultError(maxFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(10.2))), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListOfIntegers() {
+        FunctionTestUtil.assertResult(maxFunction.invoke(Collections.singletonList(1)), 1);
+        FunctionTestUtil.assertResult(maxFunction.invoke(Arrays.asList(1, 2, 3)), 3);
+        FunctionTestUtil.assertResult(maxFunction.invoke(Arrays.asList(1, 3, 2)), 3);
+        FunctionTestUtil.assertResult(maxFunction.invoke(Arrays.asList(3, 1, 2)), 3);
+    }
+
+    @Test
+    public void invokeListOfStrings() {
+        FunctionTestUtil.assertResult(maxFunction.invoke(Collections.singletonList("a")), "a");
+        FunctionTestUtil.assertResult(maxFunction.invoke(Arrays.asList("a", "b", "c")), "c");
+        FunctionTestUtil.assertResult(maxFunction.invoke(Arrays.asList("a", "c", "b")), "c");
+        FunctionTestUtil.assertResult(maxFunction.invoke(Arrays.asList("c", "a", "b")), "c");
+    }
+
+    @Test
+    public void invokeNullArray() {
+        FunctionTestUtil.assertResultError(maxFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyArray() {
+        FunctionTestUtil.assertResultError(maxFunction.invoke(new Object[]{}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayWithHeterogenousTypes() {
+        FunctionTestUtil.assertResultError(maxFunction.invoke(new Object[]{1, "test", BigDecimal.valueOf(10.2)}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayOfIntegers() {
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{1}), 1);
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{1, 2, 3}), 3);
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{1, 3, 2}), 3);
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{3, 1, 2}), 3);
+    }
+
+    @Test
+    public void invokeArrayOfStrings() {
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{"a"}), "a");
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{"a", "b", "c"}), "c");
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{"a", "c", "b"}), "c");
+        FunctionTestUtil.assertResult(maxFunction.invoke(new Object[]{"c", "a", "b"}), "c");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MeanFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MeanFunctionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class MeanFunctionTest {
+
+    private MeanFunction meanFunction;
+
+    @Before
+    public void setUp() {
+        meanFunction = new MeanFunction();
+    }
+
+    @Test
+    public void invokeNumberNull() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke((Number) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNumberBigDecimal() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(BigDecimal.TEN), BigDecimal.TEN);
+    }
+
+    @Test
+    public void invokeNumberInteger() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(10), BigDecimal.TEN);
+    }
+
+    @Test
+    public void invokeNumberDoubleWithoutDecimalPart() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(10d), BigDecimal.valueOf(10));
+    }
+
+    @Test
+    public void invokeNumberDoubleWithDecimalPart() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(10.1d), BigDecimal.valueOf(10.1));
+    }
+
+    @Test
+    public void invokeNumberFloat() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(10.1f), BigDecimal.valueOf(10.1));
+    }
+
+    @Test
+    public void invokeUnconvertableNumber() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke(Double.POSITIVE_INFINITY), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(meanFunction.invoke(Double.NEGATIVE_INFINITY), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(meanFunction.invoke(Double.NaN), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListNull() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListEmpty() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke(Collections.emptyList()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListTypeHeterogenous() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke(Arrays.asList(1, "test")), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListWithIntegers() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(Arrays.asList(10, 20, 30)), BigDecimal.valueOf(20));
+        FunctionTestUtil.assertResult(meanFunction.invoke(Arrays.asList(10, 20, 30, -10, -20, -30)), BigDecimal.ZERO);
+        FunctionTestUtil.assertResult(meanFunction.invoke(Arrays.asList(0, 0, 1)), new BigDecimal("0.3333333333333333333333333333333333"));
+    }
+
+    @Test
+    public void invokeListWithDoubles() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(Arrays.asList(10.0d, 20.0d, 30.0d)), BigDecimal.valueOf(20));
+        FunctionTestUtil.assertResult(meanFunction.invoke(Arrays.asList(10.2d, 20.2d, 30.2d)), BigDecimal.valueOf(20.2));
+    }
+
+    @Test
+    public void invokeArrayNull() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayEmpty() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke(new Object[]{}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayTypeHeterogenous() {
+        FunctionTestUtil.assertResultError(meanFunction.invoke(new Object[]{1, "test"}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayWithIntegers() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(new Object[]{10, 20, 30}), BigDecimal.valueOf(20));
+        FunctionTestUtil.assertResult(meanFunction.invoke(new Object[]{10, 20, 30, -10, -20, -30}), BigDecimal.ZERO);
+        FunctionTestUtil.assertResult(meanFunction.invoke(new Object[]{0, 0, 1}), new BigDecimal("0.3333333333333333333333333333333333"));
+    }
+
+    @Test
+    public void invokeArrayWithDoubles() {
+        FunctionTestUtil.assertResult(meanFunction.invoke(new Object[]{10.0d, 20.0d, 30.0d}), BigDecimal.valueOf(20));
+        FunctionTestUtil.assertResult(meanFunction.invoke(new Object[]{10.2d, 20.2d, 30.2d}), BigDecimal.valueOf(20.2));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MinFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MinFunctionTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class MinFunctionTest {
+
+    private MinFunction minFunction;
+
+    @Before
+    public void setUp() {
+        minFunction = new MinFunction();
+    }
+
+    @Test
+    public void invokeNullList() {
+        FunctionTestUtil.assertResultError(minFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyList() {
+        FunctionTestUtil.assertResultError(minFunction.invoke(Collections.emptyList()), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListWithHeterogenousTypes() {
+        FunctionTestUtil.assertResultError(minFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(10.2))), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListOfIntegers() {
+        FunctionTestUtil.assertResult(minFunction.invoke(Collections.singletonList(1)), 1);
+        FunctionTestUtil.assertResult(minFunction.invoke(Arrays.asList(1, 2, 3)), 1);
+        FunctionTestUtil.assertResult(minFunction.invoke(Arrays.asList(2, 1, 3)), 1);
+        FunctionTestUtil.assertResult(minFunction.invoke(Arrays.asList(2, 3, 1)), 1);
+    }
+
+    @Test
+    public void invokeListOfStrings() {
+        FunctionTestUtil.assertResult(minFunction.invoke(Collections.singletonList("a")), "a");
+        FunctionTestUtil.assertResult(minFunction.invoke(Arrays.asList("a", "b", "c")), "a");
+        FunctionTestUtil.assertResult(minFunction.invoke(Arrays.asList("b", "a", "c")), "a");
+        FunctionTestUtil.assertResult(minFunction.invoke(Arrays.asList("b", "c", "a")), "a");
+    }
+
+    @Test
+    public void invokeNullArray() {
+        FunctionTestUtil.assertResultError(minFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyArray() {
+        FunctionTestUtil.assertResultError(minFunction.invoke(new Object[]{}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayWithHeterogenousTypes() {
+        FunctionTestUtil.assertResultError(minFunction.invoke(new Object[]{1, "test", BigDecimal.valueOf(10.2)}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayOfIntegers() {
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{1}), 1);
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{1, 2, 3}), 1);
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{2, 1, 3}), 1);
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{2, 3, 1}), 1);
+    }
+
+    @Test
+    public void invokeArrayOfStrings() {
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{"a"}), "a");
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{"a", "b", "c"}), "a");
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{"b", "a", "c"}), "a");
+        FunctionTestUtil.assertResult(minFunction.invoke(new Object[]{"b", "c", "a"}), "a");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NotFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NotFunctionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class NotFunctionTest {
+
+    private NotFunction notFunction;
+
+    @Before
+    public void setUp() {
+        notFunction = new NotFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultNull(notFunction.invoke(null));
+    }
+
+    @Test
+    public void invokeWrongType() {
+        FunctionTestUtil.assertResultError(notFunction.invoke(1), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(notFunction.invoke("test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(notFunction.invoke(BigDecimal.ZERO), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTrue() {
+        FunctionTestUtil.assertResult(notFunction.invoke(true), false);
+    }
+
+    @Test
+    public void invokeFalse() {
+        FunctionTestUtil.assertResult(notFunction.invoke(false), true);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NowFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NowFunctionTest {
+
+    private NowFunction nowFunction;
+
+    @Before
+    public void setUp() {
+        nowFunction = new NowFunction();
+    }
+
+    @Test
+    public void invoke() {
+        // The current time that we need to compare will almost never be the same as another one we get for comparison purposes,
+        // because there is some execution between them, so the comparison assertion doesn't make sense.
+        // Note: We cannot guarantee any part of the date to be the same. E.g. in case when the test is executed
+        // at the exact moment when the year is flipped to the next one, we cannot guarantee the year will be the same.
+
+        FEELFnResult<TemporalAccessor> nowResult = nowFunction.invoke();
+        Assert.assertThat(nowResult.isRight(), Matchers.is(true));
+        final TemporalAccessor result = nowResult.cata(left -> null, right -> right);
+        Assert.assertThat(result, Matchers.notNullValue());
+        Assert.assertThat(result.getClass(), Matchers.typeCompatibleWith(ZonedDateTime.class));
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NumberFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/NumberFunctionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class NumberFunctionTest {
+
+    private NumberFunction numberFunction;
+
+    @Before
+    public void setUp() {
+        numberFunction = new NumberFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke(null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(numberFunction.invoke(null, " ", null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(numberFunction.invoke(null, null, "."), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(numberFunction.invoke(null, " ", "."), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeIllegalNumber() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("test", null, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNumberWithLeadingZeros() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("009876", null, null), BigDecimal.valueOf(9876));
+    }
+
+    @Test
+    public void invokeNumberWithoutDecimalPart() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9876", null, null), BigDecimal.valueOf(9876));
+    }
+
+    @Test
+    public void invokeNumberWithGroupCharSpace() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9 876", " ", null), BigDecimal.valueOf(9876));
+        FunctionTestUtil.assertResult(numberFunction.invoke("9 876 000", " ", null), BigDecimal.valueOf(9876000));
+    }
+
+    @Test
+    public void invokeNumberWithGroupCharComma() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9,876", ",", null), BigDecimal.valueOf(9876));
+        FunctionTestUtil.assertResult(numberFunction.invoke("9,876,000", ",", null), BigDecimal.valueOf(9876000));
+    }
+
+    @Test
+    public void invokeNumberWithGroupCharDot() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9.876", ".", null), BigDecimal.valueOf(9876));
+        FunctionTestUtil.assertResult(numberFunction.invoke("9.876.000", ".", null), BigDecimal.valueOf(9876000));
+    }
+
+    @Test
+    public void invokeNumberWithDecimalCharComma() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9,876", null, ","), BigDecimal.valueOf(9.876));
+    }
+
+    @Test
+    public void invokeNumberWithDecimalCharDot() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9.876", null, "."), BigDecimal.valueOf(9.876));
+    }
+
+    @Test
+    public void invokeNumberWithGroupAndDecimalChar() {
+        FunctionTestUtil.assertResult(numberFunction.invoke("9 876.124", " ", "."), BigDecimal.valueOf(9876.124));
+        FunctionTestUtil.assertResult(numberFunction.invoke("9 876 000.124", " ", "."), BigDecimal.valueOf(9876000.124));
+        FunctionTestUtil.assertResult(numberFunction.invoke("9.876.000,124", ".", ","), BigDecimal.valueOf(9876000.124));
+    }
+
+    @Test
+    public void invokeIncorrectGroup() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1 000", ".", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeInvalidGroup() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1 000", "test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyGroup() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1 000", "", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeIncorrectDecimal() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1,1", null, "."), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeInvalidDecimal() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1.1", null, "test"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyDecimal() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1.1", null, ""), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeGroupEqualsDecimal() {
+        FunctionTestUtil.assertResultError(numberFunction.invoke("1 000.1", ".", "."), InvalidParametersEvent.class);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RemoveFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/RemoveFunctionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class RemoveFunctionTest {
+
+    private RemoveFunction removeFunction;
+
+    @Before
+    public void setUp() {
+        removeFunction = new RemoveFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(removeFunction.invoke((List) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(removeFunction.invoke(null, BigDecimal.ONE), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(removeFunction.invoke(Collections.emptyList(), null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionZero() {
+        FunctionTestUtil.assertResultError(removeFunction.invoke(Collections.singletonList(1), BigDecimal.ZERO), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionOutOfListBounds() {
+        FunctionTestUtil.assertResultError(removeFunction.invoke(Collections.singletonList(1), BigDecimal.valueOf(2)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(removeFunction.invoke(Collections.singletonList(1), BigDecimal.valueOf(154)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(removeFunction.invoke(Collections.singletonList(1), BigDecimal.valueOf(-2)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(removeFunction.invoke(Collections.singletonList(1), BigDecimal.valueOf(-154)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokePositionPositive() {
+        FunctionTestUtil.assertResultList(removeFunction.invoke(Collections.singletonList(1), BigDecimal.ONE), Collections.emptyList());
+        FunctionTestUtil.assertResultList(
+                removeFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(14)), BigDecimal.ONE),
+                Arrays.asList("test", BigDecimal.valueOf(14)));
+        FunctionTestUtil.assertResultList(
+                removeFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(14)), BigDecimal.valueOf(2)),
+                Arrays.asList(1, BigDecimal.valueOf(14)));
+        FunctionTestUtil.assertResultList(
+                removeFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(14)), BigDecimal.valueOf(3)),
+                Arrays.asList(1, "test"));
+    }
+
+    @Test
+    public void invokePositionNegative() {
+        FunctionTestUtil.assertResultList(removeFunction.invoke(Collections.singletonList(1), BigDecimal.valueOf(-1)), Collections.emptyList());
+        FunctionTestUtil.assertResultList(
+                removeFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(14)), BigDecimal.valueOf(-1)),
+                Arrays.asList(1, "test"));
+        FunctionTestUtil.assertResultList(
+                removeFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(14)), BigDecimal.valueOf(-2)),
+                Arrays.asList(1, BigDecimal.valueOf(14)));
+        FunctionTestUtil.assertResultList(
+                removeFunction.invoke(Arrays.asList(1, "test", BigDecimal.valueOf(14)), BigDecimal.valueOf(-3)),
+                Arrays.asList("test", BigDecimal.valueOf(14)));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReplaceFunctionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class ReplaceFunctionTest {
+
+    private ReplaceFunction replaceFunction;
+
+    @Before
+    public void setUp() {
+        replaceFunction = new ReplaceFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", "test", null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, "test", null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, "test", "ttt"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, null, "ttt"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNullWithFlags() {
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", "test", null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, "test", null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, "test", "ttt", null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, null, "ttt", null), InvalidParametersEvent.class);
+
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, null, null, "s"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", null, null, "s"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke("testString", "test", null, "s"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, "test", null, "s"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, "test", "ttt", "s"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(replaceFunction.invoke(null, null, "ttt", "s"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeWithoutFlagsPatternMatches() {
+        FunctionTestUtil.assertResult(replaceFunction.invoke("testString", "^test", "ttt"), "tttString");
+        FunctionTestUtil.assertResult(replaceFunction.invoke("testStringtest", "^test", "ttt"), "tttStringtest");
+    }
+
+    @Test
+    public void invokeWithoutFlagsPatternNotMatches() {
+        FunctionTestUtil.assertResult(replaceFunction.invoke("testString", "ttest", "ttt"), "testString");
+        FunctionTestUtil.assertResult(replaceFunction.invoke("testString", "$test", "ttt"), "testString");
+    }
+
+    @Test
+    public void invokeWithFlagDotAll() {
+        FunctionTestUtil.assertResult(replaceFunction.invoke("fo\nbar", "o.b", "ttt", "s"), "ftttar");
+    }
+
+    @Test
+    public void invokeWithFlagMultiline() {
+        FunctionTestUtil.assertResult(replaceFunction.invoke("foo\nbar", "^b", "ttt", "m"), "foo\ntttar");
+    }
+
+    @Test
+    public void invokeWithFlagCaseInsensitive() {
+        FunctionTestUtil.assertResult(replaceFunction.invoke("foobar", "^fOO", "ttt", "i"), "tttbar");
+    }
+
+    @Test
+    public void invokeWithAllFlags() {
+        FunctionTestUtil.assertResult(replaceFunction.invoke("fo\nbar", "O.^b", "ttt", "smi"), "ftttar");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReverseFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ReverseFunctionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class ReverseFunctionTest {
+
+    private ReverseFunction reverseFunction;
+
+    @Before
+    public void setUp() {
+        reverseFunction = new ReverseFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(reverseFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyList() {
+        FunctionTestUtil.assertResultList(reverseFunction.invoke(Collections.emptyList()), Collections.emptyList());
+    }
+
+    @Test
+    public void invokeListTypeHomogenous() {
+        FunctionTestUtil.assertResultList(reverseFunction.invoke(Arrays.asList(1, 2, 3, 4)), Arrays.asList(4, 3, 2, 1));
+    }
+
+    @Test
+    public void invokeListTypeHeterogenous() {
+        FunctionTestUtil.assertResultList(
+                reverseFunction.invoke(Arrays.asList(1, "test", BigDecimal.TEN, Collections.emptyList())),
+                Arrays.asList(Collections.emptyList(), BigDecimal.TEN, "test", 1));
+
+        FunctionTestUtil.assertResultList(
+                reverseFunction.invoke(Arrays.asList(1, "test", BigDecimal.TEN, Arrays.asList(1, 2, 3))),
+                Arrays.asList(Arrays.asList(1, 2, 3), BigDecimal.TEN, "test", 1));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StartsWithFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StartsWithFunctionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class StartsWithFunctionTest {
+
+    private StartsWithFunction startsWithFunction;
+
+    @Before
+    public void setUp() {
+        startsWithFunction = new StartsWithFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(startsWithFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(startsWithFunction.invoke(null, "test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(startsWithFunction.invoke("test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyString() {
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("", ""), true);
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("", "test"), false);
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", ""), true);
+    }
+
+    @Test
+    public void invokeStartsWith() {
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", "te"), true);
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", "t"), true);
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", "test"), true);
+    }
+
+    @Test
+    public void invokeNotStartsWith() {
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", "tte"), false);
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", "tt"), false);
+        FunctionTestUtil.assertResult(startsWithFunction.invoke("test", "ttest"), false);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringFunctionTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+import org.kie.dmn.feel.runtime.impl.RangeImpl;
+
+public class StringFunctionTest {
+
+    private StringFunction stringFunction;
+
+    @Before
+    public void setUp() throws Exception {
+        stringFunction = new StringFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(null), null);
+    }
+
+    @Test
+    public void invokeMaskNull() {
+        FunctionTestUtil.assertResultError(stringFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(stringFunction.invoke((String) null, new Object[]{}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeString() {
+        FunctionTestUtil.assertResult(stringFunction.invoke("test"), "test");
+    }
+
+    @Test
+    public void invokeBigDecimal() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(BigDecimal.valueOf(10.7)), "10.7");
+    }
+
+    @Test
+    public void invokeLocalDate() {
+        final LocalDate localDate = LocalDate.now();
+        FunctionTestUtil.assertResult(stringFunction.invoke(localDate), localDate.toString());
+    }
+
+    @Test
+    public void invokeLocalTime() {
+        final LocalTime localTime = LocalTime.now();
+        FunctionTestUtil.assertResult(stringFunction.invoke(localTime), localTime.toString());
+    }
+
+    @Test
+    public void invokeOffsetTime() {
+        final OffsetTime offsetTime = OffsetTime.now();
+        FunctionTestUtil.assertResult(stringFunction.invoke(offsetTime), offsetTime.toString());
+    }
+
+    @Test
+    public void invokeLocalDateTime() {
+        final LocalDateTime localDateTime = LocalDateTime.now();
+        FunctionTestUtil.assertResult(stringFunction.invoke(localDateTime), localDateTime.toString());
+    }
+
+    @Test
+    public void invokeOffsetDateTime() {
+        final OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        FunctionTestUtil.assertResult(stringFunction.invoke(offsetDateTime), offsetDateTime.toString());
+    }
+
+    @Test
+    public void invokeZonedDateTime() {
+        final ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        FunctionTestUtil.assertResult(stringFunction.invoke(zonedDateTime), zonedDateTime.toString());
+    }
+
+    @Test
+    public void invokeDurationZero() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ZERO), "PT0S");
+    }
+
+    @Test
+    public void invokeDurationDays() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofDays(9)), "P9D");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofDays(-9)), "-P9D");
+    }
+
+    @Test
+    public void invokeDurationHours() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofHours(9)), "PT9H");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofHours(200)), "P8DT8H");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofHours(-200)), "-P8DT8H");
+    }
+
+    @Test
+    public void invokeDurationMinutes() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMinutes(9)), "PT9M");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMinutes(200)), "PT3H20M");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMinutes(5000)), "P3DT11H20M");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMinutes(-5000)), "-P3DT11H20M");
+    }
+
+    @Test
+    public void invokeDurationSeconds() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofSeconds(9)), "PT9S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofSeconds(200)), "PT3M20S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofSeconds(5000)), "PT1H23M20S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofSeconds(90061)), "P1DT1H1M1S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofSeconds(-90061)), "-P1DT1H1M1S");
+    }
+
+    @Test
+    public void invokeDurationNanosMillis() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofNanos(25)), "PT0.000000025S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofNanos(10000)), "PT0.00001S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofNanos(10025)), "PT0.000010025S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMillis(1500)), "PT1.5S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMillis(90061025)), "P1DT1H1M1.025S");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Duration.ofMillis(-90061025)), "-P1DT1H1M1.025S");
+    }
+
+    @Test
+    public void invokePeriodZero() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Period.ZERO), "P0M");
+    }
+
+    @Test
+    public void invokePeriodYears() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Period.ofYears(24)), "P24Y");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Period.ofYears(-24)), "-P24Y");
+    }
+
+    @Test
+    public void invokePeriodMonths() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Period.ofMonths(2)), "P2M");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Period.ofMonths(27)), "P2Y3M");
+        FunctionTestUtil.assertResult(stringFunction.invoke(Period.ofMonths(-27)), "-P2Y3M");
+    }
+
+    @Test
+    public void invokeListEmpty() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(Collections.emptyList()), "[ ]");
+    }
+
+    @Test
+    public void invokeListNonEmpty() {
+        final List<Object> values = new ArrayList<>();
+        values.add(1);
+        values.add(BigDecimal.valueOf(10.5));
+        values.add("test");
+        FunctionTestUtil.assertResult(stringFunction.invoke(values), "[ 1, 10.5, test ]");
+    }
+
+    @Test
+    public void invokeRangeOpenOpen() {
+        FunctionTestUtil.assertResult(
+                stringFunction.invoke(new RangeImpl(Range.RangeBoundary.OPEN, 12, 15, Range.RangeBoundary.OPEN)),
+                "( 12 .. 15 )");
+    }
+
+    @Test
+    public void invokeRangeOpenClosed() {
+        FunctionTestUtil.assertResult(
+                stringFunction.invoke(new RangeImpl(Range.RangeBoundary.OPEN, 12, 15, Range.RangeBoundary.CLOSED)),
+                "( 12 .. 15 ]");
+    }
+
+    @Test
+    public void invokeRangeClosedOpen() {
+        FunctionTestUtil.assertResult(
+                stringFunction.invoke(new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.OPEN)),
+                "[ 12 .. 15 )");
+    }
+
+    @Test
+    public void invokeRangeClosedClosed() {
+        FunctionTestUtil.assertResult(
+                stringFunction.invoke(new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED)),
+                "[ 12 .. 15 ]");
+    }
+
+    @Test
+    public void invokeContextEmpty() {
+        FunctionTestUtil.assertResult(stringFunction.invoke(new HashMap<>()), "{ }");
+    }
+
+    @Test
+    public void invokeContextNonEmpty() {
+        final Map<String, Object> childContextMap = new HashMap<>();
+        childContextMap.put("childKey1", "childValue1");
+
+        final Map<String, Object> contextMap = new HashMap<>();
+        contextMap.put("key1", "value1");
+        contextMap.put("key2", childContextMap);
+
+        FunctionTestUtil.assertResult(stringFunction.invoke(contextMap), "{ key1 : value1, key2 : { childKey1 : childValue1 } }");
+    }
+
+    @Test
+    public void invokeMaskedFormat() {
+        FunctionTestUtil.assertResult(stringFunction.invoke("%s is here!", new Object[]{"Gorgonzola"}), "Gorgonzola is here!");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLengthFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLengthFunctionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class StringLengthFunctionTest {
+
+    private StringLengthFunction stringLengthFunction;
+
+    @Before
+    public void setUp() {
+        stringLengthFunction = new StringLengthFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(stringLengthFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyString() {
+        FunctionTestUtil.assertResult(stringLengthFunction.invoke(""), BigDecimal.ZERO);
+    }
+
+    @Test
+    public void invoke() {
+        FunctionTestUtil.assertResult(stringLengthFunction.invoke("testString"), BigDecimal.TEN);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringLowerCaseFunctionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class StringLowerCaseFunctionTest {
+
+    private StringLowerCaseFunction stringLowerCaseFunction;
+
+    @Before
+    public void setUp() {
+        stringLowerCaseFunction = new StringLowerCaseFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(stringLowerCaseFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeLowercaseString() {
+        FunctionTestUtil.assertResult(stringLowerCaseFunction.invoke("teststring"), "teststring");
+    }
+
+    @Test
+    public void invokeUppercaseString() {
+        FunctionTestUtil.assertResult(stringLowerCaseFunction.invoke("TESTSTRING"), "teststring");
+    }
+
+    @Test
+    public void invokeMixedCaseString() {
+        FunctionTestUtil.assertResult(stringLowerCaseFunction.invoke("testSTRing"), "teststring");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/StringUpperCaseFunctionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class StringUpperCaseFunctionTest {
+
+    private StringUpperCaseFunction stringUpperCaseFunction;
+
+    @Before
+    public void setUp() {
+        stringUpperCaseFunction = new StringUpperCaseFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(stringUpperCaseFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeLowercaseString() {
+        FunctionTestUtil.assertResult(stringUpperCaseFunction.invoke("teststring"), "TESTSTRING");
+    }
+
+    @Test
+    public void invokeUppercaseString() {
+        FunctionTestUtil.assertResult(stringUpperCaseFunction.invoke("TESTSTRING"), "TESTSTRING");
+    }
+
+    @Test
+    public void invokeMixedCaseString() {
+        FunctionTestUtil.assertResult(stringUpperCaseFunction.invoke("testSTRing"), "TESTSTRING");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SublistFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SublistFunctionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SublistFunctionTest {
+
+    private SublistFunction sublistFunction;
+
+    @Before
+    public void setUp() {
+        sublistFunction = new SublistFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(sublistFunction.invoke((List) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(null, BigDecimal.ONE), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Collections.emptyList(), null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStartZero() {
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Arrays.asList(1, 2), BigDecimal.ZERO), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStartOutOfListBounds() {
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Arrays.asList(1, 2), BigDecimal.TEN), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Arrays.asList(1, 2), BigDecimal.valueOf(-10)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeLengthNegative() {
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Arrays.asList(1, 2), BigDecimal.valueOf(1), BigDecimal.valueOf(-3)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeLengthOutOfListBounds() {
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Arrays.asList(1, 2), BigDecimal.ONE, BigDecimal.valueOf(3)), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(sublistFunction.invoke(Arrays.asList(1, 2), BigDecimal.valueOf(-1), BigDecimal.valueOf(3)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStartPositive() {
+        FunctionTestUtil.assertResult(sublistFunction.invoke(Arrays.asList(1, 2, 3), BigDecimal.valueOf(2)), Arrays.asList(2, 3));
+        FunctionTestUtil.assertResult(sublistFunction.invoke(Arrays.asList(1, "test", 3), BigDecimal.valueOf(2)), Arrays.asList("test", 3));
+        FunctionTestUtil.assertResult(sublistFunction.invoke(Arrays.asList(1, "test", 3), BigDecimal.valueOf(2), BigDecimal.ONE), Collections.singletonList("test"));
+    }
+
+    @Test
+    public void invokeStartNegative() {
+        FunctionTestUtil.assertResult(sublistFunction.invoke(Arrays.asList(1, 2, 3), BigDecimal.valueOf(-2)), Arrays.asList(2, 3));
+        FunctionTestUtil.assertResult(sublistFunction.invoke(Arrays.asList(1, "test", 3), BigDecimal.valueOf(-2)), Arrays.asList("test", 3));
+        FunctionTestUtil.assertResult(sublistFunction.invoke(Arrays.asList(1, "test", 3), BigDecimal.valueOf(-2), BigDecimal.ONE), Collections.singletonList("test"));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SubstringAfterFunctionTest {
+
+    private SubstringAfterFunction substringAfterFunction;
+
+    @Before
+    public void setUp() {
+        substringAfterFunction = new SubstringAfterFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(substringAfterFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringAfterFunction.invoke(null, "test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringAfterFunction.invoke("test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeMatchExists() {
+        FunctionTestUtil.assertResult(substringAfterFunction.invoke("foobar", "ob"), "ar");
+        FunctionTestUtil.assertResult(substringAfterFunction.invoke("foobar", "o"), "obar");
+    }
+
+    @Test
+    public void invokeMatchNotExists() {
+        FunctionTestUtil.assertResult(substringAfterFunction.invoke("foobar", "oook"), "foobar");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringBeforeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringBeforeFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SubstringBeforeFunctionTest {
+
+    private SubstringBeforeFunction substringBeforeFunction;
+
+    @Before
+    public void setUp() {
+        substringBeforeFunction = new SubstringBeforeFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(substringBeforeFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringBeforeFunction.invoke(null, "test"), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringBeforeFunction.invoke("test", null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeMatchExists() {
+        FunctionTestUtil.assertResult(substringBeforeFunction.invoke("foobar", "ob"), "fo");
+        FunctionTestUtil.assertResult(substringBeforeFunction.invoke("foobar", "o"), "f");
+    }
+
+    @Test
+    public void invokeMatchNotExists() {
+        FunctionTestUtil.assertResult(substringBeforeFunction.invoke("foobar", "oook"), "");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/impl/RangeImplTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.Range;
+
+public class RangeImplTest {
+
+    @Test
+    public void getLowBoundary() throws Exception {
+        final Range.RangeBoundary lowBoundary = Range.RangeBoundary.CLOSED;
+        final RangeImpl rangeImpl = new RangeImpl(lowBoundary, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertEquals(lowBoundary, rangeImpl.getLowBoundary());
+    }
+
+    @Test
+    public void getLowEndPoint() throws Exception {
+        final Integer lowEndPoint = 1;
+        final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, lowEndPoint, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertEquals(lowEndPoint, rangeImpl.getLowEndPoint());
+    }
+
+    @Test
+    public void getHighEndPoint() throws Exception {
+        final Integer highEndPoint = 15;
+        final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 1, highEndPoint, Range.RangeBoundary.CLOSED);
+        Assert.assertEquals(highEndPoint, rangeImpl.getHighEndPoint());
+    }
+
+    @Test
+    public void getHighBoundary() throws Exception {
+        final Range.RangeBoundary highBoundary = Range.RangeBoundary.CLOSED;
+        final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, highBoundary);
+        Assert.assertEquals(highBoundary, rangeImpl.getHighBoundary());
+    }
+
+    @Test
+    public void includes() throws Exception {
+        RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertFalse(rangeImpl.includes(-15));
+        Assert.assertFalse(rangeImpl.includes(5));
+        Assert.assertFalse(rangeImpl.includes(10));
+        Assert.assertTrue(rangeImpl.includes(12));
+        Assert.assertFalse(rangeImpl.includes(15));
+        Assert.assertFalse(rangeImpl.includes(156));
+
+        rangeImpl = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertTrue(rangeImpl.includes(10));
+        Assert.assertTrue(rangeImpl.includes(12));
+        Assert.assertFalse(rangeImpl.includes(15));
+
+        rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertFalse(rangeImpl.includes(10));
+        Assert.assertTrue(rangeImpl.includes(12));
+        Assert.assertTrue(rangeImpl.includes(15));
+
+        rangeImpl = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertTrue(rangeImpl.includes(10));
+        Assert.assertTrue(rangeImpl.includes(12));
+        Assert.assertTrue(rangeImpl.includes(15));
+    }
+
+    @Test
+    public void equals() throws Exception {
+        RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertTrue(rangeImpl.equals(rangeImpl));
+
+        RangeImpl rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertTrue(rangeImpl.equals(rangeImpl2));
+
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertFalse(rangeImpl.equals(rangeImpl2));
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertFalse(rangeImpl.equals(rangeImpl2));
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertFalse(rangeImpl.equals(rangeImpl2));
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertFalse(rangeImpl.equals(rangeImpl2));
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 17, Range.RangeBoundary.CLOSED);
+        Assert.assertFalse(rangeImpl.equals(rangeImpl2));
+
+        rangeImpl = new RangeImpl();
+        Assert.assertTrue(rangeImpl.equals(rangeImpl));
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        final RangeImpl rangeImpl = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertEquals(rangeImpl.hashCode(), rangeImpl.hashCode());
+
+        RangeImpl rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.OPEN, 10, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.OPEN);
+        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 10, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 15, Range.RangeBoundary.CLOSED);
+        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+        rangeImpl2 = new RangeImpl(Range.RangeBoundary.CLOSED, 12, 17, Range.RangeBoundary.CLOSED);
+        Assert.assertNotEquals(rangeImpl.hashCode(), rangeImpl2.hashCode());
+    }
+}

--- a/kie-dmn/kie-dmn-tck/pom.xml
+++ b/kie-dmn/kie-dmn-tck/pom.xml
@@ -53,7 +53,7 @@
                   <goal>bootstrap</goal>
                 </goals>
                 <configuration>
-                  <connectionUrl>scm:git:https://github.com/agilepro/dmn-tck.git</connectionUrl>
+                  <connectionUrl>scm:git:https://github.com/dmn-tck/tck</connectionUrl>
                   <goals>install -Ddrools.version=${project.version}</goals>
                   <goalsDirectory>runners</goalsDirectory>
                   <profiles>drools</profiles>


### PR DESCRIPTION
- Add new unit tests for built-in FEEL functions

Fix these bugs and problems: 
- Rounding problem in EvalHelper.getBigDecimalOrNull() method - The method used .doubleValue() call which produced rounding errors. Testable by DMNRuntimeTest.testCompositeItemDefinition() while having a breakpoint on the resulting BigDecimal from getBigDecimalOrNull(). 
- AnyFunction and AllFunction didn't check if the items in the list parameter are all Booleans (they must be according to the spec.)
- ConcatenateFunction didn't check for nulls in the list parameter
- EqualsFunction didn't compare BigDecimals with compareTo() method (which checks just values and ignores scale)
- MinFunction and MaxFunction didn't check if the items in the list parameter are comparable
- NumberFunction - split of one error message into two
- ReplaceFunction - NPE when having replacement param as null
- StringFunction and CodeFunction contained duplicated code
- SublistFunction - it was possible to input negative length as parameter
- ReplaceFunction now handles regexp flags

@etirelli @tarilabs could you please review? 