### PR TITLE
Use visitor pattern instead of instanceof in ModelGenerator

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AccumulateDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AccumulateDescr.java
@@ -289,4 +289,8 @@ public class AccumulateDescr extends PatternSourceDescr
         }
     }
 
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AndDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/AndDescr.java
@@ -96,4 +96,8 @@ public class AndDescr extends AnnotatedBaseDescr
     public String toString() {
         return "[AND "+descrs+" ]";
     }
+
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/BaseDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/BaseDescr.java
@@ -164,4 +164,8 @@ public class BaseDescr
     public BaseDescr replaceVariable(String oldVar, String newVar) {
         throw new UnsupportedOperationException();
     }
+
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ConditionalBranchDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ConditionalBranchDescr.java
@@ -67,4 +67,10 @@ public class ConditionalBranchDescr extends BaseDescr {
     public String toString() {
         return "if ( " + condition + " ) " + consequence + (elseBranch != null ? " else " + elseBranch : "");
     }
+
+    @Override
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/DescrVisitor.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/DescrVisitor.java
@@ -1,0 +1,29 @@
+package org.drools.compiler.lang.descr;
+
+public interface DescrVisitor {
+
+    void visit(BaseDescr descr);
+
+    void visit(AccumulateDescr descr);
+
+    void visit(AndDescr descr);
+
+    void visit(NotDescr descr);
+
+    void visit(ExistsDescr descr);
+
+    void visit(ForallDescr descr);
+
+    void visit(OrDescr descr);
+
+    void visit(EvalDescr descr);
+
+    void visit(FromDescr descr);
+
+    void visit(NamedConsequenceDescr descr);
+
+    void visit(ConditionalBranchDescr descr);
+
+    void visit(PatternDescr descr);
+
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/EvalDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/EvalDescr.java
@@ -92,4 +92,8 @@ public class EvalDescr extends BaseDescr
             super("true");
         }
     }
+
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ExistsDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ExistsDescr.java
@@ -56,4 +56,8 @@ public class ExistsDescr extends AnnotatedBaseDescr
         }
     }
 
+    @Override
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ForallDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/ForallDescr.java
@@ -110,4 +110,10 @@ public class ForallDescr extends BaseDescr
     public String toString() {
         return "forall( "+patterns+" )";
     }
+
+    @Override
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/FromDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/FromDescr.java
@@ -67,4 +67,8 @@ public class FromDescr extends PatternSourceDescr
     public String getExpression() {
         return getDataSource().getText();
     }
+
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/NamedConsequenceDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/NamedConsequenceDescr.java
@@ -60,4 +60,8 @@ public class NamedConsequenceDescr extends BaseDescr {
     public String toString() {
         return (isBreaking() ? " break" : "do") + "[" + getName() + "]";
     }
+
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/NotDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/NotDescr.java
@@ -56,4 +56,8 @@ public class NotDescr extends AnnotatedBaseDescr
         }
     }
 
+    @Override
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/OrDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/OrDescr.java
@@ -76,4 +76,9 @@ public class OrDescr extends AnnotatedBaseDescr
     public String toString() {
         return "[OR "+descrs+" ]";
     }
+
+    @Override
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/PatternDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/PatternDescr.java
@@ -262,4 +262,8 @@ public class PatternDescr extends AnnotatedBaseDescr
         clone.setXpathStartDeclaration( xpathStartDeclaration );
         return clone;
     }
+
+    public void accept(DescrVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DeclarationSpec.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DeclarationSpec.java
@@ -11,10 +11,10 @@ import org.drools.javaparser.ast.expr.Expression;
 
 public class DeclarationSpec {
     private final String bindingId;
-    final Class<?> declarationClass;
-    final Optional<PatternDescr> optPattern;
-    final Optional<Expression> declarationSource;
-    final Optional<String> variableName;
+    public final Class<?> declarationClass;
+    public final Optional<PatternDescr> optPattern;
+    public final Optional<Expression> declarationSource;
+    public final Optional<String> variableName;
 
     public DeclarationSpec(String bindingId, Class<?> declarationClass) {
         this.bindingId = bindingId;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DeclarationSpec.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DeclarationSpec.java
@@ -11,10 +11,10 @@ import org.drools.javaparser.ast.expr.Expression;
 
 public class DeclarationSpec {
     private final String bindingId;
-    public final Class<?> declarationClass;
-    public final Optional<PatternDescr> optPattern;
-    public final Optional<Expression> declarationSource;
-    public final Optional<String> variableName;
+    private final Class<?> declarationClass;
+    private final Optional<PatternDescr> optPattern;
+    private final Optional<Expression> declarationSource;
+    private final Optional<String> variableName;
 
     public DeclarationSpec(String bindingId, Class<?> declarationClass) {
         this.bindingId = bindingId;
@@ -74,5 +74,17 @@ public class DeclarationSpec {
 
     public Class<?> getDeclarationClass() {
         return declarationClass;
+    }
+
+    public Optional<PatternDescr> getOptPattern() {
+        return optPattern;
+    }
+
+    public Optional<Expression> getDeclarationSource() {
+        return declarationSource;
+    }
+
+    public Optional<String> getVariableName() {
+        return variableName;
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseResult.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseResult.java
@@ -1,0 +1,175 @@
+package org.drools.modelcompiler.builder.generator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.drools.core.util.index.IndexUtil;
+import org.drools.javaparser.ast.expr.Expression;
+
+public class DrlxParseResult {
+
+    private final Class<?> patternType;
+    private final Expression expr;
+    private final Class<?> exprType;
+
+    private String exprId;
+    private String patternBinding;
+    private boolean isPatternBindingUnification = false;
+
+    private String exprBinding;
+
+    private IndexUtil.ConstraintType decodeConstraintType;
+    private Collection<String> usedDeclarations = new LinkedHashSet<>();
+    private Set<String> reactOnProperties = Collections.emptySet();
+    private String[] watchedProperties;
+
+    private TypedExpression left;
+    private TypedExpression right;
+    private boolean isStatic;
+
+    public DrlxParseResult( Class<?> patternType, String exprId, String patternBinding, Expression expr, Class<?> exprType) {
+        this.patternType = patternType;
+        this.exprId = exprId;
+        this.patternBinding = patternBinding;
+        this.expr = expr;
+        this.exprType = exprType;
+    }
+
+    public DrlxParseResult setDecodeConstraintType( IndexUtil.ConstraintType decodeConstraintType ) {
+        this.decodeConstraintType = decodeConstraintType;
+        return this;
+    }
+
+    public DrlxParseResult setUsedDeclarations( List<String> usedDeclarations ) {
+        this.usedDeclarations = new LinkedHashSet<>(usedDeclarations);
+        return this;
+    }
+
+    public DrlxParseResult setReactOnProperties( Set<String> reactOnProperties ) {
+        this.reactOnProperties = reactOnProperties;
+        return this;
+    }
+
+    public DrlxParseResult setPatternBindingUnification( Boolean unification) {
+        this.isPatternBindingUnification = unification;
+        return this;
+    }
+
+    public DrlxParseResult addReactOnProperty( String reactOnProperty ) {
+        if (reactOnProperties.isEmpty()) {
+            reactOnProperties = new HashSet<>();
+        }
+        this.reactOnProperties.add(reactOnProperty);
+        return this;
+    }
+
+    public DrlxParseResult setLeft( TypedExpression left ) {
+        this.left = left;
+        return this;
+    }
+
+    public DrlxParseResult setRight( TypedExpression right ) {
+        this.right = right;
+        return this;
+    }
+
+    public DrlxParseResult setStatic( boolean aStatic ) {
+        isStatic = aStatic;
+        return this;
+    }
+
+    public String getExprId() {
+        return exprId;
+    }
+
+    public String getPatternBinding() {
+        return patternBinding;
+    }
+
+    public void setExprId(String exprId) {
+        this.exprId = exprId;
+    }
+
+    public void setPatternBinding(String patternBinding) {
+        this.patternBinding = patternBinding;
+    }
+
+    public DrlxParseResult setExprBinding(String exprBinding) {
+        this.exprBinding = exprBinding;
+        return this;
+    }
+
+    public boolean hasUnificationVariable() {
+        return Optional.ofNullable(left).flatMap(TypedExpression::getUnificationVariable).isPresent() ||
+                Optional.ofNullable(right).flatMap(TypedExpression::getUnificationVariable).isPresent();
+    }
+
+    public String getUnificationVariable() {
+        return left.getUnificationVariable().isPresent() ? left.getUnificationVariable().get() : right.getUnificationVariable().get();
+    }
+
+    public String getUnificationName() {
+        return left.getUnificationName().isPresent() ? left.getUnificationName().get() : right.getUnificationName().get();
+    }
+
+    public Class<?> getUnificationVariableType() {
+        return left.getUnificationVariable().isPresent() ? right.getType() : left.getType();
+    }
+
+    public Expression getExpr() {
+        return expr;
+    }
+
+    public String getExprBinding() {
+        return exprBinding;
+    }
+
+    public Class<?> getExprType() {
+        return exprType;
+    }
+
+    public Class<?> getPatternType() {
+        return patternType;
+    }
+
+    public boolean isPatternBindingUnification() {
+        return isPatternBindingUnification;
+    }
+
+    public IndexUtil.ConstraintType getDecodeConstraintType() {
+        return decodeConstraintType;
+    }
+
+    public Collection<String> getUsedDeclarations() {
+        return usedDeclarations;
+    }
+
+    public Set<String> getReactOnProperties() {
+        return reactOnProperties;
+    }
+
+    public String[] getWatchedProperties() {
+        return watchedProperties;
+    }
+
+    public void setWatchedProperties(String[] watchedProperties) {
+        this.watchedProperties = watchedProperties;
+    }
+
+    public TypedExpression getLeft() {
+        return left;
+    }
+
+    public TypedExpression getRight() {
+        return right;
+    }
+
+    public boolean isStatic() {
+        return isStatic;
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -138,7 +138,7 @@ public class DrlxParseUtil {
                 // then drlxExpr is a single NameExpr referring to a binding, e.g.: "$p1".
                 usedDeclarations.add(name);
                 return new TypedExpression(drlxExpr);
-            } if (context.queryParameters.stream().anyMatch(qp -> qp.name.equals(name))) {
+            } if (context.getQueryParameters().stream().anyMatch(qp -> qp.name.equals(name))) {
                 // then drlxExpr is a single NameExpr referring to a query parameter, e.g.: "$p1".
                 usedDeclarations.add(name);
                 return new TypedExpression(drlxExpr);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -185,7 +185,7 @@ public class DrlxParseUtil {
                     // because reactOnProperties is referring only to the properties of the type of the pattern, not other declarations properites.
                     usedDeclarations.add(firstName);
                     if (!isInLineCast) {
-                        typeCursor = declarationById.get().declarationClass;
+                        typeCursor = declarationById.get().getDeclarationClass();
                     }
                     previous = new NameExpr(firstName);
                 } else {
@@ -196,7 +196,7 @@ public class DrlxParseUtil {
                     if(firstNodeName.getBackReferencesCount()  > 0) {
                         List<DeclarationSpec> ooPathDeclarations = context.getOOPathDeclarations();
                         DeclarationSpec backReferenceDeclaration = ooPathDeclarations.get(ooPathDeclarations.size() - 1 - firstNodeName.getBackReferencesCount());
-                        typeCursor = backReferenceDeclaration.declarationClass;
+                        typeCursor = backReferenceDeclaration.getDeclarationClass();
                         backReference = Optional.of(backReferenceDeclaration);
                         usedDeclarations.add(backReferenceDeclaration.getBindingId());
                     }
@@ -378,12 +378,20 @@ public class DrlxParseUtil {
     }
 
     public static class RemoveRootNodeResult {
-        public Optional<Expression> rootNode;
-        public Expression withoutRootNode;
+        private Optional<Expression> rootNode;
+        private Expression withoutRootNode;
 
         public RemoveRootNodeResult(Optional<Expression> rootNode, Expression withoutRootNode) {
             this.rootNode = rootNode;
             this.withoutRootNode = withoutRootNode;
+        }
+
+        public Optional<Expression> getRootNode() {
+            return rootNode;
+        }
+
+        public Expression getWithoutRootNode() {
+            return withoutRootNode;
         }
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -378,8 +378,8 @@ public class DrlxParseUtil {
     }
 
     public static class RemoveRootNodeResult {
-        Optional<Expression> rootNode;
-        Expression withoutRootNode;
+        public Optional<Expression> rootNode;
+        public Expression withoutRootNode;
 
         public RemoveRootNodeResult(Optional<Expression> rootNode, Expression withoutRootNode) {
             this.rootNode = rootNode;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -193,7 +193,7 @@ public class ModelGenerator {
             buildCallScope = attributeExpr;
         }
 
-        MethodCallExpr buildCall = new MethodCallExpr(buildCallScope, BUILD_CALL, NodeList.nodeList(context.expressions));
+        MethodCallExpr buildCall = new MethodCallExpr(buildCallScope, BUILD_CALL, NodeList.nodeList(context.getExpressions()));
 
         BlockStmt ruleConsequence = rewriteConsequence(context, ruleDescr.getConsequence().toString());
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -337,11 +337,11 @@ public class ModelGenerator {
     }
 
     private static void addVariable(KnowledgeBuilderImpl kbuilder, BlockStmt ruleBlock, DeclarationSpec decl) {
-        if (decl.declarationClass == null) {
+        if (decl.getDeclarationClass() == null) {
             kbuilder.addBuilderResult( new UnknownDeclarationError( decl.getBindingId() ) );
             return;
         }
-        Type declType = DrlxParseUtil.classToReferenceType( decl.declarationClass );
+        Type declType = DrlxParseUtil.classToReferenceType(decl.getDeclarationClass());
 
         ClassOrInterfaceType varType = JavaParser.parseClassOrInterfaceType(Variable.class.getCanonicalName());
         varType.setTypeArguments(declType);
@@ -352,9 +352,9 @@ public class ModelGenerator {
         typeCall.addArgument( new ClassExpr(declType ));
 
         declarationOfCall.addArgument(typeCall);
-        declarationOfCall.addArgument(new StringLiteralExpr(decl.variableName.orElse(decl.getBindingId())));
+        declarationOfCall.addArgument(new StringLiteralExpr(decl.getVariableName().orElse(decl.getBindingId())));
 
-        decl.declarationSource.ifPresent(declarationOfCall::addArgument);
+        decl.getDeclarationSource().ifPresent(declarationOfCall::addArgument);
 
         decl.getEntryPoint().ifPresent( ep -> {
             MethodCallExpr entryPointCall = new MethodCallExpr(null, "entryPoint");

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/OOPathExprGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/OOPathExprGenerator.java
@@ -73,14 +73,14 @@ public class OOPathExprGenerator {
         // If the OOPath has an inner binding, it will be in the context's declarations without its type (as it's inferred from the last OOPath chunk).
         // We remove the original expression without type and use its name in the last expression
         List<DeclarationSpec> declarations = context.getDeclarations();
-        final Optional<DeclarationSpec> missingClassDeclarationFound = declarations.stream().filter(d -> d.declarationClass == null).findFirst();
+        final Optional<DeclarationSpec> missingClassDeclarationFound = declarations.stream().filter(d -> d.getDeclarationClass() == null).findFirst();
 
         missingClassDeclarationFound.ifPresent(missingClassDeclaration -> {
             final String innerBindingId = missingClassDeclaration.getBindingId();
 
             final int lastIndex = declarations.size() - 1;
             final DeclarationSpec last = declarations.get(lastIndex);
-            declarations.set(lastIndex, new DeclarationSpec(innerBindingId, last.declarationClass, last.optPattern, last.declarationSource));
+            declarations.set(lastIndex, new DeclarationSpec(innerBindingId, last.getDeclarationClass(), last.getOptPattern(), last.getDeclarationSource()));
             declarations.remove(declarations.indexOf(missingClassDeclaration));
 
             // In the meanwhile some condition could have used that binding, we need to rename that also

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/OOPathExprGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/OOPathExprGenerator.java
@@ -18,12 +18,12 @@ import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.prepend;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;
 import static org.drools.modelcompiler.builder.generator.ModelGenerator.buildExpressionWithIndexing;
 
-public class OOPathExprVisitor {
+public class OOPathExprGenerator {
 
     private final RuleContext context;
     private final PackageModel packageModel;
 
-    public OOPathExprVisitor(RuleContext context, PackageModel packageModel) {
+    public OOPathExprGenerator(RuleContext context, PackageModel packageModel) {
         this.context = context;
         this.packageModel = packageModel;
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/OOPathExprGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/OOPathExprGenerator.java
@@ -33,7 +33,7 @@ public class OOPathExprGenerator {
         Class<?> previousClass = originalClass;
         String previousBind = originalBind;
 
-        List<ModelGenerator.DrlxParseResult> ooPathConditionExpressions = new ArrayList<>();
+        List<DrlxParseResult> ooPathConditionExpressions = new ArrayList<>();
 
         for (OOPathChunk chunk : ooPathExpr.getChunks()) {
 
@@ -62,7 +62,7 @@ public class OOPathExprGenerator {
 
             final Expression condition = chunk.getCondition();
             if (condition != null) {
-                final ModelGenerator.DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, fieldType, bindingId, condition.toString());
+                final DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, fieldType, bindingId, condition.toString());
                 ooPathConditionExpressions.add(drlxParseResult);
             }
 
@@ -84,7 +84,7 @@ public class OOPathExprGenerator {
             declarations.remove(declarations.indexOf(missingClassDeclaration));
 
             // In the meanwhile some condition could have used that binding, we need to rename that also
-            for(ModelGenerator.DrlxParseResult r : ooPathConditionExpressions) {
+            for(DrlxParseResult r : ooPathConditionExpressions) {
                 if(r.getExprId().equals(last.getBindingId())) {
                     r.setExprId(innerBindingId);
                 } else if(r.getPatternBinding().equals(last.getBindingId())) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/QueryGenerator.java
@@ -27,6 +27,7 @@ import org.drools.javaparser.ast.type.Type;
 import org.drools.model.Query;
 import org.drools.model.QueryDef;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.visitor.ModelGeneratorVisitor;
 
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getClassFromContext;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;
@@ -88,7 +89,7 @@ public class QueryGenerator {
         RuleContext context = packageModel.getQueryDefWithType().get(toQueryDef(queryDescr.getName())).getContext();
         final String queryDefVariableName = toQueryDef(queryDescr.getName());
 
-        visit(context, packageModel, queryDescr);
+        new ModelGeneratorVisitor(context, packageModel).visit(queryDescr.getLhs());
         final Type queryType = JavaParser.parseType(Query.class.getCanonicalName());
 
         MethodDeclaration queryMethod = new MethodDeclaration(EnumSet.of(Modifier.PRIVATE), queryType, "query_" + toId(queryDescr.getName()));
@@ -119,10 +120,6 @@ public class QueryGenerator {
             context.queryParameters.add(queryParameter);
             packageModel.putQueryVariable("query_" + descr.getName(), queryParameter);
         }
-    }
-
-    private static void visit(RuleContext context, PackageModel packageModel, QueryDescr descr) {
-        ModelGenerator.visit(context, packageModel, descr.getLhs());
     }
 
     private static ClassOrInterfaceType getQueryType(List<QueryParameter> queryParameters) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -29,8 +29,8 @@ public class RuleContext {
     private List<DeclarationSpec> declarations = new ArrayList<>();
     private List<DeclarationSpec> ooPathDeclarations = new ArrayList<>();
     Deque<Consumer<Expression>> exprPointer = new LinkedList<>();
-    List<Expression> expressions = new ArrayList<>();
-    Map<String, String> namedConsequences = new HashMap<>();
+    public List<Expression> expressions = new ArrayList<>();
+    public Map<String, String> namedConsequences = new HashMap<>();
 
     List<QueryParameter> queryParameters = new ArrayList<>();
     Optional<String> queryName = Optional.empty();
@@ -41,7 +41,7 @@ public class RuleContext {
         MVEL;
     }
 
-    BaseDescr parentDesc = null;
+    public BaseDescr parentDesc = null;
 
     public RuleContext( KnowledgeBuilderImpl kbuilder, InternalKnowledgePackage pkg, DRLIdGenerator exprIdGenerator, Optional<RuleDescr> ruleDescr) {
         this.kbuilder = kbuilder;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -28,12 +28,12 @@ public class RuleContext {
 
     private List<DeclarationSpec> declarations = new ArrayList<>();
     private List<DeclarationSpec> ooPathDeclarations = new ArrayList<>();
-    Deque<Consumer<Expression>> exprPointer = new LinkedList<>();
-    public List<Expression> expressions = new ArrayList<>();
-    public Map<String, String> namedConsequences = new HashMap<>();
+    private Deque<Consumer<Expression>> exprPointer = new LinkedList<>();
+    private List<Expression> expressions = new ArrayList<>();
+    private Map<String, String> namedConsequences = new HashMap<>();
 
-    List<QueryParameter> queryParameters = new ArrayList<>();
-    Optional<String> queryName = Optional.empty();
+    private List<QueryParameter> queryParameters = new ArrayList<>();
+    private Optional<String> queryName = Optional.empty();
 
     private RuleDialect ruleDialect = RuleDialect.JAVA; // assumed is java by default as per Drools manual.
     public static enum RuleDialect {
@@ -150,5 +150,24 @@ public class RuleContext {
         return queryParameters.stream().filter(predicate).findFirst();
     }
 
+    public List<QueryParameter> getQueryParameters() {
+        return queryParameters;
+    }
+
+    public List<Expression> getExpressions() {
+        return expressions;
+    }
+
+    public Optional<String> getQueryName() {
+        return queryName;
+    }
+
+    public void setQueryName(Optional<String> queryName) {
+        this.queryName = queryName;
+    }
+
+    public Map<String, String> getNamedConsequences() {
+        return namedConsequences;
+    }
 }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/WindowReferenceGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/WindowReferenceGenerator.java
@@ -93,9 +93,9 @@ public class WindowReferenceGenerator {
         return Optional.ofNullable(pattern.getConstraint().getDescrs().iterator().next()).map(d -> {
             String expression = d.toString();
             RuleContext context = new RuleContext(kbuilder, pkg, packageModel.getExprIdGenerator(), Optional.empty());
-            ModelGenerator.DrlxParseResult drlxParseResult = drlxParse(context, packageModel, patternType, pattern.getIdentifier(), expression);
+            DrlxParseResult drlxParseResult = drlxParse(context, packageModel, patternType, pattern.getIdentifier(), expression);
 
-            return generateLambdaWithoutParameters(drlxParseResult.usedDeclarations, drlxParseResult.expr);
+            return generateLambdaWithoutParameters(drlxParseResult.getUsedDeclarations(), drlxParseResult.getExpr());
         });
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AccumulateVisitor.java
@@ -21,6 +21,7 @@ import org.drools.javaparser.ast.stmt.ExpressionStmt;
 import org.drools.javaparser.ast.type.UnknownType;
 import org.drools.modelcompiler.builder.PackageModel;
 import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
 import org.drools.modelcompiler.builder.generator.ModelGenerator;
 import org.drools.modelcompiler.builder.generator.RuleContext;
@@ -87,20 +88,20 @@ public class AccumulateVisitor {
 
         if(expr instanceof BinaryExpr) {
 
-            final ModelGenerator.DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, Object.class, bindingId, expression);
+            final DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, Object.class, bindingId, expression);
 
-            final AccumulateFunction accumulateFunction = getAccumulateFunction(function, drlxParseResult.exprType);
+            final AccumulateFunction accumulateFunction = getAccumulateFunction(function, drlxParseResult.getExprType());
             System.out.println("drlxParseResult = " + drlxParseResult);
 
-            final String bindExpressionVariable = context.getExprId(accumulateFunction.getResultType(), drlxParseResult.left.toString());
+            final String bindExpressionVariable = context.getExprId(accumulateFunction.getResultType(), drlxParseResult.getLeft().toString());
 
             drlxParseResult.setExprBinding(bindExpressionVariable);
 
-            context.addDeclaration(new DeclarationSpec(drlxParseResult.getPatternBinding(), drlxParseResult.exprType));
+            context.addDeclaration(new DeclarationSpec(drlxParseResult.getPatternBinding(), drlxParseResult.getExprType()));
 
             functionDSL.addArgument(new ClassExpr(toType(accumulateFunction.getClass())));
-            context.addExpression(buildBinding(bindExpressionVariable, drlxParseResult.usedDeclarations, drlxParseResult.expr));
-            context.addDeclaration(new DeclarationSpec(bindExpressionVariable, drlxParseResult.exprType));
+            context.addExpression(buildBinding(bindExpressionVariable, drlxParseResult.getUsedDeclarations(), drlxParseResult.getExpr()));
+            context.addDeclaration(new DeclarationSpec(bindExpressionVariable, drlxParseResult.getExprType()));
             functionDSL.addArgument(new NameExpr(toVar(bindExpressionVariable)));
 
         } else if (expr instanceof MethodCallExpr) {
@@ -121,7 +122,7 @@ public class AccumulateVisitor {
             // Then the accumulate function will have that binding expression as a source
             final String bindExpressionVariable = context.getExprId(accumulateFunctionResultType, typedExpression.toString());
             Expression withThis = DrlxParseUtil.prepend(DrlxParseUtil._THIS_EXPR, typedExpression.getExpression());
-            ModelGenerator.DrlxParseResult result = new ModelGenerator.DrlxParseResult(accumulateFunctionResultType, "", rootNodeName, withThis, accumulateFunctionResultType)
+            DrlxParseResult result = new DrlxParseResult(accumulateFunctionResultType, "", rootNodeName, withThis, accumulateFunctionResultType)
                     .setLeft(typedExpression)
                     .setExprBinding(bindExpressionVariable);
             context.addExpression(ModelGenerator.buildBinding(result));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AccumulateVisitor.java
@@ -72,7 +72,7 @@ public class AccumulateVisitor {
         context.popExprPointer();
 
         for (Node bindExpr : bindExprs) {
-            context.expressions.add(0, (MethodCallExpr) bindExpr);
+            context.getExpressions().add(0, (MethodCallExpr) bindExpr);
         }
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AccumulateVisitor.java
@@ -110,7 +110,7 @@ public class AccumulateVisitor {
 
             final String rootNodeName = getRootNodeName(methodCallWithoutRootNode);
 
-            final TypedExpression typedExpression = parseMethodCallType(context, rootNodeName, methodCallWithoutRootNode.withoutRootNode);
+            final TypedExpression typedExpression = parseMethodCallType(context, rootNodeName, methodCallWithoutRootNode.getWithoutRootNode());
             final Class<?> methodCallExprType = typedExpression.getType();
 
             final AccumulateFunction accumulateFunction = getAccumulateFunction(function, methodCallExprType);
@@ -134,7 +134,7 @@ public class AccumulateVisitor {
             final Class<?> declarationClass = context
                     .getDeclarationById(expr.toString())
                     .orElseThrow(RuntimeException::new)
-                    .declarationClass;
+                    .getDeclarationClass();
             final AccumulateFunction accumulateFunction = getAccumulateFunction(function, declarationClass);
             functionDSL.addArgument(new ClassExpr(toType(accumulateFunction.getClass())));
             functionDSL.addArgument(new NameExpr(toVar(((NameExpr) expr).getName().asString())));
@@ -164,8 +164,7 @@ public class AccumulateVisitor {
     }
 
     private String getRootNodeName(DrlxParseUtil.RemoveRootNodeResult methodCallWithoutRootNode) {
-        final Expression rootNode = methodCallWithoutRootNode
-                .rootNode.orElseThrow(UnsupportedOperationException::new);
+        final Expression rootNode = methodCallWithoutRootNode.getRootNode().orElseThrow(UnsupportedOperationException::new);
 
         final String rootNodeName;
         if(rootNode instanceof NameExpr) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AndVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/AndVisitor.java
@@ -1,0 +1,33 @@
+package org.drools.modelcompiler.builder.generator.visitor;
+
+import org.drools.compiler.lang.descr.AndDescr;
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+
+public class AndVisitor {
+
+    private final ModelGeneratorVisitor visitor;
+    private final RuleContext context;
+
+    public AndVisitor(ModelGeneratorVisitor visitor, RuleContext context) {
+        this.visitor = visitor;
+        this.context = context;
+    }
+
+    public void visit(AndDescr descr) {
+        // if it's the first (implied) `and` wrapping the first level of patterns, skip adding it to the DSL.
+        if (this.context.getExprPointerLevel() != 1) {
+            final MethodCallExpr andDSL = new MethodCallExpr(null, "and");
+            this.context.addExpression(andDSL);
+            this.context.pushExprPointer(andDSL::addArgument);
+        }
+        for (BaseDescr subDescr : descr.getDescrs()) {
+            this.context.parentDesc = descr;
+            subDescr.accept(visitor);
+        }
+        if (this.context.getExprPointerLevel() != 1) {
+            this.context.popExprPointer();
+        }
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/ConditionalElementVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/ConditionalElementVisitor.java
@@ -1,0 +1,28 @@
+package org.drools.modelcompiler.builder.generator.visitor;
+
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.compiler.lang.descr.ConditionalElementDescr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+
+public class ConditionalElementVisitor {
+
+    private final RuleContext context;
+    private final ModelGeneratorVisitor visitor;
+
+    public ConditionalElementVisitor(RuleContext context, ModelGeneratorVisitor visitor) {
+        this.context = context;
+        this.visitor = visitor;
+    }
+
+    public void visit(ConditionalElementDescr descr, String methodName) {
+        final MethodCallExpr ceDSL = new MethodCallExpr(null, methodName);
+        this.context.addExpression(ceDSL);
+        this.context.pushExprPointer(ceDSL::addArgument );
+        for (BaseDescr subDescr : descr.getDescrs()) {
+            subDescr.accept(visitor);
+        }
+        this.context.popExprPointer();
+    }
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/EvalVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/EvalVisitor.java
@@ -3,6 +3,7 @@ package org.drools.modelcompiler.builder.generator.visitor;
 import org.drools.compiler.lang.descr.EvalDescr;
 import org.drools.modelcompiler.builder.PackageModel;
 import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
 import org.drools.modelcompiler.builder.generator.ModelGenerator;
 import org.drools.modelcompiler.builder.generator.RuleContext;
@@ -24,7 +25,7 @@ public class EvalVisitor {
         Class<?> patternType = context.getDeclarationById(bindingId)
                 .map(DeclarationSpec::getDeclarationClass)
                 .orElseThrow(RuntimeException::new);
-        ModelGenerator.DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, patternType, bindingId, expression);
+        DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, patternType, bindingId, expression);
         ModelGenerator.processExpression(context, drlxParseResult);
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/EvalVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/EvalVisitor.java
@@ -1,0 +1,32 @@
+package org.drools.modelcompiler.builder.generator.visitor;
+
+import org.drools.compiler.lang.descr.EvalDescr;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
+import org.drools.modelcompiler.builder.generator.ModelGenerator;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+
+public class EvalVisitor {
+
+    private final RuleContext context;
+    private final PackageModel packageModel;
+
+    public EvalVisitor(RuleContext context, PackageModel packageModel) {
+        this.context = context;
+        this.packageModel = packageModel;
+    }
+
+    public void visit(EvalDescr descr) {
+        String expression = descr.getContent().toString();
+        String bindingId = DrlxParseUtil.findBindingId(expression, context.getAvailableBindings())
+                .orElseThrow(() -> new UnsupportedOperationException("unable to parse eval expression: " + expression));
+        Class<?> patternType = context.getDeclarationById(bindingId)
+                .map(DeclarationSpec::getDeclarationClass)
+                .orElseThrow(RuntimeException::new);
+        ModelGenerator.DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, patternType, bindingId, expression);
+        ModelGenerator.processExpression(context, drlxParseResult);
+    }
+
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/FromVisitor.java
@@ -41,7 +41,7 @@ public class FromVisitor {
 
             if (optContainsBinding.isPresent()) {
                 final DeclarationSpec declarationSpec = ruleContext.getDeclarationById(bindingId).orElseThrow(RuntimeException::new);
-                final Class<?> clazz = declarationSpec.declarationClass;
+                final Class<?> clazz = declarationSpec.getDeclarationClass();
 
                 final DrlxParseResult drlxParseResult = drlxParse(ruleContext, packageModel, clazz, bindingId, expression);
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/FromVisitor.java
@@ -10,8 +10,8 @@ import org.drools.javaparser.ast.expr.MethodCallExpr;
 import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.modelcompiler.builder.PackageModel;
 import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
-import org.drools.modelcompiler.builder.generator.ModelGenerator.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.RuleContext;
 
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.generateLambdaWithoutParameters;
@@ -45,8 +45,8 @@ public class FromVisitor {
 
                 final DrlxParseResult drlxParseResult = drlxParse(ruleContext, packageModel, clazz, bindingId, expression);
 
-                final Expression parsedExpression = drlxParseResult.expr;
-                final Expression exprArg = generateLambdaWithoutParameters(drlxParseResult.usedDeclarations, parsedExpression);
+                final Expression parsedExpression = drlxParseResult.getExpr();
+                final Expression exprArg = generateLambdaWithoutParameters(drlxParseResult.getUsedDeclarations(), parsedExpression);
 
                 fromCall.addArgument(exprArg);
             } else {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/FromVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/FromVisitor.java
@@ -1,4 +1,4 @@
-package org.drools.modelcompiler.builder.generator;
+package org.drools.modelcompiler.builder.generator.visitor;
 
 import java.util.Optional;
 
@@ -9,7 +9,10 @@ import org.drools.javaparser.ast.expr.Expression;
 import org.drools.javaparser.ast.expr.MethodCallExpr;
 import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
 import org.drools.modelcompiler.builder.generator.ModelGenerator.DrlxParseResult;
+import org.drools.modelcompiler.builder.generator.RuleContext;
 
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.generateLambdaWithoutParameters;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/ModelGeneratorVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/ModelGeneratorVisitor.java
@@ -1,0 +1,103 @@
+package org.drools.modelcompiler.builder.generator.visitor;
+
+import org.drools.compiler.lang.descr.AccumulateDescr;
+import org.drools.compiler.lang.descr.AndDescr;
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.compiler.lang.descr.ConditionalBranchDescr;
+import org.drools.compiler.lang.descr.DescrVisitor;
+import org.drools.compiler.lang.descr.EvalDescr;
+import org.drools.compiler.lang.descr.ExistsDescr;
+import org.drools.compiler.lang.descr.ForallDescr;
+import org.drools.compiler.lang.descr.FromDescr;
+import org.drools.compiler.lang.descr.NamedConsequenceDescr;
+import org.drools.compiler.lang.descr.NotDescr;
+import org.drools.compiler.lang.descr.OrDescr;
+import org.drools.compiler.lang.descr.PatternDescr;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+
+public class ModelGeneratorVisitor implements DescrVisitor {
+
+    private final AccumulateVisitor accumulateVisitor;
+    private final AndVisitor andVisitor;
+    private final ConditionalElementVisitor conditionalElementVisitor;
+    private final OrVisitor orVisitor;
+    private final EvalVisitor evalVisitor;
+    private final FromVisitor fromVisitor;
+    private final NamedConsequenceVisitor namedConsequenceVisitor;
+    private final PatternVisitor patternVisitor;
+
+    public ModelGeneratorVisitor(RuleContext context, PackageModel packageModel) {
+        accumulateVisitor = new AccumulateVisitor(this, context, packageModel);
+        andVisitor = new AndVisitor(this, context);
+        conditionalElementVisitor = new ConditionalElementVisitor(context, this);
+        orVisitor = new OrVisitor(this, context);
+        evalVisitor = new EvalVisitor(context, packageModel);
+        fromVisitor = new FromVisitor(context, packageModel);
+        namedConsequenceVisitor = new NamedConsequenceVisitor(context, packageModel);
+        patternVisitor = new PatternVisitor(context, packageModel);
+    }
+
+    @Override
+    public void visit(BaseDescr descr) {
+        throw new UnsupportedOperationException("Unknown descr" + descr);
+    }
+
+    @Override
+    public void visit(AccumulateDescr descr) {
+        accumulateVisitor.visit((descr));
+    }
+
+    @Override
+    public void visit(AndDescr descr) {
+        andVisitor.visit(descr);
+    }
+
+    @Override
+    public void visit(NotDescr descr) {
+        conditionalElementVisitor.visit(descr, "not");
+    }
+
+    @Override
+    public void visit(ExistsDescr descr) {
+        conditionalElementVisitor.visit(descr, "exists");
+    }
+
+    @Override
+    public void visit(ForallDescr descr) {
+        conditionalElementVisitor.visit(descr, "forall");
+    }
+
+    @Override
+    public void visit(OrDescr descr) {
+        orVisitor.visit(descr, "or");
+    }
+
+    @Override
+    public void visit(EvalDescr descr) {
+        evalVisitor.visit(descr);
+    }
+
+    @Override
+    public void visit(FromDescr descr) {
+        fromVisitor.visit(descr);
+    }
+
+    @Override
+    public void visit(NamedConsequenceDescr descr) {
+        namedConsequenceVisitor.visit(descr);
+    }
+
+    @Override
+    public void visit(ConditionalBranchDescr descr) {
+        namedConsequenceVisitor.visit(descr);
+    }
+
+    @Override
+    public void visit(PatternDescr descr) {
+        patternVisitor.visit(descr);
+        if (descr.getSource() instanceof AccumulateDescr) {
+            visit((AccumulateDescr) descr.getSource());
+        }
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
@@ -1,4 +1,4 @@
-package org.drools.modelcompiler.builder.generator;
+package org.drools.modelcompiler.builder.generator.visitor;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +13,8 @@ import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.javaparser.ast.expr.StringLiteralExpr;
 import org.drools.javaparser.ast.stmt.BlockStmt;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.ModelGenerator;
+import org.drools.modelcompiler.builder.generator.RuleContext;
 
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.generateLambdaWithoutParameters;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getClassFromContext;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
@@ -92,7 +92,7 @@ public class NamedConsequenceVisitor {
     }
 
     private MethodCallExpr onDSL(NamedConsequenceDescr namedConsequence) {
-        String namedConsequenceString = context.namedConsequences.get(namedConsequence.getName());
+        String namedConsequenceString = context.getNamedConsequences().get(namedConsequence.getName());
         BlockStmt ruleVariablesBlock = new BlockStmt();
         createVariables(context.getKbuilder(), ruleVariablesBlock, packageModel, context);
         BlockStmt ruleConsequence = rewriteConsequence(context, namedConsequenceString);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
@@ -13,6 +13,7 @@ import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.javaparser.ast.expr.StringLiteralExpr;
 import org.drools.javaparser.ast.stmt.BlockStmt;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.ModelGenerator;
 import org.drools.modelcompiler.builder.generator.RuleContext;
 
@@ -69,8 +70,8 @@ public class NamedConsequenceVisitor {
         if (!condition.equals("true")) { // Default case
             when.addArgument(new StringLiteralExpr(context.getConditionId(patternType, condition)));
             when.addArgument(new NameExpr(toVar(patternRelated.getIdentifier())));
-            ModelGenerator.DrlxParseResult parseResult = drlxParse(context, packageModel, patternType, patternRelated.getIdentifier(), condition);
-            when.addArgument(generateLambdaWithoutParameters(Collections.emptySortedSet(), parseResult.expr));
+            DrlxParseResult parseResult = drlxParse(context, packageModel, patternType, patternRelated.getIdentifier(), condition);
+            when.addArgument(generateLambdaWithoutParameters(Collections.emptySortedSet(), parseResult.getExpr()));
         }
 
         MethodCallExpr then = new MethodCallExpr(when, THEN_CALL);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/OrVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/OrVisitor.java
@@ -1,0 +1,27 @@
+package org.drools.modelcompiler.builder.generator.visitor;
+
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.compiler.lang.descr.ConditionalElementDescr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+
+public class OrVisitor {
+
+    final ModelGeneratorVisitor modelGeneratorVisitor;
+    final RuleContext context;
+
+    public OrVisitor(ModelGeneratorVisitor modelGeneratorVisitor, RuleContext context) {
+        this.modelGeneratorVisitor = modelGeneratorVisitor;
+        this.context = context;
+    }
+
+    public void visit(ConditionalElementDescr descr, String methodName) {
+        final MethodCallExpr ceDSL = new MethodCallExpr(null, methodName);
+        context.addExpression(ceDSL);
+        context.pushExprPointer(ceDSL::addArgument);
+        for (BaseDescr subDescr : descr.getDescrs()) {
+            subDescr.accept(modelGeneratorVisitor);
+        }
+        context.popExprPointer();
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/PatternVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/PatternVisitor.java
@@ -1,0 +1,147 @@
+package org.drools.modelcompiler.builder.generator.visitor;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.drools.compiler.lang.descr.AnnotationDescr;
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.compiler.lang.descr.ExprConstraintDescr;
+import org.drools.compiler.lang.descr.PatternDescr;
+import org.drools.compiler.lang.descr.PatternSourceDescr;
+import org.drools.javaparser.ast.drlx.OOPathExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.ModelGenerator;
+import org.drools.modelcompiler.builder.generator.OOPathExprGenerator;
+import org.drools.modelcompiler.builder.generator.QueryGenerator;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+import org.drools.modelcompiler.builder.generator.WindowReferenceGenerator;
+import org.kie.api.definition.type.Position;
+
+import static org.drools.model.impl.NamesGenerator.generateName;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getClassFromContext;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;
+
+public class PatternVisitor {
+
+    static final String INPUT_CALL = "input";
+    private final RuleContext context;
+    private final PackageModel packageModel;
+
+    public PatternVisitor(RuleContext context, PackageModel packageModel) {
+        this.context = context;
+        this.packageModel = packageModel;
+    }
+
+    public void visit(PatternDescr pattern ) {
+        String className = pattern.getObjectType();
+        List<? extends BaseDescr> constraintDescrs = pattern.getConstraint().getDescrs();
+
+        // Expression is a query, get bindings from query parameter type
+        if ( QueryGenerator.bindQuery(context, packageModel, pattern, constraintDescrs ) ) {
+            return;
+        }
+
+        if ( QueryGenerator.createQueryCall(packageModel, context, pattern) ) {
+            return;
+        }
+
+        Class<?> patternType = getClassFromContext(context.getPkg().getTypeResolver(), className);
+
+        if (pattern.getIdentifier() == null) {
+            pattern.setIdentifier( generateName("pattern_" + patternType.getSimpleName()) );
+        }
+
+        Optional<PatternSourceDescr> source = Optional.ofNullable(pattern.getSource());
+        Optional<Expression> declarationSourceFrom = source.flatMap(new FromVisitor(context, packageModel)::visit);
+        Optional<Expression> declarationSourceWindow = source.flatMap(new WindowReferenceGenerator(packageModel, context.getPkg())::visit);
+        Optional<Expression> declarationSource = declarationSourceFrom.isPresent() ? declarationSourceFrom : declarationSourceWindow;
+        context.addDeclaration(new DeclarationSpec(pattern.getIdentifier(), patternType, Optional.of(pattern), declarationSource));
+
+        if (constraintDescrs.isEmpty() && pattern.getSource() == null) {
+            MethodCallExpr dslExpr = new MethodCallExpr(null, INPUT_CALL);
+            dslExpr.addArgument(new NameExpr(toVar(pattern.getIdentifier())));
+            context.addExpression( dslExpr );
+        } else {
+
+            final boolean allConstraintsArePositional = !constraintDescrs.isEmpty() && constraintDescrs.stream()
+                    .allMatch(c -> c instanceof ExprConstraintDescr
+                            && ((ExprConstraintDescr) c).getType().equals(ExprConstraintDescr.Type.POSITIONAL));
+            if(allConstraintsArePositional) {
+                final MethodCallExpr andDSL = new MethodCallExpr(null, "and");
+                context.addExpression(andDSL);
+                context.pushExprPointer(andDSL::addArgument);
+            }
+
+            for (BaseDescr constraint : constraintDescrs) {
+                String expression = getConstraintExpression(patternType, constraint);
+                String patternIdentifier = pattern.getIdentifier();
+                if(expression.contains(":=")) {
+                    expression = expression.replace(":=", "==");
+                }
+
+                ModelGenerator.DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, patternType, patternIdentifier, expression);
+                if (drlxParseResult == null) {
+                    return;
+                }
+
+                if(drlxParseResult.expr instanceof OOPathExpr) {
+
+                    // If the  outer pattern does not have a binding we generate it
+                    if(patternIdentifier == null) {
+                        patternIdentifier = context.getExprId(patternType, expression);
+                        context.addDeclaration(new DeclarationSpec(patternIdentifier, patternType, Optional.of(pattern), Optional.empty()));
+                    }
+
+                    new OOPathExprGenerator(context, packageModel).visit(patternType, patternIdentifier, (OOPathExpr)drlxParseResult.expr);
+                } else {
+                    // need to augment the reactOn inside drlxParseResult with the look-ahead properties.
+                    Collection<String> lookAheadFieldsOfIdentifier = context.getRuleDescr()
+                            .map(ruleDescr -> ruleDescr.lookAheadFieldsOfIdentifier(pattern))
+                            .orElseGet(Collections::emptyList);
+                    drlxParseResult.reactOnProperties.addAll(lookAheadFieldsOfIdentifier);
+                    drlxParseResult.watchedProperties = getPatternListenedProperties(pattern);
+
+                    if(pattern.isUnification()) {
+                        drlxParseResult.setPatternBindingUnification(true);
+                    }
+
+                    ModelGenerator.processExpression( context, drlxParseResult );
+                }
+            }
+            if(allConstraintsArePositional) {
+                context.popExprPointer();
+            }
+        }
+    }
+
+    private static String getConstraintExpression(Class<?> patternType, BaseDescr constraint) {
+        if (constraint instanceof ExprConstraintDescr && (( ExprConstraintDescr ) constraint).getType() == ExprConstraintDescr.Type.POSITIONAL) {
+            int position = (( ExprConstraintDescr ) constraint).getPosition();
+            return getFieldAtPosition(patternType, position) + " == " + constraint.toString();
+        }
+        return constraint.toString();
+    }
+
+
+    private static String getFieldAtPosition(Class<?> patternType, int position) {
+        for (Field field : patternType.getDeclaredFields()) {
+            Position p = field.getAnnotation(Position.class );
+            if (p != null && p.value() == position) {
+                return field.getName();
+            }
+        }
+        throw new RuntimeException( "Cannot find field in position " + position + " for " + patternType );
+    }
+
+    private static String[] getPatternListenedProperties(PatternDescr pattern) {
+        AnnotationDescr watchAnn = pattern != null ? pattern.getAnnotation("watch" ) : null;
+        return watchAnn == null ? new String[0] : watchAnn.getValue().toString().split(",");
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/PatternVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/PatternVisitor.java
@@ -17,6 +17,7 @@ import org.drools.javaparser.ast.expr.MethodCallExpr;
 import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.modelcompiler.builder.PackageModel;
 import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.ModelGenerator;
 import org.drools.modelcompiler.builder.generator.OOPathExprGenerator;
 import org.drools.modelcompiler.builder.generator.QueryGenerator;
@@ -86,12 +87,12 @@ public class PatternVisitor {
                     expression = expression.replace(":=", "==");
                 }
 
-                ModelGenerator.DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, patternType, patternIdentifier, expression);
+                DrlxParseResult drlxParseResult = ModelGenerator.drlxParse(context, packageModel, patternType, patternIdentifier, expression);
                 if (drlxParseResult == null) {
                     return;
                 }
 
-                if(drlxParseResult.expr instanceof OOPathExpr) {
+                if(drlxParseResult.getExpr() instanceof OOPathExpr) {
 
                     // If the  outer pattern does not have a binding we generate it
                     if(patternIdentifier == null) {
@@ -99,14 +100,14 @@ public class PatternVisitor {
                         context.addDeclaration(new DeclarationSpec(patternIdentifier, patternType, Optional.of(pattern), Optional.empty()));
                     }
 
-                    new OOPathExprGenerator(context, packageModel).visit(patternType, patternIdentifier, (OOPathExpr)drlxParseResult.expr);
+                    new OOPathExprGenerator(context, packageModel).visit(patternType, patternIdentifier, (OOPathExpr)drlxParseResult.getExpr());
                 } else {
                     // need to augment the reactOn inside drlxParseResult with the look-ahead properties.
                     Collection<String> lookAheadFieldsOfIdentifier = context.getRuleDescr()
                             .map(ruleDescr -> ruleDescr.lookAheadFieldsOfIdentifier(pattern))
                             .orElseGet(Collections::emptyList);
-                    drlxParseResult.reactOnProperties.addAll(lookAheadFieldsOfIdentifier);
-                    drlxParseResult.watchedProperties = getPatternListenedProperties(pattern);
+                    drlxParseResult.getReactOnProperties().addAll(lookAheadFieldsOfIdentifier);
+                    drlxParseResult.setWatchedProperties(getPatternListenedProperties(pattern));
 
                     if(pattern.isUnification()) {
                         drlxParseResult.setPatternBindingUnification(true);


### PR DESCRIPTION
This has some advantages:
- Prevent us to prevent a lot of casting and instanceof check (I think it may be also faster) 
- Remove some visitor specific logic from ModelGenerator.java
- It's easier to propagate the context and the packagemodel in every method of the visitors