### PR TITLE
DROOLS-2190 Parametrize TCK tests repository URL and branch

### DIFF
--- a/kie-dmn/kie-dmn-tck/pom.xml
+++ b/kie-dmn/kie-dmn-tck/pom.xml
@@ -31,6 +31,8 @@
 
   <properties>
     <java.module.name>org.kie.dmn.tck</java.module.name>
+    <tck.repository.url>https://github.com/dmn-tck/tck</tck.repository.url>
+    <tck.repository.branch>master</tck.repository.branch>
   </properties>
 
   <profiles>
@@ -57,7 +59,9 @@
                   <goal>bootstrap</goal>
                 </goals>
                 <configuration>
-                  <connectionUrl>scm:git:https://github.com/dmn-tck/tck</connectionUrl>
+                  <connectionUrl>scm:git:${tck.repository.url}</connectionUrl>
+                  <scmVersion>${tck.repository.branch}</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
                   <goals>install -Ddrools.version=${project.version}</goals>
                   <goalsDirectory>runners</goalsDirectory>
                   <profiles>drools</profiles>


### PR DESCRIPTION
- It is now possible to run TCK tests from specific repositories and branches. E.g. with a command 

`mvn clean install -Ptck -Dtck.repository.url=https://github.com/actico/tck.git -Dtck.repository.branch=generated-testcases-2017-12-12`

Or by creating a run profile in your IDE for this. I use such profile in IDEA. 

@etirelli @tarilabs could you please take a look? 