### PR TITLE
Don't ignore nThreads parameter

### DIFF
--- a/drools-core/src/main/java/org/drools/core/concurrent/ExecutorProviderImpl.java
+++ b/drools-core/src/main/java/org/drools/core/concurrent/ExecutorProviderImpl.java
@@ -91,7 +91,7 @@ public class ExecutorProviderImpl implements KieExecutors {
     }
 
     public ExecutorService newFixedThreadPool(int nThreads) {
-        return Executors.newFixedThreadPool(Pool.SIZE, ExecutorHolder.threadFactory);
+        return Executors.newFixedThreadPool(nThreads, ExecutorHolder.threadFactory);
     }
 
     public <T> CompletionService<T> getCompletionService() {


### PR DESCRIPTION
This looks like a copy-paste error. The `Pool.SIZE` constant is a default value that is used when calling `newFixedThreadPool()` withouth `nThreads` parameter:
```java
    public ExecutorService newFixedThreadPool() {
        return newFixedThreadPool(Pool.SIZE);
    }
```