### PR TITLE
The description attribute of decision service is now properly parsed

### DIFF
--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DecisionServiceConverter.java
@@ -89,6 +89,8 @@ public class DecisionServiceConverter extends NamedElementConverter {
         case INPUT_DATA:
             decisionService.getInputData().add((DMNElementReference) child);
             break;
+        default:
+            super.assignChildElement(parent, nodeName, child);
         }
     }
 

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/DMNXMLLoaderTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_1/DMNXMLLoaderTest.java
@@ -94,6 +94,7 @@ public class DMNXMLLoaderTest {
         DecisionService decisionService1 = def.getDecisionService().get(0);
         assertThat(decisionService1.getId(), is("_70386614-9838-420b-a2ae-ff901ada63fb"));
         assertThat(decisionService1.getName(), is("A Only Knowing B and C"));
+        assertThat(decisionService1.getDescription(), is("Description of A (BC)"));
         assertThat(decisionService1.getOutputDecision().size(), is(1));
         assertThat(decisionService1.getEncapsulatedDecision().size(), is(0));
         assertThat(decisionService1.getInputDecision().size(), is(2));

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_1/0004-decision-services.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_1/0004-decision-services.dmn
@@ -3,6 +3,7 @@
   <semantic:extensionElements>
     <drools:decisionServices xmlns:drools="http://www.drools.org/kie/dmn/1.1">
       <semantic:decisionService id="_70386614-9838-420b-a2ae-ff901ada63fb" name="A Only Knowing B and C">
+        <semantic:description>Description of A (BC)</semantic:description>
         <semantic:outputDecision href="#_c2b44706-d479-4ceb-bb74-73589d26dd04"/>
         <semantic:inputDecision href="#_e878ecd7-ecaa-42b9-b8c9-4437230f2b89"/>
         <semantic:inputDecision href="#_8758871c-af70-4da9-8355-536670bade10"/>


### PR DESCRIPTION
@tarilabs I realised today that my inexperience with XStream Parser showed a little bit. I was not calling super on a method which prevented the parsing of the description attribute of decision services. I have made the correction and added a test case.