### PR TITLE
[DROOLS-1675] Wrong FEEL external function definition throws NPE pt.2

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ASTBuilderVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ASTBuilderVisitor.java
@@ -281,6 +281,7 @@ public class ASTBuilderVisitor
         }
         BaseNode name = visit(key);
         BaseNode value = visit(expression);
+        if (value == null) return null;
         return ASTBuilderFactory.newContextEntry( ctx, name, value );
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
@@ -131,8 +131,17 @@ public class FEELParser {
             final SyntaxErrorEvent error;
 
             CommonToken token = (CommonToken) offendingSymbol;
-            if( ((Parser)recognizer).getRuleInvocationStack().contains( "nameDefinition" ) ) {
-                error = generateInvalidVariableError( offendingSymbol, line, charPositionInLine, e, token );
+            final int tokenIndex = token.getTokenIndex();
+            final Parser parser = (Parser) recognizer;
+            if( parser.getRuleInvocationStack().contains( "nameDefinition" ) ) {
+                error = generateInvalidVariableError(offendingSymbol, line, charPositionInLine, e, token);
+            } else if ( "}".equals(token.getText()) && tokenIndex > 1 && ":".equals(parser.getTokenStream().get(tokenIndex - 1).getText()) ) {
+                error = new SyntaxErrorEvent( FEELEvent.Severity.ERROR,
+                                            Msg.createMessage(Msg.MISSING_EXPRESSION, parser.getTokenStream().get(tokenIndex - 2).getText()),
+                                            e,
+                                            line,
+                                            charPositionInLine,
+                                            offendingSymbol );
             } else {
                 error = new SyntaxErrorEvent( FEELEvent.Severity.ERROR,
                                                   msg,

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionDefinitionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionDefinitionTest.java
@@ -60,6 +60,7 @@ public class FEELFunctionDefinitionTest extends BaseFEELTest {
                         null, FEELEvent.Severity.ERROR },
                 {"{ maximum : function( v1, v2 ) external { }, the max : maximum( 10, 20 ) }.the max", null, FEELEvent.Severity.ERROR },
                 {"{ maximum : function( v1, v2 ) external { missingDefiniton }, the max : maximum( 10, 20 ) }.the max", null, FEELEvent.Severity.ERROR },
+                {"{ maximum : function( v1, v2 ) external { missingDefiniton : }, the max : maximum( 10, 20 ) }.the max", null, FEELEvent.Severity.ERROR },
                 // variable number of parameters
                 {"{ \n"
                  + "    string format : function( mask, value ) external {\n"


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-1675

this PR improves error reporting for 
{ maximum : function( v1, v2 ) external { missingDefiniton : }, the max : maximum( 10, 20 ) }.the max 