### PR TITLE
DROOLS-1679 revert and empty-list if any error in FEEL list filtering

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/SilentWrappingEvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/SilentWrappingEvaluationContextImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
+import org.kie.dmn.feel.lang.EvaluationContext;
+
+/**
+ * This EvaluationContext should only be used to "try" evaluations
+ */
+public class SilentWrappingEvaluationContextImpl implements EvaluationContext {
+
+    private EvaluationContext wrapped;
+
+    /**
+     * This EvaluationContext should only be used to "try" evaluations
+     */
+    public SilentWrappingEvaluationContextImpl(EvaluationContext wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void enterFrame() {
+        wrapped.enterFrame();
+    }
+
+    @Override
+    public void exitFrame() {
+        wrapped.exitFrame();
+    }
+
+    @Override
+    public void setValue(String name, Object value) {
+        wrapped.setValue(name, value);
+    }
+
+    @Override
+    public Object getValue(String name) {
+        return wrapped.getValue(name);
+    }
+
+    @Override
+    public Object getValue(String[] name) {
+        return wrapped.getValue(name);
+    }
+
+    @Override
+    public boolean isDefined(String name) {
+        return wrapped.isDefined(name);
+    }
+
+    @Override
+    public boolean isDefined(String[] name) {
+        return isDefined(name);
+    }
+
+    @Override
+    public Map<String, Object> getAllValues() {
+        return getAllValues();
+    }
+
+    @Override
+    public void notifyEvt(Supplier<FEELEvent> event) {
+        // do nothing.
+    }
+
+    @Override
+    public Collection<FEELEventListener> getListeners() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void setRootObject(Object v) {
+        wrapped.setRootObject(v);
+    }
+
+    @Override
+    public Object getRootObject() {
+        return wrapped.getRootObject();
+    }
+
+    @Override
+    public DMNRuntime getDMNRuntime() {
+        return wrapped.getDMNRuntime();
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Either.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/Either.java
@@ -33,7 +33,7 @@ public class Either<L,R> {
     }
     
     public static <L,R> Either<L,R> ofRight(R value) {
-        return new Either<>(Optional.empty(), Optional.of(value));
+        return new Either<>(Optional.empty(), Optional.ofNullable(value));
     }
     
     public boolean isLeft() {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELListsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELListsTest.java
@@ -69,8 +69,15 @@ public class FEELListsTest extends BaseFEELTest {
                 {"[ {x:1, y:2}, {x:2, y:3} ][x = 0]", Collections.emptyList(), null },
 
                 // Other filtering
-                {"[\"a\", \"b\", \"c\"][a]", null, FEELEvent.Severity.ERROR },
-
+                {"[\"a\", \"b\", \"c\"][a]", Collections.emptyList(), null }, // DROOLS-1679
+                {"{ a list : [ { a : false, b : 2 }, { a : true, b : 3 } ], r : a list[a] }.r", Arrays.asList( new HashMap<String, Object>() {{ put("a", true);  put("b", BigDecimal.valueOf( 3 )); } } ), null },
+                {"{ a list : [ { a : false, b : 2 }, { a : null, b : 3 }, { b : 4 } ], r : a list[a] }.r", Collections.emptyList(), null },
+                {"{ a list : [ \"a\", \"b\", \"c\" ], x : 2, a : a list[x]}.a", "b", null },
+                {"{ a list : [ { x : false, y : 2 }, { x : true, y : 3 } ], x : \"asd\", a : a list[x] }.a", Arrays.asList( new HashMap<String, Object>() {{ put("x", true);  put("y", BigDecimal.valueOf( 3 )); } } ), null },
+                {"{ a list : [ { x : false, y : 2 }, { x : true, y : 3 } ], x : false, a : a list[x] }.a", Arrays.asList( new HashMap<String, Object>() {{ put("x", true);  put("y", BigDecimal.valueOf( 3 )); } } ), null },
+                {"{ a list : [ { x : false, y : 2 }, { x : true, y : 3 } ], x : null, a : a list[x] }.a", Arrays.asList( new HashMap<String, Object>() {{ put("x", true);  put("y", BigDecimal.valueOf( 3 )); } } ), null },
+                {"{ people : [ { firstName : \"bob\" }, { firstName : \"max\" } ], result : people[ lastName = null ] }.result", Arrays.asList( new HashMap<String, Object>() {{ put("firstName", "bob"); }}, new HashMap<String, Object>() {{ put("firstName", "max"); }}) , null },
+                
                 // Selection
                 {"[ {x:1, y:2}, {x:2, y:3} ].y", Arrays.asList( BigDecimal.valueOf( 2 ), BigDecimal.valueOf( 3 ) ), null },
                 {"[ {x:1, y:2}, {x:2} ].y", Arrays.asList( BigDecimal.valueOf( 2 ) ), null },


### PR DESCRIPTION
... when filter returns empty collection when there are errors
evaluating filter.

Continued from commit 6c8d3f9a1b6c3ba420445c99f50a65f066a01ca7
https://github.com/kiegroup/drools/pull/1514

@etirelli can you kindly check for me the additional tests are correct, in the sense they are indeed respecting the DMN v1.1 specification, please? Thx
(I am discovering these edge cases as a side-effect of implementing the compilation)

/cc @baldimir @kurobako @winklerm