### PR TITLE
RHDM-317 Drools engine does not compile PMML SimpleSetPredicate corre…

### DIFF
--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/compiler/scorecard/scorecard_compiler.drl
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/compiler/scorecard/scorecard_compiler.drl
@@ -139,8 +139,7 @@ salience -12
 when
     $char   : Characteristic( $attz : attributes, $charName : name, $base : baselineScore )
     $attr   : Attribute( this memberOf $attz, $code : reasonCode, $score : partialScore, $set : simpleSetPredicate != null )
-    $mock   : List() from collect( SimpleSetPredicate() from $set )
-    compilePredicate( $mock, $pred, $set ; )
+    $pred   : String() from utils.getPredicate($attr)
     ?weight( $attr, $w ; )
 then
     HashMap map = utils.container;

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/pmml_header.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/pmml_header.drlt
@@ -67,7 +67,6 @@ then
    PMML4DataFactory factory = PMML4DataFactory.get();
    PMML4Data data = factory.newPMML4Data($cid, $mn, $pi, false, false);
    pmmlData.insert(data);
-   System.out.println("Inserted "+data);
 end
 
 rule "Override Value"

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/validation/valuesNoRestriction.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/validation/valuesNoRestriction.drlt
@@ -31,7 +31,6 @@ then
    modify($in) {
       setValid( true );
    }
-   System.out.println("Validated "+$in);
 end
 @end{}
 @includeNamed{'valuesNoRestrictionRule'}

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/DecisionTreeTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/DecisionTreeTest.java
@@ -193,7 +193,6 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
         String targetValue = resultHolder.getResultValue("Fld3", "value", String.class).orElse(null);
         Assertions.assertThat(targetValue).isEqualTo("tgtY");
 
-        executor.setRunWithLogging(true);
         request = new PMMLRequestData("123","TreeTest");
         request.addRequestParam("fld1", 100.0);
         resultHolder = executor.run(request);

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/ScorecardTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/ScorecardTest.java
@@ -132,7 +132,6 @@ public class ScorecardTest extends DroolsAbstractPMMLTest {
         
         for (int p = 0; p < 3; p++) {
             checkResult(resultHolder[p],expectedScores[p],expectedResults[p]);
-            results[p].forEach(r -> { System.out.println(r);});
         }
         
     }
@@ -307,7 +306,6 @@ public class ScorecardTest extends DroolsAbstractPMMLTest {
     }
 
     @Test
-    @Ignore("RHDM-317")
     public void testScorecardWithSimpleSetPredicateWithSpaceValue() {
         KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(SOURCE_SIMPLE_SET_SPACE_VALUE_SCORECARD);
         PMMLExecutor executor = new PMMLExecutor(kieBase);


### PR DESCRIPTION
…ctly

* Added methods to PMML4Helper class, to use the PredicateRuleProducer to get correct form of the SimpleSetPredicate
* Changed scorecard_compiler.drl to call PMML4Helper method to get the correct string for SimpleSetPredicate
* Removed the @Ignore on the testScorecardWithSimpleSetPredicateWithSpaceValue in ScorecardTest
* Cleaned up/removed System.out statements