### PR TITLE
RHBRMS-2689: Unable to build project if kbase and ksession names are identical

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -140,8 +140,7 @@ public class KieBuilderImpl
         // if pomXml is invalid, it assign pomModel to null
         PomModel pomModel = getPomModel();
 
-        // if kModuleModelXML is null it will generate a default kModule, with a default kbase name
-        // if kModuleModelXML is  invalid, it will kModule to null
+        // if kModuleModelXML is null or invalid it will generate a default kModule, with a default kbase name
         buildKieModuleModel();
 
         if ( pomModel != null ) {
@@ -440,9 +439,11 @@ public class KieBuilderImpl
                 results.addMessage( Level.ERROR,
                                     "kmodule.xml",
                                     "kmodule.xml found, but unable to read\n" + e.getMessage() );
+                // Create a default kModuleModel in the event of errors parsing the XML
+                kModuleModel = KieServices.Factory.get().newKieModuleModel();
             }
         } else {
-            // There's no kmodule.xml, create a defualt one
+            // There's no kmodule.xml, create a default one
             kModuleModel = KieServices.Factory.get().newKieModuleModel();
         }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBuilderTest.java
@@ -37,6 +37,7 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.StatelessKieSession;
 import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.internal.builder.InternalKieBuilder;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
@@ -469,6 +470,7 @@ public class KieBuilderTest extends CommonTestMethodBase {
         kieBuilder.buildAll();
         final Results results = kieBuilder.getResults();
         assertEquals( expectedErrors, results.getMessages( org.kie.api.builder.Message.Level.ERROR ).size() );
+        assertNotNull(((InternalKieBuilder) kieBuilder ).getKieModuleIgnoringErrors());
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2689

This ensures there is always a default ```kModuleModel``` even if parsing of the ```kmodule.xml``` failed.

I believe this honours the ```InternalKieBuilder.getKieModuleIgnoringErrors()``` contract.