### PR TITLE
DROOLS-1734: fixing 'if' expression semantics to comply with the spec

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IfExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IfExpressionNode.java
@@ -63,16 +63,13 @@ public class IfExpressionNode
 
     @Override
     public Object evaluate(EvaluationContext ctx) {
+        // spec says: if FEEL(e1) is true then FEEL(e2) else FEEL(e3)
         Object cond = this.condition.evaluate( ctx );
-        if ( cond instanceof Boolean ) {
-            if ( ((Boolean) cond) ) {
-                return this.thenExpression.evaluate( ctx );
-            } else {
-                return this.elseExpression.evaluate( ctx );
-            }
+        if ( cond != null && cond instanceof Boolean && cond == Boolean.TRUE ) {
+            return this.thenExpression.evaluate( ctx );
+        } else {
+            return this.elseExpression.evaluate( ctx );
         }
-        ctx.notifyEvt( astEvent(Severity.ERROR, Msg.createMessage(Msg.CONDITION_WAS_NOT_A_BOOLEAN)) );
-        return null;
     }
 
     @Override

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELConditionsAndLoopsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELConditionsAndLoopsTest.java
@@ -32,7 +32,8 @@ public class FEELConditionsAndLoopsTest extends BaseFEELTest {
                 { "if true then 10+5 else 10-5", BigDecimal.valueOf( 15 ) , null},
                 { "if false then \"foo\" else \"bar\"", "bar" , null},
                 { "if date(\"2016-08-02\") > date(\"2015-12-25\") then \"yey\" else \"nay\"", "yey" , null},
-                {"if null then \"foo\" else \"bar\"", null , FEELEvent.Severity.ERROR },
+                {"if null then \"foo\" else \"bar\"", "bar" , null },
+                {"if \"xyz\" then \"foo\" else \"bar\"", "bar" , null },
 
                 // for
                 {"for x in [ 10, 20, 30 ], y in [ 1, 2, 3 ] return x * y",


### PR DESCRIPTION
Fixing 'if' expression semantics to comply with the spec in case of null values or non-boolean expressions