### PR TITLE
Handle Explicit Constraint parsing failure

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -1,0 +1,317 @@
+package org.drools.modelcompiler.builder.generator.drlxparse;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.drools.core.util.index.IndexUtil;
+import org.drools.javaparser.ast.NodeList;
+import org.drools.javaparser.ast.body.MethodDeclaration;
+import org.drools.javaparser.ast.drlx.OOPathExpr;
+import org.drools.javaparser.ast.drlx.expr.DrlxExpression;
+import org.drools.javaparser.ast.drlx.expr.PointFreeExpr;
+import org.drools.javaparser.ast.expr.BinaryExpr;
+import org.drools.javaparser.ast.expr.EnclosedExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.FieldAccessExpr;
+import org.drools.javaparser.ast.expr.IntegerLiteralExpr;
+import org.drools.javaparser.ast.expr.LiteralExpr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.expr.ThisExpr;
+import org.drools.javaparser.ast.expr.UnaryExpr;
+import org.drools.javaparser.ast.nodeTypes.NodeWithArguments;
+import org.drools.javaparser.ast.nodeTypes.NodeWithOptionalScope;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.errors.ParseExpressionErrorResult;
+import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+import org.drools.modelcompiler.builder.generator.TypedExpression;
+
+import static org.drools.javaparser.ast.expr.BinaryExpr.Operator.GREATER;
+import static org.drools.javaparser.ast.expr.BinaryExpr.Operator.GREATER_EQUALS;
+import static org.drools.javaparser.ast.expr.BinaryExpr.Operator.LESS;
+import static org.drools.javaparser.ast.expr.BinaryExpr.Operator.LESS_EQUALS;
+import static org.drools.javaparser.printer.PrintUtil.toDrlx;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.isPrimitiveExpression;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toTypedExpression;
+
+public class ConstraintParser {
+
+    public static final boolean GENERATE_EXPR_ID = true;
+
+    private RuleContext context;
+    private PackageModel packageModel;
+
+    public ConstraintParser(RuleContext context, PackageModel packageModel) {
+        this.context = context;
+        this.packageModel = packageModel;
+    }
+
+    public DrlxParseResult drlxParse(Class<?> patternType, String bindingId, String expression) {
+        return drlxParse(patternType, bindingId, expression, false);
+    }
+
+    public DrlxParseResult drlxParse(Class<?> patternType, String bindingId, String expression, boolean isPositional) {
+        if ( expression.startsWith( bindingId + "." ) ) {
+            expression = expression.substring( bindingId.length()+1 );
+        }
+
+        DrlxExpression drlx = DrlxParseUtil.parseExpression( expression );
+        DrlxParseResult drlxParseResult = getDrlxParseResult(patternType, bindingId, expression, drlx, isPositional );
+
+        drlxParseResult.accept(result -> {
+            if (drlx.getBind() != null) {
+                String bindId = drlx.getBind().asString();
+                context.addDeclaration( new DeclarationSpec( bindId, result.getExprType() ) );
+                result.setExprBinding( bindId );
+            }
+
+        });
+
+        return drlxParseResult;
+    }
+
+    private DrlxParseResult getDrlxParseResult(Class<?> patternType,
+                                                String bindingId, String expression, DrlxExpression drlx, boolean isPositional ) {
+        Expression drlxExpr = drlx.getExpr();
+
+        while (drlxExpr instanceof EnclosedExpr) {
+            drlxExpr = (( EnclosedExpr ) drlxExpr).getInner();
+        }
+
+        String exprId;
+        if ( GENERATE_EXPR_ID ) {
+            exprId = context.getExprId( patternType, expression );
+        }
+
+        if ( drlxExpr instanceof BinaryExpr ) {
+            BinaryExpr binaryExpr = (BinaryExpr) drlxExpr;
+            BinaryExpr.Operator operator = binaryExpr.getOperator();
+
+            IndexUtil.ConstraintType decodeConstraintType = DrlxParseUtil.toConstraintType(operator );
+            List<String> usedDeclarations = new ArrayList<>();
+            Set<String> reactOnProperties = new HashSet<>();
+            TypedExpression left = DrlxParseUtil.toTypedExpression( context, packageModel, patternType, binaryExpr.getLeft(), usedDeclarations, reactOnProperties, binaryExpr, isPositional);
+            TypedExpression right = DrlxParseUtil.toTypedExpression( context, packageModel, patternType, binaryExpr.getRight(), usedDeclarations, reactOnProperties, binaryExpr, isPositional);
+
+            Expression combo;
+            if ( left.isPrimitive() ) {
+                Expression rightExpr = right.getExpression() instanceof StringLiteralExpr ?
+                        new IntegerLiteralExpr( (( StringLiteralExpr ) right.getExpression()).asString() ) :
+                        right.getExpression();
+                combo = new BinaryExpr( left.getExpression(), rightExpr, operator );
+            } else {
+                if ( left == null || right == null ) {
+                    context.addCompilationError( new ParseExpressionErrorResult(drlxExpr) );
+                    return new DrlxParseFail();
+                }
+                switch ( operator ) {
+                    case EQUALS:
+                    case NOT_EQUALS:
+                        combo = getEqualityExpression( left, right, operator );
+                        break;
+                    default:
+                        if ( left.getExpression() == null || right.getExpression() == null ) {
+                            context.addCompilationError( new ParseExpressionErrorResult(drlxExpr) );
+                            return new DrlxParseFail();
+                        }
+                        combo = handleSpecialComparisonCases( operator, left, right );
+                }
+            }
+
+            if ( left.getPrefixExpression() != null ) {
+                combo = new BinaryExpr(left.getPrefixExpression(), combo, BinaryExpr.Operator.AND );
+            }
+
+            return new DrlxParseSuccess(patternType, exprId, bindingId, combo, left.getType())
+                    .setDecodeConstraintType( decodeConstraintType ).setUsedDeclarations( usedDeclarations )
+                    .setReactOnProperties( reactOnProperties ).setLeft( left ).setRight( right );
+        }
+
+        if ( drlxExpr instanceof UnaryExpr ) {
+            UnaryExpr unaryExpr = (UnaryExpr) drlxExpr;
+
+            List<String> usedDeclarations = new ArrayList<>();
+            Set<String> reactOnProperties = new HashSet<>();
+            TypedExpression left = DrlxParseUtil.toTypedExpression( context, packageModel, patternType, unaryExpr, usedDeclarations, reactOnProperties, unaryExpr, isPositional);
+
+            return new DrlxParseSuccess(patternType, exprId, bindingId, left.getExpression(), left.getType())
+                    .setUsedDeclarations( usedDeclarations ).setReactOnProperties( reactOnProperties ).setLeft( left );
+        }
+
+        if ( drlxExpr instanceof PointFreeExpr ) {
+            PointFreeExpr pointFreeExpr = (PointFreeExpr) drlxExpr;
+
+            List<String> usedDeclarations = new ArrayList<>();
+            Set<String> reactOnProperties = new HashSet<>();
+
+            final TypedExpression typedExpression = toTypedExpression(context, packageModel, patternType, pointFreeExpr, usedDeclarations, reactOnProperties, null, isPositional);
+            final Expression returnExpression = typedExpression.getExpression();
+            final Class<?> returnType = typedExpression.getType();
+
+            return new DrlxParseSuccess(patternType, exprId, bindingId, returnExpression, returnType)
+                    .setUsedDeclarations(usedDeclarations)
+                    .setReactOnProperties(reactOnProperties)
+                    .setLeft(typedExpression.getLeft())
+                    .setStatic(typedExpression.isStatic())
+                    .setValidExpression(true);
+        }
+
+        if (drlxExpr instanceof MethodCallExpr) {
+            MethodCallExpr methodCallExpr = (MethodCallExpr) drlxExpr;
+
+            // when the methodCallExpr will be placed in the model/DSL, any parameter being a "this" need to be implemented as _this by convention.
+            List<ThisExpr> rewriteThisExprs = recurseCollectArguments(methodCallExpr).stream()
+                    .filter(ThisExpr.class::isInstance)
+                    .map(ThisExpr.class::cast)
+                    .collect(Collectors.toList());
+            for (ThisExpr t : rewriteThisExprs) {
+                methodCallExpr.replace(t, new NameExpr("_this"));
+            }
+
+            Optional<MethodDeclaration> functionCall = packageModel.getFunctions().stream().filter(m -> m.getName().equals(methodCallExpr.getName())).findFirst();
+            if (functionCall.isPresent()) {
+                Class<?> returnType = DrlxParseUtil.getClassFromContext(context.getPkg().getTypeResolver(), functionCall.get().getType().asString());
+                NodeList<Expression> arguments = methodCallExpr.getArguments();
+                List<String> usedDeclarations = new ArrayList<>();
+                for (Expression arg : arguments) {
+                    if (arg instanceof NameExpr && !arg.toString().equals("_this")) {
+                        usedDeclarations.add(arg.toString());
+                    } else if (arg instanceof MethodCallExpr) {
+                        DrlxParseUtil.toTypedExpressionFromMethodCallOrField(context, null, ( MethodCallExpr ) arg, usedDeclarations, new HashSet<>(), context.getPkg().getTypeResolver());
+                    }
+                }
+                return new DrlxParseSuccess(patternType, exprId, bindingId, methodCallExpr, returnType).setUsedDeclarations(usedDeclarations);
+            } else if (methodCallExpr.getScope().isPresent() && methodCallExpr.getScope().get() instanceof StringLiteralExpr) {
+                List<String> usedDeclarations = new ArrayList<>();
+                TypedExpression converted = DrlxParseUtil.toTypedExpressionFromMethodCallOrField(context, String.class, methodCallExpr, usedDeclarations, new HashSet<>(), context.getPkg().getTypeResolver());
+                return new DrlxParseSuccess(String.class, exprId, bindingId, converted.getExpression(), converted.getType()).setLeft(converted ).setUsedDeclarations(usedDeclarations );
+            } else if (patternType != null) {
+                NameExpr _this = new NameExpr("_this");
+                TypedExpression converted = DrlxParseUtil.toMethodCallWithClassCheck(context, methodCallExpr, patternType, context.getPkg().getTypeResolver());
+                Expression withThis = DrlxParseUtil.prepend(_this, converted.getExpression());
+                return new DrlxParseSuccess(patternType, exprId, bindingId, withThis, converted.getType()).setLeft(converted );
+            } else {
+                return new DrlxParseSuccess(patternType, exprId, bindingId, methodCallExpr, null);
+            }
+        }
+
+        if (drlxExpr instanceof FieldAccessExpr) {
+            FieldAccessExpr fieldCallExpr = (FieldAccessExpr) drlxExpr;
+
+            NameExpr _this = new NameExpr("_this");
+            TypedExpression converted = DrlxParseUtil.toMethodCallWithClassCheck(context, fieldCallExpr, patternType, context.getPkg().getTypeResolver());
+            Expression withThis = DrlxParseUtil.prepend(_this, converted.getExpression());
+            return new DrlxParseSuccess(patternType, exprId, bindingId, withThis, converted.getType()).setLeft(converted );
+        }
+
+        if (drlxExpr instanceof NameExpr) {
+            NameExpr methodCallExpr = (NameExpr) drlxExpr;
+
+            NameExpr _this = new NameExpr("_this");
+            TypedExpression converted = DrlxParseUtil.toMethodCallWithClassCheck(context, methodCallExpr, patternType, context.getPkg().getTypeResolver());
+            Expression withThis = DrlxParseUtil.prepend(_this, converted.getExpression());
+
+            if (drlx.getBind() != null) {
+                return new DrlxParseSuccess(patternType, exprId, bindingId, null, converted.getType() )
+                        .setLeft( new TypedExpression( withThis, converted.getType() ) )
+                        .addReactOnProperty( methodCallExpr.getNameAsString() );
+            } else {
+                return new DrlxParseSuccess(patternType, exprId, bindingId, withThis, converted.getType() )
+                        .addReactOnProperty( methodCallExpr.getNameAsString() );
+            }
+        }
+
+        if (drlxExpr instanceof OOPathExpr ) {
+            return new DrlxParseSuccess(patternType, exprId, bindingId, drlxExpr, null);
+        }
+
+        throw new UnsupportedOperationException("Unknown expression: " + toDrlx(drlxExpr)); // TODO
+    }
+
+    private static Expression getEqualityExpression( TypedExpression left, TypedExpression right, BinaryExpr.Operator operator ) {
+        if(isAnyOperandBigDecimal(left, right)) {
+            return compareBigDecimal(operator, left, right);
+        }
+
+        Expression rightOperand = right.getExpression();
+        if (isPrimitiveExpression(right.getExpression())) {
+            if (left.getType() != String.class) {
+                return new BinaryExpr( left.getExpression(), rightOperand, operator == BinaryExpr.Operator.EQUALS ? BinaryExpr.Operator.EQUALS : BinaryExpr.Operator.NOT_EQUALS );
+            } else if ( rightOperand instanceof LiteralExpr ) {
+                rightOperand = new StringLiteralExpr( rightOperand.toString() );
+            }
+        }
+
+        MethodCallExpr methodCallExpr = new MethodCallExpr( null, "org.drools.modelcompiler.util.EvaluationUtil.areNullSafeEquals" );
+        methodCallExpr.addArgument( left.getExpression() );
+        methodCallExpr.addArgument( rightOperand ); // don't create NodeList with static method because missing "parent for child" would null and NPE
+        return operator == BinaryExpr.Operator.EQUALS ? methodCallExpr : new UnaryExpr(methodCallExpr, UnaryExpr.Operator.LOGICAL_COMPLEMENT );
+    }
+
+    private static Expression handleSpecialComparisonCases(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right ) {
+        if ( left.getType() == String.class && right.getType() == String.class && isComparisonOperator( operator ) ) {
+            MethodCallExpr methodCallExpr = new MethodCallExpr( null, "org.drools.modelcompiler.util.EvaluationUtil.compareStringsAsNumbers" );
+            methodCallExpr.addArgument( left.getExpression() );
+            methodCallExpr.addArgument( right.getExpression() );
+            methodCallExpr.addArgument( new StringLiteralExpr( operator.asString() ) );
+            return methodCallExpr;
+        }
+
+        if (isAnyOperandBigDecimal(left, right) && (isComparisonOperator(operator))) {
+            return compareBigDecimal(operator, left, right);
+        }
+
+        return new BinaryExpr( left.getExpression(), right.getExpression(), operator );
+    }
+
+    private static boolean isAnyOperandBigDecimal(TypedExpression left, TypedExpression right) {
+        return left.getType() == BigDecimal.class || right.getType() == BigDecimal.class;
+    }
+
+    public static Expression compareBigDecimal(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right) {
+        final Expression leftBigDecimal = convertExpressionToBigDecimal(left);
+        final Expression rightBigDecimal = convertExpressionToBigDecimal(right);
+        final MethodCallExpr methodCallExpr = new MethodCallExpr(leftBigDecimal, "compareTo");
+        methodCallExpr.addArgument(rightBigDecimal);
+        return new BinaryExpr(methodCallExpr, new IntegerLiteralExpr(0), operator);
+    }
+
+    private static Expression convertExpressionToBigDecimal(TypedExpression left) {
+        final Expression ret;
+        if(left.getType() != BigDecimal.class) {
+            ret = new MethodCallExpr(new NameExpr(BigDecimal.class.getCanonicalName()), "valueOf")
+                    .addArgument(left.getExpression());
+        } else {
+            ret = left.getExpression();
+        }
+        return ret;
+    }
+
+    private static boolean isComparisonOperator( BinaryExpr.Operator op ) {
+        return op == LESS || op == GREATER || op == LESS_EQUALS || op == GREATER_EQUALS;
+
+    }
+
+    private static List<Expression> recurseCollectArguments(NodeWithArguments<?> methodCallExpr) {
+        List<Expression> res = new ArrayList<>();
+        res.addAll(methodCallExpr.getArguments());
+        if ( methodCallExpr instanceof NodeWithOptionalScope ) {
+            NodeWithOptionalScope<?> nodeWithOptionalScope = (NodeWithOptionalScope) methodCallExpr;
+            if ( nodeWithOptionalScope.getScope().isPresent() ) {
+                Object scope = nodeWithOptionalScope.getScope().get();
+                if (scope instanceof NodeWithArguments) {
+                    res.addAll(recurseCollectArguments((NodeWithArguments<?>) scope));
+                }
+            }
+        }
+        return res;
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseFail.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseFail.java
@@ -1,0 +1,14 @@
+package org.drools.modelcompiler.builder.generator.drlxparse;
+
+public class DrlxParseFail implements DrlxParseResult {
+
+    @Override
+    public void accept(ParseResultVoidVisitor parseVisitor) {
+        parseVisitor.onFail(this);
+    }
+
+    @Override
+    public <T> T acceptWithReturnValue(ParseResultVisitor<T> visitor) {
+        return visitor.onFail(this);
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseResult.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseResult.java
@@ -1,0 +1,9 @@
+package org.drools.modelcompiler.builder.generator.drlxparse;
+
+public interface DrlxParseResult {
+
+    void accept(ParseResultVoidVisitor visitor);
+
+    <T> T acceptWithReturnValue(ParseResultVisitor<T> visitor);
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseSuccess.java
@@ -1,4 +1,4 @@
-package org.drools.modelcompiler.builder.generator;
+package org.drools.modelcompiler.builder.generator.drlxparse;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -10,8 +10,9 @@ import java.util.Set;
 
 import org.drools.core.util.index.IndexUtil;
 import org.drools.javaparser.ast.expr.Expression;
+import org.drools.modelcompiler.builder.generator.TypedExpression;
 
-public class DrlxParseResult {
+public class DrlxParseSuccess implements DrlxParseResult {
 
     private final Class<?> patternType;
     private Expression expr;
@@ -34,7 +35,7 @@ public class DrlxParseResult {
     private boolean isValidExpression;
     private boolean skipThisAsParam;
 
-    public DrlxParseResult( Class<?> patternType, String exprId, String patternBinding, Expression expr, Class<?> exprType) {
+    public DrlxParseSuccess(Class<?> patternType, String exprId, String patternBinding, Expression expr, Class<?> exprType) {
         this.patternType = patternType;
         this.exprId = exprId;
         this.patternBinding = patternBinding;
@@ -42,27 +43,27 @@ public class DrlxParseResult {
         this.exprType = exprType;
     }
 
-    public DrlxParseResult setDecodeConstraintType( IndexUtil.ConstraintType decodeConstraintType ) {
+    public DrlxParseSuccess setDecodeConstraintType(IndexUtil.ConstraintType decodeConstraintType ) {
         this.decodeConstraintType = decodeConstraintType;
         return this;
     }
 
-    public DrlxParseResult setUsedDeclarations( List<String> usedDeclarations ) {
+    public DrlxParseSuccess setUsedDeclarations(List<String> usedDeclarations ) {
         this.usedDeclarations = new LinkedHashSet<>(usedDeclarations);
         return this;
     }
 
-    public DrlxParseResult setReactOnProperties( Set<String> reactOnProperties ) {
+    public DrlxParseSuccess setReactOnProperties(Set<String> reactOnProperties ) {
         this.reactOnProperties = reactOnProperties;
         return this;
     }
 
-    public DrlxParseResult setPatternBindingUnification( Boolean unification) {
+    public DrlxParseSuccess setPatternBindingUnification(Boolean unification) {
         this.isPatternBindingUnification = unification;
         return this;
     }
 
-    public DrlxParseResult addReactOnProperty( String reactOnProperty ) {
+    public DrlxParseSuccess addReactOnProperty(String reactOnProperty ) {
         if (reactOnProperties.isEmpty()) {
             reactOnProperties = new HashSet<>();
         }
@@ -70,22 +71,22 @@ public class DrlxParseResult {
         return this;
     }
 
-    public DrlxParseResult setLeft( TypedExpression left ) {
+    public DrlxParseSuccess setLeft(TypedExpression left ) {
         this.left = left;
         return this;
     }
 
-    public DrlxParseResult setRight( TypedExpression right ) {
+    public DrlxParseSuccess setRight(TypedExpression right ) {
         this.right = right;
         return this;
     }
 
-    public DrlxParseResult setStatic( boolean isStatic ) {
+    public DrlxParseSuccess setStatic(boolean isStatic ) {
         this.isStatic = isStatic;
         return this;
     }
 
-    public DrlxParseResult setSkipThisAsParam( boolean skipThisAsParam ) {
+    public DrlxParseSuccess setSkipThisAsParam(boolean skipThisAsParam ) {
         this.skipThisAsParam = skipThisAsParam;
         return this;
     }
@@ -110,7 +111,7 @@ public class DrlxParseResult {
         this.patternBinding = patternBinding;
     }
 
-    public DrlxParseResult setExprBinding(String exprBinding) {
+    public DrlxParseSuccess setExprBinding(String exprBinding) {
         this.exprBinding = exprBinding;
         return this;
     }
@@ -192,8 +193,18 @@ public class DrlxParseResult {
         return skipThisAsParam;
     }
 
-    public DrlxParseResult setValidExpression( boolean validExpression ) {
+    public DrlxParseSuccess setValidExpression(boolean validExpression ) {
         this.isValidExpression = validExpression;
         return this;
+    }
+
+    @Override
+    public void accept(ParseResultVoidVisitor parseVisitor) {
+        parseVisitor.onSuccess(this);
+    }
+
+    @Override
+    public <T> T acceptWithReturnValue(ParseResultVisitor<T> visitor) {
+        return visitor.onSuccess(this);
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ParseResultVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ParseResultVisitor.java
@@ -1,0 +1,8 @@
+package org.drools.modelcompiler.builder.generator.drlxparse;
+
+public interface ParseResultVisitor<T> {
+    T onSuccess(DrlxParseSuccess drlxParseResult);
+
+    T onFail(DrlxParseFail failure);
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ParseResultVoidVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ParseResultVoidVisitor.java
@@ -1,0 +1,11 @@
+package org.drools.modelcompiler.builder.generator.drlxparse;
+
+@FunctionalInterface
+public interface ParseResultVoidVisitor {
+    void onSuccess(DrlxParseSuccess drlxParseResult);
+
+    default void onFail(DrlxParseFail failure) {
+
+    }
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
@@ -12,7 +12,8 @@ import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.javaparser.ast.expr.StringLiteralExpr;
 import org.drools.javaparser.ast.stmt.BlockStmt;
 import org.drools.modelcompiler.builder.PackageModel;
-import org.drools.modelcompiler.builder.generator.DrlxParseResult;
+import org.drools.modelcompiler.builder.generator.drlxparse.ConstraintParser;
+import org.drools.modelcompiler.builder.generator.drlxparse.DrlxParseResult;
 import org.drools.modelcompiler.builder.generator.ModelGenerator;
 import org.drools.modelcompiler.builder.generator.RuleContext;
 
@@ -20,7 +21,6 @@ import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.generateL
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getClassFromContext;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;
 import static org.drools.modelcompiler.builder.generator.ModelGenerator.createVariables;
-import static org.drools.modelcompiler.builder.generator.ModelGenerator.drlxParse;
 
 public class NamedConsequenceVisitor {
 
@@ -65,8 +65,10 @@ public class NamedConsequenceVisitor {
         if (!condition.equals("true")) { // Default case
             when.addArgument(new StringLiteralExpr(context.getConditionId(patternType, condition)));
             when.addArgument(new NameExpr(toVar(patternRelated.getIdentifier())));
-            DrlxParseResult parseResult = drlxParse(context, packageModel, patternType, patternRelated.getIdentifier(), condition);
-            when.addArgument(generateLambdaWithoutParameters(Collections.emptySortedSet(), parseResult.getExpr()));
+
+            DrlxParseResult parseResult = new ConstraintParser(context, packageModel).drlxParse(patternType, patternRelated.getIdentifier(), condition);
+            parseResult.accept(parseSuccess -> when.addArgument(generateLambdaWithoutParameters(Collections.emptySortedSet(), parseSuccess.getExpr())));
+
         }
 
         MethodCallExpr then = new MethodCallExpr(when, THEN_CALL);


### PR DESCRIPTION
Moved DrlxParseResult to separated package

Renamed drlxParse to ConstraintParser

Constraint Parser is a class with context, packageModel

Introducing two cases for failure