### PR TITLE
DROOLS-1663 defaults for DMN Import xml element attributes semantic

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -20,14 +20,13 @@ public class ImportDMNResolverUtil {
         final String iNamespace = _import.getNamespace();
         final String iName = _import.getAdditionalAttributes().get(Import.NAME_QNAME);
         final String iModelName = _import.getAdditionalAttributes().get(Import.MODELNAME_QNAME);
-        final String nameLookup = iModelName != null ? iModelName : iName;
         List<T> allInNS = all.stream()
                              .filter(m -> idExtractor.apply(m).getNamespaceURI().equals(iNamespace))
                              .collect(Collectors.toList());
         if (allInNS.size() == 1) {
             T located = allInNS.get(0);
-            // Check if the located DMN Model in the NS, correspond for the import `name`. 
-            if (nameLookup == null || idExtractor.apply(located).getLocalPart().equals(nameLookup)) {
+            // Check if the located DMN Model in the NS, correspond for the import `drools:modelName`. 
+            if (iModelName == null || idExtractor.apply(located).getLocalPart().equals(iModelName)) {
                 return Either.ofRight(located);
             } else {
                 return Either.ofLeft(String.format("While importing DMN for namespace: %s, name: %s, modelName: %s, located within namespace only %s but does not match for the actual name",
@@ -36,7 +35,7 @@ public class ImportDMNResolverUtil {
             }
         } else {
             List<T> usingNSandName = allInNS.stream()
-                                            .filter(m -> idExtractor.apply(m).getLocalPart().equals(nameLookup))
+                                            .filter(m -> idExtractor.apply(m).getLocalPart().equals(iModelName))
                                             .collect(Collectors.toList());
             if (usingNSandName.size() == 1) {
                 return Either.ofRight(usingNSandName.get(0));

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
@@ -51,8 +51,8 @@ public class ImportDMNResolverUtilTest {
     }
 
     @Test
-    public void testNSnoModelNameDefaultWithAlias() {
-        Import i = makeImport("ns1", "m1", null);
+    public void testNSnoModelNameWithAlias() {
+        Import i = makeImport("ns1", "mymodel", null);
         List<QName> available = Arrays.asList(new QName("ns1", "m1"),
                                               new QName("ns2", "m2"),
                                               new QName("ns3", "m3"));
@@ -72,13 +72,14 @@ public class ImportDMNResolverUtilTest {
     }
 
     @Test
-    public void testNSnoModelNameDefaultWithAliasButUnexistent() {
+    public void testNSnoModelNameDefaultWithAlias2() {
         Import i = makeImport("ns1", "boh", null);
         List<QName> available = Arrays.asList(new QName("ns1", "m1"),
                                               new QName("ns2", "m2"),
                                               new QName("ns3", "m3"));
         Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isLeft());
+        assertTrue(result.isRight());
+        assertEquals(new QName("ns1", "m1"), result.getOrElse(null));
     }
 
     @Test
@@ -93,14 +94,13 @@ public class ImportDMNResolverUtilTest {
     }
 
     @Test
-    public void testLocateInNSdefaultwithAlias() {
+    public void testLocateInNSnoModelNameWithAlias() {
         Import i = makeImport("nsA", "m1", null);
         List<QName> available = Arrays.asList(new QName("nsA", "m1"),
                                               new QName("nsA", "m2"),
                                               new QName("nsB", "m3"));
         Either<String, QName> result = ImportDMNResolverUtil.resolveImportDMN(i, available, Function.identity());
-        assertTrue(result.isRight());
-        assertEquals(new QName("nsA", "m1"), result.getOrElse(null));
+        assertTrue(result.isLeft());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class ImportDMNResolverUtilTest {
     }
 
     @Test
-    public void testLocateInNSdefaultWithAliasunexistent() {
+    public void testLocateInNSnoModelNameWithAlias2() {
         Import i = makeImport("nsA", "boh", null);
         List<QName> available = Arrays.asList(new QName("nsA", "m1"),
                                               new QName("nsA", "m2"),
@@ -136,6 +136,7 @@ public class ImportDMNResolverUtilTest {
 
     @Test
     public void testLocateInNSAliasedBadScenario() {
+        // this is a BAD scenario are in namespace `nsA` there are 2 models with the same name.
         Import i = makeImport("nsA", "aliased", "mA");
         List<QName> available = Arrays.asList(new QName("nsA", "mA"),
                                               new QName("nsA", "mA"),


### PR DESCRIPTION
> The "drools:name" property should never be used to lookup a model,
> it should be used exclusively to assign an alias to whatever model is
> imported, otherwise we would be overloading its semantics.

/cc @etirelli @kurobako @baldimir @winklerm