### PR TITLE
DROOLS-2388 DMN Namespace unmarshalling differs from standard one when calling DMNValidator.validate method with File param

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -155,7 +155,7 @@ public class DMNCompilerImpl
     }
 
     private void processItemDefinitions(DMNCompilerContext ctx, DMNFEELHelper feel, DMNModelImpl model, Definitions dmndefs) {
-        dmndefs.getItemDefinition().stream().forEach(x->processItemDefQNameURIs(x));
+        Definitions.normalize(dmndefs);
         
         List<ItemDefinition> ordered = new ItemDefinitionDependenciesSorter(model.getNamespace()).sort(dmndefs.getItemDefinition());
         
@@ -164,22 +164,6 @@ public class DMNCompilerImpl
             DMNType type = buildTypeDef( ctx, feel, model, idn, id, true );
             idn.setType( type );
             model.addItemDefinition( idn );
-        }
-    }
-    
-    /**
-     * Utility method to ensure any QName references contained inside the ItemDefinition have the namespace correctly valorized, also accordingly to the prefix.
-     * (Even in the case of {@link XMLConstants.DEFAULT_NS_PREFIX} it will take the DMN model namespace for the no-prefix accordingly.)
-     * @param id the ItemDefinition for which to ensure the QName references are valorized correctly.
-     */
-    private void processItemDefQNameURIs( ItemDefinition id ) {
-        QName typeRef = id.getTypeRef();
-        if ( typeRef != null && XMLConstants.NULL_NS_URI.equals( typeRef.getNamespaceURI() ) ) {
-            String actualNS = id.getNamespaceURI( typeRef.getPrefix() );
-            id.setTypeRef(new QName(actualNS, typeRef.getLocalPart(), typeRef.getPrefix()));
-        }
-        for ( ItemDefinition ic : id.getItemComponent() ) {
-            processItemDefQNameURIs( ic );
         }
     }
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/Definitions.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/Definitions.java
@@ -15,6 +15,8 @@
  */
 package org.kie.dmn.model.v1_1;
 
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -158,5 +160,27 @@ public class Definitions extends NamedElement {
                ", exporter='" + exporter + '\'' +
                ", exporterVersion='" + exporterVersion + '\'' +
                '}';
+    }
+
+    /**
+     * Utility method to ensure any QName references contained inside the ItemDefinitions have the namespace correctly valorized, also accordingly to the prefix.
+     * (Even in the case of {@link XMLConstants.DEFAULT_NS_PREFIX} it will take the DMN model namespace for the no-prefix accordingly.)
+     * @param defs the ItemDefinition for which to ensure the QName references are valorized correctly.
+     */
+    public static void normalize(final Definitions defs) {
+        for (ItemDefinition itemDefinition : defs.getItemDefinition()) {
+            processQNameURIs(itemDefinition);
+        }
+    }
+
+    private static void processQNameURIs(ItemDefinition iDef) {
+        final QName typeRef = iDef.getTypeRef();
+        if (typeRef != null && XMLConstants.NULL_NS_URI.equals(typeRef.getNamespaceURI())) {
+            final String namespace = iDef.getNamespaceURI(typeRef.getPrefix());
+            iDef.setTypeRef(new QName(namespace, typeRef.getLocalPart(), typeRef.getPrefix()));
+        }
+        for (ItemDefinition comp : iDef.getItemComponent()) {
+            processQNameURIs(comp);
+        }
     }
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/ItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/ItemDefinition.java
@@ -17,6 +17,7 @@ package org.kie.dmn.model.v1_1;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 import javax.xml.namespace.QName;
 
@@ -24,7 +25,7 @@ public class ItemDefinition extends NamedElement {
 
     private QName typeRef;
     private UnaryTests allowedValues;
-    private List<ItemDefinition> itemComponent;
+    private List<ItemDefinition> itemComponent = new ArrayList<>();
     private String typeLanguage;
     private Boolean isCollection;
 
@@ -45,9 +46,6 @@ public class ItemDefinition extends NamedElement {
     }
 
     public List<ItemDefinition> getItemComponent() {
-        if ( itemComponent == null ) {
-            itemComponent = new ArrayList<>();
-        }
         return this.itemComponent;
     }
 
@@ -71,4 +69,16 @@ public class ItemDefinition extends NamedElement {
         this.isCollection = value;
     }
 
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ")
+                .add("name: " + getName())
+                .add("typeRef: " + typeRef)
+                .add("allowedValues: " + allowedValues)
+                .add("itemComponent: " + itemComponent)
+                .add("typeLanguage: " + typeLanguage)
+                .add("isCollection: " + isCollection)
+                .toString();
+    }
 }

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
@@ -152,6 +152,7 @@ public class DMNValidatorImpl implements DMNValidator {
             Definitions dmndefs = null;
             try {
                 dmndefs = DMNMarshallerFactory.newDefaultMarshaller().unmarshal( new FileReader( xmlFile ) );
+                Definitions.normalize(dmndefs);
                 validateModelCompilation( dmndefs, results, flags );
             } catch ( Throwable t ) {
                 MsgUtil.reportMessage( LOG,
@@ -182,6 +183,7 @@ public class DMNValidatorImpl implements DMNValidator {
             }
             if( flags.contains( VALIDATE_MODEL ) || flags.contains( VALIDATE_COMPILATION ) ) {
                 Definitions dmndefs = DMNMarshallerFactory.newDefaultMarshaller().unmarshal( new StringReader( content ) );
+                Definitions.normalize(dmndefs);
                 validateModelCompilation( dmndefs, results, flags );
             }
         } catch ( Throwable t ) {


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2388