### PR TITLE
[DROOLS-2284] Refactor of toTypedExpression

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -24,7 +24,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.drools.core.util.ClassUtils;
 import org.drools.core.util.index.IndexUtil;
@@ -32,14 +31,9 @@ import org.drools.core.util.index.IndexUtil.ConstraintType;
 import org.drools.drlx.DrlxParser;
 import org.drools.javaparser.JavaParser;
 import org.drools.javaparser.ast.Node;
-import org.drools.javaparser.ast.NodeList;
 import org.drools.javaparser.ast.body.Parameter;
 import org.drools.javaparser.ast.drlx.expr.DrlxExpression;
 import org.drools.javaparser.ast.drlx.expr.HalfBinaryExpr;
-import org.drools.javaparser.ast.drlx.expr.HalfPointFreeExpr;
-import org.drools.javaparser.ast.drlx.expr.InlineCastExpr;
-import org.drools.javaparser.ast.drlx.expr.NullSafeFieldAccessExpr;
-import org.drools.javaparser.ast.drlx.expr.PointFreeExpr;
 import org.drools.javaparser.ast.expr.ArrayAccessExpr;
 import org.drools.javaparser.ast.expr.ArrayCreationExpr;
 import org.drools.javaparser.ast.expr.AssignExpr;
@@ -52,7 +46,6 @@ import org.drools.javaparser.ast.expr.DoubleLiteralExpr;
 import org.drools.javaparser.ast.expr.EnclosedExpr;
 import org.drools.javaparser.ast.expr.Expression;
 import org.drools.javaparser.ast.expr.FieldAccessExpr;
-import org.drools.javaparser.ast.expr.InstanceOfExpr;
 import org.drools.javaparser.ast.expr.IntegerLiteralExpr;
 import org.drools.javaparser.ast.expr.LambdaExpr;
 import org.drools.javaparser.ast.expr.LiteralExpr;
@@ -61,9 +54,7 @@ import org.drools.javaparser.ast.expr.MethodCallExpr;
 import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.javaparser.ast.expr.NullLiteralExpr;
 import org.drools.javaparser.ast.expr.ObjectCreationExpr;
-import org.drools.javaparser.ast.expr.SimpleName;
 import org.drools.javaparser.ast.expr.StringLiteralExpr;
-import org.drools.javaparser.ast.expr.ThisExpr;
 import org.drools.javaparser.ast.expr.UnaryExpr;
 import org.drools.javaparser.ast.nodeTypes.NodeWithOptionalScope;
 import org.drools.javaparser.ast.nodeTypes.NodeWithSimpleName;
@@ -72,21 +63,13 @@ import org.drools.javaparser.ast.stmt.BlockStmt;
 import org.drools.javaparser.ast.stmt.ExpressionStmt;
 import org.drools.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.javaparser.ast.type.PrimitiveType;
-import org.drools.javaparser.ast.type.ReferenceType;
 import org.drools.javaparser.ast.type.Type;
 import org.drools.javaparser.ast.type.UnknownType;
-import org.drools.modelcompiler.builder.PackageModel;
-import org.drools.modelcompiler.builder.errors.ParseExpressionErrorResult;
-import org.drools.modelcompiler.builder.generator.operatorspec.CustomOperatorSpec;
-import org.drools.modelcompiler.builder.generator.operatorspec.OperatorSpec;
-import org.drools.modelcompiler.builder.generator.operatorspec.TemporalOperatorSpec;
 import org.drools.modelcompiler.util.ClassUtil;
 import org.kie.soup.project.datamodel.commons.types.TypeResolver;
 
 import static java.util.Optional.of;
-
-import static org.drools.core.util.ClassUtils.getter2property;
-import static org.drools.javaparser.printer.PrintUtil.toDrlx;
+import static org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyper.findLeftLeafOfNameExpr;
 import static org.drools.modelcompiler.util.ClassUtil.findMethod;
 
 public class DrlxParseUtil {
@@ -113,314 +96,6 @@ public class DrlxParseUtil {
         }
     }
 
-    public static Optional<TypedExpression> toTypedExpression(RuleContext context, PackageModel packageModel, Class<?> patternType, Expression drlxExpr, String bindingId,
-                                                    List<String> usedDeclarations, Set<String> reactOnProperties, Expression parentExpression, boolean isPositional, List<Expression> prefixExpresssions) {
-
-        Class<?> typeCursor = patternType;
-
-        if(drlxExpr instanceof EnclosedExpr) {
-            drlxExpr = ((EnclosedExpr) drlxExpr).getInner();
-        }
-
-        if (drlxExpr instanceof UnaryExpr) {
-            UnaryExpr unaryExpr = (UnaryExpr) drlxExpr;
-            Optional<TypedExpression> optTypedExpr = toTypedExpression(context, packageModel, patternType, unaryExpr.getExpression(), bindingId, usedDeclarations, reactOnProperties, unaryExpr, isPositional, prefixExpresssions);
-            return optTypedExpr.map(typedExpr -> new TypedExpression( new UnaryExpr( typedExpr.getExpression(), unaryExpr.getOperator() ), typedExpr.getType() ));
-
-        } else if (drlxExpr instanceof BinaryExpr) {
-            BinaryExpr binaryExpr = (BinaryExpr) drlxExpr;
-
-            Operator operator = binaryExpr.getOperator();
-
-            Optional<TypedExpression> optLeft = DrlxParseUtil.toTypedExpression(context, packageModel, patternType, binaryExpr.getLeft(), bindingId, usedDeclarations, reactOnProperties, binaryExpr, isPositional, prefixExpresssions);
-            Optional<TypedExpression> optRight = DrlxParseUtil.toTypedExpression(context, packageModel, patternType, binaryExpr.getRight(), bindingId, usedDeclarations, reactOnProperties, binaryExpr, isPositional, prefixExpresssions);
-
-            return optLeft.flatMap(left -> optRight.flatMap(right -> {
-                final BinaryExpr combo = new BinaryExpr(left.getExpression(), right.getExpression(), operator);
-                return of(new TypedExpression(combo, left.getType()));
-            }));
-
-        } else if (drlxExpr instanceof HalfBinaryExpr) {
-            final Expression binaryExpr = trasformHalfBinaryToBinary(drlxExpr);
-            return toTypedExpression(context, packageModel, patternType, binaryExpr, bindingId, usedDeclarations, reactOnProperties, parentExpression, isPositional, prefixExpresssions);
-
-        } else if (drlxExpr instanceof LiteralExpr) {
-            return of(new TypedExpression(drlxExpr, getLiteralExpressionType( ( LiteralExpr ) drlxExpr )));
-
-        } else if (drlxExpr instanceof ThisExpr) {
-            return of(new TypedExpression(new NameExpr("_this"), patternType));
-
-        } else if (drlxExpr instanceof CastExpr) {
-            CastExpr castExpr = (CastExpr)drlxExpr;
-            toTypedExpression( context, packageModel, patternType, castExpr.getExpression(), bindingId, usedDeclarations, reactOnProperties, castExpr, isPositional, prefixExpresssions);
-            return of(new TypedExpression(castExpr, getClassFromContext(context.getTypeResolver(), castExpr.getType().asString())));
-
-        } else if (drlxExpr instanceof NameExpr) {
-            String name = drlxExpr.toString();
-            Optional<DeclarationSpec> decl = context.getDeclarationById(name);
-            if (decl.isPresent()) {
-                // then drlxExpr is a single NameExpr referring to a binding, e.g.: "$p1".
-                usedDeclarations.add(name);
-                return of(new TypedExpression(drlxExpr, decl.get().getDeclarationClass()));
-            } if (context.getQueryParameters().stream().anyMatch(qp -> qp.name.equals(name))) {
-                // then drlxExpr is a single NameExpr referring to a query parameter, e.g.: "$p1".
-                usedDeclarations.add(name);
-                return of(new TypedExpression(drlxExpr));
-            } else if(packageModel.getGlobals().containsKey(name)){
-                Expression plusThis = new NameExpr(name);
-                usedDeclarations.add(name);
-                return of(new TypedExpression(plusThis, packageModel.getGlobals().get(name)));
-            } else {
-                TypedExpression expression;
-                try {
-                    expression = nameExprToMethodCallExpr(name, typeCursor, null);
-                } catch (IllegalArgumentException e) {
-                    if (isPositional || context.getQueryName().isPresent()) {
-                        String unificationVariable = context.getOrCreateUnificationId(name);
-                        expression = new TypedExpression(unificationVariable, typeCursor, name);
-                        return of(expression);
-                    }
-                    return Optional.empty();
-                }
-                reactOnProperties.add(name);
-                Expression plusThis = prepend(new NameExpr("_this"), expression.getExpression());
-                return of(new TypedExpression(plusThis, expression.getType(), name));
-            }
-        } else if (drlxExpr instanceof FieldAccessExpr || drlxExpr instanceof MethodCallExpr) {
-            return toTypedExpressionFromMethodCallOrField(context, patternType, drlxExpr, bindingId, usedDeclarations, reactOnProperties, context.getTypeResolver(), prefixExpresssions);
-        } else if (drlxExpr instanceof PointFreeExpr) {
-
-            final PointFreeExpr pointFreeExpr = (PointFreeExpr)drlxExpr;
-
-            Optional<TypedExpression> optLeft = DrlxParseUtil.toTypedExpression(context, packageModel, patternType, pointFreeExpr.getLeft(), bindingId, usedDeclarations, reactOnProperties, pointFreeExpr, isPositional, prefixExpresssions);
-            OperatorSpec opSpec = getOperatorSpec(context, packageModel, patternType, drlxExpr, bindingId, usedDeclarations, reactOnProperties, isPositional, pointFreeExpr, pointFreeExpr.getRight(), pointFreeExpr.getOperator());
-
-            return optLeft.map(left -> {
-                return new TypedExpression(opSpec.getExpression( pointFreeExpr, left ), left.getType())
-                        .setStatic(opSpec.isStatic())
-                        .setLeft(left);
-            });
-
-        } else if (drlxExpr instanceof HalfPointFreeExpr) {
-
-            final HalfPointFreeExpr halfPointFreeExpr = (HalfPointFreeExpr)drlxExpr;
-            Expression parentLeft = findLeftLeafOfNameExpr(parentExpression);
-
-            Optional<TypedExpression> optLeft = DrlxParseUtil.toTypedExpression(context, packageModel, patternType, parentLeft, bindingId, usedDeclarations, reactOnProperties, halfPointFreeExpr, isPositional, prefixExpresssions);
-            OperatorSpec opSpec = getOperatorSpec(context, packageModel, patternType, drlxExpr, bindingId, usedDeclarations, reactOnProperties, isPositional, halfPointFreeExpr, halfPointFreeExpr.getRight(), halfPointFreeExpr.getOperator());
-
-            final PointFreeExpr transformedToPointFree =
-                    new PointFreeExpr(halfPointFreeExpr.getTokenRange().get(),
-                                      parentLeft,
-                                      halfPointFreeExpr.getRight(),
-                                      halfPointFreeExpr.getOperator(),
-                                      halfPointFreeExpr.isNegated(),
-                                      halfPointFreeExpr.getArg1(),
-                                      halfPointFreeExpr.getArg2(),
-                                      halfPointFreeExpr.getArg3(),
-                                      halfPointFreeExpr.getArg4()
-                                      );
-
-            return optLeft.map(left ->
-                                       new TypedExpression(opSpec.getExpression(transformedToPointFree, left ), left.getType())
-                    .setStatic(opSpec.isStatic())
-                    .setLeft(left));
-        }
-
-        throw new UnsupportedOperationException();
-    }
-
-    private static OperatorSpec getOperatorSpec(RuleContext context, PackageModel packageModel, Class<?> patternType, Expression drlxExpr, String bindingId, List<String> usedDeclarations, Set<String> reactOnProperties, boolean isPositional, Expression pointFreeExpr, NodeList<Expression> rightExpressions, SimpleName expressionOperator) {
-        for (Expression rightExpr : rightExpressions) {
-            DrlxParseUtil.toTypedExpression(context, packageModel, patternType, rightExpr, bindingId, usedDeclarations, reactOnProperties, pointFreeExpr, isPositional, new ArrayList<>());
-        }
-
-        String operator = expressionOperator.asString();
-        OperatorSpec opSpec = null;
-        if (ModelGenerator.temporalOperators.contains(operator )) {
-            opSpec = TemporalOperatorSpec.INSTANCE;
-        } else if ( org.drools.model.functions.Operator.Register.hasOperator( operator ) ) {
-            opSpec = CustomOperatorSpec.INSTANCE;
-        }
-        if (opSpec == null) {
-            throw new UnsupportedOperationException("Unknown operator '" + operator + "' in expression: " + toDrlx(drlxExpr));
-        }
-        return opSpec;
-    }
-
-    public static Optional<TypedExpression> toTypedExpressionFromMethodCallOrField(RuleContext context, Class<?> patternType, Expression drlxExpr, String bindingId, Collection<String> usedDeclarations, Set<String> reactOnProperties, TypeResolver typeResolver, List<Expression> prefixExpresssions) {
-        Class<?> typeCursor = patternType;
-
-        List<Node> childNodes = flattenScope(drlxExpr);
-        Node firstNode = childNodes.get(0);
-
-        boolean isInLineCast = firstNode instanceof InlineCastExpr;
-        if (isInLineCast) {
-            InlineCastExpr inlineCast = (InlineCastExpr) firstNode;
-            try {
-                typeCursor = typeResolver.resolveType(inlineCast.getType().toString());
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-            firstNode = inlineCast.getExpression();
-        }
-
-        Expression previous;
-
-        if (firstNode instanceof ThisExpr || (firstNode instanceof NameExpr && firstNode.toString().equals( bindingId ))) {
-            previous = new NameExpr("_this");
-            if (childNodes.size() > 1 && !isInLineCast) {
-                SimpleName fieldName = null;
-                if (childNodes.get(1) instanceof NameExpr) {
-                    fieldName = (( NameExpr ) childNodes.get( 1 )).getName();
-                } else if (childNodes.get(1) instanceof SimpleName) {
-                    fieldName = ( SimpleName ) childNodes.get( 1 );
-                }
-                if (fieldName != null) {
-                    reactOnProperties.add( getFieldName( drlxExpr, fieldName ) );
-                }
-            }
-        } else if (firstNode instanceof NameExpr) {
-            NameExpr firstNodeName = (NameExpr) firstNode;
-            String firstName = firstNodeName.getName().getIdentifier();
-            Optional<DeclarationSpec> declarationById = context.getDeclarationById(firstName);
-            if (declarationById.isPresent()) {
-                // do NOT append any reactOnProperties.
-                // because reactOnProperties is referring only to the properties of the type of the pattern, not other declarations properites.
-                usedDeclarations.add(firstName);
-                if (!isInLineCast) {
-                    typeCursor = declarationById.get().getDeclarationClass();
-                }
-                previous = new NameExpr(firstName);
-            } else {
-
-                // In OOPath a declaration is based on a position rather than a name.
-                // Only an OOPath chunk can have a backreference expression
-                Optional<DeclarationSpec> backReference = Optional.empty();
-                if(firstNodeName.getBackReferencesCount()  > 0) {
-                    List<DeclarationSpec> ooPathDeclarations = context.getOOPathDeclarations();
-                    DeclarationSpec backReferenceDeclaration = ooPathDeclarations.get(ooPathDeclarations.size() - 1 - firstNodeName.getBackReferencesCount());
-                    typeCursor = backReferenceDeclaration.getDeclarationClass();
-                    backReference = of(backReferenceDeclaration);
-                    usedDeclarations.add(backReferenceDeclaration.getBindingId());
-                }
-
-                Method firstAccessor = ClassUtils.getAccessor((!isInLineCast) ? typeCursor : patternType, firstName);
-                if (firstAccessor != null) {
-                    // Hack to review - if a property is upper case it's probably not a react on property
-                    if(!"".equals(firstName) && Character.isLowerCase(firstName.charAt(0))) {
-                        reactOnProperties.add(firstName);
-                    }
-                    if (!isInLineCast) {
-                        typeCursor = firstAccessor.getReturnType();
-                    }
-                    NameExpr thisAccessor = new NameExpr("_this");
-                    final NameExpr scope = backReference.map(d -> new NameExpr(d.getBindingId())).orElse(thisAccessor);
-                    previous = new MethodCallExpr(scope, firstAccessor.getName());
-                } else {
-                    final Optional<Node> rootNode = findRootNodeViaParent(drlxExpr);
-                    rootNode.ifPresent(n -> {
-                        // In the error messages HalfBinary are transformed to Binary
-                        Node withHalfBinaryReplaced = replaceAllHalfBinaryChildren(n);
-                        context.addCompilationError(new ParseExpressionErrorResult((Expression) withHalfBinaryReplaced));
-                    });
-                    return Optional.empty();
-                }
-            }
-        } else if (firstNode instanceof FieldAccessExpr && ((FieldAccessExpr) firstNode).getScope() instanceof ThisExpr) {
-            String firstName = ((FieldAccessExpr) firstNode).getName().getIdentifier();
-            Method firstAccessor = ClassUtils.getAccessor(typeCursor, firstName);
-            if (firstAccessor != null) {
-                reactOnProperties.add(firstName);
-                typeCursor = firstAccessor.getReturnType();
-                previous = new MethodCallExpr(new NameExpr("_this"), firstAccessor.getName());
-            } else {
-                throw new UnsupportedOperationException("firstNode I don't know about");
-                // TODO would it be fine to assume is a global if it's not in the declarations and not the first accesssor in a chain?
-            }
-        } else if (firstNode instanceof SimpleName) {
-            previous = new NameExpr("_this");
-            SimpleName fieldName = ( SimpleName ) firstNode;
-            String name = getFieldName( drlxExpr, fieldName );
-            reactOnProperties.add( name );
-            TypedExpression expression = nameExprToMethodCallExpr(name, typeCursor, null);
-            Expression plusThis = prepend(new NameExpr("_this"), expression.getExpression());
-            if (childNodes.size() != 1) {
-                throw new UnsupportedOperationException("then the below should not be a return");
-            }
-            return of(new TypedExpression(plusThis, expression.getType()));
-        } else if (firstNode instanceof MethodCallExpr) {
-            MethodCallExpr methodCallExpr = (MethodCallExpr) firstNode;
-            previous = new NameExpr("_this");
-            methodCallExpr.setScope(previous);
-            typeCursor = returnTypeOfMethodCallExpr(context, typeResolver, methodCallExpr, typeCursor, usedDeclarations);
-            previous = methodCallExpr;
-        } else if (firstNode instanceof StringLiteralExpr) {
-            typeCursor = String.class;
-            previous = (( StringLiteralExpr ) firstNode);
-        } else {
-            throw new UnsupportedOperationException("Unknown node: " + firstNode);
-        }
-
-        childNodes = childNodes.subList(1, childNodes.size());
-
-        TypedExpression typedExpression = new TypedExpression();
-        if (isInLineCast) {
-            ReferenceType castType = JavaParser.parseClassOrInterfaceType(typeCursor.getName());
-            prefixExpresssions.add(new InstanceOfExpr(previous, castType));
-            previous = new EnclosedExpr(new CastExpr(castType, previous));
-        }
-        if (drlxExpr instanceof NullSafeFieldAccessExpr) {
-            final BinaryExpr prefixExpression = new BinaryExpr(previous, new NullLiteralExpr(), Operator.NOT_EQUALS);
-            prefixExpresssions.add(prefixExpression);
-
-            final Expression scope = ((NullSafeFieldAccessExpr) drlxExpr).getScope();
-            if(scope != null) {
-                final Optional<TypedExpression> typedExpression1 = DrlxParseUtil.toTypedExpression(context, context.getPackageModel(), patternType, scope, bindingId, new ArrayList<>(), reactOnProperties, drlxExpr, false, prefixExpresssions);
-                typedExpression1.ifPresent(te -> {
-                    final Expression expression = te.getExpression();
-                    final BinaryExpr notNullScope = new BinaryExpr(expression, new NullLiteralExpr(), Operator.NOT_EQUALS);
-                    prefixExpresssions.add(0, notNullScope);
-                });
-            }
-        }
-
-        for (Node part : childNodes) {
-            if(typeCursor.isEnum()) {
-                previous = drlxExpr;
-            } else if (part instanceof SimpleName) {
-                String field = part.toString();
-                TypedExpression expression = nameExprToMethodCallExpr(field, typeCursor, previous);
-                typeCursor = expression.getType();
-                previous = expression.getExpression();
-            } else if (part instanceof MethodCallExpr) {
-                MethodCallExpr methodCallExprPart = (MethodCallExpr) part;
-                typeCursor = returnTypeOfMethodCallExpr(context, typeResolver, (MethodCallExpr) part, typeCursor, usedDeclarations);
-                methodCallExprPart.setScope(previous);
-                previous = methodCallExprPart;
-            } else {
-                throw new UnsupportedOperationException();
-            }
-        }
-
-        return of(typedExpression.setExpression(previous).setType(typeCursor));
-    }
-
-    private static Expression findLeftLeafOfNameExpr(Expression expression) {
-        if(expression instanceof BinaryExpr) {
-            BinaryExpr be = (BinaryExpr)expression;
-            return findLeftLeafOfNameExpr(be.getLeft());
-        } else if(expression instanceof NameExpr) {
-            return expression;
-        } else if(expression instanceof ThisExpr) {
-            return expression;
-        } else if(expression instanceof PointFreeExpr) {
-            return findLeftLeafOfNameExpr(((PointFreeExpr) expression).getLeft());
-        } else {
-            throw new UnsupportedOperationException("Unknown expression: " + expression);
-        }
-    }
-
     public static Expression findLeftLeafOfMethodCall(Expression expression) {
         if(expression instanceof BinaryExpr) {
             BinaryExpr be = (BinaryExpr)expression;
@@ -434,33 +109,6 @@ public class DrlxParseUtil {
 
     private static Operator toBinaryExprOperator(HalfBinaryExpr.Operator operator) {
         return Operator.valueOf(operator.name());
-    }
-    private static List<Node> flattenScope(Expression expressionWithScope) {
-        List<Node> res = new ArrayList<>();
-        if (expressionWithScope instanceof FieldAccessExpr) {
-            FieldAccessExpr fieldAccessExpr = (FieldAccessExpr) expressionWithScope;
-            res.addAll(flattenScope(fieldAccessExpr.getScope()));
-            res.add(fieldAccessExpr.getName());
-        } else if (expressionWithScope instanceof MethodCallExpr) {
-            MethodCallExpr methodCallExpr = (MethodCallExpr) expressionWithScope;
-            if (methodCallExpr.getScope().isPresent()) {
-                res.addAll(flattenScope(methodCallExpr.getScope().get()));
-            }
-            res.add(methodCallExpr.setScope(null));
-        } else {
-            res.add(expressionWithScope);
-        }
-        return res;
-    }
-
-    private static String getFieldName( Expression drlxExpr, SimpleName fieldName ) {
-        if ( drlxExpr instanceof MethodCallExpr ) {
-            String name = getter2property( fieldName.getIdentifier() );
-            if ( name != null ) {
-                return name;
-            }
-        }
-        return fieldName.getIdentifier();
     }
 
     public static TypedExpression nameExprToMethodCallExpr(String name, Class<?> clazz, Expression scope) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -197,7 +197,7 @@ public class ModelGenerator {
 
 
     private static void processRule( KnowledgeBuilderImpl kbuilder, TypeResolver typeResolver, PackageModel packageModel, PackageDescr packageDescr, RuleDescr ruleDescr) {
-        RuleContext context = new RuleContext(kbuilder, typeResolver, packageModel, ruleDescr);
+        RuleContext context = new RuleContext(kbuilder,packageModel, ruleDescr,  typeResolver);
 
         for(Entry<String, Object> kv : ruleDescr.getNamedConsequences().entrySet()) {
             context.addNamedConsequence(kv.getKey(), kv.getValue().toString());

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/QueryGenerator.java
@@ -36,7 +36,7 @@ public class QueryGenerator {
     public static final String QUERY_CALL = "query";
 
     public static void processQueryDef( KnowledgeBuilderImpl kbuilder, TypeResolver typeResolver, PackageModel packageModel, QueryDescr queryDescr ) {
-        RuleContext context = new RuleContext(kbuilder, typeResolver, packageModel, queryDescr);
+        RuleContext context = new RuleContext(kbuilder, packageModel, queryDescr, typeResolver);
         String queryName = queryDescr.getName();
         final String queryDefVariableName = toQueryDef(queryName);
         context.setQueryName(Optional.of(queryDefVariableName));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -60,13 +60,13 @@ public class RuleContext {
     public BaseDescr parentDesc = null;
 
     public RuleContext(KnowledgeBuilderImpl kbuilder, TypeResolver typeResolver, PackageModel packageModel, RuleDescr ruleDescr) {
-        this(kbuilder, packageModel, packageModel.getExprIdGenerator(), ruleDescr, typeResolver);
+        this(kbuilder, packageModel, ruleDescr, typeResolver);
     }
 
-    public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, DRLIdGenerator exprIdGenerator, RuleDescr ruleDescr, TypeResolver typeResolver) {
+    public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, RuleDescr ruleDescr, TypeResolver typeResolver) {
         this.kbuilder = kbuilder;
         this.packageModel = packageModel;
-        this.idGenerator = exprIdGenerator;
+        this.idGenerator = packageModel.getExprIdGenerator();
         this.descr = ruleDescr;
         exprPointer.push( this.expressions::add );
         this.typeResolver = typeResolver;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -16,6 +16,7 @@ import org.drools.compiler.compiler.BaseKnowledgeBuilderResultImpl;
 import org.drools.compiler.lang.descr.AnnotationDescr;
 import org.drools.compiler.lang.descr.BaseDescr;
 import org.drools.compiler.lang.descr.RuleDescr;
+import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.ruleunit.RuleUnitDescr;
 import org.drools.javaparser.ast.expr.Expression;
 import org.drools.modelcompiler.builder.PackageModel;
@@ -31,8 +32,8 @@ public class RuleContext {
     private static final Map<Class<? extends RuleUnit>, RuleUnitDescr> ruleUnitDescrCache = new HashMap<>();
 
     private final KnowledgeBuilderImpl kbuilder;
-    private final TypeResolver typeResolver;
     private final PackageModel packageModel;
+    private final TypeResolver typeResolver;
     private DRLIdGenerator idGenerator;
     private final RuleDescr descr;
 
@@ -49,6 +50,7 @@ public class RuleContext {
 
     private Map<String, String> aggregatePatternMap = new HashMap<>();
 
+
     private RuleDialect ruleDialect = RuleDialect.JAVA; // assumed is java by default as per Drools manual.
     public static enum RuleDialect {
         JAVA,
@@ -57,13 +59,17 @@ public class RuleContext {
 
     public BaseDescr parentDesc = null;
 
-    public RuleContext( KnowledgeBuilderImpl kbuilder, TypeResolver typeResolver, PackageModel packageModel, RuleDescr ruleDescr) {
+    public RuleContext(KnowledgeBuilderImpl kbuilder, TypeResolver typeResolver, PackageModel packageModel, RuleDescr ruleDescr) {
+        this(kbuilder, packageModel, packageModel.getExprIdGenerator(), ruleDescr, typeResolver);
+    }
+
+    public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, DRLIdGenerator exprIdGenerator, RuleDescr ruleDescr, TypeResolver typeResolver) {
         this.kbuilder = kbuilder;
-        this.typeResolver = typeResolver;
         this.packageModel = packageModel;
-        this.idGenerator = packageModel.getExprIdGenerator();
+        this.idGenerator = exprIdGenerator;
         this.descr = ruleDescr;
         exprPointer.push( this.expressions::add );
+        this.typeResolver = typeResolver;
         findUnitClass();
     }
 
@@ -83,7 +89,7 @@ public class RuleContext {
 
         if (unitName != null) {
             try {
-                Class<? extends RuleUnit> unitClass = ( Class<? extends RuleUnit> ) typeResolver.resolveType( unitName );
+                Class<? extends RuleUnit> unitClass = ( Class<? extends RuleUnit> ) getTypeResolver().resolveType( unitName );
                 ruleUnitDescr = ruleUnitDescrCache.computeIfAbsent( unitClass, RuleUnitDescr::new );
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException( e );
@@ -178,11 +184,7 @@ public class RuleContext {
         return exprPointer.size();
     }
 
-    public TypeResolver getTypeResolver() {
-        return typeResolver;
-    }
-
-    public String getExprId( Class<?> patternType, String drlConstraint) {
+    public String getExprId(Class<?> patternType, String drlConstraint) {
         return idGenerator.getExprId(patternType, drlConstraint);
     }
 
@@ -248,6 +250,10 @@ public class RuleContext {
 
     public PackageModel getPackageModel() {
         return packageModel;
+    }
+
+    public TypeResolver getTypeResolver() {
+        return typeResolver;
     }
 }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -59,10 +59,6 @@ public class RuleContext {
 
     public BaseDescr parentDesc = null;
 
-    public RuleContext(KnowledgeBuilderImpl kbuilder, TypeResolver typeResolver, PackageModel packageModel, RuleDescr ruleDescr) {
-        this(kbuilder, packageModel, ruleDescr, typeResolver);
-    }
-
     public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, RuleDescr ruleDescr, TypeResolver typeResolver) {
         this.kbuilder = kbuilder;
         this.packageModel = packageModel;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/WindowReferenceGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/WindowReferenceGenerator.java
@@ -106,7 +106,7 @@ public class WindowReferenceGenerator {
         return descrs.stream()
                 .map( descr -> {
                     String expression = descr.toString();
-                    RuleContext context = new RuleContext(kbuilder, typeResolver, packageModel, null);
+                    RuleContext context = new RuleContext(kbuilder, packageModel, null, typeResolver);
                     DrlxParseResult drlxParseResult = new ConstraintParser(context, packageModel).drlxParse(patternType, pattern.getIdentifier(), expression);
                     return drlxParseResult.acceptWithReturnValue(new ParseResultVisitor<Optional<Expression>>() {
                         @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
@@ -1,0 +1,425 @@
+package org.drools.modelcompiler.builder.generator.expressiontyper;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.drools.core.util.ClassUtils;
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.Node;
+import org.drools.javaparser.ast.NodeList;
+import org.drools.javaparser.ast.drlx.expr.HalfBinaryExpr;
+import org.drools.javaparser.ast.drlx.expr.HalfPointFreeExpr;
+import org.drools.javaparser.ast.drlx.expr.InlineCastExpr;
+import org.drools.javaparser.ast.drlx.expr.NullSafeFieldAccessExpr;
+import org.drools.javaparser.ast.drlx.expr.PointFreeExpr;
+import org.drools.javaparser.ast.expr.BinaryExpr;
+import org.drools.javaparser.ast.expr.CastExpr;
+import org.drools.javaparser.ast.expr.EnclosedExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.FieldAccessExpr;
+import org.drools.javaparser.ast.expr.InstanceOfExpr;
+import org.drools.javaparser.ast.expr.LiteralExpr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.NullLiteralExpr;
+import org.drools.javaparser.ast.expr.SimpleName;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.expr.ThisExpr;
+import org.drools.javaparser.ast.expr.UnaryExpr;
+import org.drools.javaparser.ast.type.ReferenceType;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.errors.ParseExpressionErrorResult;
+import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.ModelGenerator;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+import org.drools.modelcompiler.builder.generator.TypedExpression;
+import org.drools.modelcompiler.builder.generator.operatorspec.CustomOperatorSpec;
+import org.drools.modelcompiler.builder.generator.operatorspec.OperatorSpec;
+import org.drools.modelcompiler.builder.generator.operatorspec.TemporalOperatorSpec;
+
+import static java.util.Optional.of;
+import static org.drools.core.util.ClassUtils.getter2property;
+import static org.drools.javaparser.printer.PrintUtil.toDrlx;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.findRootNodeViaParent;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getClassFromContext;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getLiteralExpressionType;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.nameExprToMethodCallExpr;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.prepend;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.replaceAllHalfBinaryChildren;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.returnTypeOfMethodCallExpr;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.trasformHalfBinaryToBinary;
+
+public class ExpressionTyper {
+
+    private final RuleContext ruleContext;
+    private final PackageModel packageModel;
+    private Class<?> patternType;
+    private String bindingId;
+    private boolean isPositional;
+    private final ExpressionTyperContext context;
+    private final List<String> usedDeclarations;
+    private final Set<String> reactOnProperties;
+    private final List<Expression> prefixExpresssions;
+
+    public ExpressionTyper(RuleContext ruleContext, Class<?> patternType, String bindingId, boolean isPositional) {
+        this(ruleContext, patternType, bindingId, isPositional, new ExpressionTyperContext());
+    }
+
+    public ExpressionTyper(RuleContext ruleContext, Class<?> patternType, String bindingId, boolean isPositional, ExpressionTyperContext context) {
+        this.ruleContext = ruleContext;
+        packageModel = ruleContext.getPackageModel();
+        this.patternType = patternType;
+        this.bindingId = bindingId;
+        this.isPositional = isPositional;
+        this.context = context;
+        this.usedDeclarations = context.getUsedDeclarations();
+        this.reactOnProperties = context.getReactOnProperties();
+        this.prefixExpresssions = context.getPrefixExpresssions();
+    }
+
+    public TypedExpressionResult toTypedExpression(Expression drlxExpr) {
+        final Optional<TypedExpression> typedExpression = toTypedExpressionRec(drlxExpr);
+        return new TypedExpressionResult(typedExpression, context);
+    }
+
+    private Optional<TypedExpression> toTypedExpressionRec(Expression drlxExpr) {
+
+        Class<?> typeCursor = patternType;
+
+        if(drlxExpr instanceof EnclosedExpr) {
+            drlxExpr = ((EnclosedExpr) drlxExpr).getInner();
+        }
+
+        if (drlxExpr instanceof UnaryExpr) {
+            UnaryExpr unaryExpr = (UnaryExpr) drlxExpr;
+            Optional<TypedExpression> optTypedExpr = toTypedExpressionRec(unaryExpr.getExpression());
+            return optTypedExpr.map(typedExpr -> new TypedExpression( new UnaryExpr( typedExpr.getExpression(), unaryExpr.getOperator() ), typedExpr.getType() ));
+
+        } else if (drlxExpr instanceof BinaryExpr) {
+            BinaryExpr binaryExpr = (BinaryExpr) drlxExpr;
+
+            BinaryExpr.Operator operator = binaryExpr.getOperator();
+
+            Optional<TypedExpression> optLeft = toTypedExpressionRec(binaryExpr.getLeft());
+            Optional<TypedExpression> optRight = toTypedExpressionRec(binaryExpr.getRight());
+
+            return optLeft.flatMap(left -> optRight.flatMap(right -> {
+                final BinaryExpr combo = new BinaryExpr(left.getExpression(), right.getExpression(), operator);
+                return of(new TypedExpression(combo, left.getType()));
+            }));
+
+        } else if (drlxExpr instanceof HalfBinaryExpr) {
+            final Expression binaryExpr = trasformHalfBinaryToBinary(drlxExpr);
+            return toTypedExpressionRec(binaryExpr);
+
+        } else if (drlxExpr instanceof LiteralExpr) {
+            return of(new TypedExpression(drlxExpr, getLiteralExpressionType( ( LiteralExpr ) drlxExpr )));
+
+        } else if (drlxExpr instanceof ThisExpr) {
+            return of(new TypedExpression(new NameExpr("_this"), patternType));
+
+        } else if (drlxExpr instanceof CastExpr) {
+            CastExpr castExpr = (CastExpr)drlxExpr;
+            toTypedExpressionRec(castExpr.getExpression());
+            return of(new TypedExpression(castExpr, getClassFromContext(ruleContext.getTypeResolver(), castExpr.getType().asString())));
+
+        } else if (drlxExpr instanceof NameExpr) {
+            String name = drlxExpr.toString();
+            Optional<DeclarationSpec> decl = ruleContext.getDeclarationById(name);
+            if (decl.isPresent()) {
+                // then drlxExpr is a single NameExpr referring to a binding, e.g.: "$p1".
+                usedDeclarations.add(name);
+                return of(new TypedExpression(drlxExpr, decl.get().getDeclarationClass()));
+            } if (ruleContext.getQueryParameters().stream().anyMatch(qp -> qp.getName().equals(name))) {
+                // then drlxExpr is a single NameExpr referring to a query parameter, e.g.: "$p1".
+                usedDeclarations.add(name);
+                return of(new TypedExpression(drlxExpr));
+            } else if(packageModel.getGlobals().containsKey(name)){
+                Expression plusThis = new NameExpr(name);
+                usedDeclarations.add(name);
+                return of(new TypedExpression(plusThis, packageModel.getGlobals().get(name)));
+            } else {
+                TypedExpression expression;
+                try {
+                    expression = nameExprToMethodCallExpr(name, typeCursor, null);
+                } catch (IllegalArgumentException e) {
+                    if (isPositional || ruleContext.getQueryName().isPresent()) {
+                        String unificationVariable = ruleContext.getOrCreateUnificationId(name);
+                        expression = new TypedExpression(unificationVariable, typeCursor, name);
+                        return of(expression);
+                    }
+                    return Optional.empty();
+                }
+                reactOnProperties.add(name);
+                Expression plusThis = prepend(new NameExpr("_this"), expression.getExpression());
+                return of(new TypedExpression(plusThis, expression.getType(), name));
+            }
+        } else if (drlxExpr instanceof FieldAccessExpr || drlxExpr instanceof MethodCallExpr) {
+            return toTypedExpressionFromMethodCallOrField(drlxExpr).getTypedExpression();
+        } else if (drlxExpr instanceof PointFreeExpr) {
+
+            final PointFreeExpr pointFreeExpr = (PointFreeExpr)drlxExpr;
+
+            Optional<TypedExpression> optLeft = toTypedExpressionRec(pointFreeExpr.getLeft());
+            OperatorSpec opSpec = getOperatorSpec(drlxExpr, pointFreeExpr.getRight(), pointFreeExpr.getOperator());
+
+            return optLeft.map(left -> {
+                return new TypedExpression(opSpec.getExpression( pointFreeExpr, left ), left.getType())
+                        .setStatic(opSpec.isStatic())
+                        .setLeft(left);
+            });
+
+        } else if (drlxExpr instanceof HalfPointFreeExpr) {
+
+            final HalfPointFreeExpr halfPointFreeExpr = (HalfPointFreeExpr)drlxExpr;
+            Expression parentLeft = findLeftLeafOfNameExpr(halfPointFreeExpr.getParentNode().orElseThrow(UnsupportedOperationException::new));
+
+            Optional<TypedExpression> optLeft = toTypedExpressionRec(parentLeft);
+            OperatorSpec opSpec = getOperatorSpec(drlxExpr, halfPointFreeExpr.getRight(), halfPointFreeExpr.getOperator());
+
+            final PointFreeExpr transformedToPointFree =
+                    new PointFreeExpr(halfPointFreeExpr.getTokenRange().get(),
+                                      parentLeft,
+                                      halfPointFreeExpr.getRight(),
+                                      halfPointFreeExpr.getOperator(),
+                                      halfPointFreeExpr.isNegated(),
+                                      halfPointFreeExpr.getArg1(),
+                                      halfPointFreeExpr.getArg2(),
+                                      halfPointFreeExpr.getArg3(),
+                                      halfPointFreeExpr.getArg4()
+                    );
+
+            return optLeft.map(left ->
+                                       new TypedExpression(opSpec.getExpression(transformedToPointFree, left ), left.getType())
+                                               .setStatic(opSpec.isStatic())
+                                               .setLeft(left));
+        }
+
+        throw new UnsupportedOperationException();
+    }
+
+    private OperatorSpec getOperatorSpec( Expression drlxExpr, NodeList<Expression> rightExpressions, SimpleName expressionOperator) {
+        for (Expression rightExpr : rightExpressions) {
+            toTypedExpressionRec(rightExpr);
+        }
+
+        String operator = expressionOperator.asString();
+        OperatorSpec opSpec = null;
+        if (ModelGenerator.temporalOperators.contains(operator )) {
+            opSpec = TemporalOperatorSpec.INSTANCE;
+        } else if ( org.drools.model.functions.Operator.Register.hasOperator( operator ) ) {
+            opSpec = CustomOperatorSpec.INSTANCE;
+        }
+        if (opSpec == null) {
+            throw new UnsupportedOperationException("Unknown operator '" + operator + "' in expression: " + toDrlx(drlxExpr));
+        }
+        return opSpec;
+    }
+
+    private TypedExpressionResult toTypedExpressionFromMethodCallOrField(Expression drlxExpr) {
+        Class<?> typeCursor = patternType;
+
+        List<Node> childNodes = flattenScope(drlxExpr);
+        Node firstNode = childNodes.get(0);
+
+        boolean isInLineCast = firstNode instanceof InlineCastExpr;
+        if (isInLineCast) {
+            InlineCastExpr inlineCast = (InlineCastExpr) firstNode;
+            try {
+                typeCursor = ruleContext.getTypeResolver().resolveType(inlineCast.getType().toString());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+            firstNode = inlineCast.getExpression();
+        }
+
+        Expression previous;
+
+        if (firstNode instanceof ThisExpr || (firstNode instanceof NameExpr && firstNode.toString().equals( bindingId ))) {
+            previous = new NameExpr("_this");
+            if (childNodes.size() > 1 && !isInLineCast) {
+                SimpleName fieldName = null;
+                if (childNodes.get(1) instanceof NameExpr) {
+                    fieldName = (( NameExpr ) childNodes.get( 1 )).getName();
+                } else if (childNodes.get(1) instanceof SimpleName) {
+                    fieldName = ( SimpleName ) childNodes.get( 1 );
+                }
+                if (fieldName != null) {
+                    reactOnProperties.add( getFieldName( drlxExpr, fieldName ) );
+                }
+            }
+        } else if (firstNode instanceof NameExpr) {
+            NameExpr firstNodeName = (NameExpr) firstNode;
+            String firstName = firstNodeName.getName().getIdentifier();
+            Optional<DeclarationSpec> declarationById = ruleContext.getDeclarationById(firstName);
+            if (declarationById.isPresent()) {
+                // do NOT append any reactOnProperties.
+                // because reactOnProperties is referring only to the properties of the type of the pattern, not other declarations properites.
+                usedDeclarations.add(firstName);
+                if (!isInLineCast) {
+                    typeCursor = declarationById.get().getDeclarationClass();
+                }
+                previous = new NameExpr(firstName);
+            } else {
+
+                // In OOPath a declaration is based on a position rather than a name.
+                // Only an OOPath chunk can have a backreference expression
+                Optional<DeclarationSpec> backReference = Optional.empty();
+                if(firstNodeName.getBackReferencesCount()  > 0) {
+                    List<DeclarationSpec> ooPathDeclarations = ruleContext.getOOPathDeclarations();
+                    DeclarationSpec backReferenceDeclaration = ooPathDeclarations.get(ooPathDeclarations.size() - 1 - firstNodeName.getBackReferencesCount());
+                    typeCursor = backReferenceDeclaration.getDeclarationClass();
+                    backReference = of(backReferenceDeclaration);
+                    usedDeclarations.add(backReferenceDeclaration.getBindingId());
+                }
+
+                Method firstAccessor = ClassUtils.getAccessor((!isInLineCast) ? typeCursor : patternType, firstName);
+                if (firstAccessor != null) {
+                    // Hack to review - if a property is upper case it's probably not a react on property
+                    if(!"".equals(firstName) && Character.isLowerCase(firstName.charAt(0))) {
+                        reactOnProperties.add(firstName);
+                    }
+                    if (!isInLineCast) {
+                        typeCursor = firstAccessor.getReturnType();
+                    }
+                    NameExpr thisAccessor = new NameExpr("_this");
+                    final NameExpr scope = backReference.map(d -> new NameExpr(d.getBindingId())).orElse(thisAccessor);
+                    previous = new MethodCallExpr(scope, firstAccessor.getName());
+                } else {
+                    final Optional<Node> rootNode = findRootNodeViaParent(drlxExpr);
+                    rootNode.ifPresent(n -> {
+                        // In the error messages HalfBinary are transformed to Binary
+                        Node withHalfBinaryReplaced = replaceAllHalfBinaryChildren(n);
+                        ruleContext.addCompilationError(new ParseExpressionErrorResult((Expression) withHalfBinaryReplaced));
+                    });
+                    return new TypedExpressionResult(Optional.empty(), context);
+                }
+            }
+        } else if (firstNode instanceof FieldAccessExpr && ((FieldAccessExpr) firstNode).getScope() instanceof ThisExpr) {
+            String firstName = ((FieldAccessExpr) firstNode).getName().getIdentifier();
+            Method firstAccessor = ClassUtils.getAccessor(typeCursor, firstName);
+            if (firstAccessor != null) {
+                reactOnProperties.add(firstName);
+                typeCursor = firstAccessor.getReturnType();
+                previous = new MethodCallExpr(new NameExpr("_this"), firstAccessor.getName());
+            } else {
+                throw new UnsupportedOperationException("firstNode I don't know about");
+                // TODO would it be fine to assume is a global if it's not in the declarations and not the first accesssor in a chain?
+            }
+        } else if (firstNode instanceof SimpleName) {
+            previous = new NameExpr("_this");
+            SimpleName fieldName = ( SimpleName ) firstNode;
+            String name = getFieldName( drlxExpr, fieldName );
+            reactOnProperties.add( name );
+            TypedExpression expression = nameExprToMethodCallExpr(name, typeCursor, null);
+            Expression plusThis = prepend(new NameExpr("_this"), expression.getExpression());
+            if (childNodes.size() != 1) {
+                throw new UnsupportedOperationException("then the below should not be a return");
+            }
+            return new TypedExpressionResult( of(new TypedExpression(plusThis, expression.getType())), context);
+        } else if (firstNode instanceof MethodCallExpr) {
+            MethodCallExpr methodCallExpr = (MethodCallExpr) firstNode;
+            previous = new NameExpr("_this");
+            methodCallExpr.setScope(previous);
+            typeCursor = returnTypeOfMethodCallExpr(ruleContext, ruleContext.getTypeResolver(), methodCallExpr, typeCursor, usedDeclarations);
+            previous = methodCallExpr;
+        } else if (firstNode instanceof StringLiteralExpr) {
+            typeCursor = String.class;
+            previous = (( StringLiteralExpr ) firstNode);
+        } else {
+            throw new UnsupportedOperationException("Unknown node: " + firstNode);
+        }
+
+        childNodes = childNodes.subList(1, childNodes.size());
+
+        TypedExpression typedExpression = new TypedExpression();
+        if (isInLineCast) {
+            ReferenceType castType = JavaParser.parseClassOrInterfaceType(typeCursor.getName());
+            prefixExpresssions.add(new InstanceOfExpr(previous, castType));
+            previous = new EnclosedExpr(new CastExpr(castType, previous));
+        }
+        if (drlxExpr instanceof NullSafeFieldAccessExpr) {
+            final BinaryExpr prefixExpression = new BinaryExpr(previous, new NullLiteralExpr(), BinaryExpr.Operator.NOT_EQUALS);
+            prefixExpresssions.add(prefixExpression);
+
+            final Expression scope = ((NullSafeFieldAccessExpr) drlxExpr).getScope();
+            if(scope != null) {
+                final Optional<TypedExpression> typedExpression1 = toTypedExpressionRec(scope);
+                typedExpression1.ifPresent(te -> {
+                    final Expression expression = te.getExpression();
+                    final BinaryExpr notNullScope = new BinaryExpr(expression, new NullLiteralExpr(), BinaryExpr.Operator.NOT_EQUALS);
+                    prefixExpresssions.add(0, notNullScope);
+                });
+            }
+        }
+
+        for (Node part : childNodes) {
+            if(typeCursor.isEnum()) {
+                previous = drlxExpr;
+            } else if (part instanceof SimpleName) {
+                String field = part.toString();
+                TypedExpression expression = nameExprToMethodCallExpr(field, typeCursor, previous);
+                typeCursor = expression.getType();
+                previous = expression.getExpression();
+            } else if (part instanceof MethodCallExpr) {
+                MethodCallExpr methodCallExprPart = (MethodCallExpr) part;
+                typeCursor = returnTypeOfMethodCallExpr(ruleContext, ruleContext.getTypeResolver(), (MethodCallExpr) part, typeCursor, usedDeclarations);
+                methodCallExprPart.setScope(previous);
+                previous = methodCallExprPart;
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        return new TypedExpressionResult(of(typedExpression.setExpression(previous).setType(typeCursor)), context);
+    }
+
+
+    private static String getFieldName( Expression drlxExpr, SimpleName fieldName ) {
+        if ( drlxExpr instanceof MethodCallExpr ) {
+            String name = getter2property( fieldName.getIdentifier() );
+            if ( name != null ) {
+                return name;
+            }
+        }
+        return fieldName.getIdentifier();
+    }
+
+    public static Expression findLeftLeafOfNameExpr(Node expression) {
+        if(expression instanceof BinaryExpr) {
+            BinaryExpr be = (BinaryExpr)expression;
+            return findLeftLeafOfNameExpr(be.getLeft());
+        } else if(expression instanceof NameExpr) {
+            return (Expression) expression;
+        } else if(expression instanceof ThisExpr) {
+            return (Expression) expression;
+        } else if(expression instanceof PointFreeExpr) {
+            return findLeftLeafOfNameExpr(((PointFreeExpr) expression).getLeft());
+        } else {
+            throw new UnsupportedOperationException("Unknown expression: " + expression);
+        }
+    }
+
+    private static List<Node> flattenScope(Expression expressionWithScope) {
+        List<Node> res = new ArrayList<>();
+        if (expressionWithScope instanceof FieldAccessExpr) {
+            FieldAccessExpr fieldAccessExpr = (FieldAccessExpr) expressionWithScope;
+            res.addAll(flattenScope(fieldAccessExpr.getScope()));
+            res.add(fieldAccessExpr.getName());
+        } else if (expressionWithScope instanceof MethodCallExpr) {
+            MethodCallExpr methodCallExpr = (MethodCallExpr) expressionWithScope;
+            if (methodCallExpr.getScope().isPresent()) {
+                res.addAll(flattenScope(methodCallExpr.getScope().get()));
+            }
+            res.add(methodCallExpr.setScope(null));
+        } else {
+            res.add(expressionWithScope);
+        }
+        return res;
+    }
+
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyperContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyperContext.java
@@ -1,0 +1,27 @@
+package org.drools.modelcompiler.builder.generator.expressiontyper;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.drools.javaparser.ast.expr.Expression;
+
+public class ExpressionTyperContext {
+
+    List<String> usedDeclarations = new ArrayList<>();
+    Set<String> reactOnProperties = new HashSet<>();
+    List<Expression> prefixExpresssions = new ArrayList<>();
+
+    public List<String> getUsedDeclarations() {
+        return usedDeclarations;
+    }
+
+    public Set<String> getReactOnProperties() {
+        return reactOnProperties;
+    }
+
+    public List<Expression> getPrefixExpresssions() {
+        return prefixExpresssions;
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/TypedExpressionResult.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/TypedExpressionResult.java
@@ -1,0 +1,41 @@
+package org.drools.modelcompiler.builder.generator.expressiontyper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.modelcompiler.builder.generator.TypedExpression;
+
+public class TypedExpressionResult {
+
+    final Optional<TypedExpression> typedExpression;
+    final ExpressionTyperContext expressionTyperContext;
+
+    public TypedExpressionResult(Optional<TypedExpression> typedExpression, ExpressionTyperContext expressionTyperContext) {
+        this.typedExpression = typedExpression;
+        this.expressionTyperContext = expressionTyperContext;
+    }
+
+    public Optional<TypedExpression> getTypedExpression() {
+        return typedExpression;
+    }
+
+    public List<String> getUsedDeclarations() {
+        return expressionTyperContext.getUsedDeclarations();
+    }
+
+    public Set<String> getReactOnProperties() {
+        return expressionTyperContext.getReactOnProperties();
+    }
+
+    public ExpressionTyperContext getExpressionTyperContext() {
+        return expressionTyperContext;
+    }
+
+    public List<Expression> getPrefixExpressions() {
+        return expressionTyperContext.getPrefixExpresssions();
+    }
+
+
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ToTypedExpressionTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ToTypedExpressionTest.java
@@ -24,7 +24,7 @@ public class ToTypedExpressionTest {
     private final HashSet<String> imports = new HashSet<>();
     private final PackageModel packageModel = new PackageModel("", null);
     final TypeResolver typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
-    private final RuleContext ruleContext = new RuleContext(null, typeResolver, packageModel, null);
+    private final RuleContext ruleContext = new RuleContext(null, packageModel, null, typeResolver);
 
     {
         imports.add("org.drools.modelcompiler.domain.Person");

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ToTypedExpressionTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ToTypedExpressionTest.java
@@ -1,8 +1,6 @@
 package org.drools.modelcompiler.builder.generator;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.drools.javaparser.ast.NodeList;
 import org.drools.javaparser.ast.drlx.expr.PointFreeExpr;
@@ -11,36 +9,36 @@ import org.drools.javaparser.ast.expr.NameExpr;
 import org.drools.javaparser.ast.expr.SimpleName;
 import org.drools.javaparser.ast.expr.StringLiteralExpr;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyper;
+import org.drools.modelcompiler.builder.generator.expressiontyper.TypedExpressionResult;
 import org.drools.modelcompiler.domain.Overloaded;
 import org.drools.modelcompiler.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.commons.types.ClassTypeResolver;
 import org.kie.soup.project.datamodel.commons.types.TypeResolver;
 
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.*;
 
 public class ToTypedExpressionTest {
 
     private final HashSet<String> imports = new HashSet<>();
     private final PackageModel packageModel = new PackageModel("", null);
-    private final RuleContext ruleContext = new RuleContext(null, null, packageModel, null);
+    final TypeResolver typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
+    private final RuleContext ruleContext = new RuleContext(null, typeResolver, packageModel, null);
 
     {
         imports.add("org.drools.modelcompiler.domain.Person");
     }
 
-    final TypeResolver typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
 
     @Test
     public void toTypedExpressionTest() {
         assertEquals(typedResult("$mark.getAge()", int.class), toTypedExpression("$mark.age", null, aPersonDecl("$mark")));
         assertEquals(typedResult("$p.getName()", String.class), toTypedExpression("$p.name", null, aPersonDecl("$p")));
 
-        final Set<String> reactOnProperties = new HashSet<>();
-        assertEquals(typedResult("_this.getName().length()", int.class), toTypedExpression("name.length", Person.class, reactOnProperties));
-        Assert.assertThat(reactOnProperties, hasItem("name"));
+        TypedExpression actual = toTypedExpression("name.length", Person.class);
+        assertEquals(typedResult("_this.getName().length()", int.class), actual);
+
 
         assertEquals(typedResult("_this.method(5,9,\"x\")", int.class), toTypedExpression("method(5,9,\"x\")", Overloaded.class));
         assertEquals(typedResult("_this.getAddress().getCity().length()", int.class), toTypedExpression("address.getCity().length", Person.class));
@@ -53,23 +51,21 @@ public class ToTypedExpressionTest {
     @Test
     public void pointFreeTest() {
         final PointFreeExpr expression = new PointFreeExpr(null, new NameExpr("name"), NodeList.nodeList(new StringLiteralExpr("[A-Z]")), new SimpleName("matches"), false, null, null, null, null);
-        final TypedExpression actual = DrlxParseUtil.toTypedExpression(ruleContext, packageModel, Person.class, expression, null, new ArrayList<>(), new HashSet<>(), null, true, new ArrayList<>()).get();
+        TypedExpressionResult typedExpressionResult = new ExpressionTyper(ruleContext, Person.class, null, true).toTypedExpression(expression);
+        final TypedExpression actual = typedExpressionResult.getTypedExpression().get();
         final TypedExpression expected = typedResult("eval(org.drools.model.operators.MatchesOperator.INSTANCE, _this.getName(), \"[A-Z]\")", String.class);
         assertEquals(expected, actual);
     }
 
-    private TypedExpression toTypedExpression(String inputExpression, Class<?> patternType, Set<String> reactOnProperties, DeclarationSpec... declarations) {
+    private TypedExpression toTypedExpression(String inputExpression, Class<?> patternType, DeclarationSpec... declarations) {
 
         for(DeclarationSpec d : declarations) {
             ruleContext.addDeclaration(d);
         }
         Expression expression = DrlxParseUtil.parseExpression(inputExpression).getExpr();
-        return DrlxParseUtil.toTypedExpressionFromMethodCallOrField(ruleContext, patternType, expression, null, new ArrayList<>(), reactOnProperties, typeResolver, new ArrayList<>()).get();
+        return new ExpressionTyper(ruleContext, patternType, null, true).toTypedExpression(expression).getTypedExpression().get();
     }
 
-    private TypedExpression toTypedExpression(String inputExpression, Class<?> patternType, DeclarationSpec... declarations) {
-        return toTypedExpression(inputExpression, patternType, new HashSet<>(), declarations);
-    }
 
     private TypedExpression typedResult(String expressionResult, Class<?> classResult) {
         Expression resultExpression = DrlxParseUtil.parseExpression(expressionResult).getExpr();


### PR DESCRIPTION
Moved ToTypedExpression in a separated class

Removed RuleContext, PackageModel from all method of ConstraintParser.java

Introduced new method call that instantiate the context

Introduced TypedExpression context

Removed parentExpression

Partial application of  patternType, bindingId, isPositional

Removed all 9 parameters to ExpressionTyper method

Removed type resolver dependency