### PR TITLE
DMN adjust logging level for ItemDefinitionDependenciesGeneratedTest

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ItemDefinitionDependenciesGeneratedTest.java
@@ -180,10 +180,10 @@ public class ItemDefinitionDependenciesGeneratedTest {
 
     @Test
     public void testOrdering() {
-        logger.info("Item definitions:");
+        logger.debug("Item definitions:");
         itemDefinitions.forEach(itemDefinition -> {
-            logger.info(itemDefinition.getName());
-            itemDefinition.getItemComponent().forEach(dependency -> logger.info(dependency.getName()));
+            logger.debug(itemDefinition.getName());
+            itemDefinition.getItemComponent().forEach(dependency -> logger.debug(dependency.getName()));
         });
         List<ItemDefinition> orderedList = orderingStrategy(itemDefinitions);
 


### PR DESCRIPTION
@baldimir this was generating quite many logging lines, but I believe the original intention is for those to be printed out only if now needs to debug any issue with the dependency ordering.

What do you think?