### PR TITLE
Fix asSystemSpecificPath method to deal with lower case Windows drive letter

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/IoUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/IoUtils.java
@@ -343,9 +343,9 @@ public class IoUtils {
 
     public static String asSystemSpecificPath(String urlPath, int colonIndex) {
         String ic = urlPath.substring( Math.max( 0, colonIndex - 2 ), colonIndex + 1 );
-        if  ( ic.matches( "\\/[A-Z]:" ) ) {
+        if  ( ic.matches( "\\/[a-zA-Z]:" ) ) {
             return urlPath.substring( colonIndex - 2 );
-        } else if  ( ic.matches( "[A-Z]:" ) ) {
+        } else if  ( ic.matches( "[a-zA-Z]:" ) ) {
             return urlPath.substring( colonIndex - 1 );
         } else {
             return urlPath.substring( colonIndex + 1 );

--- a/drools-core/src/test/java/org/drools/core/util/IoUtilsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/IoUtilsTest.java
@@ -32,4 +32,12 @@ public class IoUtilsTest {
         byte[] bytes = IoUtils.readBytesFromInputStream( new ReaderInputStream( new StringReader( "" ) ) );
         assertEquals(0, bytes.length);
     }
+	
+	@Test
+    public void testAsSystemSpecificPath() {
+        String urlPath = "c:\\workdir\\server-local\\instance\\tmp\\vfs\\deployment\\deploymentf7b5abe7c4c1cb56\\rules-with-kjar-1.0.jar-57cc270a5729d6b2\\rules-with-kjar-1.0.jar";
+        String specificPath = IoUtils.asSystemSpecificPath(urlPath, 1);
+        // Check that windows drive (even in lower case) is not removed
+        assertEquals(urlPath, specificPath);
+    }
 }


### PR DESCRIPTION
Fix asSystemSpecificPath method so that windows drive, even in lower case (as 'c:\'), is not removed