### PR TITLE
DROOLS-1775 fix JavaBackendTypeTest.testPerson fails on ConcurrentModificationExcptn

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
@@ -2,7 +2,14 @@ package org.kie.dmn.feel.lang.impl;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -15,9 +22,10 @@ import org.kie.dmn.feel.parser.feel11.ParserHelper;
 import org.kie.dmn.feel.util.EvalHelper;
 
 public class JavaBackedType implements CompositeType {
-    private static Map<Class<?>, JavaBackedType> cache = new HashMap<>();
+
+    private static Map<Class<?>, JavaBackedType> cache = new ConcurrentHashMap<>();
     
-    private static Set<Method> javaObjectMethods = new HashSet<>( Arrays.asList( Object.class.getMethods() ) );
+    private static Set<Method> javaObjectMethods = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Object.class.getMethods())));
     
     private Class<?> wrapped;
     private Map<String, Type> properties = new LinkedHashMap<>();


### PR DESCRIPTION
Looking at the code, and the stacktrace reported by @baldimir , it would look the problem is originating by concurrent call of

```
JavaBackedType.of()
```

Which internally performs some memoization using the cache Map called `cache`. What would happen during specific race condition, two separate thread would cause the call to `computeIfAbsent` line61 concurrently, which in the case of simple HashMap would cause the ConcurrentModException.

Replacing with ConcurrentHashMap for fast reads and only lock on write.

I tried to include a reproducer, [for instance this one](https://gist.github.com/tarilabs/b44b2451070aa1eebb79234d13c63dde), but I was really unable to have it demonstrate the problem while running and the approach would not be deterministic in reproducing the suspected race condition.

So without going for the need of a byteman or similar test, I would propose for this modification to be merged based on the simple code analysis which can be done statically by looking at the code, and summarized above.

Thanks