### PR TITLE
RHBA-626 Tree model does not work on models expecting numeric output

### DIFF
--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
@@ -68,9 +68,11 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.KnowledgeBuilderResult;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.pmml.pmml_4_2.model.Miningmodel;
+import org.kie.pmml.pmml_4_2.model.PMML4ModelType;
 import org.kie.pmml.pmml_4_2.model.PMML4UnitImpl;
 import org.kie.pmml.pmml_4_2.model.PMMLMiningField;
 import org.kie.pmml.pmml_4_2.model.PMMLOutputField;
+import org.kie.pmml.pmml_4_2.model.Treemodel;
 import org.kie.pmml.pmml_4_2.model.mining.MiningSegment;
 import org.kie.pmml.pmml_4_2.model.mining.MiningSegmentation;
 import org.mvel2.templates.SimpleTemplateRegistry;
@@ -546,8 +548,13 @@ public class PMML4Compiler implements PMMLCompiler {
                 models.forEach(model -> {
                     Map.Entry<String, String> inputPojo = model.getMappedMiningPojo();
                     Map.Entry<String, String> ruleUnit = model.getMappedRuleUnit();
+                    Map.Entry<String, String> outcome = null;
+                    if (model.getModelType() == PMML4ModelType.TREE) {
+                    	outcome = ((Treemodel)model).getTreeNodeJava();
+                    }
                     if (inputPojo != null) javaClasses.put(inputPojo.getKey(), inputPojo.getValue());
                     if (ruleUnit != null) javaClasses.put(ruleUnit.getKey(), ruleUnit.getValue());
+                    if (outcome != null) javaClasses.put(outcome.getKey(), outcome.getValue());
                 });
             }
         }

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/AbstractModel.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/AbstractModel.java
@@ -163,6 +163,7 @@ public abstract class AbstractModel<T> implements PMML4Model {
     }
 
  
+    @Override
     public Map.Entry<String, String> getMappedOutputPojo() {
         Map<String,String> result = new HashMap<>();
         if (!templateRegistry.contains(getOutputPojoTemplateName())) {
@@ -226,8 +227,8 @@ public abstract class AbstractModel<T> implements PMML4Model {
     @Override
     public List<PMMLMiningField> getMiningFields() {
         List<PMMLMiningField> fields = new ArrayList<>();
-        Map<String,MiningField> excludesTargetMap =
-                getFilteredMiningFieldMap(false, FIELDUSAGETYPE.TARGET);
+        Map<String,MiningField> excludesTargetMap = miningFieldMap;
+//                getFilteredMiningFieldMap(false, FIELDUSAGETYPE.TARGET);
         Map<String, PMMLDataField> dataDictionary = getOwner().getDataDictionaryMap();
         for (String key: excludesTargetMap.keySet()) {
             PMMLDataField df = dataDictionary.get(key);
@@ -255,6 +256,7 @@ public abstract class AbstractModel<T> implements PMML4Model {
         }
         return fields;
     }
+    
 
     @Override
     public PMMLMiningField findMiningField(String fieldName) {

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/Treemodel.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/Treemodel.java
@@ -15,10 +15,17 @@
  */
 package org.kie.pmml.pmml_4_2.model;
 
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import org.kie.dmg.pmml.pmml_4_2.descr.DATATYPE;
+import org.kie.dmg.pmml.pmml_4_2.descr.FIELDUSAGETYPE;
+import org.kie.dmg.pmml.pmml_4_2.descr.MiningField;
 import org.kie.dmg.pmml.pmml_4_2.descr.MiningSchema;
 import org.kie.dmg.pmml.pmml_4_2.descr.Output;
 import org.kie.dmg.pmml.pmml_4_2.descr.OutputField;
@@ -26,17 +33,51 @@ import org.kie.dmg.pmml.pmml_4_2.descr.Scorecard;
 import org.kie.dmg.pmml.pmml_4_2.descr.TreeModel;
 import org.kie.pmml.pmml_4_2.PMML4Model;
 import org.kie.pmml.pmml_4_2.PMML4Unit;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
 import org.mvel2.templates.CompiledTemplate;
 import org.mvel2.templates.TemplateCompiler;
 import org.mvel2.templates.TemplateRegistry;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.TemplateRuntimeError;
 
 public class Treemodel extends AbstractModel<TreeModel> {
 	private static final String MINING_POJO_TEMPLATE="/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeMiningPojo.mvel";
 	private static final String OUTPUT_POJO_TEMPLATE="/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeOutputPojo.mvel";
 	private static final String RULE_UNIT_TEMPLATE="/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeRuleUnit.mvel";
+	private static final String TREE_NODE_POJO_TEMPLATE="/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeNodePojo.mvel";
+	private static final String TREE_NODE_POJO_TEMPLATE_NAME = "TreemodelTreeNodePojo";
 
 	public Treemodel( String modelId, TreeModel rawModel, PMML4Model parentModel, PMML4Unit owner) {
 		super(modelId, PMML4ModelType.TREE, owner, parentModel, rawModel);
+	}
+	
+	public Map.Entry<String, String> getTreeNodeJava() {
+		Map<String,String> result = new HashMap<>();
+		if (!templateRegistry.contains(TREE_NODE_POJO_TEMPLATE_NAME)) {
+			InputStream istrm = Treemodel.class.getResourceAsStream(TREE_NODE_POJO_TEMPLATE);
+			if (istrm != null) {
+		        CompiledTemplate ct = TemplateCompiler.compileTemplate(istrm);
+		        templateRegistry.addNamedTemplate(TREE_NODE_POJO_TEMPLATE_NAME,ct);
+			}
+		}
+		Map<String,Object> vars = new HashMap<>();
+		vars.put("pmmlPackageName", PMML_JAVA_PACKAGE_NAME);
+		vars.put("outcomeType",getOutputFieldType());
+		vars.put("context", this.getModelId());
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            TemplateRuntime.execute( templateRegistry.getNamedTemplate(TREE_NODE_POJO_TEMPLATE_NAME),
+                                     null,
+                                     new MapVariableResolverFactory(vars),
+                                     baos );
+        } catch (TemplateRuntimeError tre) {
+            // need to figure out logging here
+            return null;
+        }
+        String fullName = PMML_JAVA_PACKAGE_NAME+"."+this.getModelId()+"TreeNode";
+		result.put(fullName, new String(baos.toByteArray()));
+		if (!result.isEmpty()) return result.entrySet().iterator().next();
+		return null;
 	}
 
 	@Override
@@ -82,7 +123,7 @@ public class Treemodel extends AbstractModel<TreeModel> {
 
 	@Override
 	protected void addMiningTemplateToRegistry(TemplateRegistry registry) {
-        InputStream inputStream = Scorecard.class.getResourceAsStream(MINING_POJO_TEMPLATE);
+        InputStream inputStream = Treemodel.class.getResourceAsStream(MINING_POJO_TEMPLATE);
         if (inputStream != null) {
 	        CompiledTemplate ct = TemplateCompiler.compileTemplate(inputStream);
 	        registry.addNamedTemplate(getMiningPojoTemplateName(),ct);
@@ -109,6 +150,41 @@ public class Treemodel extends AbstractModel<TreeModel> {
 				registry.addNamedTemplate(getRuleUnitTemplateName(), ct);
 			}
 		}
+	}
+	
+	private String getOutputFieldType() {
+		String fieldType = null;
+		List<OutputField> outFields = getRawOutputFields();
+		if (outFields != null && !outFields.isEmpty() ) {
+			for (Iterator<OutputField> iter = outFields.iterator(); iter.hasNext() && fieldType == null;) {
+				OutputField field = iter.next();
+			    DATATYPE datatype = field.getDataType();
+			    if (datatype == null) {
+			    	String targetName = field.getTargetField();
+			    	if (targetName != null) {
+			    		PMMLMiningField mf = findMiningField(targetName);
+			    		if (mf != null) {
+			    			fieldType = mf.getType();
+			    		}
+			    	}
+			    } else {
+			    	fieldType = helper.mapDatatype(datatype);
+			    }
+			}
+		} else {
+			Map<String,MiningField> miningFields = 
+					getFilteredMiningFieldMap(true, FIELDUSAGETYPE.PREDICTED, FIELDUSAGETYPE.TARGET);
+			if (miningFields != null && !miningFields.isEmpty()) {
+				for (Iterator<String> iter = miningFields.keySet().iterator(); iter.hasNext() && fieldType == null;) {
+					String fldName = iter.next();
+					PMMLMiningField mf = findMiningField(fldName);
+					if (mf != null) {
+						fieldType = mf.getType();
+					}
+				}
+			}
+		}
+		return fieldType;
 	}
 
 }

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/mining/MiningSegmentation.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/mining/MiningSegmentation.java
@@ -46,9 +46,11 @@ public class MiningSegmentation {
 	
 	private static TemplateRegistry templates;
 	private static Map<String,String> templateNameToFile;
-	private static final String segmentActivationSelectFirst = "org/kie/pmml/pmml_4_2/templates/mvel/mining/selectFirstSegOnly.mvel";
-	private static final String segmentSelectAll = "org/kie/pmml/pmml_4_2/templates/mvel/mining/selectAllSegments.mvel";
-	private static final String segmentModelChain = "org/kie/pmml/pmml_4_2/templates/mvel/mining/modelChain.mvel";
+	private static final String BASE_DIR = "org/kie/pmml/pmml_4_2/templates/mvel/mining/";
+	private static final String segmentActivationSelectFirst = BASE_DIR+"selectFirstSegOnly.mvel";
+	private static final String segmentSelectAll = BASE_DIR+"selectAllSegments.mvel";
+	private static final String segmentModelChain = BASE_DIR+"modelChain.mvel";
+	private static final String segmentWeightedAvg = BASE_DIR+"weightedAvg.mvel";
 	
 	public MiningSegmentation(Miningmodel owner, Segmentation segmentation) {
 		this.owner = owner;
@@ -77,6 +79,7 @@ public class MiningSegmentation {
 			templateNameToFile.put(MULTIPLEMODELMETHOD.SELECT_FIRST.name(), segmentActivationSelectFirst);
 			templateNameToFile.put(MULTIPLEMODELMETHOD.SELECT_ALL.name(), segmentSelectAll);
 			templateNameToFile.put(MULTIPLEMODELMETHOD.MODEL_CHAIN.name(), segmentModelChain);
+			templateNameToFile.put(MULTIPLEMODELMETHOD.WEIGHTED_AVERAGE.name(), segmentWeightedAvg);
 		}
 	}
 	

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/tree/AbstractTreeToken.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/tree/AbstractTreeToken.java
@@ -121,6 +121,8 @@ public abstract class AbstractTreeToken {
 		return this.correlationId;
 	}
 	
+	
+
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 		builder.append("correlationId=").append(this.correlationId).append(", ");

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/tree/TreeNode.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/tree/TreeNode.java
@@ -31,7 +31,6 @@ import java.util.Set;
     id          : String            @key
     parent      : String
     children    : java.util.List
-    outcome     : String
     recordCount : int
     counts      : java.util.Map
     confidence  : java.util.Map
@@ -43,7 +42,6 @@ public class TreeNode {
     private String id;
     private String parent;
     private List children;
-    private String outcome;
     private int recordCount;
     private Map counts;
     private Map confidence;
@@ -51,13 +49,12 @@ public class TreeNode {
 
 
 
-    public TreeNode(String correlationId, String context, String id, String parent, List children, String outcome, int recordCount,
+    public TreeNode(String correlationId, String context, String id, String parent, List children, int recordCount,
             Map counts, Map confidence, String defaultChld) {
         this.context = context;
         this.id = id;
         this.parent = parent;
         this.children = children;
-        this.outcome = outcome;
         this.recordCount = recordCount;
         this.counts = counts;
         this.confidence = confidence;
@@ -86,12 +83,6 @@ public class TreeNode {
     }
     public void setChildren(List children) {
         this.children = children;
-    }
-    public String getOutcome() {
-        return outcome;
-    }
-    public void setOutcome(String outcome) {
-        this.outcome = outcome;
     }
     public int getRecordCount() {
         return recordCount;
@@ -267,7 +258,6 @@ public class TreeNode {
             }
         }
         builder.append("], ");
-        builder.append("outcome=").append(this.outcome).append(", ");
         builder.append("recordCount=").append(this.recordCount).append(", ");
         builder.append("counts=[");
         Iterator keyIter = this.counts.keySet().iterator();

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeAggregateEval.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeAggregateEval.drlt
@@ -29,7 +29,7 @@ rule "Eval Tree Node @{context} - @{id} - Down Aggregate Mark"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience $children.size() + 1
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", $master : parent, $children : children )
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", $master : parent, $children : children )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}", marker == null,
                                  visitMode == "AGGREGATE_NODES", @{missings}  )
 then
@@ -45,7 +45,7 @@ rule "Eval Tree Node @{context} - @{id} - True On Aggregates"
 salience 3
 no-loop
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", children.size == 0, $counts : counts )
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", children.size == 0, $counts : counts )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}",
                                  results.keySet not contains "@{id}",
                                  visitMode == "AGGREGATE_NODES",

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeCommon.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeCommon.drlt
@@ -27,7 +27,7 @@
 rule "Eval Tree Node @{context} - Up"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 when
-    $node : TreeNode( context == "@{context}", $id : id, $master : parent )
+    $node : @{context}TreeNode( context == "@{context}", $id : id, $master : parent )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id )
     not @{name}( context == "@{context}" )
 then

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeDefaultEval.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeDefaultEval.drlt
@@ -30,7 +30,7 @@ rule "Eval Tree Node @{context} - @{id} - Default Child"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 3
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", $def : defaultChld != "null" && != null )
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", $def : defaultChld != "null" && != null )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}", visitMode == "DEFAULT_CHILD", 
                                  downward == true, results.keySet not contains "@{id}", $conf : confidence,
                                  @{missings} )
@@ -48,7 +48,7 @@ rule "Eval Tree Node @{context} - @{id} - Default Child Undo Jump"
 salience 5
 no-loop
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", $def : defaultChld != "null" && != null )
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", $def : defaultChld != "null" && != null )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}", visitMode == "DEFAULT_CHILD", 
                                  downward == false, $conf : confidence, @{missings} )
 then

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeEval.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeEval.drlt
@@ -29,7 +29,7 @@ rule "Eval Tree Node @{context} - @{id} - Down"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience $children.size() - $children.indexOf( $child )
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", $children : children, children.size > 0 )
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", $children : children, children.size > 0 )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}", $trail : trail,
                                  ( @{constraints} ) || ( visitMode == "AGGREGATE_NODES" && ( @{missings} ) ) )
     $child : String( this not memberOf $trail ) from $children
@@ -61,7 +61,7 @@ rule "Eval Tree Node @{context} - @{id} - True"
 salience 3
 no-loop
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", $out : outcome,
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", $out : outcome,
                       children.size == 0, $conf : confidence, $tot : recordCount )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}", $baseConf : confidence,
                                  $res : results, results.keySet not contains "@{id}",
@@ -85,7 +85,7 @@ rule "Eval Tree Node @{context} - @{id} - Unknown Weighted"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 3
 when
-    $node : TreeNode( context == "@{context}", $id : id == "@{id}", $out : outcome )
+    $node : @{context}TreeNode( context == "@{context}", $id : id == "@{id}", $out : outcome )
     $tok  : @{context}TreeToken( context == "@{context}", current == "@{id}",
                                  visitMode == "WEIGHTED_CONFIDENCE" || == "LAST_PREDICTION" || == "NULL_PREDICTION",
                                  results.keySet not contains "@{id}",

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeInit.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeInit.drlt
@@ -31,7 +31,7 @@ salience 99
 when
     ModelMarker( "@{context}" ; enabled == true )
 then
-    TreeNode node;
+    @{context}TreeNode node;
     java.util.Map count;
     java.util.Map confs;
 
@@ -41,7 +41,7 @@ then
         confs = new java.util.HashMap();
             @foreach{ val : confs[ node.id ].keySet() } confs.put( @{format( tgtType, val ) }, @{ confs[ node.id ][ val ] } ); @end{}
 
-        node = new TreeNode( "","@{context}",
+        node = new @{context}TreeNode( "","@{context}",
                              "@{node.id}",
                              "@{parents[ node.id ]}",
                              java.util.Arrays.asList( @foreach{ child : node.nodes } "@{ child.id }" @end{','} ),
@@ -60,14 +60,14 @@ rule "Ensure Tree Statistics are Filled - @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 100
 when
-    $node : TreeNode( context == "@{context}", $id : id, $master : counts, $confs : confidence, counts.size() == 0, $children : children, $numChi : children.size() )
+    $node : @{context}TreeNode( context == "@{context}", $id : id, $master : counts, $confs : confidence, counts.size() == 0, $children : children, $numChi : children.size() )
 
-    accumulate( TreeNode( context == $node.context, id memberOf $children, counts.size() > 0, $sub : counts, $x : recordCount )
+    accumulate( @{context}TreeNode( context == $node.context, id memberOf $children, counts.size() > 0, $sub : counts, $x : recordCount )
                 and $k : String() from $sub.keySet(),
                           $keys : collectSet( $k );
                           $keys.size() > 0 )
 
-    accumulate( TreeNode( context == $node.context, id memberOf $children, $sub : counts, $x : recordCount > 0 ),
+    accumulate( @{context}TreeNode( context == $node.context, id memberOf $children, $sub : counts, $x : recordCount > 0 ),
                           $subs : collectList( $sub ),
                           $num  : count( $sub ),
                           $tot  : sum( $x );
@@ -99,7 +99,7 @@ end
 rule "Ensure Tree Scores are Filled - @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 when
-    $node : TreeNode( context == "@{context}", $id : id, outcome == null, confidence.size() > 0, $conf : confidence )
+    $node : @{context}TreeNode( context == "@{context}", $id : id, outcome == null, confidence.size() > 0, $conf : confidence )
     accumulate( $k : String() from $conf.keySet(),
                      $maxConf : max( $conf.get( $k ) ) )
     java.util.Map.Entry( $best : key, value == $maxConf ) from $conf.entrySet()

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleAggregate.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleAggregate.drlt
@@ -29,7 +29,7 @@ rule "Handle aggregate-prediction missing values on my way back @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id, $children : children )
+    $node : @{context}TreeNode( context == "@{context}", $id : id, $children : children )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id, $res : results,
                                  visitMode == "AGGREGATE_NODES", marker == $id, downward == false, trail.containsAll( $children ) )
     not @{name}( context == "@{context}" )

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleLast.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleLast.drlt
@@ -28,7 +28,7 @@ rule "Handle last-prediction missing values on my way back @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id,
+    $node : @{context}TreeNode( context == "@{context}", $id : id,
                       $out : outcome, $children : children, $count : recordCount, $confs : confidence )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id, $trail : trail, $res : results, visitMode == "LAST_PREDICTION" )
 
@@ -50,7 +50,7 @@ rule "Handle last-prediction missing values on my way back without confidence @{
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id,
+    $node : @{context}TreeNode( context == "@{context}", $id : id,
                       $out : outcome, $children : children, $count : recordCount, confidence.size == 0 )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id, $trail : trail, $res : results, visitMode == "LAST_PREDICTION" )
 

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleNone.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleNone.drlt
@@ -28,7 +28,7 @@ rule "Handle none-prediction missing values on my way back @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id, $children : children, $out : outcome, $tot : recordCount, $conf : confidence )
+    $node : @{context}TreeNode( context == "@{context}", $id : id, $children : children, $out : outcome, $tot : recordCount, $conf : confidence )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id,
                                  trail.containsAll( $children ), $res : results, visitMode == "NONE", downward == false )
     not @{name}( context == "@{context}" )

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleNull.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleNull.drlt
@@ -28,7 +28,7 @@ rule "Handle null-prediction missing values on my way back @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id, $children : children )
+    $node : @{context}TreeNode( context == "@{context}", $id : id, $children : children )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id, $trail : trail, $res : results, visitMode == "NULL_PREDICTION" )
 
     not @{name}( context == "@{context}" )

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleWeighted.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/tree/treeMissHandleWeighted.drlt
@@ -30,11 +30,11 @@ rule "Handle weighted missing values on my way back @{context}"
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id,
+    $node : @{context}TreeNode( context == "@{context}", $id : id,
                       $out : outcome, $children : children, $count : recordCount, $confs : confidence )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id, visitMode == "WEIGHTED_CONFIDENCE", $res : results )
 
-    $childNodes: java.util.List() from collect( TreeNode( parent == $id ) )
+    $childNodes: java.util.List() from collect( @{context}TreeNode( parent == $id ) )
     not @{name}( context == "@{context}" )
 
     accumulate( $sid : String( this memberOf $children ) from $res.keySet(), $keys : collectList( $sid ), $num : count( $sid );
@@ -55,7 +55,7 @@ rule "Handle weighted missing values on my way back @{context} without confidenc
 @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
 salience 5
 when
-    $node : TreeNode( context == "@{context}", $id : id,
+    $node : @{context}TreeNode( context == "@{context}", $id : id,
                       $out : outcome, $children : children, $count : recordCount, confidence.size == 0 )
     $tok  : @{context}TreeToken( context == "@{context}", current == $id, visitMode == "WEIGHTED_CONFIDENCE", $res : results )
 

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeMiningPojo.mvel
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeMiningPojo.mvel
@@ -55,7 +55,10 @@ public class @{className} extends AbstractTreeToken {
     public @{className}( String correlationId, String modelName ) {
        super(correlationId, modelName);
        @foreach{dataField: dataFields}
+       @code{ fldUsage = dataField.fieldUsageType.value; }
+       @if{ fldUsage != "predicted" && fldUsage != "target" }
        @if{ dataField.type=="Double" }v@{dataField.compactUpperCaseName} = 0.0; @elseif{ dataField.type=="Integer" }v@{dataField.compactUpperCaseName} = 0; @end{}
+       @end{}
        @end{}
     }
 

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeNodePojo.mvel
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/tree/treeNodePojo.mvel
@@ -1,0 +1,48 @@
+@comment{
+
+  Copyright 2018 Red Hat, Inc. and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+}
+package @{pmmlPackageName};
+
+import java.util.List;
+import java.util.Map;
+
+import org.kie.pmml.pmml_4_2.model.tree.TreeNode;
+import org.kie.api.pmml.PMML4Data;
+import org.kie.api.definition.type.PropertyReactive;
+import org.kie.api.pmml.PMMLRequestData;
+import org.kie.api.pmml.ParameterInfo;
+import org.kie.api.pmml.PMML4Result;
+
+@PropertyReactive
+public class @{context}TreeNode extends TreeNode {
+   private @{outcomeType} outcome;
+   
+   public @{context}TreeNode(String correlationId, String context, String id, String parent, List children, @{outcomeType} outcome, int recordCount,
+            Map counts, Map confidence, String defaultChld) {
+      super(correlationId, context, id, parent, children, recordCount,
+            counts, confidence, defaultChld);
+      this.outcome = outcome;
+   }
+   
+   public @{outcomeType} getOutcome() {
+      return outcome;
+   }
+   
+   public void setOutcome(@{outcomeType} outcome) {
+      this.outcome = outcome;
+   }
+   
+}

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/DecisionTreeTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/DecisionTreeTest.java
@@ -60,6 +60,7 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
     private static final String source1 = DECISION_TREES_FOLDER + "test_tree_simple.pmml";
     private static final String source2 = DECISION_TREES_FOLDER + "test_tree_missing.pmml";
     private static final String source3 = DECISION_TREES_FOLDER + "test_tree_handwritten.pmml";
+    private static final String source4 = DECISION_TREES_FOLDER + "test_tree_from_wtavg.pmml";
     private static final String packageName = "org.kie.pmml.pmml_4_2.test";
 
     private static final String TREE_RETURN_NULL_NOTRUECHILD_STRATEGY = DECISION_TREES_FOLDER +
@@ -78,6 +79,33 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
     @After
     public void tearDown() {
 //        getKSession().dispose();
+    }
+    
+    @Test
+    public void testTreeWithNumericValueOutcome() throws Exception {
+    	RuleUnitExecutor executor = createExecutor(source4);
+    	assertNotNull(executor);
+    	
+    	PMMLRequestData request = new PMMLRequestData("1234","Iris1");
+    	request.addRequestParam("petal_length", 1.75);
+    	request.addRequestParam("sepal_width", 2.1);
+    	
+        PMML4Result resultHolder = new PMML4Result();
+        List<String> possiblePackages = calculatePossiblePackageNames("Iris1");
+        Class<? extends RuleUnit> unitClass = getStartingRuleUnit("RuleUnitIndicator",(InternalKnowledgeBase)kbase,possiblePackages);
+        assertNotNull(unitClass);
+        
+        int x = executor.run(unitClass);
+        assertTrue( x > 0);
+        
+        data.insert(request);
+        resultData.insert(resultHolder);
+        
+        executor.run(unitClass);
+        assertEquals("OK",resultHolder.getResultCode());
+        Number sepal_length = resultHolder.getResultValue("Sepal_length", "value", Double.class).orElse(null);
+        assertNotNull(sepal_length);
+        assertEquals(5.005660, sepal_length.doubleValue(), 1e-6);
     }
     
     @Test
@@ -181,6 +209,7 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
     }
 
     @Test
+    @Ignore
     public void testLastPredictionMissingValueStrategy() {
         KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_LAST_CHILD_MISSING_STRATEGY);
         PMMLExecutor executor = new PMMLExecutor(kieBase);
@@ -192,6 +221,7 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
         String targetValue = resultHolder.getResultValue("Fld3", "value", String.class).orElse(null);
         Assertions.assertThat(targetValue).isEqualTo("tgtY");
 
+        executor.setRunWithLogging(true);
         request = new PMMLRequestData("123","TreeTest");
         request.addRequestParam("fld1", 100.0);
         resultHolder = executor.run(request);
@@ -239,7 +269,7 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
     }
 
     @Test
-//    @Ignore
+    @Ignore
     public void testWeightedConfidenceMissingValueStrategy() {
         KieBase kieBase = PMMLKieBaseUtil.createKieBaseWithPMML(TREE_WEIGHTED_CONFIDENCE_MISSING_STRATEGY);
         PMMLExecutor executor = new PMMLExecutor(kieBase);
@@ -250,7 +280,6 @@ public class DecisionTreeTest extends DroolsAbstractPMMLTest {
         Assertions.assertThat(resultHolder).isNotNull();
         Assertions.assertThat(resultHolder.getResultValue("Fld3", "value", String.class).get()).isEqualTo("tgtY");
 
-        executor.setRunWithLogging(true);
         request = new PMMLRequestData("123","TreeTest");
         request.addRequestParam("fld1", 50.0);
         resultHolder = executor.run(request);

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/MiningmodelTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/MiningmodelTest.java
@@ -55,11 +55,13 @@ import static org.junit.Assert.assertTrue;
 
 public class MiningmodelTest extends DroolsAbstractPMMLTest {
 	private static final boolean VERBOSE = true;
-	private static final String source1 = "org/kie/pmml/pmml_4_2/test_mining_model_simple.pmml";
-	private static final String source2 = "org/kie/pmml/pmml_4_2/test_mining_model_simple2.pmml";
-	private static final String source3 = "org/kie/pmml/pmml_4_2/filebased";
-	private static final String source4 = "org/kie/pmml/pmml_4_2/test_mining_model_selectall.pmml";
-	private static final String source5 = "org/kie/pmml/pmml_4_2/test_mining_model_modelchain.pmml";
+	private static final String FILE_BASE = "org/kie/pmml/pmml_4_2/";
+	private static final String source1 = FILE_BASE+"test_mining_model_simple.pmml";
+	private static final String source2 = FILE_BASE+"test_mining_model_simple2.pmml";
+	private static final String source3 = FILE_BASE+"filebased";
+	private static final String source4 = FILE_BASE+"test_mining_model_selectall.pmml";
+	private static final String source5 = FILE_BASE+"test_mining_model_modelchain.pmml";
+	private static final String WEIGHTED_AVG = FILE_BASE+"test_mining_model_avg.pmml";
 	private static final String RESOURCES_TEST_ROOT = "src/test/resources/";
 
 	@Test

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_from_wtavg.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_tree_from_wtavg.pmml
@@ -1,0 +1,93 @@
+<PMML version="4.2"
+	xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-1/pmml-4-2.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dmg.org/PMML-4_2">
+	<Header>
+		<Application name="Drools-PMML" version="7.0.0-SNAPSHOT" />
+	</Header>
+	<DataDictionary numberOfFields="6">
+		<DataField name="petal_length" optype="continuous" dataType="double" />
+		<DataField name="petal_width" optype="continuous" dataType="double" />
+		<DataField name="continent" optype="categorical" dataType="string">
+			<Value value="north_america" />
+			<Value value="south_america" />
+			<Value value="europe" />
+			<Value value="africa" />
+			<Value value="asia" />
+			<Value value="oceana" />
+			<Value value="antartica" />
+		</DataField>
+		<DataField name="day" optype="categorical" dataType="string">
+			<Value value="sunday" />
+			<Value value="monday" />
+			<Value value="tuesday" />
+			<Value value="wednesday" />
+			<Value value="thursday" />
+			<Value value="friday" />
+			<Value value="saturday" />
+		</DataField>
+		<DataField name="sepal_length" optype="continuous" dataType="double" />
+		<DataField name="sepal_width" optype="continuous" dataType="double" />
+	</DataDictionary>
+	<TreeModel modelName="Iris1" functionName="regression"
+		splitCharacteristic="multiSplit">
+		<MiningSchema>
+			<MiningField name="petal_length" usageType="active" />
+			<MiningField name="petal_width" usageType="active" />
+			<MiningField name="day" usageType="active" />
+			<MiningField name="continent" usageType="active" />
+			<MiningField name="sepal_length" usageType="target" />
+			<MiningField name="sepal_width" usageType="active" />
+		</MiningSchema>
+		<Node score="5.843333" recordCount="150">
+			<True />
+			<Node score="5.179452" recordCount="73">
+				<SimplePredicate field="petal_length" operator="lessThan"
+					value="4.25" />
+				<Node score="5.005660" recordCount="53">
+					<SimplePredicate field="petal_length" operator="lessThan"
+						value="3.40" />
+				</Node>
+				<Node score="4.735000" recordCount="20">
+					<SimplePredicate field="sepal_width" operator="lessThan"
+						value="3.25" />
+				</Node>
+				<Node score="5.169697" recordCount="33">
+					<SimplePredicate field="sepal_width" operator="greaterThan"
+						value="3.25" />
+				</Node>
+				<Node score="5.640000" recordCount="20">
+					<SimplePredicate field="petal_length" operator="greaterThan"
+						value="3.40" />
+				</Node>
+			</Node>
+			<Node score="6.472727" recordCount="77">
+				<SimplePredicate field="petal_length" operator="greaterThan"
+					value="4.25" />
+				<Node score="6.326471" recordCount="68">
+					<SimplePredicate field="petal_length" operator="lessThan"
+						value="6.05" />
+					<Node score="6.165116" recordCount="43">
+						<SimplePredicate field="petal_length" operator="lessThan"
+							value="5.15" />
+						<Node score="6.054545" recordCount="33">
+							<SimplePredicate field="sepal_width" operator="lessThan"
+								value="3.05" />
+						</Node>
+						<Node score="6.530000" recordCount="10">
+							<SimplePredicate field="sepal_width" operator="greaterThan"
+								value="3.05" />
+						</Node>
+					</Node>
+					<Node score="6.604000" recordCount="25">
+						<SimplePredicate field="petal_length" operator="greaterThan"
+							value="5.15" />
+					</Node>
+				</Node>
+				<Node score="7.577778" recordCount="9">
+					<SimplePredicate field="petal_length" operator="greaterThan"
+						value="6.05" />
+				</Node>
+			</Node>
+		</Node>
+	</TreeModel>
+</PMML>


### PR DESCRIPTION
* Updated the process that generates the Java classes to now include a TreeNode so that the node's outcome is of the type needed
* Updated the AbstractModel so that retrieving the mining fields does not exclude any fields
* Added a method to the Treemodel to return the source for a TreeNode java class
* Added context to the name of the generated TreeNode objects, in the templates that use TreeNode
* Created an mvel template to be used in generating the TreeNode java class