### PR TITLE
DROOLS-2111 Fix a case where mapping function modifies the map

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -2429,7 +2429,7 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
         final Map<String, Object> builderCache = getBuilderCache();
         final T cachedValue = (T) builderCache.get(key);
         if (cachedValue == null) {
-            T newValue = creator.get();
+            final T newValue = creator.get();
             builderCache.put(key, newValue);
             return newValue;
         } else {

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -2426,7 +2426,15 @@ public class KnowledgeBuilderImpl implements KnowledgeBuilder {
     }
 
     public <T> T getCachedOrCreate(String key, Supplier<T> creator) {
-        return (T) getBuilderCache().computeIfAbsent(key, k -> creator.get());
+        final Map<String, Object> builderCache = getBuilderCache();
+        final T cachedValue = (T) builderCache.get(key);
+        if (cachedValue == null) {
+            T newValue = creator.get();
+            builderCache.put(key, newValue);
+            return newValue;
+        } else {
+            return cachedValue;
+        }
     }
 
     // composite build lifecycle


### PR DESCRIPTION
In JDK 9 it is now not allowed to use mapping function that changes the map with HashMap.computeIfAbsent() method. 

@mariofusco @etirelli @tarilabs could you please review? 