### PR TITLE
[7.5.x] DROOLS-2252: (RHDM-83) "Unable to expand" error with accumulate in Guided Rule Editor with DSL

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -279,7 +279,6 @@ public class RuleModelDRLPersistenceImpl
 
     /**
      * Marshal model attributes
-     *
      * @param buf
      * @param model
      */
@@ -310,7 +309,6 @@ public class RuleModelDRLPersistenceImpl
 
     /**
      * Marshal model metadata
-     *
      * @param buf
      * @param model
      */
@@ -325,7 +323,6 @@ public class RuleModelDRLPersistenceImpl
 
     /**
      * Marshal LHS patterns
-     *
      * @param buf
      * @param model
      */
@@ -692,7 +689,7 @@ public class RuleModelDRLPersistenceImpl
                 buf.append(" from ");
                 renderExpression(pattern.getExpression());
                 if (!isSubPattern) {
-                   buf.append(")");
+                    buf.append(")");
                 }
                 buf.append("\n");
             }
@@ -796,19 +793,34 @@ public class RuleModelDRLPersistenceImpl
                 buf.append(",\n");
 
                 if (pattern.useFunctionOrCode().equals(FromAccumulateCompositeFactPattern.USE_FUNCTION)) {
+                    if (isDSLEnhanced) {
+                        buf.append(">");
+                    }
                     buf.append(indentation + "\t");
                     buf.append(pattern.getFunction());
                 } else {
+                    if (isDSLEnhanced) {
+                        buf.append(">");
+                    }
                     buf.append(indentation + "\tinit( ");
                     buf.append(pattern.getInitCode());
                     buf.append(" ),\n");
+                    if (isDSLEnhanced) {
+                        buf.append(">");
+                    }
                     buf.append(indentation + "\taction( ");
                     buf.append(pattern.getActionCode());
                     buf.append(" ),\n");
                     if (pattern.getReverseCode() != null && !pattern.getReverseCode().trim().equals("")) {
+                        if (isDSLEnhanced) {
+                            buf.append(">");
+                        }
                         buf.append(indentation + "\treverse( ");
                         buf.append(pattern.getReverseCode());
                         buf.append(" ),\n");
+                    }
+                    if (isDSLEnhanced) {
+                        buf.append(">");
                     }
                     buf.append(indentation + "\tresult( ");
                     buf.append(pattern.getResultCode());

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -161,7 +161,54 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
         assertTrue(newModel.lhs[0] instanceof FactPattern);
         assertTrue(newModel.lhs[1] instanceof FromCollectCompositeFactPattern);
 
-        final String[] rows = newDrl.split("\n");
+        assertDSLEscaping(newDrl);
+    }
+
+    @Test
+    public void testDSLWithFromAccumulate() {
+        final RuleModel m = new RuleModel();
+        m.name = "testDSLWithFromAccumulate";
+        m.lhs = new IPattern[2];
+        m.rhs = new IAction[0];
+
+        final FromAccumulateCompositeFactPattern from = new FromAccumulateCompositeFactPattern();
+
+        final FactPattern person = new FactPattern("Person");
+        person.setBoundName("$p");
+
+        m.lhs[0] = person;
+
+        from.setFactPattern(new FactPattern("java.lang.Number"));
+        from.setSourcePattern(person);
+        from.setFunction("count($p)");
+
+        m.lhs[1] = from;
+
+        final RuleModel modelSpy = spy(m);
+        doReturn(true).when(modelSpy).hasDSLSentences();
+
+        final String drl = ruleModelPersistence.marshal(modelSpy);
+        final RuleModel tempModel = spy(ruleModelPersistence.unmarshalUsingDSL(drl,
+                                                                               null,
+                                                                               dmo,
+                                                                               ""));
+        doReturn(true).when(tempModel).hasDSLSentences();
+
+        final String newDrl = ruleModelPersistence.marshal(tempModel);
+
+        final RuleModel newModel = ruleModelPersistence.unmarshalUsingDSL(newDrl,
+                                                                          null,
+                                                                          dmo,
+                                                                          "");
+
+        assertTrue(newModel.lhs[0] instanceof FactPattern);
+        assertTrue(newModel.lhs[1] instanceof FromAccumulateCompositeFactPattern);
+
+        assertDSLEscaping(newDrl);
+    }
+
+    private void assertDSLEscaping(final String drl) {
+        final String[] rows = drl.split("\n");
         boolean foundWhen = false;
         for (final String row : rows) {
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2252

(https://issues.jboss.org/browse/RHDM-83)

This is the corollary of https://github.com/kiegroup/drools/pull/1700 for 7.5.x

(cherry picked from commit 407aea1fab547ac3f5ce34c0111b0f40deb5b8a6)