### PR TITLE
RHDM-44 remove the drools-verifier reference

### DIFF
--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -114,15 +114,6 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-verifier</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-verifier</artifactId>
-      <classifier>sources</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
       <artifactId>drools-persistence-jpa</artifactId>
     </dependency>
     <dependency>

--- a/drools-test-coverage/test-suite/pom.xml
+++ b/drools-test-coverage/test-suite/pom.xml
@@ -54,11 +54,6 @@
       <artifactId>drools-workbench-models-guided-dtable</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-verifier</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.kie</groupId>


### PR DESCRIPTION
There is still drools-verifier reference in drools-test-coverage module. I removed them for RHDM-44 since it's already removed in kie-parent.
I leave the drools-verifier in the maven module, so they can still be built and available in maven repository.
But we just don't have them in our boms.
