### PR TITLE
[7.7.x] DROOLS-2426 Remove Thread.sleep() from ParallelEvaluationTest

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParallelEvaluationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParallelEvaluationTest.java
@@ -609,7 +609,7 @@ public class ParallelEvaluationTest {
         ksession.dispose();
     }
 
-    @Test(timeout = 100000L)
+    @Test(timeout = 20000L)
     public void testFireUntilHaltWithExpiration2() throws InterruptedException {
         String drl =
                 "import " + A.class.getCanonicalName() + "\n" +


### PR DESCRIPTION
Backport of https://github.com/kiegroup/drools/pull/1843