### PR TITLE
DROOLS-1760 Enhance test coverage of FEEL built-in functions part 2

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AppendFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/AppendFunction.java
@@ -29,7 +29,7 @@ public class AppendFunction
         super( "append" );
     }
 
-    public FEELFnResult<List> invoke( @ParameterName( "list" ) List list, @ParameterName( "item" ) Object[] items ) {
+    public FEELFnResult<List<Object>> invoke( @ParameterName( "list" ) List list, @ParameterName( "item" ) Object[] items ) {
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunction.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -187,7 +188,7 @@ public abstract class BaseFEELFunction
         CandidateMethod candidate = null;
         // first, look for exact matches
         for ( Method m : getClass().getDeclaredMethods() ) {
-            if ( !m.getName().equals( "invoke" ) ) {
+            if ( !Modifier.isPublic(m.getModifiers()) || !m.getName().equals( "invoke" ) ) {
                 continue;
             }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ConcatenateFunction.java
@@ -29,7 +29,7 @@ public class ConcatenateFunction
         super( "concatenate" );
     }
 
-    public FEELFnResult<List> invoke(@ParameterName("list") Object[] lists) {
+    public FEELFnResult<List<Object>> invoke(@ParameterName("list") Object[] lists) {
         if ( lists == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DistinctValuesFunction.java
@@ -29,7 +29,7 @@ public class DistinctValuesFunction
         super( "distinct values" );
     }
 
-    public FEELFnResult<List> invoke(@ParameterName( "list" ) Object list) {
+    public FEELFnResult<List<Object>> invoke(@ParameterName( "list" ) Object list) {
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/IndexOfFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/IndexOfFunction.java
@@ -29,7 +29,7 @@ public class IndexOfFunction
         super( "index of" );
     }
 
-    public FEELFnResult<List> invoke(@ParameterName( "list" ) List list, @ParameterName( "match" ) Object match) {
+    public FEELFnResult<List<BigDecimal>> invoke(@ParameterName( "list" ) List list, @ParameterName( "match" ) Object match) {
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RemoveFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/RemoveFunction.java
@@ -19,11 +19,8 @@ package org.kie.dmn.feel.runtime.functions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class RemoveFunction
         extends BaseFEELFunction {
@@ -32,7 +29,7 @@ public class RemoveFunction
         super( "remove" );
     }
 
-    public FEELFnResult<List> invoke(@ParameterName( "list" ) List list, @ParameterName( "position" ) BigDecimal position) {
+    public FEELFnResult<List<Object>> invoke(@ParameterName( "list" ) List list, @ParameterName( "position" ) BigDecimal position) {
         if ( list == null ) { 
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReverseFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/ReverseFunction.java
@@ -29,12 +29,12 @@ public class ReverseFunction
         super( "reverse" );
     }
 
-    public FEELFnResult<List> invoke(@ParameterName("list") List list) {
+    public FEELFnResult<List<Object>> invoke(@ParameterName("list") List list) {
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
         // spec requires us to return a new list
-        List result = new ArrayList( list );
+        final List<Object> result = new ArrayList<>( list );
         Collections.reverse( result );
         return FEELFnResult.ofResult( result );
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SortFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SortFunction.java
@@ -16,15 +16,13 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.lang.EvaluationContext;
-import org.kie.dmn.feel.lang.ast.BooleanNode;
 import org.kie.dmn.feel.runtime.FEELFunction;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SortFunction
         extends BaseFEELFunction {
@@ -36,57 +34,44 @@ public class SortFunction
     public FEELFnResult<List<Object>> invoke(@ParameterName( "ctx" ) EvaluationContext ctx,
                                              @ParameterName("list") List list,
                                              @ParameterName("precedes") FEELFunction function) {
-        if ( list == null ) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
-        } else if ( function == null ){
+        if ( function == null ) {
             return invoke( list );
-        }
-        List<Object> newList = new ArrayList<Object>( list );
-        AtomicBoolean hasError = new AtomicBoolean( false );
-        newList.sort( (a, b) -> {
-            try {
-                Object result = function.invokeReflectively( ctx, new Object[] {a, b} );
-                if( !(result instanceof Boolean) || ((Boolean)result) == true ) {
+        } else {
+            return invoke(list, (a, b) -> {
+                final Object result = function.invokeReflectively(ctx, new Object[]{a, b});
+                if (!(result instanceof Boolean) || ((Boolean) result)) {
                     return -1;
                 } else {
                     return 1;
                 }
-            } catch ( Throwable t ) {
-                hasError.set( true );
-                return 0;
-            }
-        } );
-        if( hasError.get() ) {
-            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "precedes", "raised an exception while sorting list "+list ) );
-        } else {
-            return FEELFnResult.ofResult( newList );
+            } );
         }
     }
 
     public FEELFnResult<List<Object>> invoke(@ParameterName("list") List list) {
+        return invoke(list, (a, b) -> {
+            if( a instanceof Comparable && b instanceof Comparable ) {
+                return ((Comparable) a).compareTo( b );
+            } else {
+                return 0;
+            }
+        });
+    }
+
+    private FEELFnResult<List<Object>> invoke(final List list, final Comparator<? super Object> comparator) {
         if ( list == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "cannot be null"));
         }
-        List<Object> newList = new ArrayList<Object>( list );
-        AtomicBoolean hasError = new AtomicBoolean( false );
-        newList.sort( (a, b) -> {
-            try {
-                if( a instanceof Comparable && b instanceof Comparable ) {
-                    return ((Comparable)a).compareTo( b );
-                } else {
-                    return 0;
-                }
-            } catch ( Throwable t ) {
-                // we might need to capture the exception for error reporting as well
-                hasError.set( true );
-                return 0;
-            }
-        } );
-        if( hasError.get() ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent(Severity.ERROR, "list", "raised an exception while sorting by natural order" ) );
-        } else {
-            return FEELFnResult.ofResult( newList );
+        final List<Object> newList = new ArrayList<Object>( list );
+        try {
+            newList.sort(comparator);
+        } catch (final Throwable ex) {
+            return FEELFnResult.ofError(
+                    new InvalidParametersEvent(Severity.ERROR, "list",
+                            "raised an exception while sorting by natural order", ex ) );
         }
+
+        return FEELFnResult.ofResult( newList );
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringFunction.java
@@ -27,23 +27,7 @@ public class SubstringFunction
     }
 
     public FEELFnResult<String> invoke(@ParameterName("string") String string, @ParameterName("start position") Number start) {
-        if ( string == null ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "string", "cannot be null" ) );
-        }
-        if ( start == null ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "start position", "cannot be null" ) );
-        }
-        if ( Math.abs( start.intValue() ) > string.length() ) {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "parameter 'start position' inconsistent with parameter 'string' length" ) );
-        }
-
-        if ( start.intValue() > 0 ) {
-            return FEELFnResult.ofResult( string.substring( start.intValue() - 1 ) );
-        } else if ( start.intValue() < 0 ) {
-            return FEELFnResult.ofResult( string.substring( string.length() + start.intValue() ) );
-        } else {
-            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "start position", "cannot be zero" ) );
-        }
+        return invoke(string, start, null);
     }
 
     public FEELFnResult<String> invoke(@ParameterName("string") String string, @ParameterName("start position") Number start, @ParameterName("length") Number length) {
@@ -53,14 +37,19 @@ public class SubstringFunction
         if ( start == null ) {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "start position", "cannot be null" ) );
         }
+        if ( length != null && length.intValue() <= 0 ) {
+            return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "length", "must be a positive number when specified" ) );
+        }
         if ( Math.abs( start.intValue() ) > string.length() ) {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "parameter 'start position' inconsistent with parameter 'string' length" ) );
         }
 
         if ( start.intValue() > 0 ) {
-            return FEELFnResult.ofResult( string.substring( start.intValue() - 1, Math.min( string.length(), start.intValue() + length.intValue() - 1 ) ) );
+            final int end = length != null ? Math.min( string.length(), start.intValue() + length.intValue() - 1 ) : string.length();
+            return FEELFnResult.ofResult( string.substring( start.intValue() - 1, end ) );
         } else if ( start.intValue() < 0 ) {
-            return FEELFnResult.ofResult( string.substring( string.length() + start.intValue(), Math.min( string.length(), string.length() + start.intValue() + length.intValue() ) ) );
+            final int end = length != null ? Math.min( string.length(), string.length() + start.intValue() + length.intValue() ) : string.length();
+            return FEELFnResult.ofResult( string.substring( string.length() + start.intValue(), end ) );
         } else {
             return FEELFnResult.ofError( new InvalidParametersEvent( Severity.ERROR, "start position", "cannot be zero" ) );
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SumFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/SumFunction.java
@@ -34,14 +34,22 @@ public class SumFunction
     }
 
     public FEELFnResult<BigDecimal> invoke(@ParameterName("list") List list) {
+        if ( list == null ) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "the list cannot be null"));
+        }
         BigDecimal sum = BigDecimal.ZERO;
         for ( Object element : list ) {
             if ( element instanceof BigDecimal ) {
                 sum = sum.add( (BigDecimal) element );
             } else if ( element instanceof Number ) {
-                sum = sum.add( EvalHelper.getBigDecimalOrNull( element ) );
+                BigDecimal value = EvalHelper.getBigDecimalOrNull( element );
+                if (value == null) {
+                    return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "an element in the list is not suitable for the sum"));
+                } else {
+                    sum = sum.add( value );
+                }
             } else {
-                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "an element in the list is not suitable for the sum"));
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "list", "an element in the list is not a number"));
             }
         }
         return FEELFnResult.ofResult( sum );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/UnionFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/UnionFunction.java
@@ -18,16 +18,11 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-
 import java.util.Set;
-import java.util.SortedSet;
-import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 public class UnionFunction
         extends BaseFEELFunction {
@@ -36,22 +31,17 @@ public class UnionFunction
         super( "union" );
     }
 
-    public FEELFnResult<List> invoke(@ParameterName("list") Object[] lists) {
+    public FEELFnResult<List<Object>> invoke(@ParameterName("list") Object[] lists) {
         if ( lists == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "lists", "cannot be null"));
         }
 
         final Set<Object> resultSet = new LinkedHashSet<>();
         for ( final Object list : lists ) {
-            if ( list != null ) {
-                if ( list instanceof Collection ) {
-                    resultSet.addAll((Collection) list);
-                } else {
-                    resultSet.add(list);
-                }
+            if ( list instanceof Collection ) {
+                resultSet.addAll((Collection) list);
             } else {
-                // TODO review accordingly to spec, original behavior was: return null;
-                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "lists", "one of the elements in list is null"));
+                resultSet.add(list);
             }
         }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/UnionFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/UnionFunction.java
@@ -18,8 +18,12 @@ package org.kie.dmn.feel.runtime.functions;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 
+import java.util.Set;
+import java.util.SortedSet;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
@@ -36,21 +40,22 @@ public class UnionFunction
         if ( lists == null ) {
             return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "lists", "cannot be null"));
         }
-        // spec requires us to return a new list
-        List result = new ArrayList();
-        for ( Object list : lists ) {
-            if ( list instanceof Collection ) {
-                ((Collection) list).stream().forEach( i -> {
-                    if ( !result.contains( i ) ) result.add( i );
-                } );
-            } else if ( list != null ) {
-                // singleton list
-                if ( !result.contains( list ) ) result.add( list );
+
+        final Set<Object> resultSet = new LinkedHashSet<>();
+        for ( final Object list : lists ) {
+            if ( list != null ) {
+                if ( list instanceof Collection ) {
+                    resultSet.addAll((Collection) list);
+                } else {
+                    resultSet.add(list);
+                }
             } else {
                 // TODO review accordingly to spec, original behavior was: return null;
                 return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "lists", "one of the elements in list is null"));
             }
         }
-        return FEELFnResult.ofResult( result );
+
+        // spec requires us to return a new list
+        return FEELFnResult.ofResult( new ArrayList<>(resultSet) );
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELFunctionsTest.java
@@ -131,7 +131,7 @@ public class FEELFunctionsTest extends BaseFEELTest {
                 { "index of( null, 1 )", null , FEELEvent.Severity.ERROR},
                 { "union( [1, 2, 1], [2, 3], 2, 4 )", Arrays.asList( BigDecimal.valueOf( 1 ), BigDecimal.valueOf( 2 ), BigDecimal.valueOf( 3 ), BigDecimal.valueOf( 4 ) ) , null},
                 { "union( [1, 2, null], 4 )", Arrays.asList( BigDecimal.valueOf( 1 ), BigDecimal.valueOf( 2 ), null, BigDecimal.valueOf( 4 ) ) , null},
-                { "union( null, 4 )", null , FEELEvent.Severity.ERROR},
+                { "union( null, 4 )", Arrays.asList( null, BigDecimal.valueOf(4) ), null},
                 { "distinct values( [1, 2, 3, 2, 4] )", Arrays.asList( BigDecimal.valueOf( 1 ), BigDecimal.valueOf( 2 ), BigDecimal.valueOf( 3 ), BigDecimal.valueOf( 4 ) ) , null},
                 { "distinct values( [1, 2, null, 2, 4] )", Arrays.asList( BigDecimal.valueOf( 1 ), BigDecimal.valueOf( 2 ), null, BigDecimal.valueOf( 4 ) ) , null},
                 { "distinct values( 1 )", Arrays.asList( BigDecimal.valueOf( 1 ) ) , null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/FunctionTestUtil.java
@@ -42,9 +42,9 @@ public final class FunctionTestUtil {
         Assert.assertThat(resultValue, Matchers.comparesEqualTo(expectedResult));
     }
 
-    public static void assertResultList(final FEELFnResult<List> result, final List<Object> expectedResult) {
+    public static <T> void assertResultList(final FEELFnResult<List<T>> result, final List<Object> expectedResult) {
         assertResultNotError(result);
-        final List<Object> resultList = result.cata(left -> null, right -> right);
+        final List<T> resultList = result.cata(left -> null, right -> right);
         Assert.assertThat(resultList, Matchers.hasSize(expectedResult.size()));
         if (expectedResult.isEmpty()) {
             Assert.assertThat(resultList, Matchers.empty());

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/MatchesFunctionTest.java
@@ -37,6 +37,11 @@ public class MatchesFunctionTest {
     }
 
     @Test
+    public void invokeUnsupportedFlags() {
+        FunctionTestUtil.assertResult(matchesFunction.invoke("foobar", "fo.bar", "g"), true);
+    }
+
+    @Test
     public void invokeWithoutFlagsMatch() {
         FunctionTestUtil.assertResult(matchesFunction.invoke("test", "test"), true);
         FunctionTestUtil.assertResult(matchesFunction.invoke("foobar", "^fo*b"), true);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SortFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SortFunctionTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Symbol;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SortFunctionTest {
+
+    private SortFunction sortFunction;
+
+    @Before
+    public void setUp() {
+        sortFunction = new SortFunction();
+    }
+
+    @Test
+    public void invokeListParamNull() {
+        FunctionTestUtil.assertResultError(sortFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListEmpty() {
+        FunctionTestUtil.assertResultList(sortFunction.invoke(Collections.emptyList()), Collections.emptyList());
+    }
+
+    @Test
+    public void invokeListSingleItem() {
+        FunctionTestUtil.assertResultList(sortFunction.invoke(Collections.singletonList(10)), Collections.singletonList(10));
+    }
+
+    @Test
+    public void invokeListTypeHeterogenous() {
+        FunctionTestUtil.assertResultError(
+                sortFunction.invoke(Arrays.asList(10, "test", BigDecimal.TEN)),
+                InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeList() {
+        FunctionTestUtil.assertResultList(sortFunction.invoke(Arrays.asList(10, 4, 5, 12)), Arrays.asList(4, 5, 10, 12));
+        FunctionTestUtil.assertResultList(sortFunction.invoke(Arrays.asList("a", "c", "b")), Arrays.asList("a", "b", "c"));
+    }
+
+    @Test
+    public void invokeWithSortFunctionNull() {
+        FunctionTestUtil.assertResultList(
+                sortFunction.invoke(null, Arrays.asList(10, 4, 5, 12), null), Arrays.asList(4, 5, 10, 12));
+    }
+
+    @Test
+    public void invokeWithSortFunction() {
+        FunctionTestUtil.assertResultList(
+                sortFunction.invoke(null, Arrays.asList(10, 4, 5, 12), getBooleanFunction(true)), Arrays.asList(12, 5, 4, 10));
+        FunctionTestUtil.assertResultList(
+                sortFunction.invoke(null, Arrays.asList(10, 4, 5, 12), getBooleanFunction(false)), Arrays.asList(10, 4, 5, 12));
+    }
+
+    @Test
+    public void invokeExceptionInSortFunction() {
+        FunctionTestUtil.assertResultError(
+                sortFunction.invoke(null, Arrays.asList(10, 4, 5, 12), getFunctionThrowingException()),
+                InvalidParametersEvent.class);
+    }
+
+    private FEELFunction getBooleanFunction(final boolean functionResult) {
+        return new FEELFunction() {
+            @Override
+            public String getName() {
+                return "alwaysBoolean";
+            }
+
+            @Override
+            public Symbol getSymbol() {
+                return null;
+            }
+
+            @Override
+            public List<List<String>> getParameterNames() {
+                return null;
+            }
+
+            @Override
+            public Object invokeReflectively(final EvaluationContext ctx, final Object[] params) {
+                return functionResult;
+            }
+        };
+    }
+
+    private FEELFunction getFunctionThrowingException() {
+        return new FEELFunction() {
+            @Override
+            public String getName() {
+                return "throwException";
+            }
+
+            @Override
+            public Symbol getSymbol() {
+                return null;
+            }
+
+            @Override
+            public List<List<String>> getParameterNames() {
+                return null;
+            }
+
+            @Override
+            public Object invokeReflectively(final EvaluationContext ctx, final Object[] params) {
+                throw new IllegalStateException("test exception");
+            }
+        };
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SubstringFunctionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SubstringFunctionTest {
+
+    private SubstringFunction substringFunction;
+
+    @Before
+    public void setUp() {
+        substringFunction = new SubstringFunction();
+    }
+
+    @Test
+    public void invokeNull2ParamsMethod() {
+        FunctionTestUtil.assertResultError(substringFunction.invoke((String) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke(null, 0), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNull3ParamsMethod() {
+        FunctionTestUtil.assertResultError(substringFunction.invoke(null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", null, 2), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke(null, 0, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke(null, null, 2), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke(null, 0, 2), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStartZero() {
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", 0), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", 0, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStartOutOfListBounds() {
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", 10), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", 10, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", -10), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", -10, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeLengthNegative() {
+        FunctionTestUtil.assertResultError(substringFunction.invoke("test", 1, -3), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeLengthOutOfListBounds() {
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", 2, 3), "est");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", -3, 3), "est");
+    }
+
+    @Test
+    public void invokeStartPositive() {
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", 1), "test");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", 2), "est");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", 4), "t");
+
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", 2, 1), "e");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", 2, 2), "es");
+    }
+
+    @Test
+    public void invokeStartNegative() {
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", -1), "t");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", -2), "st");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", -4), "test");
+
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", -2, 1), "s");
+        FunctionTestUtil.assertResult(substringFunction.invoke("test", -3, 2), "es");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SumFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SumFunctionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SumFunctionTest {
+
+    private SumFunction sumFunction;
+
+    @Before
+    public void setUp() {
+        sumFunction = new SumFunction();
+    }
+
+    @Test
+    public void invokeNullNumber() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke((Number) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNullList() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke((List) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNullArray() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SumFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/SumFunctionTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,17 +33,60 @@ public class SumFunctionTest {
     }
 
     @Test
-    public void invokeNullNumber() {
+    public void invokeNumberParamNull() {
         FunctionTestUtil.assertResultError(sumFunction.invoke((Number) null), InvalidParametersEvent.class);
     }
 
     @Test
-    public void invokeNullList() {
+    public void invokeNumberParamUnsupportedNumber() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke(Double.NaN), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeNumberParamSupportedNumber() {
+        FunctionTestUtil.assertResult(sumFunction.invoke(BigDecimal.TEN), BigDecimal.TEN);
+        FunctionTestUtil.assertResult(sumFunction.invoke(10), BigDecimal.TEN);
+        FunctionTestUtil.assertResult(sumFunction.invoke(-10), BigDecimal.valueOf(-10));
+        FunctionTestUtil.assertResult(sumFunction.invoke(10.12), BigDecimal.valueOf(10.12));
+    }
+
+    @Test
+    public void invokeListParam() {
         FunctionTestUtil.assertResultError(sumFunction.invoke((List) null), InvalidParametersEvent.class);
     }
 
     @Test
-    public void invokeNullArray() {
+    public void invokeListParamContainsUnsupportedNumber() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke(Arrays.asList(10, 2, Double.NaN)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListParamContainsUnsupportedType() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke(Arrays.asList(10, "test", 2)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListParamSupportedTypes() {
+        FunctionTestUtil.assertResult(sumFunction.invoke(Arrays.asList(4, -1, 12.1, (long) 5, BigDecimal.TEN)), BigDecimal.valueOf(30.1));
+    }
+
+    @Test
+    public void invokeArrayParam() {
         FunctionTestUtil.assertResultError(sumFunction.invoke((Object[]) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayParamContainsUnsupportedNumber() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke(new Object[]{10, 2, Double.NaN}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayParamContainsUnsupportedType() {
+        FunctionTestUtil.assertResultError(sumFunction.invoke(new Object[]{10, "test", 2}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeArrayParamSupportedTypes() {
+        FunctionTestUtil.assertResult(sumFunction.invoke(new Object[]{4, -1, 12.1, (long) 5, BigDecimal.TEN}), BigDecimal.valueOf(30.1));
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TimeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TimeFunctionTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAccessor;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class TimeFunctionTest {
+
+    private TimeFunction timeFunction;
+
+    @Before
+    public void setUp() {
+        timeFunction = new TimeFunction();
+    }
+
+    @Test
+    public void invokeStringParamNull() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke((String) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStringParamNotDateOrTime() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke("test"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStringParamDate() {
+        FunctionTestUtil.assertResult(timeFunction.invoke("2017-10-09"), LocalTime.of(0,0,0));
+        FunctionTestUtil.assertResult(timeFunction.invoke("2017-10-09T10:15:06"), LocalTime.of(10,15,6));
+    }
+
+    @Test
+    public void invokeStringParamTimeWrongFormat() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke("10-15:06"), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeStringParamNoOffset() {
+        FunctionTestUtil.assertResult(timeFunction.invoke("10:15:06"), LocalTime.of(10,15,6));
+    }
+
+    @Test
+    public void invokeStringParamWithOffset() {
+        FunctionTestUtil.assertResult(timeFunction.invoke("10:15:06+01:00"), OffsetTime.of(10,15,6, 0, ZoneOffset.ofHours(1)));
+        FunctionTestUtil.assertResult(timeFunction.invoke("10:15:06-01:00"), OffsetTime.of(10,15,6, 0, ZoneOffset.ofHours(-1)));
+    }
+
+    @Test
+    public void invokeTemporalAccessorParamNull() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke((TemporalAccessor) null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTemporalAccessorParamUnsupportedAccessor() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke(DayOfWeek.MONDAY), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTemporalAccessorParamDate() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke(LocalDate.of(2017, 6, 12)), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTemporalAccessorParamTime() {
+        FunctionTestUtil.assertResult(timeFunction.invoke(LocalTime.of(11, 43)), LocalTime.of(11, 43, 0));
+    }
+
+    @Test
+    public void invokeTemporalAccessorParamDateTime() {
+        FunctionTestUtil.assertResult(timeFunction.invoke(LocalDateTime.of(2017, 6, 12, 11, 43)), LocalTime.of(11, 43, 0));
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsNull() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke(null, null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(null, null, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(null, 1, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(null, 1, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, null, null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, null, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, 1, null, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsUnsupportedNumber() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke(Double.POSITIVE_INFINITY, 1, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(Double.NEGATIVE_INFINITY, 1, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, Double.POSITIVE_INFINITY, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, Double.NEGATIVE_INFINITY, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, 1, Double.POSITIVE_INFINITY, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, 1, Double.NEGATIVE_INFINITY, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsOutOfBounds() {
+        FunctionTestUtil.assertResultError(timeFunction.invoke(40, 1, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, 900, 1, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(timeFunction.invoke(1, 1, 900, null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsNoOffset() {
+        FunctionTestUtil.assertResult(timeFunction.invoke(10, 43, 15, null), LocalTime.of(10, 43, 15));
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsNoOffsetWithNanoseconds() {
+        FunctionTestUtil.assertResult(timeFunction.invoke(10, 43, BigDecimal.valueOf(15.154), null), LocalTime.of(10, 43, 15, 154000000));
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsWithOffset() {
+        FunctionTestUtil.assertResult(timeFunction.invoke(10, 43, 15, Duration.ofHours(1)), OffsetTime.of(10, 43, 15, 0, ZoneOffset.ofHours(1)));
+        FunctionTestUtil.assertResult(timeFunction.invoke(10, 43, 15, Duration.ofHours(-1)), OffsetTime.of(10, 43, 15, 0, ZoneOffset.ofHours(-1)));
+    }
+
+    @Test
+    public void invokeTimeUnitsParamsWithOffsetWithNanoseconds() {
+        FunctionTestUtil.assertResult(
+                timeFunction.invoke(10, 43, BigDecimal.valueOf(15.154), Duration.ofHours(1)),
+                OffsetTime.of(10, 43, 15, 154000000, ZoneOffset.ofHours(1)));
+        FunctionTestUtil.assertResult(
+                timeFunction.invoke(10, 43, BigDecimal.valueOf(15.154), Duration.ofHours(-1)),
+                OffsetTime.of(10, 43, 15, 154000000, ZoneOffset.ofHours(-1)));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TodayFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/TodayFunctionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TodayFunctionTest {
+
+    private TodayFunction todayFunction;
+
+    @Before
+    public void setUp() {
+        todayFunction = new TodayFunction();
+    }
+
+    @Test
+    public void invoke() {
+        FunctionTestUtil.assertResult(todayFunction.invoke(), LocalDate.now());
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/UnionFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/UnionFunctionTest.java
@@ -17,9 +17,7 @@
 package org.kie.dmn.feel.runtime.functions;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,12 +60,11 @@ public class UnionFunctionTest {
 
     @Test
     public void invokeListIsNull() {
-        FunctionTestUtil.assertResultError(unionFunction.invoke(new Object[]{null}), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResult(unionFunction.invoke(new Object[]{null}), Collections.singletonList(null));
     }
 
     @Test
     public void invokeListContainsNull() {
-        // TODO - Ask Edson about this - nulls in list
         FunctionTestUtil.assertResult(unionFunction.invoke(new Object[]{Arrays.asList(null, 10, null)}), Arrays.asList(null, 10));
     }
 

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/UnionFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/UnionFunctionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class UnionFunctionTest {
+
+    private UnionFunction unionFunction;
+
+    @Before
+    public void setUp() {
+        unionFunction = new UnionFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(unionFunction.invoke(null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeEmptyArray() {
+        FunctionTestUtil.assertResultList(unionFunction.invoke(new Object[]{}), Collections.emptyList());
+    }
+
+    @Test
+    public void invokeSingleObject() {
+        FunctionTestUtil.assertResult(unionFunction.invoke(new Object[]{10}), Collections.singletonList(10));
+    }
+
+    @Test
+    public void invokeSingleObjectInAList() {
+        FunctionTestUtil.assertResult(unionFunction.invoke(new Object[]{Collections.singletonList(10)}), Collections.singletonList(10));
+    }
+
+    @Test
+    public void invokeSingleObjectInAnArray() {
+        final int[] testArray = new int[]{10};
+        FunctionTestUtil.assertResult(unionFunction.invoke(new Object[]{testArray}), Collections.singletonList(testArray));
+    }
+
+    @Test
+    public void invokeListIsNull() {
+        FunctionTestUtil.assertResultError(unionFunction.invoke(new Object[]{null}), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeListContainsNull() {
+        // TODO - Ask Edson about this - nulls in list
+        FunctionTestUtil.assertResult(unionFunction.invoke(new Object[]{Arrays.asList(null, 10, null)}), Arrays.asList(null, 10));
+    }
+
+    @Test
+    public void invokeListsNoDuplicates() {
+        final Object[] params = new Object[]{Arrays.asList(10, 8, 3), Arrays.asList(1, 15, 2)};
+        FunctionTestUtil.assertResultList(unionFunction.invoke(params), Arrays.asList(10, 8, 3, 1, 15, 2));
+    }
+
+    @Test
+    public void invokeListsSomeDuplicates() {
+        final Object[] params = new Object[]{Arrays.asList(10, 8, 3), Arrays.asList(1, 10, 2), Arrays.asList(10, 3, 2, 5)};
+        FunctionTestUtil.assertResultList(unionFunction.invoke(params), Arrays.asList(10, 8, 3, 1, 2, 5));
+    }
+
+    @Test
+    public void invokeListsAllDuplicates() {
+        final Object[] params = new Object[]{Arrays.asList(10, 8, 3), Arrays.asList(10, 8, 3), Arrays.asList(3, 10, 8)};
+        FunctionTestUtil.assertResultList(unionFunction.invoke(params), Arrays.asList(10, 8, 3));
+    }
+
+    @Test
+    public void invokeListAndSingleObject() {
+        FunctionTestUtil.assertResultList(unionFunction.invoke(new Object[]{Arrays.asList(10, 4, 5), 1}), Arrays.asList(10, 4, 5, 1));
+    }
+
+    @Test
+    public void invokeListAndSingleObjectWithDuplicates() {
+        FunctionTestUtil.assertResultList(unionFunction.invoke(new Object[]{5, Arrays.asList(10, 4, 5), 10}), Arrays.asList(5, 10, 4));
+    }
+
+    @Test
+    public void invokeMixedTypes() {
+        FunctionTestUtil.assertResultList(
+                unionFunction.invoke(new Object[]{"test", Arrays.asList(10, "test", 5), BigDecimal.TEN}),
+                Arrays.asList("test", 10, 5, BigDecimal.TEN));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunctionTest.java
@@ -16,20 +16,16 @@
 
 package org.kie.dmn.feel.runtime.functions;
 
-import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
 import java.time.Period;
 import java.time.Year;
 import java.time.YearMonth;
-import java.time.chrono.JapaneseDate;
 import java.time.temporal.Temporal;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
-import org.mockito.cglib.core.Local;
 
 public class YearsAndMonthsFunctionTest {
 
@@ -50,6 +46,7 @@ public class YearsAndMonthsFunctionTest {
     @Test
     public void invokeUnsupportedTemporal() {
         FunctionTestUtil.assertResultError(yamFunction.invoke(Instant.EPOCH, Instant.EPOCH), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(yamFunction.invoke(LocalDate.of(2017, 1, 1), Instant.EPOCH), InvalidParametersEvent.class);
     }
 
     @Test

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/YearsAndMonthsFunctionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.chrono.JapaneseDate;
+import java.time.temporal.Temporal;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+import org.mockito.cglib.core.Local;
+
+public class YearsAndMonthsFunctionTest {
+
+    private YearsAndMonthsFunction yamFunction;
+
+    @Before
+    public void setUp() {
+        yamFunction = new YearsAndMonthsFunction();
+    }
+
+    @Test
+    public void invokeNull() {
+        FunctionTestUtil.assertResultError(yamFunction.invoke((Temporal) null, null), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(yamFunction.invoke(null, LocalDate.now()), InvalidParametersEvent.class);
+        FunctionTestUtil.assertResultError(yamFunction.invoke(LocalDate.now(), null), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeUnsupportedTemporal() {
+        FunctionTestUtil.assertResultError(yamFunction.invoke(Instant.EPOCH, Instant.EPOCH), InvalidParametersEvent.class);
+    }
+
+    @Test
+    public void invokeYear() {
+        FunctionTestUtil.assertResult(yamFunction.invoke(Year.of(2017), Year.of(2020)), Period.of(3, 0, 0));
+        FunctionTestUtil.assertResult(yamFunction.invoke(Year.of(2017), Year.of(2014)), Period.of(-3, 0, 0));
+    }
+
+    @Test
+    public void invokeYearMonth() {
+        FunctionTestUtil.assertResult(
+                yamFunction.invoke(YearMonth.of(2017, 6), Year.of(2020)),
+                Period.of(2, 7, 0));
+        FunctionTestUtil.assertResult(
+                yamFunction.invoke(YearMonth.of(2017, 6), Year.of(2014)),
+                Period.of(-3, -5, 0));
+    }
+
+    @Test
+    public void invokeYearLocalDate() {
+        FunctionTestUtil.assertResult(
+                yamFunction.invoke(LocalDate.of(2017, 6, 12), Year.of(2020)),
+                Period.of(2, 6, 0));
+    }
+
+    @Test
+    public void invokeYearMonthLocalDate() {
+        FunctionTestUtil.assertResult(
+                yamFunction.invoke(
+                        LocalDate.of(2017, 6, 12),
+                        YearMonth.of(2020, 4)),
+                Period.of(2, 9, 0));
+    }
+
+    @Test
+    public void invokeLocalDateLocalDate() {
+        FunctionTestUtil.assertResult(
+                yamFunction.invoke(
+                        LocalDate.of(2017, 6, 12),
+                        LocalDate.of(2020, 7, 13)),
+                Period.of(3, 1, 0));
+    }
+
+    @Test
+    public void invokeLocalDateTime() {
+        FunctionTestUtil.assertResult(
+                yamFunction.invoke(
+                        LocalDateTime.of(2017, 6, 12, 12, 43),
+                        LocalDate.of(2020, 7, 13)),
+                Period.of(3, 1, 0));
+    }
+}


### PR DESCRIPTION
- Adds additional coverage for FEEL built-in functions
- SortFunction fixed so it fails fast when there is an exception in comparator
- SubstringFunction - handling wrong and null length param
- SumFunction - fix case when list contains element not convertible to BigDecimal
- UnionFunction - align handling of nulls with the spec
- YearsAndMonthsFunction - add support for Year and YearMonth temporal

@etirelli @tarilabs could you please review this? 