### PR TITLE
DMN: Clarify error messages for wrong "name" attributes

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-A-non-equal.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-A-non-equal.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-A-non-equal" name="0004-simpletable-A-non-equal">
+  <decision id="_0004-simpletable-A-non-equal" name="_0004-simpletable-A-non-equal">
     <variable name="Approval Status" typeRef="feel:string"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-A.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-A.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-A" name="0004-simpletable-A">
+  <decision id="_0004-simpletable-A" name="_0004-simpletable-A">
     <variable name="Approval Status" typeRef="feel:string"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-count.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-count.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-C-count" name="0004-simpletable-C-count">
+  <decision id="_0004-simpletable-C-count" name="_0004-simpletable-C-count">
     <variable name="Status number"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-max.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-max.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-C-max" name="0004-simpletable-C-max">
+  <decision id="_0004-simpletable-C-max" name="_0004-simpletable-C-max">
     <variable name="Status number"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-min.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-min.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-C-min" name="0004-simpletable-C-min">
+  <decision id="_0004-simpletable-C-min" name="_0004-simpletable-C-min">
     <variable name="Status number"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-sum-multiple-outputs.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-sum-multiple-outputs.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-C-sum-multiple-outputs" name="0004-simpletable-C-sum-multiple-outputs">
+  <decision id="_0004-simpletable-C-sum-multiple-outputs" name="_0004-simpletable-C-sum-multiple-outputs">
     <variable name="Decision Result"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-sum.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C-sum.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-C-sum" name="0004-simpletable-C-sum">
+  <decision id="_0004-simpletable-C-sum" name="_0004-simpletable-C-sum">
     <variable name="Status number"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-C.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-C" name="0004-simpletable-C">
+  <decision id="_0004-simpletable-C" name="_0004-simpletable-C">
     <variable name="Status number"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-F.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-F.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-F" name="0004-simpletable-F">
+  <decision id="_0004-simpletable-F" name="_0004-simpletable-F">
     <variable name="Decision Result"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-O-multiple-outputs.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-O-multiple-outputs.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-O-multiple-outputs" name="0004-simpletable-O-multiple-outputs">
+  <decision id="_0004-simpletable-O-multiple-outputs" name="_0004-simpletable-O-multiple-outputs">
     <variable name="Decision Result"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-O.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-O.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-O" name="0004-simpletable-O">
+  <decision id="_0004-simpletable-O" name="_0004-simpletable-O">
     <variable name="Approval Status"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-P-multiple-outputs.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-P-multiple-outputs.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-P-multiple-outputs" name="0004-simpletable-P-multiple-outputs">
+  <decision id="_0004-simpletable-P-multiple-outputs" name="_0004-simpletable-P-multiple-outputs">
     <variable name="Decision Result"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-P.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-P.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-P" name="0004-simpletable-P">
+  <decision id="_0004-simpletable-P" name="_0004-simpletable-P">
     <variable name="Approval Status" typeRef="feel:string"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-R.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-R.dmn
@@ -38,7 +38,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-R" name="0004-simpletable-R">
+  <decision id="_0004-simpletable-R" name="_0004-simpletable-R">
     <variable name="Approval Status"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U-noinputvalues.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U-noinputvalues.dmn
@@ -22,7 +22,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-U-noinputvalues" name="0004-simpletable-U-noinputvalues">
+  <decision id="_0004-simpletable-U-noinputvalues" name="_0004-simpletable-U-noinputvalues">
     <variable name="Approval Status" typeRef="feel:string"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0004-simpletable-U.dmn
@@ -22,7 +22,7 @@
              xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
              typeLanguage="http://www.omg.org/spec/FEEL/20140401">
-  <decision id="_0004-simpletable-U" name="0004-simpletable-U">
+  <decision id="_0004-simpletable-U" name="_0004-simpletable-U">
     <variable name="Approval Status" typeRef="feel:string"/>
     <informationRequirement>
       <requiredInput href="#_Age"/>

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Msg.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Msg.java
@@ -42,9 +42,9 @@ public final class Msg {
     public static final Message1 UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY = new Message1("Unable to find external function as defined by: %s");
     public static final Message1 PARAMETER_COUNT_MISMATCH_ON_FUNCTION_DEFINITION = new Message1("Parameter count mismatch on function definition: %s");
     public static final Message1 CAN_T_INVOKE_AN_UNARY_TEST_WITH_S_PARAMETERS_UNARY_TESTS_REQUIRE_1_SINGLE_PARAMETER = new Message1("Can't invoke an unary test with %s parameters. Unary tests require 1 single parameter.");
-    public static final Message2 INVALID_VARIABLE_NAME = new Message2( "A variable name cannot contain the %s '%s'");
-    public static final Message2 INVALID_VARIABLE_NAME_START = new Message2( "A variable name cannot start with the %s '%s'");
-    public static final Message0 INVALID_VARIABLE_NAME_EMPTY = new Message0( "A variable name cannot be null or empty");
+    public static final Message2 INVALID_VARIABLE_NAME = new Message2( "Name cannot contain the %s '%s'");
+    public static final Message2 INVALID_VARIABLE_NAME_START = new Message2( "Name cannot start with the %s '%s'");
+    public static final Message0 INVALID_VARIABLE_NAME_EMPTY = new Message0( "Name cannot be null or empty");
     public static final Message1 MISSING_EXPRESSION = new Message1( "The context entry for key '%s' is missing the value expression");
     public static final Message2 ERROR_COMPILE_EXPR_DT_FUNCTION_RULE_IDX = new Message2( "Error compiling output expression in decision table FEEL function, rule index %s: '%s'");
 


### PR DESCRIPTION
The reason behind this change is that the error messages talk about name attribute which can be present not just for variables. 

+ fix name attribute in unrelated tests

@etirelli @tarilabs could you please review? I didn't create JIRA for this because it is a very minor change (but I can create one when needed).