### PR TITLE
Allow 3 and 4 arguments query, replace unification parameter `:=` pattern with `==`

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
@@ -32,6 +32,8 @@ import org.drools.model.impl.JavaClassType;
 import org.drools.model.impl.Query0DefImpl;
 import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
+import org.drools.model.impl.Query3DefImpl;
+import org.drools.model.impl.Query4DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.SourceImpl;
 import org.drools.model.impl.TypeMetaDataImpl;
@@ -431,6 +433,22 @@ public class DSL {
 
     public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, Class<B> type2 ) {
         return new Query2DefImpl<A,B>( pkg, name, type1, type2 );
+    }
+
+    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        return new Query3DefImpl<A,B,C>(name, type1, type2, type3 );
+    }
+
+    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        return new Query3DefImpl<A,B,C>( pkg, name, type1, type2, type3 );
+    }
+
+    public static <A,B,C, D> Query4Def<A,B,C,D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
+        return new Query4DefImpl<A,B,C,D>(name, type1, type2, type3, type4 );
+    }
+
+    public static <A,B,C, D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
+        return new Query4DefImpl<A,B,C,D>( pkg, name, type1, type2, type3, type4 );
     }
 
     public static <T> Value<T> valueOf(T value) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
@@ -16,22 +16,17 @@
 
 package org.drools.model;
 
-import org.drools.model.view.ViewItemBuilder;
+import org.drools.model.view.QueryCallViewItem;
 
-public interface QueryDef {
+public interface Query3Def<A, B, C> extends QueryDef {
 
-    Class[] QUERIES_BY_ARITY = new Class[] {
-            QueryDef.class, Query1Def.class, Query2Def.class, Query3Def.class, Query4Def.class
-    };
-
-    static Class getQueryClassByArity(int arity) {
-        return QUERIES_BY_ARITY[arity];
+    default QueryCallViewItem call(Argument<A> aVar, Argument<B> bVar, Argument<C> cVar) {
+        return call( true, aVar, bVar, cVar);
     }
 
-    String getPackage();
-    String getName();
+    QueryCallViewItem call(boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar);
 
-    Variable<?>[] getArguments();
-
-    Query build( ViewItemBuilder... viewItemBuilders );
+    Variable<A> getArg1();
+    Variable<B> getArg2();
+    Variable<C> getArg3();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
@@ -16,22 +16,18 @@
 
 package org.drools.model;
 
-import org.drools.model.view.ViewItemBuilder;
+import org.drools.model.view.QueryCallViewItem;
 
-public interface QueryDef {
+public interface Query4Def<A, B, C, D> extends QueryDef {
 
-    Class[] QUERIES_BY_ARITY = new Class[] {
-            QueryDef.class, Query1Def.class, Query2Def.class, Query3Def.class, Query4Def.class
-    };
-
-    static Class getQueryClassByArity(int arity) {
-        return QUERIES_BY_ARITY[arity];
+    default QueryCallViewItem call(Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar) {
+        return call( true, aVar, bVar, cVar, dVar);
     }
 
-    String getPackage();
-    String getName();
+    QueryCallViewItem call(boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar);
 
-    Variable<?>[] getArguments();
-
-    Query build( ViewItemBuilder... viewItemBuilders );
+    Variable<A> getArg1();
+    Variable<B> getArg2();
+    Variable<C> getArg3();
+    Variable<D> getArg4();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query3Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+
+import static org.drools.model.DSL.declarationOf;
+import static org.drools.model.DSL.type;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query3DefImpl<A, B, C> extends QueryDefImpl implements Query3Def<A, B, C> {
+    private final Variable<A> arg1;
+    private final Variable<B> arg2;
+    private final Variable<C> arg3;
+
+    public Query3DefImpl(String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        this(DEFAULT_PACKAGE, name, type1, type2, type3);
+    }
+
+    public Query3DefImpl(String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3  ) {
+        super( pkg, name );
+        this.arg1 = declarationOf( type(type1) );
+        this.arg2 = declarationOf( type(type2) );
+        this.arg3 = declarationOf( type(type3) );
+    }
+
+    @Override
+    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar ) {
+        return new QueryCallViewItemImpl( this, open, aVar, bVar, cVar );
+    }
+
+    @Override
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] {arg1, arg2, arg3};
+    }
+
+    public Variable<A> getArg1() {
+        return arg1;
+    }
+
+    public Variable<B> getArg2() {
+        return arg2;
+    }
+
+    @Override
+    public Variable<C> getArg3() {
+        return arg3;
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query3Def;
+import org.drools.model.Query4Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+
+import static org.drools.model.DSL.declarationOf;
+import static org.drools.model.DSL.type;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query4DefImpl<A, B, C, D> extends QueryDefImpl implements Query4Def<A, B, C, D> {
+    private final Variable<A> arg1;
+    private final Variable<B> arg2;
+    private final Variable<C> arg3;
+    private final Variable<D> arg4;
+
+    public Query4DefImpl(String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4 ) {
+        this(DEFAULT_PACKAGE, name, type1, type2, type3, type4);
+    }
+
+    public Query4DefImpl(String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4  ) {
+        super( pkg, name );
+        this.arg1 = declarationOf( type(type1) );
+        this.arg2 = declarationOf( type(type2) );
+        this.arg3 = declarationOf( type(type3) );
+        this.arg4 = declarationOf( type(type4) );
+    }
+
+    @Override
+    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar) {
+        return new QueryCallViewItemImpl( this, open, aVar, bVar, cVar, dVar );
+    }
+
+    @Override
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] {arg1, arg2, arg3, arg4};
+    }
+
+    public Variable<A> getArg1() {
+        return arg1;
+    }
+
+    public Variable<B> getArg2() {
+        return arg2;
+    }
+
+    @Override
+    public Variable<C> getArg3() {
+        return arg3;
+    }
+
+    @Override
+    public Variable<D> getArg4() {
+        return arg4;
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -78,14 +78,19 @@ public class DrlxParseUtil {
                 return ConstraintType.LESS_THAN;
             case LESS_EQUALS:
                 return ConstraintType.LESS_OR_EQUAL;
+            default:
+                return ConstraintType.UNKNOWN;
         }
-        throw new UnsupportedOperationException("Unknown operator " + operator);
     }
 
     public static TypedExpression toTypedExpression(RuleContext context, PackageModel packageModel, Class<?> patternType, Expression drlxExpr,
                                                     List<String> usedDeclarations, Set<String> reactOnProperties) {
 
         Class<?> typeCursor = patternType;
+
+        if(drlxExpr instanceof EnclosedExpr) {
+            drlxExpr = ((EnclosedExpr) drlxExpr).getInner();
+        }
 
         if (drlxExpr instanceof UnaryExpr) {
             UnaryExpr unaryExpr = (UnaryExpr) drlxExpr;
@@ -97,6 +102,10 @@ public class DrlxParseUtil {
 
         } else if (drlxExpr instanceof ThisExpr) {
             return new TypedExpression(new NameExpr("_this"));
+
+        } else if (drlxExpr instanceof CastExpr) {
+            CastExpr castExpr = (CastExpr)drlxExpr;
+            return new TypedExpression(castExpr, getClassFromContext(context.getPkg(), castExpr.getType().asString()));
 
         } else if (drlxExpr instanceof NameExpr) {
             String name = drlxExpr.toString();

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -610,6 +610,9 @@ public class ModelGenerator {
             for (BaseDescr constraint : constraintDescrs) {
                 String expression = getConstraintExpression(patternType, constraint);
                 String patternIdentifier = pattern.getIdentifier();
+                if(expression.contains(":=")) {
+                    expression = expression.replace(":=", "==");
+                }
                 DrlxParseResult drlxParseResult = drlxParse(context, packageModel, patternType, patternIdentifier, expression);
 
                 if(drlxParseResult.expr instanceof OOPathExpr) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/QueryTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/QueryTest.java
@@ -219,6 +219,26 @@ public class QueryTest extends BaseModelTest {
     }
 
     @Test
+    public void testUnificationParameterInPattern() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "query personsAges(int ages)\n" +
+                        "$p : Person(ages := age)\n" +
+                "end\n";
+
+        KieSession ksession = getKieSession( str );
+
+        ksession.insert( new Person( "Mark", 39 ) );
+        ksession.insert( new Person( "Mario", 41 ) );
+
+        QueryResults results = ksession.getQueryResults( "personsAges",  41 );
+
+        assertEquals( 1, results.size() );
+        Person p = (Person) results.iterator().next().get( "$p" );
+        assertEquals( "Mario", p.getName() );
+    }
+
+    @Test
     public void testQueryCallingQuery() {
         String str =
                 "import " + Relationship.class.getCanonicalName() + ";" +

--- a/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/query.drl
+++ b/drools-test-coverage/test-suite/src/test/resources/org/drools/testcoverage/functional/query.drl
@@ -21,11 +21,6 @@ import org.drools.testcoverage.common.model.Pet;
 import java.util.ArrayList;
 import java.util.List;
 
-// query with empty name
-query ""
-    person : Person()
-end
-
 // simple query, just returns all persons
 query "simple query with no parameters"
     person : Person()


### PR DESCRIPTION
Also parse Cast Expressions