### PR TITLE
DROOLS-2191 Ignore test failing randomly until resolved

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/SharedSessionParallelTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/SharedSessionParallelTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CyclicBarrier;
 
 import org.assertj.core.api.Assertions;
 import org.drools.compiler.integrationtests.facts.BeanA;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -236,6 +237,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         checkList(1, threadCount, list2, (threadCount - 1) * objectCount);
     }
 
+    @Ignore("Fails randomly - ignored until resolved")
     @Test
     public void testLongRunningRule2() throws InterruptedException {
         final int threadCount = 100;


### PR DESCRIPTION
@mariofusco @etirelli could you please merge this @Ignore for now? I will investigate the test in 

https://issues.jboss.org/browse/DROOLS-2191