### PR TITLE
[RHDM-376 DROOLS-2305] Use Java 8 Eclipse compiler options when running on Java 9

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompilerSettings.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompilerSettings.java
@@ -89,6 +89,9 @@ public final class EclipseJavaCompilerSettings extends JavaCompilerSettings {
         put("1.6", CompilerOptions_VERSION_1_6);
         put("1.7", CompilerOptions_VERSION_1_7);
         put("1.8", CompilerOptions_VERSION_1_8);
+        // TODO use Java 8 options when running on Java 9. This should be fixed when ECJ is upgraded to a
+        // version that supports Java 9
+        put("9", CompilerOptions_VERSION_1_8);
     }};
     
     private String toNativeVersion( final String pVersion ) {

--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/JavaCompilerSettings.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/JavaCompilerSettings.java
@@ -28,8 +28,8 @@ package org.drools.compiler.commons.jci.compilers;
  */
 public class JavaCompilerSettings {
 
-    private String targetVersion = "1.6";
-    private String sourceVersion = "1.6";
+    private String targetVersion = "1.8";
+    private String sourceVersion = "1.8";
     private String sourceEncoding = "UTF-8";
     private boolean warnings = false;
     private boolean deprecations = false;

--- a/drools-compiler/src/test/java/org/drools/compiler/commons/jci/compilers/NativeJavaCompilerSettingsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/commons/jci/compilers/NativeJavaCompilerSettingsTest.java
@@ -30,8 +30,8 @@ public class NativeJavaCompilerSettingsTest {
         Assertions.assertThat(options).hasSize(6);
         Assertions.assertThat(options).contains("-source", "-target", "-encoding");
         // check the order is correct, value of the option needs to be right after the option name
-        Assertions.assertThat(options).contains("1.6", Index.atIndex(options.indexOf("-source") + 1));
-        Assertions.assertThat(options).contains("1.6", Index.atIndex(options.indexOf("-target") + 1));
+        Assertions.assertThat(options).contains("1.8", Index.atIndex(options.indexOf("-source") + 1));
+        Assertions.assertThat(options).contains("1.8", Index.atIndex(options.indexOf("-target") + 1));
         Assertions.assertThat(options).contains("UTF-8", Index.atIndex(options.indexOf("-encoding") + 1));
     }
 


### PR DESCRIPTION
master PR: https://github.com/kiegroup/drools/pull/1765

@mariofusco could you please review?