### PR TITLE
Remove org.eclipse.sisu.plexus since it seems not relevant in sourcecode

### DIFF
--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -139,16 +139,6 @@
       <artifactId>aether-transport-http</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.sisu</groupId>
-      <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.el</groupId>
-          <artifactId>javax.el-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
     </dependency>


### PR DESCRIPTION
This PR is trying to remove the potential  dependencies not referenced on org eclipse sisu plexus.  
I can't find the reference in source code and the eclipse sisu plexus is not able to rebuild from source. 