### PR TITLE
Add the input pattern only when there's an OOPath expression and before any constraint

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OOPathTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OOPathTest.java
@@ -380,7 +380,6 @@ public class OOPathTest extends BaseModelTest {
     }
 
     @Test
-    @Ignore
     public void testOrConstraintWithJoin() {
         final String drl =
                 "import " + Employee.class.getCanonicalName() + ";" +
@@ -411,7 +410,6 @@ public class OOPathTest extends BaseModelTest {
     }
 
     @Test
-    @Ignore
     public void testOrConstraint() {
         final String drl =
                 "import " + Employee.class.getCanonicalName() + ";" +

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OOPathTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OOPathTest.java
@@ -350,7 +350,6 @@ public class OOPathTest extends BaseModelTest {
     }
 
     @Test
-    @Ignore
     public void testOrConstraintNoBinding() {
         final String drl =
                 "import " + Employee.class.getCanonicalName() + ";" +


### PR DESCRIPTION
Before
`Tests run: 1310, Failures: 48, Errors: 8, Skipped: 24`
After
`Tests run: 1310, Failures: 36, Errors: 4, Skipped: 24`
