### PR TITLE
[7.5.x] DROOLS-2263 : Unexpected results in GDST when using enumerations with commas

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -115,6 +115,7 @@ import org.drools.workbench.models.datamodel.workitems.PortableObjectParameterDe
 import org.drools.workbench.models.datamodel.workitems.PortableParameterDefinition;
 import org.drools.workbench.models.datamodel.workitems.PortableStringParameterDefinition;
 import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
+import org.kie.soup.commons.util.ListSplitter;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.soup.project.datamodel.commons.imports.ImportsParser;
 import org.kie.soup.project.datamodel.commons.imports.ImportsWriter;
@@ -1314,17 +1315,11 @@ public class RuleModelDRLPersistenceImpl
                 workingValue = workingValue.substring(0,
                                                       workingValue.length() - 1);
             }
-            final String[] values = workingValue.split(",");
+
+            final String[] values = ListSplitter.split("\"", true, workingValue);
             buf.append(" ( ");
             for (String v : values) {
                 v = v.trim();
-                if (v.startsWith("\"")) {
-                    v = v.substring(1);
-                }
-                if (v.endsWith("\"")) {
-                    v = v.substring(0,
-                                    v.length() - 1);
-                }
                 constraintValueBuilder.buildLHSFieldValue(buf,
                                                           type,
                                                           fieldType,

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
@@ -17,7 +17,9 @@
 package org.drools.workbench.models.guided.dtable.backend;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -74,6 +76,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLCon
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.kie.soup.commons.util.ListSplitter;
 import org.kie.soup.project.datamodel.commons.imports.ImportsWriter;
 import org.kie.soup.project.datamodel.commons.packages.PackageNameWriter;
 import org.kie.soup.project.datamodel.oracle.DataType;
@@ -742,25 +745,30 @@ public class GuidedDTDRLPersistence {
     /**
      * take a CSV list and turn it into DRL syntax
      */
-    String makeInList(String cell) {
+    String makeInList(final String cell) {
         if (cell.startsWith("(")) {
             return cell;
         }
-        String res = "";
-        StringTokenizer st = new StringTokenizer(cell,
-                                                 ",");
-        while (st.hasMoreTokens()) {
-            String t = st.nextToken().trim();
-            if (t.startsWith("\"")) {
-                res += t;
+
+        String result = "";
+        Iterator<String> iterator = Arrays.asList(ListSplitter.split("\"",
+                                                                     true,
+                                                                     cell)).iterator();
+        while (iterator.hasNext()) {
+
+            final String item = iterator.next();
+
+            if (item.startsWith("\"")) {
+                result += item;
             } else {
-                res += "\"" + t + "\"";
+                result += "\"" + item + "\"";
             }
-            if (st.hasMoreTokens()) {
-                res += ", ";
+            if (iterator.hasNext()) {
+                result += ", ";
             }
         }
-        return "(" + res + ")";
+
+        return "(" + result + ")";
     }
 
     private boolean no(String operator) {

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
@@ -303,6 +303,8 @@ public class GuidedDTDRLPersistenceTest {
     @Test
     public void testCellCSV() {
         GuidedDTDRLPersistence p = new GuidedDTDRLPersistence();
+        assertEquals( "(\"Helsinki, Finland\", \"Boston\")",
+                      p.makeInList( "\"Helsinki, Finland\",Boston" ) );
         assertEquals("(\"Michael\", \"Mark\", \"Peter\")",
                      p.makeInList("Michael, Mark, Peter"));
         assertEquals("(\"Michael\")",


### PR DESCRIPTION
(cherry picked from commit 69ca5dbbea8381dd9dedba877e52bd395b21a025)
(cherry picked from commit a7f3419edb51717aaf214910764775980fac0313)

https://issues.jboss.org/browse/DROOLS-2263

Bundle:
https://github.com/kiegroup/kie-soup/pull/30
https://github.com/kiegroup/drools/pull/1728
https://github.com/kiegroup/drools-wb/pull/778