### PR TITLE
[DROOLS-2284] Support string operators

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Operator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Operator.java
@@ -25,6 +25,9 @@ import org.drools.model.operators.InOperator;
 import org.drools.model.operators.MatchesOperator;
 import org.drools.model.operators.MemberOfOperator;
 import org.drools.model.operators.SoundsLikeOperator;
+import org.drools.model.operators.StringEndsWithOperator;
+import org.drools.model.operators.StringLengthWithOperator;
+import org.drools.model.operators.StringStartsWithOperator;
 
 public interface Operator<A, B> extends Predicate2<A, B[]> {
 
@@ -56,6 +59,9 @@ public interface Operator<A, B> extends Predicate2<A, B[]> {
             register( ExcludesOperator.INSTANCE );
             register( MemberOfOperator.INSTANCE );
             register( SoundsLikeOperator.INSTANCE );
+            register( StringStartsWithOperator.INSTANCE );
+            register( StringEndsWithOperator.INSTANCE );
+            register( StringLengthWithOperator.INSTANCE );
         }
 
         public static void register(Operator operator) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringEndsWithOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringEndsWithOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.operators;
+
+import org.drools.model.functions.Operator;
+
+public class StringEndsWithOperator implements Operator.SingleValue<String, String> {
+
+    public static final StringEndsWithOperator INSTANCE = new StringEndsWithOperator();
+
+    @Override
+    public boolean eval( String s1, String s2 ) {
+       return s1.endsWith(s2);
+    }
+
+    @Override
+    public String getOperatorName() {
+        return "str[endsWith]";
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringLengthWithOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringLengthWithOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.operators;
+
+import org.drools.model.functions.Operator;
+
+public class StringLengthWithOperator implements Operator.SingleValue<String, Integer> {
+
+    public static final StringLengthWithOperator INSTANCE = new StringLengthWithOperator();
+
+    @Override
+    public boolean eval( String s1, Integer length ) {
+       return s1.length() == length;
+    }
+
+    @Override
+    public String getOperatorName() {
+        return "str[length]";
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringStartsWithOperator.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/operators/StringStartsWithOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.operators;
+
+import org.drools.model.functions.Operator;
+
+public class StringStartsWithOperator implements Operator.SingleValue<String, String> {
+
+    public static final StringStartsWithOperator INSTANCE = new StringStartsWithOperator();
+
+    @Override
+    public boolean eval( String s1, String s2 ) {
+       return s1.startsWith(s2);
+    }
+
+    @Override
+    public String getOperatorName() {
+        return "str[startsWith]";
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -411,6 +411,8 @@ public class DrlxParseUtil {
             return findLeftLeafOfNameExpr(be.getLeft());
         } else if(expression instanceof NameExpr) {
             return expression;
+        } else if(expression instanceof ThisExpr) {
+            return expression;
         } else if(expression instanceof PointFreeExpr) {
             return findLeftLeafOfNameExpr(((PointFreeExpr) expression).getLeft());
         } else {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelOperatorsTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelOperatorsTest.java
@@ -47,7 +47,7 @@ public class MvelOperatorsTest extends BaseModelTest {
         assertEquals(1, ksession.fireAllRules());
     }
 
-    @Test @Ignore
+    @Test
     public void testStr() {
         String str =
             "rule R when\n" +
@@ -59,6 +59,39 @@ public class MvelOperatorsTest extends BaseModelTest {
 
         ksession.insert( "Mario" );
         assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testStrNot() {
+        String str =
+            "rule R when\n" +
+            "    String(this not str[startsWith] \"M\")" +
+            "then\n" +
+            "end ";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert( "Mario" );
+        ksession.insert( "Luca" );
+        ksession.insert( "Edoardo" );
+        assertEquals(2, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testStrHalf() {
+        String str =
+            "rule R when\n" +
+            "    String(this str[startsWith] \"M\" || str[endsWith] \"a\" || str[length] 10)"+
+            "then\n" +
+            "end ";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert( "Mario" );
+        ksession.insert( "Luca" );
+        ksession.insert( "Edoardo" );
+        ksession.insert( "Valentina" );
+        assertEquals(3, ksession.fireAllRules());
     }
 
     @Test


### PR DESCRIPTION
Such as `startsWith`, `endsWith` and `length`

Requires merge of `mvel-operators2` in drlx-parser