### PR TITLE
[7.5.x] DROOLS-2404 Move TestStatusListener usage to a separate Maven profile

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -159,13 +159,6 @@
       <scope>test</scope>
     </dependency>
     
-    <!-- Required for TestListener in maven-surefire-plugin. -->
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-test-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
   </dependencies>
 
   <build>
@@ -200,18 +193,6 @@
     </pluginManagement>
     
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>org.kie.test.util.TestStatusListener</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -260,6 +241,37 @@
       <properties>
         <excludedGroups/>
       </properties>
+    </profile>
+    <profile>
+      <id>enableTestStatusListener</id>
+      <activation>
+        <property>
+          <name>enableTestStatusListener</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-test-util</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <properties>
+                <property>
+                  <name>listener</name>
+                  <value>org.kie.test.util.TestStatusListener</value>
+                </property>
+              </properties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>grammarsProfile</id>

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
@@ -8969,8 +8969,7 @@ public class Misc2Test extends CommonTestMethodBase {
             "Helpful to test thread dump when a timeout occur on the JUnit listener.\n" + 
             "See org.kie.test.util.TestStatusListener#testFailure()")
     @Test(timeout=5_000L)
-    public void testDeadlock() throws Exception {
-        final Object see_also = org.kie.test.util.TestStatusListener.class;
+    public void testDeadlock() {
         Object lock1 = 1L;
         Object lock2 = 2L;
         Runnable task1 = () -> {


### PR DESCRIPTION
(cherry picked from commit 2d25dc1)

Master PR: https://github.com/kiegroup/drools/pull/1824