### PR TITLE
GUVNOR-3565

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieMetaInfoBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieMetaInfoBuilder.java
@@ -59,7 +59,7 @@ public class KieMetaInfoBuilder {
         return generateKieModuleMetaInfo(null);
     }
 
-    private KieModuleMetaInfo generateKieModuleMetaInfo(ResourceStore trgMfs) {
+    public KieModuleMetaInfo generateKieModuleMetaInfo(ResourceStore trgMfs) {
         // TODO: I think this method is wrong because it is only inspecting packages that are included
         // in at least one kbase, but I believe it should inspect all packages, even if not included in
         // any kbase, as they could be included in the future


### PR DESCRIPTION
Changed visibility from private to public of the generateKieModuleMetaInfo method to read the TypeMetaInfos in the Kie-maven-plugin