### PR TITLE
[RHBRMS-3027] avoid ProjectClassLoader creation when creating a new K…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -17,6 +17,7 @@ package org.drools.compiler.kie.builder.impl;
 
 import com.google.protobuf.ExtensionRegistry;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleCache.CompDataEntry;
 import org.drools.compiler.kie.builder.impl.KieModuleCache.CompilationData;
 import org.drools.compiler.kie.builder.impl.KieModuleCache.Header;
@@ -148,7 +149,12 @@ public abstract class AbstractKieModule
         return releaseId;
     }
 
-    public KnowledgeBuilder getKnowledgeBuilderForKieBase(String kieBaseName) {
+    @Override
+    public ClassLoader getModuleClassLoader() {
+        return kBuilders.isEmpty() ? null : (( KnowledgeBuilderImpl ) kBuilders.values().iterator().next()).getRootClassLoader();
+    }
+
+    public KnowledgeBuilder getKnowledgeBuilderForKieBase( String kieBaseName) {
         return kBuilders.get(kieBaseName);
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -88,4 +88,6 @@ public interface InternalKieModule extends KieModule {
     PomModel getPomModel();
 
     KnowledgeBuilderConfiguration getBuilderConfiguration( KieBaseModel kBaseModel );
+
+    ClassLoader getModuleClassLoader();
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -15,6 +15,20 @@
 
 package org.drools.compiler.kie.builder.impl;
 
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.management.ObjectName;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.PackageBuilderErrors;
 import org.drools.compiler.kie.util.ChangeSetBuilder;
@@ -23,6 +37,7 @@ import org.drools.compiler.kproject.models.KieBaseModelImpl;
 import org.drools.compiler.kproject.models.KieSessionModelImpl;
 import org.drools.compiler.management.KieContainerMonitor;
 import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.SessionConfigurationImpl;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.ProjectClassLoader;
 import org.drools.core.definitions.impl.KnowledgePackageImpl;
@@ -64,20 +79,6 @@ import org.kie.internal.builder.ResourceChangeSet;
 import org.kie.internal.definition.KnowledgePackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.management.ObjectName;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.drools.compiler.kie.builder.impl.AbstractKieModule.buildKnowledgePackages;
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.filterFileInKBase;
@@ -768,7 +769,7 @@ public class KieContainerImpl
     }
 
     private KieSessionConfiguration getKieSessionConfiguration( KieSessionModel kSessionModel ) {
-        KieSessionConfiguration ksConf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+        KieSessionConfiguration ksConf = new SessionConfigurationImpl( null, kProject.getClassLoader() );
         ksConf.setOption( kSessionModel.getClockType() );
         ksConf.setOption( kSessionModel.getBeliefSystem() );
         return ksConf;

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieServicesImpl.java
@@ -15,6 +15,13 @@
 
 package org.drools.compiler.kie.builder.impl;
 
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.drools.compiler.kie.builder.impl.event.KieServicesEventListerner;
 import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
@@ -45,13 +52,6 @@ import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.internal.utils.ServiceRegistryImpl;
-
-import java.io.File;
-import java.lang.ref.WeakReference;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import static org.drools.compiler.compiler.io.memory.MemoryFileSystem.readFromJar;
 import static org.drools.core.common.ProjectClassLoader.findParentClassLoader;
@@ -184,6 +184,9 @@ public class KieServicesImpl implements InternalKieServices {
         InternalKieModule kieModule = (InternalKieModule) getRepository().getKieModule(releaseId);
         if (kieModule == null) {
             throw new RuntimeException("Cannot find KieModule: " + releaseId);
+        }
+        if (classLoader == null) {
+            classLoader = kieModule.getModuleClassLoader();
         }
         KieProject kProject = new KieModuleKieProject( kieModule, classLoader );
 


### PR DESCRIPTION
…… (#1610)

* [RHBRMS-3027] avoid ProjectClassLoader creation when creating a new KieSession

* [RHBRMS-3027] reuse kiemodule classloader during kieproject creation

* [RHBRMS-3027] fix tests

(cherry picked from commit e7e70e18937af4d679e8ea1c2de6fcecf8f6b58a)