### PR TITLE
[6.5.x] [RHBRMS-3092] Wrong error message on KieScanner update

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -334,9 +334,9 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
             }
 
             if ( allUpdatesSucceeded ) {
-                log.error("Some errors occured while updating the following artifacts: " + updatedArtifacts);
-            } else {
                 log.info("The following artifacts have been updated: " + updatedArtifacts);
+            } else {
+                log.error("Some errors occured while updating the following artifacts: " + updatedArtifacts);
             }
             
             // show we catch exceptions here and shutdown the scanner if one happens?


### PR DESCRIPTION
(cherry picked from commit f702410978cbb44a37ccc67858aa08770ea1572e)