### PR TITLE
Fix FEEL date and time() handling of the first parameter `date`

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateAndTimeFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DateAndTimeFunction.java
@@ -26,6 +26,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
 
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
@@ -60,9 +61,10 @@ public class DateAndTimeFunction
         }
         if ( !(date instanceof LocalDate) ) {
             // FEEL Spec Table 58 "date is a date or date time [...] creates a date time from the given date (ignoring any time component)" [that means ignoring any TZ from `date` parameter, too]
-            date = BuiltInFunctions.getFunction(DateFunction.class).invoke(date).getOrElse(null);
+            // I try to convert `date` to a LocalDate, if the query method returns null would signify conversion is not possible.
+            date = date.query(TemporalQueries.localDate());
 
-            if (!(date instanceof LocalDate)) {
+            if (date == null) {
                 return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "date", "must be an instance of LocalDate (or must be possible to convert to a FEEL date using built-in date(date) )"));
             }
         }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ComposingDifferentFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/ComposingDifferentFunctionsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ComposingDifferentFunctionsTest {
+
+    private DateAndTimeFunction dateTimeFunction;
+    private TimeFunction timeFunction;
+
+    @Before
+    public void setUp() {
+        dateTimeFunction = new DateAndTimeFunction();
+        timeFunction = new TimeFunction();
+    }
+
+    @Test
+    public void testComposite1() {
+        FEELFnResult<TemporalAccessor> p1 = dateTimeFunction.invoke("2017-08-10T10:20:00+02:00");
+        FEELFnResult<TemporalAccessor> p2 = timeFunction.invoke("23:59:01");
+
+        FunctionTestUtil.assertResult(p1, ZonedDateTime.of(2017, 8, 10, 10, 20, 0, 0, ZoneId.of("+02:00")));
+        FunctionTestUtil.assertResult(p2, LocalTime.of(23, 59, 1));
+
+        FEELFnResult<TemporalAccessor> result = dateTimeFunction.invoke(p1.getOrElse(null), p2.getOrElse(null));
+        FunctionTestUtil.assertResult(result, LocalDateTime.of(2017, 8, 10, 23, 59, 1));
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateTimeFunctionTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/functions/DateTimeFunctionTest.java
@@ -68,10 +68,7 @@ public class DateTimeFunctionTest {
 
     @Test
     public void invokeParamTemporalWrongTemporal() {
-        FunctionTestUtil.assertResultError(
-                dateTimeFunction.invoke(
-                        LocalDateTime.of(2017, 6, 12, 0, 0),
-                        LocalTime.of(10, 6, 20)), InvalidParametersEvent.class);
+        // reminder: 1st parameter accordingly to FEEL Spec Table 58 "date is a date or date time [...] creates a date time from the given date (ignoring any time component)" [that means ignoring any TZ from `date` parameter, too]
         FunctionTestUtil.assertResultError(
                 dateTimeFunction.invoke(
                         LocalDate.of(2017, 6, 12),


### PR DESCRIPTION
FEEL Spec Table 58 "date is a date or date time [...]
creates a date time from the given date (ignoring any time component)"

[that means ignoring any TZ from `date` parameter, too]

/cc @etirelli @baldimir @kurobako 