### PR TITLE
DROOLS-2443 update publication URL for DMN XSD

### DIFF
--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DRGELEM_NOT_UNIQUE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DRGELEM_NOT_UNIQUE.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Message" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DROOLS-1447.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DROOLS-1447.dmn
@@ -17,7 +17,7 @@
 <definitions id="DROOLS-1447" name="DROOLS-1447"
   namespace="https://github.com/kiegroup/kie-dmn" xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
   xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+  xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <extensionElements />
   <decision id="_c7523fa1-22af-4673-8990-fdf920b35667" name="Decision Logic 1" >
     <variable id="_b1e4588e-9ce1-4474-8e4e-48dbcdb7524b" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_EMPTY_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_EMPTY_ENTRY.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="0004-simpletable-U">
     <variable name="0004-simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/FORMAL_PARAM_DUPLICATED.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/FORMAL_PARAM_DUPLICATED.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_INCONSISTENT_PARAM_NAMES.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_INCONSISTENT_PARAM_NAMES.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:string"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_EXPR.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:string"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGET.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGET.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGETbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGETbis.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_WRONG_PARAM_COUNT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_WRONG_PARAM_COUNT.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:string"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMCOMP_DUPLICATED.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMCOMP_DUPLICATED.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
       <typeRef>feel:number</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
       <typeRef>feel:number</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
       <typeRef>feel:number</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="code in list of codes" id="d_GreetingMessage">
         <variable name="code in list of codes" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID_bis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID_bis.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="code in list of codes" id="d_GreetingMessage">
         <variable name="code in list of codes" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_DUP_COLUMN.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_DUP_COLUMN.dmn
@@ -19,7 +19,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Employee Relation" id="d_EmployeeRelation">
     <variable name="Employee Relation" typeRef="feel:list"/>
     <relation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELLCOUNTMISMATCH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELLCOUNTMISMATCH.dmn
@@ -19,7 +19,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Employee Relation" id="d_EmployeeRelation">
     <variable name="Employee Relation" typeRef="feel:list"/>
     <relation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELL_NOTLITERAL.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELL_NOTLITERAL.dmn
@@ -19,7 +19,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Employee Relation" id="d_EmployeeRelation">
     <variable name="Employee Relation" typeRef="feel:list"/>
     <relation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <encapsulatedLogic>
       <literalExpression>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/UNKNOWN_VARIABLE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/UNKNOWN_VARIABLE.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <inputData id="_e026e26d-7806-45c8-811e-a4408eee8a31" name="Annual Salary">
     <variable id="_20d1791d-7df5-4579-b6af-ac235ec38c9e" name="Annual Salary" typeRef="feel:number"/>
   </inputData>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/VARIABLE_LEADING_TRAILING_SPACES.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/VARIABLE_LEADING_TRAILING_SPACES.dmn
@@ -22,7 +22,7 @@
     xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <itemDefinition label="Person" name="Person">
     <itemComponent id="_387b5a3c-484d-4de6-81bc-cad30986439c" name="Name">
       <typeRef>feel:string</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <literalExpression>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredAuthority href="#auth1"/> 

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredDecision href="#dec1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredInput href="#input1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredAuthority href="#auth1"/> 

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredDecision href="#dec1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredInput href="#input1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <textAnnotation id="someDecision1"/>
   <textAnnotation id="someDecision2"/>
   <organizationUnit name="someUnit1" id="someUnit1">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <textAnnotation id="someDecision1"/>
   <textAnnotation id="someDecision2"/>
   <organizationUnit name="someUnit1" id="someUnit1">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <textAnnotation id="someDecision1"/>
   <textAnnotation id="someDecision2"/>
   <performanceIndicator name="someIndicator" id="someIndicator">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISMATCH_VAR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_EXPR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_VAR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_DUP_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_DUP_ENTRY.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_NOTYPEREF.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_NOTYPEREF.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_ENTRIES.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_ENTRIES.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_EXPR.dmn
@@ -19,7 +19,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="a" id="d_a">
         <variable name="a" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="self" id="d_self">
         <variable name="self" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_DIAMOND.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_DIAMOND.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="a" id="d_a">
         <variable name="a" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_KITE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_KITE.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="a" id="d_a">
         <variable name="a" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <decisionMaker href="#someDecMaker1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <decisionOwner href="#someDecOwner1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISMATCH_VAR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Messageee" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_EXPR.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VAR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <informationRequirement>
             <requiredInput href="#i_FullName"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VARbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VARbis.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <informationRequirement>
             <requiredInput href="#i_FullName"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MULTIPLE_EXPRESSIONS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MULTIPLE_EXPRESSIONS.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <impactedPerformanceIndicator href="#someIndicator1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dmnelementref/ELEMREF_NOHASH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dmnelementref/ELEMREF_NOHASH.dmn
@@ -18,7 +18,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_DECISION.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_DECISION.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_INPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_INPUT.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISMATCH_VAR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Message" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISSING_VAR.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Message" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/invalidXml.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/invalidXml.dmn
@@ -20,6 +20,6 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <erroneousTag />
 </definitions>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_MISSING_BKM.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_MISSING_BKM.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <knowledgeRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <knowledgeRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <knowledgeSource name="knowSource1" id="knowSource1">
     <owner href="#owner1"/>
   </knowledgeSource>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn
@@ -20,7 +20,7 @@
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <knowledgeSource name="knowSource1" id="knowSource1">
     <owner href="#owner1"/>
   </knowledgeSource>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn
@@ -21,7 +21,7 @@
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:myns="http://about:blank"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <itemDefinition name="myns:tEmploymentStatus">
         <typeRef>feel:string</typeRef>
         <allowedValues>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn
@@ -21,7 +21,7 @@
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:tns="https://github.com/kiegroup/kie-dmn"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
   <itemDefinition name="tEligibility" isCollection="false">
     <typeRef>feel:string</typeRef>
     <allowedValues>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_FEEL_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_FEEL_TYPE.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <inputData name="Full Name" id="i_FullName">
         <variable name="Full Name" typeRef="feel:ssstringgg" /> <!-- TEST -->
     </inputData>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_NS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_NS.dmn
@@ -20,7 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
     <inputData name="Full Name" id="i_FullName">
         <variable name="Full Name" typeRef="nsUnexisting:asd" /> <!-- TEST already failing for XSD validation no valid QNAME -->
     </inputData>


### PR DESCRIPTION
URGENT

fix following
```
$ curl http://www.omg.org/spec/DMN/20151101/dmn.xsd
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<HTML><HEAD>
<TITLE>302 Found</TITLE>
</HEAD><BODY>
<H1>Found</H1>
The document has moved <A HREF="https://www.omg.org/spec/DMN/20151101/dmn.xsd">here</A>.<P>
<HR>
<ADDRESS>Apache/1.3.34 Server at <A HREF="mailto:webmaster@omg.org">www.omg.org</A> Port 80</ADDRESS>
</BODY></HTML>
```

/cc @etirelli @kurobako @baldimir @winklerm