### PR TITLE
[7.5.x] DROOLS-2263: Cover marshalling of enums with comma inside

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -1862,6 +1862,33 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
     }
 
     @Test
+    public void testInOperatorStringCommaInside() {
+
+        final RuleModel model = new RuleModel();
+        model.name = "in";
+
+        final FactPattern pattern = new FactPattern("Person");
+        final SingleFieldConstraint constraint = new SingleFieldConstraint();
+        constraint.setFieldType(DataType.TYPE_STRING);
+        constraint.setFieldName("field1");
+        constraint.setOperator("in");
+        constraint.setValue("value1, \"value2, value3\"");
+        constraint.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
+        pattern.addConstraint(constraint);
+
+        model.addLhsItem(pattern);
+
+        final String expected = "rule \"in\" \n"
+                + "dialect \"mvel\" \n"
+                + "when \n"
+                + "     Person(field1 in ( \"value1\", \"value2, value3\" ) ) \n"
+                + " then \n"
+                + "end";
+
+        checkMarshalling(expected, model);
+    }
+
+    @Test
     public void testInOperatorNumber() {
 
         RuleModel m = new RuleModel();

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
@@ -2788,7 +2788,7 @@ public class GuidedDTDRLPersistenceTest {
         p1.getChildColumns().add(cc2);
 
         dt.setData(DataUtilities.makeDataLists(new Object[][]{
-                new Object[]{1l, "desc", "Pupa, Brains", "55, 66"},
+                new Object[]{1l, "desc", "Pupa, Brains, \"John, Snow\"", "55, 66"},
                 new Object[]{2l, "desc", "", ""}
         }));
 
@@ -2796,7 +2796,7 @@ public class GuidedDTDRLPersistenceTest {
         String drl = p.marshal(dt);
 
         int index = -1;
-        index = drl.indexOf("Smurf( name in ( \"Pupa\", \"Brains\" ) , age in ( 55, 66 ) )");
+        index = drl.indexOf("Smurf( name in ( \"Pupa\", \"Brains\", \"John, Snow\" ) , age in ( 55, 66 ) )");
         assertTrue(index > -1);
 
         index = drl.indexOf("Smurf( )",


### PR DESCRIPTION
This is **cherry-pick** of #1732

Dependent on
- kiegroup/drools#1728
- kiegroup/kie-soup#32

@manstis @Rikkola please have a look
