### PR TITLE
Fix test failing on Windows

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/BuildFromKJarTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/BuildFromKJarTest.java
@@ -70,7 +70,7 @@ public class BuildFromKJarTest {
         kfs.writeKModuleXML(getDefaultKieModuleModel(ks).toXML());
         kfs.writePomXML(KJARUtils.getPom(releaseId));
 
-        String javaSrc = Person.class.getCanonicalName().replace( '.', File.separatorChar ) + ".java";
+        String javaSrc = Person.class.getCanonicalName().replace( '.', '/' ) + ".java";
         Resource javaResource = ks.getResources().newFileSystemResource( "src/test/java/" + javaSrc );
         kfs.write( "src/main/java/" + javaSrc, javaResource );
 


### PR DESCRIPTION
The modified test failed on Windows, because a Person class couldn't be found. 

@mariofusco could you please review? 