### PR TITLE
DROOLS-1753: fixing replace() function with escape characters

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/antlr4/org/kie/dmn/feel/parser/feel11/FEEL_1_1.g4
+++ b/kie-dmn/kie-dmn-feel/src/main/antlr4/org/kie/dmn/feel/parser/feel11/FEEL_1_1.g4
@@ -626,7 +626,7 @@ StringCharacter
 
 fragment
 EscapeSequence
-	:	'\\' [btnfr"'\\]
+	:	'\\' ~[u]     // required to support FEEL regexps
     |   UnicodeEscape // This is not in the spec but prevents having to preprocess the input
 	;
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -144,7 +144,11 @@ public class EvalHelper {
                                 }
                                 break;
                             }
+                            default:
+                                r.append( "\\" ).append( cn );
                         }
+                    } else {
+                        r.append( c );
                     }
                 } else {
                     r.append( c );

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
@@ -71,6 +71,7 @@ public class FEELFunctionsTest extends BaseFEELTest {
                 { "replace(\"banana\",\"a\",\"o\")", "bonono" , null},
                 { "replace(\"banana\",\"(an)+\", \"**\")", "b**a" , null},
                 { "replace(\"banana\",\"[aeiouy]\",\"[$0]\")", "b[a]n[a]n[a]" , null},
+                { "replace(\"0123456789\",\"(\\d{3})(\\d{3})(\\d{4})\",\"($1) $2-$3\")", "(012) 345-6789" , null},
                 { "list contains([1, 2, 3], 2)", Boolean.TRUE , null},
                 { "list contains([1, 2, 3], 5)", Boolean.FALSE , null},
                 { "count([1, 2, 3])", BigDecimal.valueOf( 3 ) , null},


### PR DESCRIPTION
/cc @tarilabs @baldimir 