### PR TITLE
DROOLS-2191 Remove wrong assert from testLongRunningRule2

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/SharedSessionParallelTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/SharedSessionParallelTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CyclicBarrier;
 
 import org.assertj.core.api.Assertions;
 import org.drools.compiler.integrationtests.facts.BeanA;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -191,7 +190,6 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
             "then " +
             "    modify($bean) { setSeed($n-1) };" +
             "    list.add(\"\" + $bean.getSeed());" +
-            "    Thread.sleep(5);" +
             "end";
 
         final String listDrl = "global java.util.List list2;\n" +
@@ -219,7 +217,6 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
                     return true;
                 } else {
                     barrier.await();
-                    Thread.sleep(100);
                     for (int i = 0; i < objectCount; i++) {
                         kieSession.insert(new BeanA(counter));
                     }
@@ -237,7 +234,6 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         checkList(1, threadCount, list2, (threadCount - 1) * objectCount);
     }
 
-    @Ignore("Fails randomly - ignored until resolved")
     @Test
     public void testLongRunningRule2() throws InterruptedException {
         final int threadCount = 100;
@@ -247,7 +243,6 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
             "when " +
             "    String( this == \"wait\" ) " +
             "then " +
-            "    Thread.sleep(10);" +
             "end";
 
         final String longRunningDrl = "import " + BeanA.class.getCanonicalName() + ";\n" +
@@ -272,12 +267,13 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
                     kieSession.insert("wait");
                     kieSession.insert(new BeanA(seed));
                     barrier.await();
-                    return kieSession.fireAllRules() == seed * threadCount + 1;
+                    kieSession.fireAllRules();
+                    return true;
                 } else {
                     barrier.await();
-                    Thread.sleep(10);
                     kieSession.insert(new BeanA(seed));
-                    return kieSession.fireAllRules() == 0;
+                    kieSession.fireAllRules();
+                    return true;
                 }
             } catch (final Exception ex) {
                 throw new RuntimeException(ex);
@@ -330,7 +326,6 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
                     return true;
                 } else {
                     barrier.await();
-                    Thread.sleep(100);
                     for (int i = 0; i < objectCount; i++) {
                         kieSession.insert(new BeanA(counter));
                     }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/SharedSessionParallelTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/SharedSessionParallelTest.java
@@ -18,6 +18,7 @@ package org.drools.compiler.integrationtests.concurrency;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -76,7 +77,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
     @Test
     public void testCheckOneThreadOnly() throws InterruptedException {
         final int threadCount = 100;
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
 
         final String drl = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "global java.util.List list;\n" +
@@ -131,7 +132,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
 
         final KieSession kieSession = getKieBase(drl).newKieSession();
 
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
 
         final TestExecutor exec = counter -> {
             kieSession.setGlobal("globalList", list);
@@ -159,7 +160,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
             "end";
 
         final KieSession kieSession = getKieBase(drl).newKieSession();
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
 
         final TestExecutor exec = counter -> {
             kieSession.setGlobal("list", list);
@@ -203,8 +204,8 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         final KieSession kieSession = getKieBase(longRunningDrl, listDrl).newKieSession();
 
         final CyclicBarrier barrier = new CyclicBarrier(threadCount);
-        final List<String> list = new ArrayList<>();
-        final List<String> list2 = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
+        final List<String> list2 = Collections.synchronizedList(new ArrayList<>());
 
         final TestExecutor exec = counter -> {
             try {
@@ -258,7 +259,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         final KieSession kieSession = getKieBase(longRunningDrl, waitingRule).newKieSession();
 
         final CyclicBarrier barrier = new CyclicBarrier(threadCount);
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
 
         final TestExecutor exec = counter -> {
             try {
@@ -312,8 +313,8 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         final KieSession kieSession = getKieBase(longRunningDrl, listDrl).newKieSession();
 
         final CyclicBarrier barrier = new CyclicBarrier(threadCount);
-        final List<String> list = new ArrayList<>();
-        final List<String> list2 = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
+        final List<String> list2 = Collections.synchronizedList(new ArrayList<>());
 
         final TestExecutor exec = counter -> {
             try {
@@ -368,7 +369,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
 
         final KieSession kieSession = getKieBase(drl).newKieSession();
         final CyclicBarrier barrier = new CyclicBarrier(threadCount);
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
         final BeanA bean = new BeanA(seed);
 
         final TestExecutor exec = counter -> {
@@ -407,16 +408,14 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
             "end";
 
         final KieSession kieSession = getKieBase(drl).newKieSession();
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
         final BeanA[] beans = new BeanA[threadCount];
 
         final TestExecutor exec = counter -> {
             final BeanA bean = new BeanA(seed);
             beans[counter] = bean;
             try {
-                if (counter == 0) {
-                    kieSession.setGlobal("list", list);
-                }
+                kieSession.setGlobal("list", list);
                 kieSession.insert(bean);
                 kieSession.fireAllRules();
                 return true;
@@ -451,7 +450,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         }
 
         final KieSession kieSession = getKieBase(drls).newKieSession();
-        final List<String> list = new ArrayList<>();
+        final List<String> list = Collections.synchronizedList(new ArrayList<>());
 
         final TestExecutor exec = counter -> {
             kieSession.setGlobal("list", list);


### PR DESCRIPTION
The test shares a KieSession, so it was wrong to assert over number of fires in the threads, because each thread can fire facts from the other threads. 