### PR TITLE
exec model provide Drools support for PropertyChangeListeners

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/DroolsEntryPoint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/DroolsEntryPoint.java
@@ -20,6 +20,8 @@ public interface DroolsEntryPoint {
 
     void insert(Object object);
 
+    void insert(Object object, boolean dynamic);
+
     void update(Object object, String... modifiedProperties);
 
     void update(Object object, BitMask modifiedProperties);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/consequence/LambdaConsequence.java
@@ -45,7 +45,6 @@ import org.drools.modelcompiler.RuleContext;
 import org.kie.api.runtime.rule.EntryPoint;
 
 import static java.util.Arrays.asList;
-
 import static org.drools.core.reteoo.PropertySpecificUtil.calculatePositiveMask;
 
 public class LambdaConsequence implements Consequence {
@@ -132,6 +131,11 @@ public class LambdaConsequence implements Consequence {
         }
 
         @Override
+        public void insert(Object object, boolean dynamic) {
+            workingMemory.insert(object, dynamic);
+        }
+
+        @Override
         public void insertLogical(Object object) {
             knowledgeHelper.insertLogical(object);
         }
@@ -186,6 +190,11 @@ public class LambdaConsequence implements Consequence {
         @Override
         public void insert( Object object ) {
             entryPoint.insert( object );
+        }
+
+        @Override
+        public void insert(Object object, boolean dynamic) {
+            ((WorkingMemoryEntryPoint) entryPoint).insert(object, dynamic);
         }
 
         @Override


### PR DESCRIPTION
```
BEFORE
Tests run: 1310, Failures: 84, Errors: 44, Skipped: 24

AFTER
Tests run: 1310, Failures: 80, Errors: 44, Skipped: 24
```

/cc @mariofusco @lucamolteni 