### PR TITLE
Executable model Pojo generation should inherit all DRL imports

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
@@ -219,7 +219,7 @@ public class DSL {
         return new OOPathBuilder<T>(source).firstChunk();
     }
 
-    public static ExprViewItem not(ExprViewItem expression, ExprViewItem... expressions) {
+    public static ExprViewItem not(ViewItemBuilder<?> expression, ViewItemBuilder<?>... expressions) {
         return new ExistentialExprViewItem( Condition.Type.NOT, and( expression, expressions) );
     }
 
@@ -239,7 +239,7 @@ public class DSL {
         return not(new Expr2ViewItemImpl<T, U>( var1, var2, new Predicate2.Impl<T, U>(predicate)) );
     }
 
-    public static ExprViewItem exists(ExprViewItem expression, ExprViewItem... expressions) {
+    public static ExprViewItem exists(ViewItemBuilder<?> expression, ViewItemBuilder<?>... expressions) {
         return new ExistentialExprViewItem( Condition.Type.EXISTS, and( expression, expressions) );
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/GeneratedClassWithPackage.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/GeneratedClassWithPackage.java
@@ -1,14 +1,23 @@
 package org.drools.modelcompiler.builder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.drools.javaparser.ast.body.ClassOrInterfaceDeclaration;
 
 public class GeneratedClassWithPackage {
     private final ClassOrInterfaceDeclaration generatedClass;
     private final String packageName;
+    private final Collection<String> imports = new ArrayList<>();
 
     public GeneratedClassWithPackage(ClassOrInterfaceDeclaration generatedClass, String packageName) {
         this.generatedClass = generatedClass;
         this.packageName = packageName;
+    }
+
+    public GeneratedClassWithPackage(ClassOrInterfaceDeclaration generatedClass, String packageName, Collection<String> imports) {
+        this(generatedClass, packageName);
+        this.imports.addAll(imports);
     }
 
     public ClassOrInterfaceDeclaration getGeneratedClass() {
@@ -17,6 +26,14 @@ public class GeneratedClassWithPackage {
 
     public String getPackageName() {
         return packageName;
+    }
+
+    public void addImport(String importClass) {
+        imports.add(importClass);
+    }
+
+    public Collection<String> getImports() {
+        return imports;
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/JavaParserCompiler.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/JavaParserCompiler.java
@@ -17,6 +17,7 @@
 package org.drools.modelcompiler.builder;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -109,16 +110,19 @@ public class JavaParserCompiler {
             final String folderName = pkgName.replace( '.', '/' );
             final ClassOrInterfaceDeclaration generatedClass = generatedPojo.getGeneratedClass();
             final String varsSourceName = String.format("src/main/java/%s/%s.java", folderName, generatedClass.getName());
-            srcMfs.write( varsSourceName, toPojoSource(pkgName, generatedClass).getBytes() );
+            srcMfs.write(varsSourceName, toPojoSource(pkgName, generatedPojo.getImports(), generatedClass).getBytes());
             sources.add( varsSourceName );
         }
 
         return sources.toArray( new String[sources.size()] );
     }
 
-    private static String toPojoSource(String pkgName, ClassOrInterfaceDeclaration pojo) {
+    public static String toPojoSource(String pkgName, Collection<String> imports, ClassOrInterfaceDeclaration pojo) {
         CompilationUnit cu = new CompilationUnit();
         cu.setPackageDeclaration( pkgName );
+        for (String i : imports) {
+            cu.addImport(i);
+        }
         cu.addType(pojo);
         return getPrettyPrinter().print(cu);
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -71,7 +71,7 @@ public class ModelBuilderImpl extends KnowledgeBuilderImpl {
 
         List<GeneratedClassWithPackage> allGeneratedPojos =
                 packageModels.values().stream()
-                        .flatMap(p -> p.getGeneratedPOJOsSource().stream().map(c -> new GeneratedClassWithPackage(c, p.getName())))
+                             .flatMap(p -> p.getGeneratedPOJOsSource().stream().map(c -> new GeneratedClassWithPackage(c, p.getName(), p.getImports())))
                         .collect(Collectors.toList());
 
 
@@ -103,6 +103,7 @@ public class ModelBuilderImpl extends KnowledgeBuilderImpl {
         InternalKnowledgePackage pkg = pkgRegistry.getPackage();
         String pkgName = pkg.getName();
         PackageModel model = packageModels.computeIfAbsent(pkgName, s -> new PackageModel(pkgName, this.getBuilderConfiguration()));
+        model.addImports(pkg.getTypeResolver().getImports());
         generatePOJO(pkg, packageDescr, model);
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
-import org.drools.javaparser.JavaParser;
-import org.drools.javaparser.ast.CompilationUnit;
 import org.drools.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.drools.javaparser.printer.PrettyPrinter;
 
@@ -30,7 +28,7 @@ public class ModelWriter {
             String folderName = pkgName.replace( '.', '/' );
 
             for (ClassOrInterfaceDeclaration generatedPojo : pkgModel.getGeneratedPOJOsSource()) {
-                final String source = toPojoSource( pkgModel.getName(), prettyPrinter, generatedPojo );
+                final String source = JavaParserCompiler.toPojoSource(pkgModel.getName(), pkgModel.getImports(), generatedPojo);
                 pkgModel.print( source );
                 String pojoSourceName = "src/main/java/" + folderName + "/" + generatedPojo.getName() + ".java";
                 srcMfs.write( pojoSourceName, source.getBytes() );
@@ -52,21 +50,6 @@ public class ModelWriter {
 
     private String generateRulesFileName() {
         return RULES_FILE_NAME + generateUUID();
-    }
-
-    private String toPojoSource(String packageName, PrettyPrinter prettyPrinter, ClassOrInterfaceDeclaration pojo ) {
-        CompilationUnit cu = new CompilationUnit();
-        cu.setPackageDeclaration( packageName );
-
-        // fixed part
-        cu.addImport(JavaParser.parseImport("import java.util.*;" ) );
-        cu.addImport( JavaParser.parseImport( "import org.drools.model.*;" ) );
-        cu.addImport( JavaParser.parseImport( "import static org.drools.model.DSL.*;" ) );
-        cu.addImport( JavaParser.parseImport( "import org.drools.model.Index.ConstraintType;" ) );
-
-        cu.addType( pojo );
-
-        return prettyPrinter.print( cu );
     }
 
     public void writeModelFile( List<String> modelSources, MemoryFileSystem trgMfs) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -107,6 +107,10 @@ public class PackageModel {
         this.imports.addAll(imports);
     }
 
+    public Collection<String> getImports() {
+        return this.imports;
+    }
+
     public void addGlobals(Map<String, String> values) {
         Map<String, Class<?>> transformed;
         transformed = values


### PR DESCRIPTION
... and fix DSL for not() and exists() for allowing single and() as 
the only parameter.

/cc @mariofusco @lucamolteni 