### PR TITLE
DROOLS-1752: Fixing 'substring after' function

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunction.java
@@ -38,7 +38,7 @@ public class SubstringAfterFunction
         if( index >= 0 ) {
             return FEELFnResult.ofResult( string.substring( index+match.length() ) );
         } else {
-            return FEELFnResult.ofResult( string );
+            return FEELFnResult.ofResult( "" );
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
@@ -52,7 +52,7 @@ public class FEELFunctionsTest extends BaseFEELTest {
                 { "substring before( \"foobar\", \"xyz\")", "" , null},
                 { "substring before( \"foobar\", \"foo\")", "" , null},
                 { "substring after( \"foobar\", \"foo\")", "bar" , null},
-                { "substring after( \"foobar\", \"xyz\")", "foobar" , null},
+                { "substring after( \"foobar\", \"xyz\")", "" , null},
                 { "substring after( \"foobar\", \"bar\")", "" , null},
                 { "contains(\"foobar\", \"ob\")", Boolean.TRUE , null},
                 { "contains(\"foobar\", \"of\")", Boolean.FALSE , null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringAfterFunctionTest.java
@@ -44,6 +44,6 @@ public class SubstringAfterFunctionTest {
 
     @Test
     public void invokeMatchNotExists() {
-        FunctionTestUtil.assertResult(substringAfterFunction.invoke("foobar", "oook"), "foobar");
+        FunctionTestUtil.assertResult(substringAfterFunction.invoke("foobar", "oook"), "");
     }
 }


### PR DESCRIPTION
(cherry picked from commit 9c1c282edbcbaed0e671c2dcd52160078706c10a)