### PR TITLE
Exec model MVEL script fix DSL for on() with varargs and imports

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DSL.java
@@ -1,5 +1,7 @@
 package org.drools.model;
 
+import static org.drools.model.impl.ViewBuilder.viewItems2Patterns;
+
 import java.util.concurrent.TimeUnit;
 
 import org.drools.model.consequences.ConditionalConsequenceBuilder;
@@ -33,8 +35,8 @@ import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
 import org.drools.model.impl.RuleBuilder;
-import org.drools.model.impl.UnitDataImpl;
 import org.drools.model.impl.TypeMetaDataImpl;
+import org.drools.model.impl.UnitDataImpl;
 import org.drools.model.impl.ValueImpl;
 import org.drools.model.impl.WindowImpl;
 import org.drools.model.impl.WindowReferenceImpl;
@@ -54,8 +56,6 @@ import org.drools.model.view.InputViewItemImpl;
 import org.drools.model.view.TemporalExprViewItem;
 import org.drools.model.view.ViewItem;
 import org.drools.model.view.ViewItemBuilder;
-
-import static org.drools.model.impl.ViewBuilder.viewItems2Patterns;
 
 public class DSL {
 
@@ -425,6 +425,10 @@ public class DSL {
 
     public static <A, B, C> ConsequenceBuilder._3<A, B, C> on(Variable<A> decl1, Variable<B> decl2, Variable<C> decl3) {
         return new ConsequenceBuilder._3(decl1, decl2, decl3);
+    }
+
+    public static ConsequenceBuilder._N on(Variable... declarations) {
+        return new ConsequenceBuilder._N(declarations);
     }
 
     // -- rule --

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceBuilder.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/consequences/ConsequenceBuilder.java
@@ -1,5 +1,7 @@
 package org.drools.model.consequences;
 
+import static org.drools.model.functions.FunctionUtils.toFunctionN;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,10 +18,9 @@ import org.drools.model.functions.BlockN;
 import org.drools.model.functions.Function0;
 import org.drools.model.functions.Function1;
 import org.drools.model.functions.Function2;
+import org.drools.model.functions.Function3;
 import org.drools.model.functions.FunctionN;
 import org.drools.model.functions.ScriptBlock;
-
-import static org.drools.model.functions.FunctionUtils.toFunctionN;
 
 public class ConsequenceBuilder {
 
@@ -193,8 +194,27 @@ public class ConsequenceBuilder {
             return this;
         }
 
-        public <R> _3 insert(final Function2<A, B, R> f) {
+        public <R> _3 insert(final Function3<A, B, C, R> f) {
             addInsert(toFunctionN(f));
+            return this;
+        }
+    }
+
+    public static class _N extends AbstractValidBuilder<_N> {
+
+        public _N(Variable... declarations) {
+            super(declarations);
+        }
+
+        public _N executeScript(String language, String script) {
+            this.usingDrools = true;
+            this.language = language;
+            this.block = new ScriptBlock(script);
+            return this;
+        }
+
+        public <R> _N insert(final FunctionN<R> f) {
+            addInsert(f);
             return this;
         }
     }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Function3.java
@@ -1,0 +1,27 @@
+package org.drools.model.functions;
+
+import java.io.Serializable;
+
+public interface Function3<A, B, C, R> extends Serializable {
+
+    R apply(A a, B b, C c);
+
+    class Impl<A, B, C, R> extends IntrospectableLambda implements Function3<A, B, C, R> {
+
+        private final Function3<A, B, C, R> function;
+
+        public Impl(Function3<A, B, C, R> function) {
+            this.function = function;
+        }
+
+        @Override
+        public R apply(A a, B b, C c) {
+            return function.apply(a, b, c);
+        }
+
+        @Override
+        public Object getLambda() {
+            return function;
+        }
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/FunctionUtils.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/FunctionUtils.java
@@ -15,4 +15,8 @@ public final class FunctionUtils {
     public static <A, B, R> FunctionN<R> toFunctionN(final Function2<A, B, R> f) {
         return objs -> f.apply( (A)objs[0], (B)objs[1] );
     }
+
+    public static <A, B, C, R> FunctionN<R> toFunctionN(final Function3<A, B, C, R> f) {
+        return objs -> f.apply((A) objs[0], (B) objs[1], (C) objs[2]);
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/MVELConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/MVELConsequence.java
@@ -97,7 +97,9 @@ public class MVELConsequence implements Consequence {
         String[] default_inputIdentifiers = new String[]{"this", "drools", "kcontext", "rule"};
         String[] inputIdentifiers = Stream.concat(Arrays.asList(default_inputIdentifiers).stream(), facts.entrySet().stream().map(kv -> kv.getKey().getName())).collect(Collectors.toList()).toArray(new String[]{});
         String[] default_inputTypes = new String[]{"org.drools.core.spi.KnowledgeHelper", "org.drools.core.spi.KnowledgeHelper", "org.drools.core.spi.KnowledgeHelper", "org.kie.api.definition.rule.Rule"};
-        String[] inputTypes = Stream.concat(Arrays.asList(default_inputTypes).stream(), facts.entrySet().stream().map(kv -> kv.getKey().getType().asClass().getCanonicalName())).collect(Collectors.toList()).toArray(new String[]{});
+        String[] inputTypes = Stream.concat(Arrays.asList(default_inputTypes).stream(), facts.entrySet().stream().map(kv -> kv.getKey().getType().asClass().getName())).collect(Collectors.toList()).toArray(new String[]{});
+        // ^^ please notice about inputTypes, it is to use the Class.getName(), because is later used by the Classloader internally in MVEL to load the class,
+        //    do NOT replace with getCanonicalName() otherwise inner classes will not be loaded correctly.
         int languageLevel = 4;
         boolean strictMode = true;
         boolean readLocalsFromTuple = false;
@@ -158,4 +160,5 @@ public class MVELConsequence implements Consequence {
 
         MVEL.executeExpression(compiledExpression, knowledgeHelper, cachingFactory);
     }
+
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -16,6 +16,10 @@
 
 package org.drools.modelcompiler;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -24,10 +28,6 @@ import org.drools.modelcompiler.domain.Person;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class MvelDialectTest extends BaseModelTest {
 
@@ -134,6 +134,118 @@ public class MvelDialectTest extends BaseModelTest {
         ksession.fireAllRules();
 
         List<Address> results = getObjectsIntoList(ksession, Address.class);
+        assertEquals(1, results.size());
+    }
+    
+    public static class TempDecl1 {}
+    public static class TempDecl2 {}
+    public static class TempDecl3 {}
+    public static class TempDecl4 {}
+    public static class TempDecl5 {}
+    public static class TempDecl6 {}
+    public static class TempDecl7 {}
+    public static class TempDecl8 {}
+    public static class TempDecl9 {}
+    public static class TempDecl10 {}
+
+    @Test
+    public void testMVEL10declarations() {
+        String str = "\n" +
+                     "import " + TempDecl1.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl2.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl3.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl4.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl5.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl6.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl7.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl8.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl9.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl10.class.getCanonicalName() + ";\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $i1 : TempDecl1()\n" +
+                     "  $i2 : TempDecl2()\n" +
+                     "  $i3 : TempDecl3()\n" +
+                     "  $i4 : TempDecl4()\n" +
+                     "  $i5 : TempDecl5()\n" +
+                     "  $i6 : TempDecl6()\n" +
+                     "  $i7 : TempDecl7()\n" +
+                     "  $i8 : TempDecl8()\n" +
+                     "  $i9 : TempDecl9()\n" +
+                     "  $i10 : TempDecl10()\n" +
+                     "then\n" +
+                     "  insert(\"matched\");\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert(new TempDecl1());
+        ksession.insert(new TempDecl2());
+        ksession.insert(new TempDecl3());
+        ksession.insert(new TempDecl4());
+        ksession.insert(new TempDecl5());
+        ksession.insert(new TempDecl6());
+        ksession.insert(new TempDecl7());
+        ksession.insert(new TempDecl8());
+        ksession.insert(new TempDecl9());
+        ksession.insert(new TempDecl10());
+        ksession.fireAllRules();
+
+        List<String> results = getObjectsIntoList(ksession, String.class);
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    public void testMVEL10declarationsBis() {
+        String str = "\n" +
+                     "import " + TempDecl1.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl2.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl3.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl4.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl5.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl6.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl7.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl8.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl9.class.getCanonicalName() + ";\n" +
+                     "import " + TempDecl10.class.getCanonicalName() + ";\n" +
+                     "rule Rinit\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "then\n" +
+                     "  insert( new TempDecl1() );\n" +
+                     "  insert( new TempDecl2() );\n" +
+                     "  insert( new TempDecl3() );\n" +
+                     "  insert( new TempDecl4() );\n" +
+                     "  insert( new TempDecl5() );\n" +
+                     "  insert( new TempDecl6() );\n" +
+                     "  insert( new TempDecl7() );\n" +
+                     "  insert( new TempDecl8() );\n" +
+                     "  insert( new TempDecl9() );\n" +
+                     "  insert( new TempDecl10());\n" +
+                     "end\n" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  $i1 : TempDecl1()\n" +
+                     "  $i2 : TempDecl2()\n" +
+                     "  $i3 : TempDecl3()\n" +
+                     "  $i4 : TempDecl4()\n" +
+                     "  $i5 : TempDecl5()\n" +
+                     "  $i6 : TempDecl6()\n" +
+                     "  $i7 : TempDecl7()\n" +
+                     "  $i8 : TempDecl8()\n" +
+                     "  $i9 : TempDecl9()\n" +
+                     "  $i10 : TempDecl10()\n" +
+                     "then\n" +
+                     "   insert(\"matched\");\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.fireAllRules();
+
+        List<String> results = getObjectsIntoList(ksession, String.class);
         assertEquals(1, results.size());
     }
 }


### PR DESCRIPTION
/cc @mariofusco @lucamolteni 

before
![image](https://user-images.githubusercontent.com/1699252/34568852-5df7410e-f167-11e7-846c-077ed5d1f07a.png)

after
![image](https://user-images.githubusercontent.com/1699252/34568867-6a9df574-f167-11e7-8492-34bc7fe964c0.png)

total problem count unchanged :)
there are 12 test which moved no longer failing for MVEL but for this CCE:

```
java.lang.ClassCastException: org.drools.model.patterns.AccumulatePatternImpl cannot be cast to org.drools.model.patterns.PatternImpl
	at org.drools.model.impl.ViewBuilder.viewItem2Condition(ViewBuilder.java:310)
	at org.drools.model.impl.ViewBuilder.viewItems2Condition(ViewBuilder.java:196)
	at org.drools.model.impl.ViewBuilder.viewItems2Patterns(ViewBuilder.java:70)
	at org.drools.model.impl.RuleBuilder.build(RuleBuilder.java:63)
	at org.drools.testcoverage.functional.Rules88a7f5d254854ef8a01da7f3fc683284.rule_Row_321_32moveToBiggerCities(Rules88a7f5d254854ef8a01da7f3fc683284.java:99)
	at org.drools.testcoverage.functional.Rules88a7f5d254854ef8a01da7f3fc683284.<init>(Rules88a7f5d254854ef8a01da7f3fc683284.java:75)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.drools.modelcompiler.CanonicalKieModule.createInstance(CanonicalKieModule.java:185)
	at org.drools.modelcompiler.CanonicalKieModule.getModels(CanonicalKieModule.java:144)
	at org.drools.modelcompiler.CanonicalKieModule.getModelForKBase(CanonicalKieModule.java:159)
	at org.drools.modelcompiler.CanonicalKieModule.createKiePackages(CanonicalKieModule.java:120)
	at org.drools.modelcompiler.CanonicalKieModule.lambda$createKieBase$0(CanonicalKieModule.java:115)
	at java.util.HashMap.computeIfAbsent(HashMap.java:1126)
	at org.drools.modelcompiler.CanonicalKieModule.createKieBase(CanonicalKieModule.java:115)
	at org.drools.compiler.kie.builder.impl.KieContainerImpl.createKieBase(KieContainerImpl.java:389)
	at org.drools.compiler.kie.builder.impl.KieContainerImpl.getKieBase(KieContainerImpl.java:357)
	at org.drools.compiler.kie.builder.impl.KieContainerImpl.getKieBase(KieContainerImpl.java:338)
	at org.drools.testcoverage.common.util.KieBaseUtil.getKieBaseFromReleaseIdByName(KieBaseUtil.java:94)
	at org.drools.testcoverage.common.util.KieBaseUtil.getDefaultKieBaseFromReleaseId(KieBaseUtil.java:47)
	at org.drools.testcoverage.common.util.KieBaseUtil.getDefaultKieBaseFromKieModule(KieBaseUtil.java:43)
	at org.drools.testcoverage.common.util.KieBaseUtil.getDefaultKieBaseFromKieBuilder(KieBaseUtil.java:39)
	at org.drools.testcoverage.common.util.KieBaseUtil.getKieBaseFromResources(KieBaseUtil.java:66)
	at org.drools.testcoverage.functional.GuidedDecisionTableTest.initKieSession(GuidedDecisionTableTest.java:523)
	at org.drools.testcoverage.functional.GuidedDecisionTableTest.testMoveToBiggerCitiesTooBigGapBetweenCitySizes(GuidedDecisionTableTest.java:459)
```
