### PR TITLE
DROOLS-2447 DMNValidator for schema to use an embed version of DMN XSD

### DIFF
--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
@@ -73,7 +73,7 @@ public class DMNValidatorImpl implements DMNValidator {
             schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
                                   .newSchema(new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20151101/dmn.xsd")));
         } catch (SAXException e) {
-            e.printStackTrace();
+            throw new RuntimeException("Unable to initialize correctly DMNValidator.", e);
         }
     }
     

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
@@ -70,7 +70,8 @@ public class DMNValidatorImpl implements DMNValidator {
     static Schema schema;
     static {
         try {
-            schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema();
+            schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                                  .newSchema(new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20151101/dmn.xsd")));
         } catch (SAXException e) {
             e.printStackTrace();
         }
@@ -258,7 +259,6 @@ public class DMNValidatorImpl implements DMNValidator {
             problems.add(new DMNMessageImpl( DMNMessage.Severity.ERROR, MsgUtil.createMessage( Msg.FAILED_XML_VALIDATION, e.getMessage() ), Msg.FAILED_XML_VALIDATION.getType(), null, e));
             logDebugMessages( problems );
         }
-        // TODO detect if the XSD is not provided through schemaLocation, and validate against embedded
         return problems;
     }
 

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20151101/dmn.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20151101/dmn.xsd
@@ -1,0 +1,438 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.omg.org/spec/DMN/20151101/dmn.xsd" elementFormDefault="qualified">
+	<xsd:element name="DMNElement" type="tDMNElement" abstract="true"/>
+	<xsd:complexType name="tDMNElement">
+		<xsd:sequence>
+			<xsd:element name="description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="extensionElements" minOccurs="0" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="label" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:element name="namedElement" type="tNamedElement" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tDMNElementReference">
+		<xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="definitions" type="tDefinitions" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="import" type="tImport" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="itemDefinition" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="drgElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="elementCollection" type="tElementCollection" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="businessContextElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/FEEL/20140401"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/FEEL/20140401"/>
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="exporter" type="xsd:string" use="optional"/>
+				<xsd:attribute name="exporterVersion" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="import" type="tImport"/>
+	<xsd:complexType name="tImport">
+		<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+		<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="elementCollection" type="tElementCollection" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tElementCollection">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="drgElement" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="drgElement" type="tDRGElement" abstract="true" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDRGElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decision" type="tDecision" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tDecision">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="question" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="allowedAnswers" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="informationRequirement" type="tInformationRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supportedObjective" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="impactedPerformanceIndicator" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionMaker" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwner" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingProcess" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingTask" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- decisionLogic -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessContextElement" type="tBusinessContextElement" abstract="true"/>
+	<xsd:complexType name="tBusinessContextElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="performanceIndicator" type="tPerformanceIndicator" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tPerformanceIndicator">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="impactingDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="organizationUnit" type="tOrganizationUnit" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tOrganizationUnit">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="decisionMade" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwned" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessKnowledgeModel" type="tBusinessKnowledgeModel" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tBusinessKnowledgeModel">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="encapsulatedLogic" type="tFunctionDefinition" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="inputData" type="tInputData" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInputData">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeSource" type="tKnowledgeSource" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tKnowledgeSource">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="owner" type="tDMNElementReference" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInformationRequirement">
+		<xsd:sequence>
+			<xsd:choice minOccurs="1" maxOccurs="1">
+				<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+				<xsd:element name="requiredInput" type="tDMNElementReference"/>
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="tKnowledgeRequirement">
+		<xsd:sequence>
+			<xsd:element name="requiredKnowledge" type="tDMNElementReference" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="tAuthorityRequirement">
+		<xsd:choice minOccurs="1" maxOccurs="1">
+			<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+			<xsd:element name="requiredInput" type="tDMNElementReference"/>
+			<xsd:element name="requiredAuthority" type="tDMNElementReference"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:element name="expression" type="tExpression" abstract="true"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="typeRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element name="typeRef" type="xsd:QName"/>
+						<xsd:element name="allowedValues" type="tUnaryTests" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:element name="itemComponent" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:choice>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="literalExpression" type="tLiteralExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tLiteralExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:element name="text" type="xsd:string"/>
+					<xsd:element name="importedValues" type="tImportedValues"/>
+				</xsd:choice>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocation" type="tInvocation" substitutionGroup="expression"/>
+	<xsd:complexType name="tInvocation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- calledFunction -->
+					<xsd:element ref="expression" minOccurs="0"/>
+					<xsd:element name="binding" type="tBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tBinding">
+		<xsd:sequence>
+			<xsd:element name="parameter" type="tInformationItem" minOccurs="1" maxOccurs="1"/>
+			<!-- bindingFormula -->
+			<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="informationItem" type="tInformationItem" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tInformationItem">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="typeRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionTable" type="tDecisionTable" substitutionGroup="expression"/>
+	<xsd:complexType name="tDecisionTable">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="input" type="tInputClause" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="output" type="tOutputClause" maxOccurs="unbounded"/>
+					<!-- NB: when the hit policy is FIRST or RULE ORDER, the ordering of the rules is significant and MUST be preserved -->
+					<xsd:element name="rule" type="tDecisionRule" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"/>
+				<xsd:attribute name="aggregation" type="tBuiltinAggregator" use="optional"/>
+				<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"/>
+				<xsd:attribute name="outputLabel" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tDecisionRule">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputEntry" type="tUnaryTests" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputEntry" type="tLiteralExpression" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tImportedValues">
+		<xsd:complexContent>
+			<xsd:extension base="tImport">
+				<xsd:sequence>
+					<xsd:element name="importedElement" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="artifact" type="tArtifact" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tArtifact">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="tDMNElementReference"/>
+					<xsd:element name="targetRef" type="tDMNElementReference"/>
+				</xsd:sequence>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tDecisionTableOrientation">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rule-as-Row"/>
+			<xsd:enumeration value="Rule-as-Column"/>
+			<xsd:enumeration value="CrossTable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tHitPolicy">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNIQUE"/>
+			<xsd:enumeration value="FIRST"/>
+			<xsd:enumeration value="PRIORITY"/>
+			<xsd:enumeration value="ANY"/>
+			<xsd:enumeration value="COLLECT"/>
+			<xsd:enumeration value="RULE ORDER"/>
+			<xsd:enumeration value="OUTPUT ORDER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tBuiltinAggregator">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SUM"/>
+			<xsd:enumeration value="COUNT"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="tOutputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="outputValues" type="tUnaryTests" minOccurs="0"/>
+					<xsd:element name="defaultOutputEntry" type="tLiteralExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="typeRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputExpression" type="tLiteralExpression"/>
+					<xsd:element name="inputValues" type="tUnaryTests" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="context" type="tContext" substitutionGroup="expression"/>
+	<xsd:complexType name="tContext">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="contextEntry" type="tContextEntry" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tContextEntry">
+		<xsd:sequence>
+			<xsd:element name="variable" type="tInformationItem" minOccurs="0" maxOccurs="1"/>
+			<!-- value -->
+			<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="functionDefinition" type="tFunctionDefinition" substitutionGroup="expression"/>
+	<xsd:complexType name="tFunctionDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="formalParameter" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- body -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="relation" type="tRelation" substitutionGroup="expression"/>
+	<xsd:complexType name="tRelation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="column" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="row" type="tList" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="list" type="tList" substitutionGroup="expression"/>
+	<xsd:complexType name="tList">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- element -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tUnaryTests">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tNamedElement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionService" type="tDecisionService" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDecisionService">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="outputDecision" type="tDMNElementReference" maxOccurs="unbounded"/>
+					<xsd:element name="encapsulatedDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputData" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -281,4 +281,18 @@ public class ValidatorTest extends AbstractValidatorTest {
         List<DMNMessage> validate = validator.validate(getReader("UsingSemanticNS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
     }
+
+    @Test
+    public void testUsingSemanticNamespacePrefixAndExtensions() {
+        // DROOLS-2447
+        List<DMNMessage> validate = validator.validate(getReader("Hello_World_semantic_namespace_with_extensions.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
+    @Test
+    public void testNoPrefixAndExtensions() {
+        // DROOLS-2447
+        List<DMNMessage> validate = validator.validate(getReader("Hello_World_no_prefix_with_extensions.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DRGELEM_NOT_UNIQUE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DRGELEM_NOT_UNIQUE.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Message" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DROOLS-1447.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DROOLS-1447.dmn
@@ -16,8 +16,7 @@
   -->
 <definitions id="DROOLS-1447" name="DROOLS-1447"
   namespace="https://github.com/kiegroup/kie-dmn" xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
-  xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+  xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <extensionElements />
   <decision id="_c7523fa1-22af-4673-8990-fdf920b35667" name="Decision Logic 1" >
     <variable id="_b1e4588e-9ce1-4474-8e4e-48dbcdb7524b" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_EMPTY_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_EMPTY_ENTRY.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="0004-simpletable-U">
     <variable name="0004-simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_PRIORITY_MISSING_OUTVALS.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/FORMAL_PARAM_DUPLICATED.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/FORMAL_PARAM_DUPLICATED.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/Hello_World_no_prefix_with_extensions.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/Hello_World_no_prefix_with_extensions.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+             xmlns:thismodel="http://www.trisotech.com/definitions/_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+             xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+             xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+             xmlns:trisofeed="http://trisotech.com/feed"
+             xmlns:drools="http://drools.org"
+             xmlns:kie="https://github.com/kiegroup/drools"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             exporter="DMN Modeler" exporterVersion="5.2.2"
+             id="_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+             name="Hello World semantic namespace"
+             namespace="http://www.trisotech.com/definitions/_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+             triso:logoChoice="Default">
+  <extensionElements>
+    <kie:mykieext a1="value_a1">
+      <drools:mydroolsext b1="value_b1">Hello Extensions</drools:mydroolsext>
+    </kie:mykieext> 
+  </extensionElements>
+  <itemDefinition label="tName" name="tName">
+    <typeRef>feel:string</typeRef>
+  </itemDefinition>
+  <inputData id="_e34ee32e-ebe8-40e4-9ed6-477ad50951a9" name="My Name" triso:displayName="My Name">
+    <variable id="_a0a3d084-e6e7-4bb8-8b52-c557ef0f43cb" name="My Name" typeRef="feel:string"/>
+  </inputData>
+  <decision id="_70b66b6b-931a-46bb-b9f0-e3e727322896" name="Hello Name" triso:displayName="Hello Name">
+    <variable id="_f2640616-bbba-4bbc-ac7e-2d3376e1c3de" name="Hello Name" typeRef="thismodel:tName"/>
+    <informationRequirement>
+      <requiredInput href="#_e34ee32e-ebe8-40e4-9ed6-477ad50951a9"/>
+    </informationRequirement>
+    <literalExpression id="_95ae7282-553f-4f29-9432-2e1d323d43b7">
+      <text>"Hello " + My Name</text>
+    </literalExpression>
+  </decision>
+</definitions>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/Hello_World_semantic_namespace_with_extensions.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/Hello_World_semantic_namespace_with_extensions.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+					  xmlns="http://www.trisotech.com/definitions/_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+					  xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+					  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+					  xmlns:trisofeed="http://trisotech.com/feed"
+                      xmlns:drools="http://drools.org"
+                      xmlns:kie="https://github.com/kiegroup/drools"
+					  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					  exporter="DMN Modeler" exporterVersion="5.2.2"
+					  id="_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+					  name="Hello World semantic namespace"
+					  namespace="http://www.trisotech.com/definitions/_f2695525-ffe9-4c96-a9ec-15c18e555f68"
+					  triso:logoChoice="Default">
+  <semantic:extensionElements>
+    <kie:mykieext a1="value_a1">
+      <drools:mydroolsext b1="value_b1">Hello Extensions</drools:mydroolsext>
+    </kie:mykieext> 
+  </semantic:extensionElements>
+  <semantic:itemDefinition label="tName" name="tName">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+  </semantic:itemDefinition>
+  <semantic:inputData id="_e34ee32e-ebe8-40e4-9ed6-477ad50951a9" name="My Name" triso:displayName="My Name">
+    <semantic:variable id="_a0a3d084-e6e7-4bb8-8b52-c557ef0f43cb" name="My Name" typeRef="feel:string"/>
+  </semantic:inputData>
+  <semantic:decision id="_70b66b6b-931a-46bb-b9f0-e3e727322896" name="Hello Name" triso:displayName="Hello Name">
+    <semantic:variable id="_f2640616-bbba-4bbc-ac7e-2d3376e1c3de" name="Hello Name" typeRef="tName"/>
+    <semantic:informationRequirement>
+      <semantic:requiredInput href="#_e34ee32e-ebe8-40e4-9ed6-477ad50951a9"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression id="_95ae7282-553f-4f29-9432-2e1d323d43b7">
+      <semantic:text>"Hello " + My Name</semantic:text>
+    </semantic:literalExpression>
+  </semantic:decision>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_INCONSISTENT_PARAM_NAMES.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_INCONSISTENT_PARAM_NAMES.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:string"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_EXPR.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:string"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGET.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGET.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGETbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_MISSING_TARGETbis.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_WRONG_PARAM_COUNT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/INVOCATION_WRONG_PARAM_COUNT.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:string"/>
         <invocation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMCOMP_DUPLICATED.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMCOMP_DUPLICATED.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
       <typeRef>feel:number</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
       <typeRef>feel:number</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/ITEMDEF_NOT_UNIQUE_DROOLS-1450.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
       <typeRef>feel:number</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/MortgageRecommender.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/MortgageRecommender.dmn
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns="http://www.trisotech.com/dmn/definitions/_2b51bb3a-9e6e-4054-9772-b37ea5b006aa" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="5.1.7.201703201809" id="_2b51bb3a-9e6e-4054-9772-b37ea5b006aa" name="Chapter 15 - Mortgage Recommender" namespace="http://www.trisotech.com/dmn/definitions/_2b51bb3a-9e6e-4054-9772-b37ea5b006aa" triso:logoChoice="Default">
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+                      xmlns="http://www.trisotech.com/dmn/definitions/_2b51bb3a-9e6e-4054-9772-b37ea5b006aa"
+                      xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+                      xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+                      xmlns:trisofeed="http://trisotech.com/feed"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      exporter="DMN Modeler" exporterVersion="5.1.7.201703201809" id="_2b51bb3a-9e6e-4054-9772-b37ea5b006aa"
+                      name="Chapter 15 - Mortgage Recommender"
+                      namespace="http://www.trisotech.com/dmn/definitions/_2b51bb3a-9e6e-4054-9772-b37ea5b006aa" triso:logoChoice="Default">
   <semantic:extensionElements>
     <triso:ProjectCharter>
       <projectDescription xmlns="">&lt;p&gt;Source: DMN Method &amp;amp; Style by Bruce Silver. Publication date: 2016.&lt;/p&gt;</projectDescription>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="code in list of codes" id="d_GreetingMessage">
         <variable name="code in list of codes" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID_bis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID_bis.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="code in list of codes" id="d_GreetingMessage">
         <variable name="code in list of codes" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_DUP_COLUMN.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_DUP_COLUMN.dmn
@@ -18,8 +18,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Employee Relation" id="d_EmployeeRelation">
     <variable name="Employee Relation" typeRef="feel:list"/>
     <relation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELLCOUNTMISMATCH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELLCOUNTMISMATCH.dmn
@@ -18,8 +18,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Employee Relation" id="d_EmployeeRelation">
     <variable name="Employee Relation" typeRef="feel:list"/>
     <relation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELL_NOTLITERAL.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/RELATION_ROW_CELL_NOTLITERAL.dmn
@@ -18,8 +18,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Employee Relation" id="d_EmployeeRelation">
     <variable name="Employee Relation" typeRef="feel:list"/>
     <relation>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <encapsulatedLogic>
       <literalExpression>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/UNKNOWN_VARIABLE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/UNKNOWN_VARIABLE.dmn
@@ -19,8 +19,7 @@
     namespace="https://www.drools.org/kie-dmn/definitions"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <inputData id="_e026e26d-7806-45c8-811e-a4408eee8a31" name="Annual Salary">
     <variable id="_20d1791d-7df5-4579-b6af-ac235ec38c9e" name="Annual Salary" typeRef="feel:number"/>
   </inputData>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/UsingSemanticNS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/UsingSemanticNS.dmn
@@ -7,7 +7,6 @@
                       xmlns:trisofeed="http://trisotech.com/feed"
                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                      xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd "
                       exporter="DMN Modeler" exporterVersion="6.0.5.2" id="_15be17d6-e30e-4c43-9fc8-1b3c271edcd8" name="Drawing 1"
                       namespace="http://www.trisotech.com/dmn/definitions/_15be17d6-e30e-4c43-9fc8-1b3c271edcd8" triso:logoChoice="Default">
   <semantic:extensionElements/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/VARIABLE_LEADING_TRAILING_SPACES.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/VARIABLE_LEADING_TRAILING_SPACES.dmn
@@ -21,8 +21,7 @@
     xmlns:kie="https://www.drools.org/kie-dmn/definitions"
     xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <itemDefinition label="Person" name="Person">
     <itemComponent id="_387b5a3c-484d-4de6-81bc-cad30986439c" name="Name">
       <typeRef>feel:string</typeRef>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <literalExpression>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredAuthority href="#auth1"/> 

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredDecision href="#dec1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredInput href="#input1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredAuthority href="#auth1"/> 

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredDecision href="#dec1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <businessKnowledgeModel name="bkm1">
     <authorityRequirement>
         <requiredInput href="#input1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <textAnnotation id="someDecision1"/>
   <textAnnotation id="someDecision2"/>
   <organizationUnit name="someUnit1" id="someUnit1">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <textAnnotation id="someDecision1"/>
   <textAnnotation id="someDecision2"/>
   <organizationUnit name="someUnit1" id="someUnit1">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <textAnnotation id="someDecision1"/>
   <textAnnotation id="someDecision2"/>
   <performanceIndicator name="someIndicator" id="someIndicator">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISMATCH_VAR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_EXPR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/businessknowledgemodel/BKM_MISSING_VAR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <businessKnowledgeModel name="Greeting Message" id="d_GreetingMessage">
         <encapsulatedLogic>
           <formalParameter name="Post-bureauAffordability" typeRef="feel:boolean"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_DUP_ENTRY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_DUP_ENTRY.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_NOTYPEREF.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_ENTRY_NOTYPEREF.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_ENTRIES.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_ENTRIES.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/context/CONTEXT_MISSING_EXPR.dmn
@@ -18,8 +18,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision id="d1" name="Decision1">
         <variable name="Decision1" typeRef="feel:context"/>
         <context>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="a" id="d_a">
         <variable name="a" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="self" id="d_self">
         <variable name="self" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_DIAMOND.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_DIAMOND.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="a" id="d_a">
         <variable name="a" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_KITE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DEADLY_KITE.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="a" id="d_a">
         <variable name="a" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <decisionMaker href="#someDecMaker1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <decisionOwner href="#someDecOwner1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISMATCH_VAR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Messageee" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_EXPR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_EXPR.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VAR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <informationRequirement>
             <requiredInput href="#i_FullName"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VARbis.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MISSING_VARbis.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <informationRequirement>
             <requiredInput href="#i_FullName"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MULTIPLE_EXPRESSIONS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_MULTIPLE_EXPRESSIONS.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision name="Greeting Message" id="d_GreetingMessage">
     <variable name="Greeting Message" typeRef="feel:string"/>
     <impactedPerformanceIndicator href="#someIndicator1"/>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dmnelementref/ELEMREF_NOHASH.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/dmnelementref/ELEMREF_NOHASH.dmn
@@ -17,8 +17,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_DECISION.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_DECISION.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_INPUT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/informationrequirement/INFOREQ_MISSING_INPUT.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISMATCH_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISMATCH_VAR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Message" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISSING_VAR.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/inputdata/INPUTDATA_MISSING_VAR.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <decision name="Greeting Message" id="d_GreetingMessage">
         <variable name="Greeting Message" typeRef="feel:string"/>
         <informationRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/invalidXml.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/invalidXml.dmn
@@ -19,7 +19,6 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <erroneousTag />
 </definitions>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_MISSING_BKM.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_MISSING_BKM.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <knowledgeRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <decision id="_0004-simpletable-U" name="simpletable-U">
     <variable name="simpletable-U" typeRef="feel:string"/>
     <knowledgeRequirement>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <knowledgeSource name="knowSource1" id="knowSource1">
     <owner href="#owner1"/>
   </knowledgeSource>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn
@@ -19,8 +19,7 @@
              namespace="https://github.com/kiegroup/kie-dmn"
              xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <knowledgeSource name="knowSource1" id="knowSource1">
     <owner href="#owner1"/>
   </knowledgeSource>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn
@@ -20,8 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:myns="http://about:blank"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:myns="http://about:blank">
     <itemDefinition name="myns:tEmploymentStatus">
         <typeRef>feel:string</typeRef>
         <allowedValues>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn
@@ -20,8 +20,7 @@
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
     xmlns:tns="https://github.com/kiegroup/kie-dmn"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <itemDefinition name="tEligibility" isCollection="false">
     <typeRef>feel:string</typeRef>
     <allowedValues>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_FEEL_TYPE.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_FEEL_TYPE.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <inputData name="Full Name" id="i_FullName">
         <variable name="Full Name" typeRef="feel:ssstringgg" /> <!-- TEST -->
     </inputData>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_NS.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/typeref/TYPEREF_NO_NS.dmn
@@ -19,8 +19,7 @@
     namespace="https://github.com/kiegroup/kie-dmn"
     xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
     xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd https://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <inputData name="Full Name" id="i_FullName">
         <variable name="Full Name" typeRef="nsUnexisting:asd" /> <!-- TEST already failing for XSD validation no valid QNAME -->
     </inputData>

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/validation.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/validation.dmn
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns="http://www.trisotech.com/definitions/_7cc1e1cc-cdc8-4afb-9ec1-d4e04d87156f" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="5.1.10" id="_7cc1e1cc-cdc8-4afb-9ec1-d4e04d87156f" name="t1. validation" namespace="http://www.trisotech.com/definitions/_7cc1e1cc-cdc8-4afb-9ec1-d4e04d87156f" triso:logoChoice="Default">
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+                      xmlns="http://www.trisotech.com/definitions/_7cc1e1cc-cdc8-4afb-9ec1-d4e04d87156f"
+                      xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+                      xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+                      xmlns:trisofeed="http://trisotech.com/feed"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="5.1.10" id="_7cc1e1cc-cdc8-4afb-9ec1-d4e04d87156f"
+                      name="t1. validation"
+                      namespace="http://www.trisotech.com/definitions/_7cc1e1cc-cdc8-4afb-9ec1-d4e04d87156f" triso:logoChoice="Default">
   <semantic:extensionElements/>
   <semantic:itemDefinition label="tRiskCategory" name="tRiskCategory">
     <semantic:typeRef>feel:string</semantic:typeRef>


### PR DESCRIPTION
With this change a DMNValidator called for schema validation, would always use the embedded version of the DMN XSD, rather than relying on the `xsi:schemaLocation` inside each single dmn model XML file (which the user could point actually at any xsd).

/cc @etirelli @baldimir @kurobako @winklerm