### PR TITLE
Add tests for PMML descision trees

### DIFF
--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/DecisionTreeTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/DecisionTreeTest.java
@@ -21,9 +21,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.InternalRuleUnitExecutor;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.io.Resource;
@@ -38,6 +40,8 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 import org.kie.pmml.pmml_4_2.DroolsAbstractPMMLTest;
 import org.kie.pmml.pmml_4_2.PMML4Result;
+import org.kie.pmml.pmml_4_2.PMMLExecutor;
+import org.kie.pmml.pmml_4_2.PMMLKieBaseUtil;
 import org.kie.pmml.pmml_4_2.model.AbstractModel;
 import org.kie.pmml.pmml_4_2.model.PMMLRequestData;
 import org.kie.pmml.pmml_4_2.model.ParameterInfo;
@@ -50,14 +54,26 @@ import static org.junit.Assert.assertTrue;
 
 public class DecisionTreeTest extends DroolsAbstractPMMLTest {
 
+    private static final String DECISION_TREES_FOLDER = "org/kie/pmml/pmml_4_2/";
 
     private static final boolean VERBOSE = false;
-    private static final String source1 = "org/kie/pmml/pmml_4_2/test_tree_simple.pmml";
-    private static final String source2 = "org/kie/pmml/pmml_4_2/test_tree_missing.pmml";
-    private static final String source3 = "org/kie/pmml/pmml_4_2/test_tree_handwritten.pmml";
+    private static final String source1 = DECISION_TREES_FOLDER + "test_tree_simple.pmml";
+    private static final String source2 = DECISION_TREES_FOLDER + "test_tree_missing.pmml";
+    private static final String source3 = DECISION_TREES_FOLDER + "test_tree_handwritten.pmml";
     private static final String packageName = "org.kie.pmml.pmml_4_2.test";
 
-
+    private static final String TREE_RETURN_NULL_NOTRUECHILD_STRATEGY = DECISION_TREES_FOLDER +
+            "test_tree_return_null_notruechild_strategy.pmml";
+    private static final String TREE_RETURN_LAST_NOTRUE_CHILD_STRATEGY = DECISION_TREES_FOLDER +
+            "test_tree_return_last_notruechild_strategy.pmml";
+    private static final String TREE_DEFAULT_CHILD_MISSING_STRATEGY =
+            DECISION_TREES_FOLDER + "test_tree_default_child_missing_value_strategy.pmml";
+    private static final String TREE_LAST_CHILD_MISSING_STRATEGY = DECISION_TREES_FOLDER +
+            "test_tree_last_missing_value_strategy.pmml";
+    private static final String TREE_RETURN_NULL_MISSING_STRATEGY = DECISION_TREES_FOLDER +
+            "test_tree_return_null_missing_value_strategy.pmml";
+    private static final String TREE_WEIGHTED_CONFIDENCE_MISSING_STRATEGY = DECISION_TREES_FOLDER +
+            "test_tree_weightedconfidence_missing_value_strategy.pmml";
 
     @After
     public void tearDown() {
@@ -126,7 +142,120 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
         assertEquals("tgtY",targetValue);
     }
     
-    
+    @Test
+    @Ignore("RHDM-342")
+    public void testReturnNullNoTrueChildPredictionStrategy() {
+        KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_RETURN_NULL_NOTRUECHILD_STRATEGY);
+        PMMLExecutor executor = new PMMLExecutor(kieBase);
+
+        PMMLRequestData request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 30.0);
+        PMML4Result resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        String targetValue = resultHolder.getResultValue("Fld2", "value", String.class).orElse(null);
+        Assertions.assertThat(targetValue).isEqualTo("tgtY");
+
+        request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 50.0);
+        resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld2", "value", String.class)).isEmpty();
+    }
+
+    @Test
+    @Ignore("RHDM-345")
+    public void testReturnLastNoTrueChildPredictionStrategy() {
+        KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_RETURN_LAST_NOTRUE_CHILD_STRATEGY);
+        PMMLExecutor executor = new PMMLExecutor(kieBase);
+
+        PMMLRequestData request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 30.0);
+        PMML4Result resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        String targetValue = resultHolder.getResultValue("Fld2", "value", String.class).orElse(null);
+        Assertions.assertThat(targetValue).isEqualTo("tgtY");
+
+        request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 50.0);
+        resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld2", "value", String.class)).isEqualTo("tgtX");
+    }
+
+    @Test
+    @Ignore("RHDM-341")
+    public void testLastPredictionMissingValueStrategy() {
+        KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_LAST_CHILD_MISSING_STRATEGY);
+        PMMLExecutor executor = new PMMLExecutor(kieBase);
+
+        PMMLRequestData request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 30.0);
+        PMML4Result resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtY");
+
+        request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 100.0);
+        resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtA");
+    }
+
+    @Test
+    @Ignore("RHDM-342")
+    public void testNullPredictionMissingValueStrategy() {
+        KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_RETURN_NULL_MISSING_STRATEGY);
+        PMMLExecutor executor = new PMMLExecutor(kieBase);
+
+        PMMLRequestData request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 30.0);
+        PMML4Result resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtY");
+
+        request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 100.0);
+        resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEmpty();
+    }
+
+    @Test
+    public void testDefaultChildMissingValueStrategy() {
+        KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_DEFAULT_CHILD_MISSING_STRATEGY);
+        PMMLExecutor executor = new PMMLExecutor(kieBase);
+
+        PMMLRequestData request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 30.0);
+        PMML4Result resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtY");
+
+        request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 100.0);
+        resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtZ");
+    }
+
+    @Test
+    @Ignore("RHDM-343")
+    public void testWeightedConfidenceMissingValueStrategy() {
+        KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_WEIGHTED_CONFIDENCE_MISSING_STRATEGY);
+        PMMLExecutor executor = new PMMLExecutor(kieBase);
+
+        PMMLRequestData request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 30.0);
+        PMML4Result resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtY");
+
+        request = new PMMLRequestData("123","TreeTest");
+        request.addRequestParam("fld1", 50.0);
+        resultHolder = executor.run(request);
+        Assertions.assertThat(resultHolder).isNotNull();
+        Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtX");
+    }
     
     protected Object getToken( KieSession kSession, String treeModelName ) {
         String className = AbstractModel.PMML_JAVA_PACKAGE_NAME + "." + treeModelName + "TreeToken";

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_default_child_missing_value_strategy.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_default_child_missing_value_strategy.pmml
@@ -1,0 +1,42 @@
+<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="3">
+    <DataField dataType="double" name="fld1" optype="continuous"/>
+    <DataField dataType="double" name="fld2" optype="continuous"/>
+    <DataField dataType="string" name="fld3" optype="categorical">
+      <Value value="tgtX"/>
+      <Value value="tgtY"/>
+      <Value value="tgtZ"/>
+    </DataField>
+  </DataDictionary>
+
+  <TreeModel functionName="classification" modelName="TreeTest" missingValueStrategy="defaultChild">
+    <MiningSchema>
+      <MiningField name="fld1"/>
+      <MiningField name="fld2"/>
+      <MiningField name="fld3" usageType="predicted"/>
+    </MiningSchema>
+
+    <Node id="N1" score="tgtX">
+      <True/>
+      <Node id="T1" score="tgtY" defaultChild="T4">
+        <SimplePredicate field="fld1" operator="lessThan" value="40.0"/>
+      </Node>
+      <Node id="N2" score="tgtY" defaultChild="T4">
+        <SimplePredicate field="fld1" operator="greaterOrEqual" value="40.0"/>
+        <Node id="T2" score="tgtX" defaultChild="T4">
+          <SimplePredicate field="fld2" operator="lessThan" value="5.0"/>
+        </Node>
+        <Node id="T3" score="tgtY" defaultChild="T4">
+          <SimplePredicate field="fld2" operator="greaterOrEqual" value="5.0"/>
+        </Node>
+      </Node>
+      <Node id="N3">
+        <False/>
+        <Node id="T4" score="tgtZ">
+          <True/>
+        </Node>
+      </Node>
+    </Node>
+  </TreeModel>
+</PMML>

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_last_missing_value_strategy.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_last_missing_value_strategy.pmml
@@ -1,0 +1,43 @@
+<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="3">
+    <DataField dataType="double" name="fld1" optype="continuous"/>
+    <DataField dataType="double" name="fld2" optype="continuous"/>
+    <DataField dataType="string" name="fld3" optype="categorical">
+      <Value value="tgtA"/>
+      <Value value="tgtX"/>
+      <Value value="tgtY"/>
+      <Value value="tgtZ"/>
+    </DataField>
+  </DataDictionary>
+
+  <TreeModel functionName="classification" modelName="TreeTest" missingValueStrategy="lastPrediction">
+    <MiningSchema>
+      <MiningField name="fld1"/>
+      <MiningField name="fld2"/>
+      <MiningField name="fld3" usageType="predicted"/>
+    </MiningSchema>
+
+    <Node id="N1" score="tgtX">
+      <True/>
+      <Node id="T1" score="tgtY" defaultChild="T4">
+        <SimplePredicate field="fld1" operator="lessThan" value="40.0"/>
+      </Node>
+      <Node id="N2" score="tgtA" defaultChild="T4">
+        <SimplePredicate field="fld1" operator="greaterOrEqual" value="40.0"/>
+        <Node id="T2" score="tgtX" defaultChild="T4">
+          <SimplePredicate field="fld2" operator="lessThan" value="5.0"/>
+        </Node>
+        <Node id="T3" score="tgtY" defaultChild="T4">
+          <SimplePredicate field="fld2" operator="greaterOrEqual" value="5.0"/>
+        </Node>
+      </Node>
+      <Node id="N3">
+        <False/>
+        <Node id="T4" score="tgtZ">
+          <True/>
+        </Node>
+      </Node>
+    </Node>
+  </TreeModel>
+</PMML>

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_return_last_notruechild_strategy.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_return_last_notruechild_strategy.pmml
@@ -1,0 +1,24 @@
+<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="2">
+    <DataField dataType="double" name="fld1" optype="continuous"/>
+    <DataField dataType="string" name="fld2" optype="categorical">
+      <Value value="tgtX"/>
+      <Value value="tgtY"/>
+    </DataField>
+  </DataDictionary>
+
+  <TreeModel functionName="classification" modelName="TreeTest" noTrueChildStrategy="returnLastPrediction">
+    <MiningSchema>
+      <MiningField name="fld1"/>
+      <MiningField name="fld2" usageType="predicted"/>
+    </MiningSchema>
+
+    <Node id="N1" score="tgtX">
+      <True/>
+      <Node id="T1" score="tgtY">
+        <SimplePredicate field="fld1" operator="lessThan" value="40.0"/>
+      </Node>
+    </Node>
+  </TreeModel>
+</PMML>

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_return_null_missing_value_strategy.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_return_null_missing_value_strategy.pmml
@@ -1,0 +1,43 @@
+<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="3">
+    <DataField dataType="double" name="fld1" optype="continuous"/>
+    <DataField dataType="double" name="fld2" optype="continuous"/>
+    <DataField dataType="string" name="fld3" optype="categorical">
+      <Value value="tgtA"/>
+      <Value value="tgtX"/>
+      <Value value="tgtY"/>
+      <Value value="tgtZ"/>
+    </DataField>
+  </DataDictionary>
+
+  <TreeModel functionName="classification" modelName="TreeTest" missingValueStrategy="nullPrediction">
+    <MiningSchema>
+      <MiningField name="fld1"/>
+      <MiningField name="fld2"/>
+      <MiningField name="fld3" usageType="predicted"/>
+    </MiningSchema>
+
+    <Node id="N1" score="tgtX">
+      <True/>
+      <Node id="T1" score="tgtY" defaultChild="T4">
+        <SimplePredicate field="fld1" operator="lessThan" value="40.0"/>
+      </Node>
+      <Node id="N2" score="tgtA" defaultChild="T4">
+        <SimplePredicate field="fld1" operator="greaterOrEqual" value="40.0"/>
+        <Node id="T2" score="tgtX" defaultChild="T4">
+          <SimplePredicate field="fld2" operator="lessThan" value="5.0"/>
+        </Node>
+        <Node id="T3" score="tgtY" defaultChild="T4">
+          <SimplePredicate field="fld2" operator="greaterOrEqual" value="5.0"/>
+        </Node>
+      </Node>
+      <Node id="N3">
+        <False/>
+        <Node id="T4" score="tgtZ">
+          <True/>
+        </Node>
+      </Node>
+    </Node>
+  </TreeModel>
+</PMML>

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_return_null_notruechild_strategy.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_return_null_notruechild_strategy.pmml
@@ -1,0 +1,24 @@
+<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="2">
+    <DataField dataType="double" name="fld1" optype="continuous"/>
+    <DataField dataType="string" name="fld2" optype="categorical">
+      <Value value="tgtX"/>
+      <Value value="tgtY"/>
+    </DataField>
+  </DataDictionary>
+
+  <TreeModel functionName="classification" modelName="TreeTest" noTrueChildStrategy="returnNullPrediction">
+    <MiningSchema>
+      <MiningField name="fld1"/>
+      <MiningField name="fld2" usageType="predicted"/>
+    </MiningSchema>
+
+    <Node id="N1" score="tgtX">
+      <True/>
+      <Node id="T1" score="tgtY">
+        <SimplePredicate field="fld1" operator="lessThan" value="40.0"/>
+      </Node>
+    </Node>
+  </TreeModel>
+</PMML>

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_weightedconfidence_missing_value_strategy.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_weightedconfidence_missing_value_strategy.pmml
@@ -1,0 +1,45 @@
+<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="3">
+    <DataField dataType="double" name="fld1" optype="continuous"/>
+    <DataField dataType="double" name="fld2" optype="continuous"/>
+    <DataField dataType="string" name="fld3" optype="categorical">
+      <Value value="tgtX"/>
+      <Value value="tgtY"/>
+    </DataField>
+  </DataDictionary>
+
+  <TreeModel functionName="classification" modelName="TreeTest" missingValueStrategy="weightedConfidence">
+    <MiningSchema>
+      <MiningField name="fld1"/>
+      <MiningField name="fld2"/>
+      <MiningField name="fld3" usageType="predicted"/>
+    </MiningSchema>
+
+    <Node id="N1" score="tgtX">
+      <True/>
+      <ScoreDistribution value="tgtX" recordCount="60" confidence="0.6"/>
+      <ScoreDistribution value="tgtY" recordCount="40" confidence="0.4"/>
+      <Node id="T1" score="tgtY" recordCount="20">
+        <SimplePredicate field="fld1" operator="lessThan" value="40.0"/>
+        <ScoreDistribution value="tgtX" recordCount="10" confidence="0.5"/>
+        <ScoreDistribution value="tgtY" recordCount="10" confidence="0.5"/>
+      </Node>
+      <Node id="N2" score="tgtY" recordCount="60">
+        <SimplePredicate field="fld1" operator="greaterOrEqual" value="40.0"/>
+        <ScoreDistribution value="tgtX" recordCount="36" confidence="0.5"/>
+        <ScoreDistribution value="tgtY" recordCount="24" confidence="0.5"/>
+        <Node id="T2" score="tgtX" recordCount="20">
+          <SimplePredicate field="fld2" operator="lessThan" value="5.0"/>
+          <ScoreDistribution value="tgtX" recordCount="16" confidence="0.8"/>
+          <ScoreDistribution value="tgtY" recordCount="4" confidence="0.2"/>
+        </Node>
+        <Node id="T3" score="tgtY" recordCount="40">
+          <SimplePredicate field="fld2" operator="greaterOrEqual" value="5.0"/>
+          <ScoreDistribution value="tgtX" recordCount="32" confidence="0.8"/>
+          <ScoreDistribution value="tgtY" recordCount="16" confidence="0.2"/>
+        </Node>
+      </Node>
+    </Node>
+  </TreeModel>
+</PMML>


### PR DESCRIPTION
Add tests for various types of trees evaluation strategies:
- noTrueChildStrategy, which defines what to do in situations where scoring cannot reach a leaf node
-- returnNullPrediction strategy - testReturnNullNoTrueChildPredictionStrategy()
-- returnLastPrediction strategy - testReturnLastNoTrueChildPredictionStrategy()

- missingValueStrategy, which defines a strategy for dealing with missing values:
-- lastPrediction strategy - testLastPredictionMissingValueStrategy()
-- nullPrediction strategy - testNullPredictionMissingValueStrategy()
-- defaultChild strategy - testDefaultChildMissingValueStrategy()
-- weightedConfidence - testWeightedConfidenceMissingValueStrategy()