### PR TITLE
DROOLS-2139 Use static import for assert methods instead of extending Assert class

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/CommonTestMethodBase.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/CommonTestMethodBase.java
@@ -15,6 +15,11 @@
 
 package org.drools.compiler;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.function.Predicate;
+
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.integrationtests.SerializationHelper;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
@@ -24,7 +29,6 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.reteoo.builder.NodeFactory;
-import org.junit.Assert;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
@@ -56,10 +60,10 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.util.Collection;
-import java.util.function.Predicate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This contains methods common to many of the tests in drools-compiler. </p>
@@ -67,7 +71,7 @@ import java.util.function.Predicate;
  * common so that tests in drools-compiler can be reused (with persistence) in
  * drools-persistence-jpa.
  */
-public class CommonTestMethodBase extends Assert {
+public class CommonTestMethodBase {
 
     private static Logger logger = LoggerFactory.getLogger(CommonTestMethodBase.class);
 

--- a/drools-compiler/src/test/java/org/drools/compiler/InlineCastTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/InlineCastTest.java
@@ -23,6 +23,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class InlineCastTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/NestedAccessorsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/NestedAccessorsTest.java
@@ -16,6 +16,9 @@
 package org.drools.compiler;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/drools-compiler/src/test/java/org/drools/compiler/beliefsystem/abductive/AbductionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/beliefsystem/abductive/AbductionTest.java
@@ -55,6 +55,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AbductionTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/builder/KieBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/builder/KieBuilderTest.java
@@ -48,6 +48,11 @@ import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class KieBuilderTest extends CommonTestMethodBase {
     protected FileManager fileManager;
     

--- a/drools-compiler/src/test/java/org/drools/compiler/command/MoreBatchExecutionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/command/MoreBatchExecutionTest.java
@@ -24,16 +24,20 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.junit.After;
 import org.junit.Test;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.api.command.Command;
-import org.kie.internal.command.CommandFactory;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.QueryResults;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.command.CommandFactory;
+import org.kie.internal.io.ResourceFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MoreBatchExecutionTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/command/SimpleBatchExecutionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/command/SimpleBatchExecutionTest.java
@@ -36,6 +36,11 @@ import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class SimpleBatchExecutionTest extends CommonTestMethodBase {
 
     private KieSession ksession;

--- a/drools-compiler/src/test/java/org/drools/compiler/common/ActivationIteratorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/common/ActivationIteratorTest.java
@@ -37,6 +37,9 @@ import org.kie.internal.utils.KieHelper;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class ActivationIteratorTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/common/ActiveActivationsIteratorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/common/ActiveActivationsIteratorTest.java
@@ -21,6 +21,7 @@ import org.drools.core.common.AgendaItem;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.util.Iterator;
+import org.junit.Assert;
 import org.junit.Test;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
@@ -28,6 +29,8 @@ import org.kie.internal.utils.KieHelper;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.Assert.fail;
 
 public class ActiveActivationsIteratorTest extends CommonTestMethodBase {
 
@@ -107,7 +110,7 @@ public class ActiveActivationsIteratorTest extends CommonTestMethodBase {
                                List list) {
         for ( Object object : objects ) {
             if ( !list.contains( object ) ) {
-                fail( "does not contain:" + object );
+                fail("does not contain:" + object );
             }
         }
     }

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/xml/changeset/ChangeSetTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/xml/changeset/ChangeSetTest.java
@@ -44,6 +44,10 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.xml.sax.SAXException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class ChangeSetTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/xml/rules/XmlPackageReaderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/xml/rules/XmlPackageReaderTest.java
@@ -41,6 +41,11 @@ import org.drools.compiler.lang.descr.QueryDescr;
 import org.drools.compiler.lang.descr.RuleDescr;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class XmlPackageReaderTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/LogicalTraitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/LogicalTraitTest.java
@@ -52,6 +52,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 @RunWith(Parameterized.class)
 public class LogicalTraitTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitFieldsAndLegacyClassesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitFieldsAndLegacyClassesTest.java
@@ -39,6 +39,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class TraitFieldsAndLegacyClassesTest extends CommonTestMethodBase {

--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitMapCoreTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitMapCoreTest.java
@@ -29,9 +29,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class TraitMapCoreTest extends CommonTestMethodBase {
-
-
 
     @Test(timeout=10000)
     public void testMapCoreManyTraits(  ) {
@@ -92,13 +95,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertEquals( 3.0, map.get( "GPA" ) );
     }
 
-
-
-
-
-
-
-
     @Test(timeout=10000)
     public void donMapTest() {
         String source = "package org.drools.traits.test; \n" +
@@ -152,8 +148,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertEquals( map.get( "height"), 184.0 );
 
     }
-
-
 
     @Test(timeout=10000)
     public void testMapCore2(  ) {
@@ -282,9 +276,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
 
     }
 
-
-
-
     @Test(timeout=10000)
     public void testMapCoreAliasing(  ) {
         String source = "package org.drools.core.factmodel.traits.test;\n" +
@@ -351,8 +342,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
 
     }
 
-
-
     @Test(timeout=10000)
     public void testMapCoreAliasingLogicalTrueWithTypeClash(  ) {
         String source = "package org.drools.core.factmodel.traits.test;\n" +
@@ -403,7 +392,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
 
         assertTrue( list.size() == 1 && list.get( 0 ) == null );
     }
-
 
     @Test
     public void testDrools216(){
@@ -808,8 +796,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertTrue(list.contains("person has personID"));
     }
 
-
-
     @Test
     public void testMapTraitsMismatchTypes()
     {
@@ -873,7 +859,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertNotNull( list.get( 1 ) );
     }
 
-
     @Test
     public void testMapTraitNoType()
     {
@@ -929,7 +914,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertTrue(list.contains("correct2"));
     }
 
-
     @Test(timeout=10000)
     public void testMapTraitMismatchTypes()
     {
@@ -978,8 +962,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertEquals( 1, list.size() );
         assertEquals( null, list.get( 0 ) );
     }
-
-
 
     @Test
     public void testMapTraitPossibilities1()
@@ -1046,7 +1028,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertEquals( 1, list.size() );
         assertNotNull(list.get(0));
     }
-
 
     @Test
     public void testMapTraitPossibilities2()
@@ -1120,7 +1101,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertNotNull(list.get(0));
     }
 
-
     @Test
     public void testMapTraitPossibilities3()
     {
@@ -1192,7 +1172,6 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertEquals( 1, list.size() );
         assertNotNull(list.get(0));
     }
-
 
     @Test
     public void testMapTraitPossibilities4()
@@ -1269,65 +1248,62 @@ public class TraitMapCoreTest extends CommonTestMethodBase {
         assertNotNull(list.get(0));
     }
 
+    @Test()
+    public void donCustomMapTest() {
+        String source = "package org.drools.traits.test; \n" +
+                "import java.util.*\n;" +
+                "import " + TraitMapCoreTest.DomainMap.class.getCanonicalName() + ";\n" +
+                "" +
+                "global List list; \n" +
+                "" +
+                "" +
+                "declare trait PersonMap" +
+                "@propertyReactive \n" +
+                "   name : String \n" +
+                "   age  : int \n" +
+                "   height : Double \n" +
+                "end\n" +
+                "" +
+                "" +
+                "rule Don \n" +
+                "when \n" +
+                "  $m : Map( this[ \"age\"] == 18 ) " +
+                "then \n" +
+                "   don( $m, PersonMap.class );\n" +
+                "end \n" +
+                "" +
+                "rule Log \n" +
+                "when \n" +
+                "   $p : PersonMap( name == \"john\", age > 10 ) \n" +
+                "then \n" +
+                "   modify ( $p ) { \n" +
+                "       setHeight( 184.0 ); \n" +
+                "   }" +
+                "end \n";
 
+        KieSession ksession = loadKnowledgeBaseFromString( source ).newKieSession();
+        TraitFactory.setMode( VirtualPropertyMode.MAP, ksession.getKieBase() );
 
+        List list = new ArrayList();
+        ksession.setGlobal( "list", list );
 
-	@Test()
-	public void donCustomMapTest() {
-		String source = "package org.drools.traits.test; \n" +
-				"import java.util.*\n;" +
-				"import " + TraitMapCoreTest.DomainMap.class.getCanonicalName() + ";\n" +
-				"" +
-				"global List list; \n" +
-				"" +
-				"" +
-				"declare trait PersonMap" +
-				"@propertyReactive \n" +
-				"   name : String \n" +
-				"   age  : int \n" +
-				"   height : Double \n" +
-				"end\n" +
-				"" +
-				"" +
-				"rule Don \n" +
-				"when \n" +
-				"  $m : Map( this[ \"age\"] == 18 ) " +
-				"then \n" +
-				"   don( $m, PersonMap.class );\n" +
-				"end \n" +
-				"" +
-				"rule Log \n" +
-				"when \n" +
-				"   $p : PersonMap( name == \"john\", age > 10 ) \n" +
-				"then \n" +
-				"   modify ( $p ) { \n" +
-				"       setHeight( 184.0 ); \n" +
-				"   }" +
-				"end \n";
+        HashMap map = new DomainMap();
+        map.put( "name", "john" );
+        map.put( "age", 18 );
 
-		KieSession ksession = loadKnowledgeBaseFromString( source ).newKieSession();
-		TraitFactory.setMode( VirtualPropertyMode.MAP, ksession.getKieBase() );
+        ksession.insert( map );
+        ksession.fireAllRules();
 
-		List list = new ArrayList();
-		ksession.setGlobal( "list", list );
+        assertTrue( map.containsKey( "height" ) );
+        assertEquals( map.get( "height"), 184.0 );
 
-		HashMap map = new DomainMap();
-		map.put( "name", "john" );
-		map.put( "age", 18 );
+        assertEquals( 2, ksession.getObjects().size() );
+        assertEquals( 1, ksession.getObjects( new ClassObjectFilter( DomainMap.class ) ).size() );
 
-		ksession.insert( map );
-		ksession.fireAllRules();
+    }
 
-		assertTrue( map.containsKey( "height" ) );
-		assertEquals( map.get( "height"), 184.0 );
+    @Traitable
+    public static class DomainMap extends HashMap<String,Object> implements TraitableMap {
 
-		assertEquals( 2, ksession.getObjects().size() );
-		assertEquals( 1, ksession.getObjects( new ClassObjectFilter( DomainMap.class ) ).size() );
-
-	}
-
-	@Traitable
-	public static class DomainMap extends HashMap<String,Object> implements TraitableMap {
-
-	}
+    }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
@@ -100,6 +100,14 @@ import org.kie.internal.utils.KieHelper;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 @RunWith(Parameterized.class)
@@ -343,7 +351,7 @@ public class TraitTest extends CommonTestMethodBase {
         if (!errors.isEmpty()) {
             System.err.println( errors.toString() );
         }
-        Assert.assertTrue( errors.isEmpty() );
+        assertTrue( errors.isEmpty() );
 
     }
 
@@ -364,7 +372,7 @@ public class TraitTest extends CommonTestMethodBase {
         if (!errors.isEmpty()) {
             System.err.println( errors );
         }
-        Assert.assertTrue( errors.isEmpty() );
+        assertTrue( errors.isEmpty() );
 
     }
 
@@ -432,7 +440,7 @@ public class TraitTest extends CommonTestMethodBase {
             proxy4.getFields().put( "field",
                                     "xyz" );
 
-            Assert.assertEquals( proxy2,
+            assertEquals( proxy2,
                                  proxy4 );
 
         } catch (InstantiationException e) {
@@ -1355,8 +1363,8 @@ public class TraitTest extends CommonTestMethodBase {
 
         ks.fireAllRules();
 
-        Assert.assertTrue( info.contains( "DON" ) );
-        Assert.assertTrue( info.contains( "EQUAL" ) );
+        assertTrue( info.contains( "DON" ) );
+        assertTrue( info.contains( "EQUAL" ) );
 
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -81,6 +81,12 @@ import org.mockito.Mockito;
 import static java.util.Arrays.asList;
 import static org.drools.compiler.TestUtil.assertDrlHasCompilationError;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ActivateAndDeleteOnListenerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ActivateAndDeleteOnListenerTest.java
@@ -41,6 +41,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * see JBPM-4764

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AlphaNetworkModifyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AlphaNetworkModifyTest.java
@@ -31,6 +31,8 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+
 public class AlphaNetworkModifyTest extends CommonTestMethodBase {
     
     public ObjectTypeNode getObjectTypeNode(KieBase kbase, String nodeName) {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AlphaTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AlphaTest.java
@@ -31,6 +31,8 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.conf.ShareAlphaNodesOption;
 
+import static org.junit.Assert.assertEquals;
+
 public class AlphaTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/AnnotationsTest.java
@@ -39,7 +39,6 @@ import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.io.impl.ByteArrayResource;
 import org.drools.core.rule.Pattern;
 import org.drools.core.rule.RuleConditionElement;
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
@@ -57,6 +56,13 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.builder.conf.LanguageLevelOption;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AnnotationsTest  extends CommonTestMethodBase {
 
@@ -274,13 +280,13 @@ public class AnnotationsTest  extends CommonTestMethodBase {
         Rule rule = kbase.getRule( "org.drools.compiler.integrationtests",
                                    "X" );
 
-        Assert.assertEquals( "John Doe",
+        assertEquals( "John Doe",
                              rule.getMetaData().get( "author" ) );
-        Assert.assertEquals( "Hello World!",
+        assertEquals( "Hello World!",
                              rule.getMetaData().get( "output" ) );
-        Assert.assertEquals( 20,
+        assertEquals( 20,
                              ((Number)rule.getMetaData().get( "value" )).intValue() );
-        Assert.assertEquals( "Hello World!",
+        assertEquals( "Hello World!",
                              rule.getMetaData().get( "alt" ) );
 
     }
@@ -306,7 +312,7 @@ public class AnnotationsTest  extends CommonTestMethodBase {
         Rule rule = kbase.getRule( "org.drools.compiler.integrationtests",
                                    "X" );
 
-        Assert.assertEquals( " \"<- these are supposed to be the only quotes ->\" ",
+        assertEquals( " \"<- these are supposed to be the only quotes ->\" ",
                              rule.getMetaData().get( "alt" ) );
 
     }
@@ -317,7 +323,7 @@ public class AnnotationsTest  extends CommonTestMethodBase {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
                       ResourceType.DRL );
-        Assert.assertFalse( kbuilder.getErrors().toString(),
+        assertFalse( kbuilder.getErrors().toString(),
                             kbuilder.hasErrors() );
 
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase( id,

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ArrayTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ArrayTest.java
@@ -26,6 +26,9 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class ArrayTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
@@ -70,6 +70,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.drools.compiler.integrationtests.SerializationHelper.getSerialisedStatefulKnowledgeSession;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.kie.api.runtime.rule.Variable.v;
 
 public class BackwardChainingTest extends CommonTestMethodBase {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BetaTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BetaTest.java
@@ -26,6 +26,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+
 public class BetaTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BranchTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/BranchTest.java
@@ -29,6 +29,9 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class BranchTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CellTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CellTest.java
@@ -28,6 +28,8 @@ import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class CellTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -70,7 +70,6 @@ import org.drools.core.time.impl.DurationTimer;
 import org.drools.core.time.impl.PseudoClockScheduler;
 import org.drools.core.util.DateUtils;
 import org.drools.core.util.DroolsStreamUtils;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
@@ -112,8 +111,18 @@ import org.mockito.ArgumentCaptor;
 
 import static org.drools.compiler.TestUtil.assertDrlHasCompilationError;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class CepEspTest extends CommonTestMethodBase {
     
@@ -2428,13 +2437,13 @@ public class CepEspTest extends CommonTestMethodBase {
                 times( 4 ) ).afterMatchFired(captor.capture());
         List<AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        Assert.assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
                            is( "R1" ) );
-        Assert.assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
                            is( "R1" ) );
-        Assert.assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
                            is( "R1" ) );
-        Assert.assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
                            is( "R3" ) );
     }
 
@@ -2504,13 +2513,13 @@ public class CepEspTest extends CommonTestMethodBase {
                 times( 4 ) ).afterMatchFired(captor.capture());
         List<AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        Assert.assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
                            is( "R1" ) );
-        Assert.assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
                            is( "R1" ) );
-        Assert.assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
                            is( "R1" ) );
-        Assert.assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
+        assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
                            is( "R3" ) );
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
@@ -30,6 +30,9 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class CepJavaTypeTest extends CommonTestMethodBase {
 
     @Role(value = Role.Type.EVENT)

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepQueryTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepQueryTest.java
@@ -33,6 +33,9 @@ import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Tests queries using temporal operators on events from two entry points.
  */
@@ -91,13 +94,6 @@ public class CepQueryTest extends CommonTestMethodBase {
 
         firstEntryPoint.insert(new TestEvent("zero"));
         secondEntryPoint.insert(new TestEvent("one"));
-//        clock.advanceTime(10, TimeUnit.SECONDS);
-//
-//        secondEntryPoint.insert(new TestEvent("two"));
-//        clock.advanceTime(10, TimeUnit.SECONDS);
-//
-//        secondEntryPoint.insert(new TestEvent("three"));
-//        ksession.fireAllRules();
     }
 
     /**

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ClassLoaderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ClassLoaderTest.java
@@ -40,6 +40,11 @@ import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class ClassLoaderTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
@@ -35,6 +35,9 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class ConstraintsTest extends CommonTestMethodBase {
     
     @Test
@@ -71,7 +74,7 @@ public class ConstraintsTest extends CommonTestMethodBase {
         ksession.insert(message);
         final int rules = ksession.fireAllRules();
 
-        Assert.assertEquals(1, rules);
+        assertEquals(1, rules);
     }
 
     @Test
@@ -113,7 +116,7 @@ public class ConstraintsTest extends CommonTestMethodBase {
         ksession.insert(message);
         final int rules = ksession.fireAllRules();
 
-        Assert.assertEquals(1, rules);
+        assertEquals(1, rules);
     }
 
     @Test
@@ -164,7 +167,7 @@ public class ConstraintsTest extends CommonTestMethodBase {
         ksession.insert(message);
         final int rules = ksession.fireAllRules();
 
-        Assert.assertEquals(1, rules);
+        assertEquals(1, rules);
     }
 
     @Test
@@ -190,11 +193,11 @@ public class ConstraintsTest extends CommonTestMethodBase {
 
         ksession.insert(new Mailbox("foo@mail"));
         int rules = ksession.fireAllRules();
-        Assert.assertEquals(0, rules);
+        assertEquals(0, rules);
 
         ksession.insert(new Mailbox("john@mail"));
         rules = ksession.fireAllRules();
-        Assert.assertEquals(2, rules);
+        assertEquals(2, rules);
     }
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CustomOperatorTest.java
@@ -45,6 +45,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
 
+import static org.junit.Assert.assertEquals;
+
 public class CustomOperatorTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DateComparisonTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DateComparisonTest.java
@@ -28,6 +28,9 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * This is a sample class to launch a rule.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DeclarativeAgendaTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DeclarativeAgendaTest.java
@@ -44,6 +44,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class DeclarativeAgendaTest extends CommonTestMethodBase {
     
     @Test(timeout=10000)

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DroolsEventListTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DroolsEventListTest.java
@@ -34,6 +34,9 @@ import org.kie.api.runtime.rule.Row;
 
 import ca.odell.glazedlists.SortedList;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class DroolsEventListTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DroolsFromRHSTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DroolsFromRHSTest.java
@@ -18,10 +18,13 @@ package org.drools.compiler.integrationtests;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.drools.compiler.CommonTestMethodBase;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
 
 public class DroolsFromRHSTest extends CommonTestMethodBase {
 
@@ -37,11 +40,9 @@ public class DroolsFromRHSTest extends CommonTestMethodBase {
         ksession.insert(0);
         ksession.fireAllRules();
 
-        assertEquals( 10,
-                results.size() );
+        assertEquals( 10, results.size() );
         for ( int i = 0; i < 10; i++ ) {
-            assertEquals(i,
-                    results.get( i ) );
+            assertEquals(i, results.get( i ) );
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DslTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DslTest.java
@@ -42,6 +42,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class DslTest extends CommonTestMethodBase {
    
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRuleLoadTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRuleLoadTest.java
@@ -30,6 +30,10 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class DynamicRuleLoadTest extends CommonTestMethodBase {
 
     private final String drl1 =

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRuleRemovalTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRuleRemovalTest.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DynamicRuleRemovalTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesChangesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesChangesTest.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.junit.Assert.assertEquals;
+
 public class DynamicRulesChangesTest extends CommonTestMethodBase {
 
     private static final int PARALLEL_THREADS = 1;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesTest.java
@@ -63,6 +63,11 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/EnumTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/EnumTest.java
@@ -30,6 +30,9 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test for declared Enums

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/EventAccessorRestoreTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/EventAccessorRestoreTest.java
@@ -37,6 +37,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class EventAccessorRestoreTest extends CommonTestMethodBase {
 
     @Rule

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExecutionFlowControlTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExecutionFlowControlTest.java
@@ -46,6 +46,9 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 public class ExecutionFlowControlTest extends CommonTestMethodBase {
 
     @Test(timeout = 10000)
@@ -736,8 +739,8 @@ public class ExecutionFlowControlTest extends CommonTestMethodBase {
         System.out.println( "Holds: " + inrec.getValue() );
         ksession.insert( inrec );
         ksession.fireAllRules();
-        Assert.assertEquals( 1, ksession.getFactHandles().size() );
-        Assert.assertEquals( "setting 1", inrec.getOutcome() );
+        assertEquals( 1, ksession.getFactHandles().size() );
+        assertEquals( "setting 1", inrec.getOutcome() );
 
         ksession.dispose();
         ksession = kbase.newKieSession();
@@ -745,8 +748,8 @@ public class ExecutionFlowControlTest extends CommonTestMethodBase {
         System.out.println( "Holds: " + inrec.getValue() );
         ksession.insert( inrec );
         ksession.fireAllRules();
-        Assert.assertEquals( 1, ksession.getFactHandles().size() );
-        Assert.assertEquals( "setting null", inrec.getOutcome() );
+        assertEquals( 1, ksession.getFactHandles().size() );
+        assertEquals( "setting null", inrec.getOutcome() );
 
         ksession.dispose();
         ksession = kbase.newKieSession();
@@ -754,8 +757,8 @@ public class ExecutionFlowControlTest extends CommonTestMethodBase {
         System.out.println( "Holds: " + inrec.getValue() );
         ksession.insert( inrec );
         ksession.fireAllRules(); // appropriate rule is not fired!
-        Assert.assertEquals( 1, ksession.getFactHandles().size() );
-        Assert.assertEquals( "setting 0", inrec.getOutcome() );
+        assertEquals( 1, ksession.getFactHandles().size() );
+        assertEquals( "setting 0", inrec.getOutcome() );
     }
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExtendsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ExtendsTest.java
@@ -48,6 +48,14 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * Test for declared bean Extension
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FailureOnRemovalTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FailureOnRemovalTest.java
@@ -41,6 +41,9 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 public class FailureOnRemovalTest extends CommonTestMethodBase {
     
     private static final String  LS                   = System.getProperty( "line.separator" );

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FireUntilHaltTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FireUntilHaltTest.java
@@ -29,6 +29,9 @@ import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 public class FireUntilHaltTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FirstOrderLogicTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FirstOrderLogicTest.java
@@ -15,6 +15,10 @@
 
 package org.drools.compiler.integrationtests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FunctionsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/FunctionsTest.java
@@ -27,6 +27,9 @@ import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class FunctionsTest extends CommonTestMethodBase {
 
     @SuppressWarnings("unchecked")

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/GeneratedBeansTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/GeneratedBeansTest.java
@@ -26,6 +26,10 @@ import org.kie.api.KieBase;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class GeneratedBeansTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/HelloWorldTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/HelloWorldTest.java
@@ -38,6 +38,10 @@ import org.mvel2.MVELRuntime;
 import org.mvel2.debug.Debugger;
 import org.mvel2.debug.Frame;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * This is a sample class to launch a rule.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/I18nTest.java
@@ -41,6 +41,10 @@ import org.kie.api.runtime.KieSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * Tests DRL's with foreign characters.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -60,7 +60,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class IndexingTest extends CommonTestMethodBase {
 
@@ -817,19 +821,19 @@ public class IndexingTest extends CommonTestMethodBase {
         FactHandle fq1 = kieSession.insert(queen1);
         FactHandle fq2 = kieSession.insert(queen2);
         // initially both queens have null row
-        Assert.assertEquals( 0, kieSession.fireAllRules() );
+        assertEquals( 0, kieSession.fireAllRules() );
 
         // now Q1 is the only queen on row1
         kieSession.update(fq1, queen1.setRow(row1));
-        Assert.assertEquals(0, kieSession.fireAllRules());
+        assertEquals(0, kieSession.fireAllRules());
 
         // Q1 moved to row2 but it's still alone
         kieSession.update(fq1, queen1.setRow(row2));
-        Assert.assertEquals(0, kieSession.fireAllRules());
+        assertEquals(0, kieSession.fireAllRules());
 
         // now Q2 is on row2 together with Q1 -> rule should fire
         kieSession.update(fq2, queen2.setRow(row2));
-        Assert.assertEquals(1, kieSession.fireAllRules());
+        assertEquals(1, kieSession.fireAllRules());
     }
 
     public static class Queen {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IntegrationInterfacesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/IntegrationInterfacesTest.java
@@ -15,6 +15,8 @@
 
 package org.drools.compiler.integrationtests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/JBRULESTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/JBRULESTest.java
@@ -17,6 +17,9 @@
 package org.drools.compiler.integrationtests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/JittingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/JittingTest.java
@@ -28,6 +28,8 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.conf.ConstraintJittingThresholdOption;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+
 public class JittingTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBaseIncludesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBaseIncludesTest.java
@@ -28,6 +28,8 @@ import org.kie.api.runtime.KieContainer;
 
 import java.util.Collection;
 
+import static org.junit.Assert.assertEquals;
+
 // DROOLS-1044
 public class KieBaseIncludesTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieBuilderTest.java
@@ -42,6 +42,11 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class KieBuilderTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieCompilationCacheTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieCompilationCacheTest.java
@@ -36,6 +36,9 @@ import org.kie.api.io.Resource;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 /**
  * This is a sample class to launch a rule.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieDefaultPackageTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieDefaultPackageTest.java
@@ -22,6 +22,8 @@ import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Testing use of default Package.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieHelloWorldTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieHelloWorldTest.java
@@ -43,6 +43,11 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 /**
  * This is a sample class to launch a rule.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieSessionIterationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KieSessionIterationTest.java
@@ -26,6 +26,8 @@ import org.kie.internal.utils.KieHelper;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Tests iteration through the list of KieSessions of a KieBase.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KnowledgeContextTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/KnowledgeContextTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class KnowledgeContextTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MBeansMonitoringTest.java
@@ -55,6 +55,12 @@ import org.kie.internal.runtime.conf.ForceEagerActivationOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class MBeansMonitoringTest extends CommonTestMethodBase {
     public static final Logger LOG = LoggerFactory.getLogger(MBeansMonitoringTest.class);
     
@@ -181,7 +187,7 @@ public class MBeansMonitoringTest extends CommonTestMethodBase {
     	mbserver.invoke( kbOn, "startInternalMBeans", new Object[0], new String[0] );
 
     	Object expOffset = mbserver.getAttribute( new ObjectName( kbOn + ",group=EntryPoints,EntryPoint=DEFAULT,ObjectType=org.drools.compiler.StockTick" ), "ExpirationOffset" );
-    	Assert.assertEquals( 10001, ((Number) expOffset).longValue() );
+    	assertEquals( 10001, ((Number) expOffset).longValue() );
     }
     
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MVELTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MVELTest.java
@@ -58,6 +58,11 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.mvel2.MVEL;
 import org.mvel2.ParserContext;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class MVELTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MapConstraintTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MapConstraintTest.java
@@ -17,6 +17,10 @@
 package org.drools.compiler.integrationtests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -103,7 +107,7 @@ public class MapConstraintTest extends CommonTestMethodBase {
         final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add(ResourceFactory.newByteArrayResource(str.getBytes()), ResourceType.DRL);
 
-        Assert.assertTrue(kbuilder.hasErrors());
+        assertTrue(kbuilder.hasErrors());
     }
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MatchTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MatchTest.java
@@ -29,6 +29,11 @@ import org.kie.internal.utils.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class MatchTest extends CommonTestMethodBase {
 
     private static Logger logger = LoggerFactory.getLogger(MatchTest.class);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MergePackageTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MergePackageTest.java
@@ -28,6 +28,10 @@ import org.junit.Test;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class MergePackageTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
@@ -68,7 +68,6 @@ import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.Memory;
 import org.drools.core.common.NodeMemories;
-import org.drools.core.common.TupleSets;
 import org.drools.core.conflict.SalienceConflictResolver;
 import org.drools.core.definitions.impl.KnowledgePackageImpl;
 import org.drools.core.definitions.rule.impl.RuleImpl;
@@ -80,9 +79,6 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.io.impl.ByteArrayResource;
-import org.drools.core.reteoo.AlphaNode;
-import org.drools.core.reteoo.BetaMemory;
-import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.ObjectTypeNode;
@@ -92,7 +88,6 @@ import org.drools.core.reteoo.ReteDumper;
 import org.drools.core.reteoo.SegmentMemory;
 import org.drools.core.spi.KnowledgeHelper;
 import org.drools.core.spi.Salience;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
@@ -147,6 +142,12 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Arrays.asList;
 import static org.drools.compiler.TestUtil.assertDrlHasCompilationError;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -3981,8 +3982,8 @@ public class Misc2Test extends CommonTestMethodBase {
 
         //We must have 1 INFO result.
         KnowledgeBuilderResults infos = kbuilder.getResults( ResultSeverity.INFO );
-        Assert.assertNotNull( infos );
-        Assert.assertEquals( 1, infos.size() );
+        assertNotNull( infos );
+        assertEquals( 1, infos.size() );
 
     }
 
@@ -7551,7 +7552,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
         ksession.fireAllRules();
 
-        Assert.assertEquals( 1, globalList.size() );
+        assertEquals( 1, globalList.size() );
     }
 
     public static class NonStringConstructorClass {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MultithreadTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MultithreadTest.java
@@ -60,6 +60,10 @@ import org.kie.internal.utils.KieHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * This is a test case for multi-thred issues
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/NamedConsequencesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/NamedConsequencesTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class NamedConsequencesTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/NullSafeDereferencingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/NullSafeDereferencingTest.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+
 public class NullSafeDereferencingTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/NullTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/NullTest.java
@@ -33,6 +33,9 @@ import org.kie.api.KieBaseConfiguration;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class NullTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/OutOfMemoryTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/OutOfMemoryTest.java
@@ -40,6 +40,9 @@ import org.slf4j.LoggerFactory;
 import java.io.FileWriter;
 import java.util.HashMap;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
 /** Run all the tests with the ReteOO engine implementation */
 public class OutOfMemoryTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParserTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParserTest.java
@@ -31,6 +31,12 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.builder.conf.LanguageLevelOption;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class ParserTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PhreakConcurrencyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PhreakConcurrencyTest.java
@@ -50,6 +50,10 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Ignore
 public class PhreakConcurrencyTest extends CommonTestMethodBase {
@@ -123,7 +127,6 @@ public class PhreakConcurrencyTest extends CommonTestMethodBase {
         }
 
         assertTrue(success);
-
         assertEquals(EP_NR, ksession.fireAllRules());
 
         for (int i = 0; i < EP_NR; i++) {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityBlockerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityBlockerTest.java
@@ -43,6 +43,8 @@ import org.kie.internal.builder.conf.PropertySpecificOption;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+
 public class PropertyReactivityBlockerTest extends CommonTestMethodBase {
     
     @Test()

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PropertyReactivityTest.java
@@ -40,6 +40,10 @@ import org.kie.internal.builder.conf.PropertySpecificOption;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class PropertyReactivityTest extends CommonTestMethodBase {
 
     @Test(timeout=10000)

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PropertySpecificTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PropertySpecificTest.java
@@ -54,6 +54,10 @@ import org.kie.internal.utils.KieHelper;
 
 import static org.drools.core.reteoo.PropertySpecificUtil.calculateNegativeMask;
 import static org.drools.core.reteoo.PropertySpecificUtil.calculatePositiveMask;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class PropertySpecificTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryTest.java
@@ -70,6 +70,13 @@ import org.kie.api.runtime.rule.Variable;
 import org.kie.api.runtime.rule.ViewChangedEventListener;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 public class QueryTest extends CommonTestMethodBase {
 
     @org.junit.Rule

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryTest2.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryTest2.java
@@ -27,6 +27,7 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.fail;
 
 public class QueryTest2 extends CommonTestMethodBase {
     

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleChainingTest.java
@@ -17,6 +17,8 @@
 package org.drools.compiler.integrationtests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleMetadataTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/RuleMetadataTest.java
@@ -22,6 +22,10 @@ import org.drools.core.rule.ConsequenceMetaData;
 import org.junit.Test;
 import org.kie.api.KieBase;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class RuleMetadataTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ShadowProxyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ShadowProxyTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class ShadowProxyTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
@@ -29,6 +29,10 @@ import org.kie.api.runtime.rule.Agenda;
 import org.kie.internal.utils.KieHelper;
 
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SharingTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrEvaluatorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrEvaluatorTest.java
@@ -34,6 +34,9 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class StrEvaluatorTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
@@ -62,6 +62,12 @@ import org.mockito.ArgumentCaptor;
 
 import static org.drools.core.rule.TypeDeclaration.NEVER_EXPIRES;
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -368,11 +374,11 @@ public class StreamsTest extends CommonTestMethodBase {
                times(3)).afterMatchFired(captor.capture());
         List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        Assert.assertThat(aafe.get(0).getMatch().getRule().getName(),
+        assertThat(aafe.get(0).getMatch().getRule().getName(),
                           is("R1"));
-        Assert.assertThat(aafe.get(1).getMatch().getRule().getName(),
+        assertThat(aafe.get(1).getMatch().getRule().getName(),
                           is("R2"));
-        Assert.assertThat(aafe.get(2).getMatch().getRule().getName(),
+        assertThat(aafe.get(2).getMatch().getRule().getName(),
                           is("R3"));
     }
 
@@ -409,7 +415,7 @@ public class StreamsTest extends CommonTestMethodBase {
                 times(1)).afterMatchFired(captor.capture());
         List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        Assert.assertThat(aafe.get(0).getMatch().getRule().getName(),
+        assertThat(aafe.get(0).getMatch().getRule().getName(),
                 is("R1"));
     }
     
@@ -639,9 +645,9 @@ public class StreamsTest extends CommonTestMethodBase {
                times(1)).afterMatchFired(captor.capture());
 
         AfterMatchFiredEvent aafe = captor.getValue();
-        Assert.assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
+        assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
                           is(95));
-        Assert.assertThat(((Number) aafe.getMatch().getDeclarationValue("$cnt")).intValue(),
+        assertThat(((Number) aafe.getMatch().getDeclarationValue("$cnt")).intValue(),
                           is(3));
 
     }
@@ -685,7 +691,7 @@ public class StreamsTest extends CommonTestMethodBase {
                times(1)).afterMatchFired(captor.capture());
 
         AfterMatchFiredEvent aafe = captor.getValue();
-        Assert.assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
+        assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
                           is(33));
     }
     
@@ -722,9 +728,9 @@ public class StreamsTest extends CommonTestMethodBase {
                times(1)).afterMatchFired(captor.capture());
 
         AfterMatchFiredEvent aafe = captor.getValue();
-        Assert.assertThat( (StockTick) aafe.getMatch().getDeclarationValue("f1"),
+        assertThat( (StockTick) aafe.getMatch().getDeclarationValue("f1"),
                            is(st1));
-        Assert.assertThat( (StockTick) aafe.getMatch().getDeclarationValue("f2"),
+        assertThat( (StockTick) aafe.getMatch().getDeclarationValue("f2"),
                            is(st2));
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrictAnnotationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrictAnnotationTest.java
@@ -43,6 +43,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import static org.junit.Assert.assertEquals;
+
 public class StrictAnnotationTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
@@ -31,6 +31,8 @@ import org.kie.api.runtime.rule.Agenda;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+
 public class SubnetworkTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarTest.java
@@ -60,6 +60,9 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TimerAndCalendarTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TreeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TreeTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class TreeTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TruthMaintenanceTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TruthMaintenanceTest.java
@@ -61,6 +61,14 @@ import org.kie.internal.logger.KnowledgeRuntimeLoggerFactory;
 import org.kie.internal.utils.KieHelper;
 
 import static org.drools.compiler.integrationtests.SerializationHelper.getSerialisedStatefulKnowledgeSession;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 public class TruthMaintenanceTest extends CommonTestMethodBase {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/UnlinkingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/UnlinkingTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class UnlinkingTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/VarargsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/VarargsTest.java
@@ -29,6 +29,9 @@ import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class VarargsTest extends CommonTestMethodBase {
     
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/WorkingMemoryLoggerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/WorkingMemoryLoggerTest.java
@@ -29,6 +29,10 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class WorkingMemoryLoggerTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/BindTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/BindTest.java
@@ -16,6 +16,9 @@
 
 package org.drools.compiler.integrationtests.drl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/ConsequenceTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/ConsequenceTest.java
@@ -17,6 +17,10 @@
 package org.drools.compiler.integrationtests.drl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/DRLDumperTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/DRLDumperTest.java
@@ -34,6 +34,9 @@ import org.kie.internal.builder.conf.LanguageLevelOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class DRLDumperTest extends CommonTestMethodBase {
 
     private static Logger logger = LoggerFactory.getLogger( DRLDumperTest.class );

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/DRLTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/DRLTest.java
@@ -17,6 +17,11 @@
 package org.drools.compiler.integrationtests.drl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/DeclareTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/DeclareTest.java
@@ -35,6 +35,12 @@ import org.kie.internal.builder.KnowledgeBuilderError;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class DeclareTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/ExceptionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/ExceptionTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.fail;
+
 public class ExceptionTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/GlobalTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/GlobalTest.java
@@ -38,6 +38,9 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.runtime.StatelessKnowledgeSession;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class GlobalTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/ImportsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/ImportsTest.java
@@ -38,6 +38,10 @@ import org.kie.internal.io.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 public class ImportsTest extends CommonTestMethodBase {
 
     private static Logger logger = LoggerFactory.getLogger(ImportsTest.class);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/LiteralTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/LiteralTest.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.drools.compiler.Cheese;
 import org.drools.compiler.CommonTestMethodBase;
 import org.drools.compiler.Person;
@@ -29,7 +30,8 @@ import org.drools.compiler.integrationtests.SerializationHelper;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import static org.junit.Assert.assertEquals;
 
 public class LiteralTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/NestingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/NestingTest.java
@@ -35,6 +35,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.conf.LanguageLevelOption;
 
+import static org.junit.Assert.assertEquals;
+
 public class NestingTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/PatternTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/PatternTest.java
@@ -48,6 +48,10 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 public class PatternTest extends CommonTestMethodBase {
 
     @Test
@@ -416,7 +420,7 @@ public class PatternTest extends CommonTestMethodBase {
         final FactHandle fh1 = ksession.insert(p1);
 
         final Person p2 = new Person("darth", 25);
-        final FactHandle fh2 = ksession.insert(p2); // creates activation.
+        ksession.insert(p2); // creates activation.
 
         p1.setName("yoda");
         ksession.update(fh1, p1); // creates activation

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/RHSTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/RHSTest.java
@@ -32,6 +32,10 @@ import org.kie.internal.builder.KnowledgeBuilderErrors;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 public class RHSTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/RuleFlowGroupTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/RuleFlowGroupTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class RuleFlowGroupTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/VariableTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/drl/VariableTest.java
@@ -23,6 +23,8 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.fail;
+
 public class VariableTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/eventgenerator/SimpleEventGeneratorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/eventgenerator/SimpleEventGeneratorTest.java
@@ -25,6 +25,8 @@ import org.drools.compiler.integrationtests.eventgenerator.Event.EventType;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/AddRuleTest.java
@@ -30,6 +30,9 @@ import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 public class AddRuleTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -69,6 +69,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class IncrementalCompilationTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/RemoveRuleTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/RemoveRuleTest.java
@@ -18,6 +18,7 @@ package org.drools.compiler.integrationtests.incrementalcompilation;
 
 import java.util.Arrays;
 import java.util.Collection;
+
 import org.drools.compiler.CommonTestMethodBase;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.impl.InternalKnowledgeBase;
@@ -25,11 +26,15 @@ import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.reteoo.ObjectSink;
 import org.drools.core.reteoo.ObjectTypeNode;
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public class RemoveRuleTest extends CommonTestMethodBase {
 
@@ -116,7 +121,7 @@ public class RemoveRuleTest extends CommonTestMethodBase {
 
         final Collection<KiePackage> kpgs = loadKnowledgePackagesFromString( str );
 
-        Assert.assertEquals(1, kpgs.size());
+        assertEquals(1, kpgs.size());
 
         final InternalKnowledgeBase kbase = (InternalKnowledgeBase) getKnowledgeBase();
         kbase.addPackages( kpgs );

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/marshalling/MarshallingIssuesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/marshalling/MarshallingIssuesTest.java
@@ -32,6 +32,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OptionalDataException;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class MarshallingIssuesTest extends CommonTestMethodBase  {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/marshalling/MarshallingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/marshalling/MarshallingTest.java
@@ -106,6 +106,12 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.utils.KieHelper;
 
 import static org.drools.compiler.integrationtests.SerializationHelper.getSerialisedStatefulKnowledgeSession;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MarshallingTest extends CommonTestMethodBase {
 
@@ -214,7 +220,7 @@ public class MarshallingTest extends CommonTestMethodBase {
         assertEquals( "match Integer",
                       rules[3].getName() );
 
-        Assert.assertEquals(1, session.getObjects().size());
+        assertEquals(1, session.getObjects().size());
         assertEquals( bob,
                       IteratorToList.convert( session.getObjects().iterator() ).get(0) );
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/AndTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/AndTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class AndTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/ContainsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/ContainsTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class ContainsTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EnabledTest.java
@@ -16,6 +16,8 @@
 
 package org.drools.compiler.integrationtests.operators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EqualsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EqualsTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class EqualsTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EvalRewriteTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EvalRewriteTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class EvalRewriteTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EvalTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/EvalTest.java
@@ -38,6 +38,10 @@ import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class EvalTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/ExistsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/ExistsTest.java
@@ -27,6 +27,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+
 public class ExistsTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/FormulaTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/FormulaTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class FormulaTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.drools.compiler.Address;
 import org.drools.compiler.Cheese;
 import org.drools.compiler.Cheesery;
@@ -62,8 +63,12 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.builder.conf.LanguageLevelOption;
 import org.kie.internal.builder.conf.PropertySpecificOption;
 import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.utils.KieHelper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class FromTest extends CommonTestMethodBase {
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/InTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/InTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class InTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/InstanceOfTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/InstanceOfTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class InstanceOfTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/MatchesTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class MatchesTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/MathTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/MathTest.java
@@ -29,6 +29,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+
 public class MathTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/MemberOfTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class MemberOfTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -25,6 +25,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+
 public class NotTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/OrTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/OrTest.java
@@ -40,6 +40,10 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class OrTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/SoundsLikeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/operators/SoundsLikeTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class SoundsLikeTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/sequential/SequentialTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/sequential/SequentialTest.java
@@ -60,6 +60,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class SequentialTest extends CommonTestMethodBase {
 
     private KieBaseConfiguration kconf;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/AgendaFilterTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/AgendaFilterTest.java
@@ -17,6 +17,8 @@
 package org.drools.compiler.integrationtests.session;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/CrossProductTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/CrossProductTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class CrossProductTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/DeleteTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/DeleteTest.java
@@ -43,6 +43,11 @@ import org.kie.api.runtime.rule.QueryResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class DeleteTest extends CommonTestMethodBase {
 
     private static Logger logger = LoggerFactory.getLogger(DeleteTest.class);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/EntryPointTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/EntryPointTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertTrue;
+
 public class EntryPointTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/FieldAccessTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/FieldAccessTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+
 public class FieldAccessTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/InsertTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/InsertTest.java
@@ -29,6 +29,10 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 public class InsertTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/LocaleTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/LocaleTest.java
@@ -26,6 +26,8 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+
 public class LocaleTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/RuleRuntimeEventTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/RuleRuntimeEventTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.compiler.integrationtests.session;
 
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/StatefulSessionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/StatefulSessionTest.java
@@ -36,6 +36,12 @@ import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class StatefulSessionTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/StatelessSessionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/StatelessSessionTest.java
@@ -49,6 +49,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
 public class StatelessSessionTest extends CommonTestMethodBase {
     final List list = new ArrayList();
     final Cheesery cheesery = new Cheesery();
@@ -62,8 +68,7 @@ public class StatelessSessionTest extends CommonTestMethodBase {
 
         session.execute( stilton );
 
-        assertEquals( "stilton",
-                      list.get( 0 ) );
+        assertEquals( "stilton", list.get( 0 ) );
     }
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/TypeCoercionTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/TypeCoercionTest.java
@@ -29,6 +29,8 @@ import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.junit.Assert.assertEquals;
+
 public class TypeCoercionTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/UpdateTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/session/UpdateTest.java
@@ -16,6 +16,8 @@
 
 package org.drools.compiler.integrationtests.session;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -262,23 +264,20 @@ public class UpdateTest extends CommonTestMethodBase {
         final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_JoinNodeModifyObject.drl"));
         final KieSession ksession = kbase.newKieSession();
 
-        try {
-            final List orderedFacts = new ArrayList();
-            final List errors = new ArrayList();
-            ksession.setGlobal("orderedNumbers", orderedFacts);
-            ksession.setGlobal("errors", errors);
-            final int MAX = 2;
-            for (int i = 1; i <= MAX; i++) {
-                final IndexedNumber n = new IndexedNumber(i, MAX - i + 1);
-                ksession.insert(n);
-            }
-            ksession.fireAllRules();
-            assertTrue("Processing generated errors: " + errors.toString(), errors.isEmpty());
-            for (int i = 1; i <= MAX; i++) {
-                final IndexedNumber n = (IndexedNumber) orderedFacts.get(i - 1);
-                assertEquals("Fact is out of order", i, n.getIndex());
-            }
-        } finally {
+        final List orderedFacts = new ArrayList();
+        final List errors = new ArrayList();
+        ksession.setGlobal("orderedNumbers", orderedFacts);
+        ksession.setGlobal("errors", errors);
+        final int MAX = 2;
+        for (int i = 1; i <= MAX; i++) {
+            final IndexedNumber n = new IndexedNumber(i, MAX - i + 1);
+            ksession.insert(n);
+        }
+        ksession.fireAllRules();
+        assertTrue("Processing generated errors: " + errors.toString(), errors.isEmpty());
+        for (int i = 1; i <= MAX; i++) {
+            final IndexedNumber n = (IndexedNumber) orderedFacts.get(i - 1);
+            assertEquals("Fact is out of order", i, n.getIndex());
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/waltz/Waltz.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/waltz/Waltz.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.fail;
+
 /**
  * This is a sample file to launch a rule package from a rule source file.
  */

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImplTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImplTest.java
@@ -24,6 +24,8 @@ import org.kie.api.builder.KieFileSystem;
 import org.kie.api.io.Resource;
 import org.kie.internal.builder.IncrementalResults;
 
+import static org.junit.Assert.assertEquals;
+
 public class KieBuilderSetImplTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/lang/api/DescrBuilderTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/lang/api/DescrBuilderTest.java
@@ -53,6 +53,12 @@ import org.mockito.ArgumentCaptor;
 
 import static org.drools.compiler.compiler.xml.rules.DumperTestHelper.assertEqualsIgnoreWhitespace;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/rule/builder/dialect/java/AsmGeneratorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/rule/builder/dialect/java/AsmGeneratorTest.java
@@ -31,6 +31,10 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class AsmGeneratorTest extends CommonTestMethodBase {
      
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/simulation/BatchRunFluentTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/simulation/BatchRunFluentTest.java
@@ -31,6 +31,11 @@ import org.kie.api.runtime.builder.Scope;
 import org.kie.api.runtime.builder.ExecutableBuilder;
 import org.kie.api.runtime.builder.KieSessionFluent;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 public class BatchRunFluentTest extends CommonTestMethodBase {
     String header = "package org.drools.compiler\n" +
                     "import " + Message.class.getCanonicalName() + "\n";

--- a/drools-compiler/src/test/java/org/drools/compiler/test/PositionalTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/test/PositionalTest.java
@@ -29,6 +29,10 @@ import org.kie.api.KieBase;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class PositionalTest extends CommonTestMethodBase {
 
     @Test

--- a/drools-compiler/src/test/java/org/drools/compiler/util/debug/SessionInspectorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/util/debug/SessionInspectorTest.java
@@ -38,6 +38,9 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.api.io.ResourceType;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
 public class SessionInspectorTest extends CommonTestMethodBase {
 
     @Test

--- a/kie-ci/src/test/java/org/kie/declarativetypes/JavaBeansEventRoleTest.java
+++ b/kie-ci/src/test/java/org/kie/declarativetypes/JavaBeansEventRoleTest.java
@@ -24,6 +24,8 @@ import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.KieModule;
 import org.kie.scanner.KieModuleMetaData;
 
+import static org.junit.Assert.assertTrue;
+
 public class JavaBeansEventRoleTest extends CommonTestMethodBase {
 
     @Test


### PR DESCRIPTION
- Removes "extends Assert" from CommonTestMethodBase test class.
- Adds static imports where necessary. 

@mariofusco could you please review? 