### PR TITLE
code fix related to PLANNER-865

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -1411,7 +1411,7 @@ public class RuleModelDRLPersistenceImpl
         private Map<String, FieldConstraint> bindingsFields;
         protected DRLConstraintValueBuilder constraintValueBuilder;
         protected RHSGeneratorContextFactory generatorContextFactory;
-        protected Collection<RuleModelIActionPersistenceExtension> extensions;
+        //        protected Collection<RuleModelIActionPersistenceExtension> extensions;
 
         protected final RHSGeneratorContext rootContext;
 
@@ -1430,7 +1430,6 @@ public class RuleModelDRLPersistenceImpl
             this.bindingsFields = bindingsFields;
             this.constraintValueBuilder = constraintValueBuilder;
             this.generatorContextFactory = generatorContextFactory;
-            this.extensions = extensions;
             this.rootContext = generatorContextFactory.newGeneratorContext();
             this.indentation = indentation;
             this.instantiatedWorkItems = new HashSet<String>();


### PR DESCRIPTION
There were line removal which was not followed by removal of https://github.com/kiegroup/drools/blob/master/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java#L1433 and now it assigns the same variable to itself.

I found it by accident in findbugs report https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/droolsjbpm-build-bootstrap-downstream-pullrequests-7.5.x/5/findbugsResult/module.1185363731/source.746398736072648405/#1423
