### PR TITLE
DROOLS-1663 fix parameter name dependency resolution for DT in Context

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -585,6 +585,7 @@ public class DMNEvaluatorCompiler {
                                               Msg.IMPORT_NOT_FOUND_FOR_NODE_MISSING_ALIAS,
                                               new QName(depEntry.getValue().getModelNamespace(), depEntry.getValue().getModelName()),
                                               node);
+                        return null;
                     }
                     parameterNames.add(importAlias.get() + "." + depEntry.getKey()); // this dependency is from an imported model, need to add parameter with "alias." DMN Import name prefix.
                 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -3,6 +3,7 @@ package org.kie.dmn.core.compiler;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -11,6 +12,7 @@ import javax.xml.namespace.QName;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNType;
 import org.kie.dmn.api.core.ast.BusinessKnowledgeModelNode;
+import org.kie.dmn.api.core.ast.DMNNode;
 import org.kie.dmn.api.core.ast.DecisionNode;
 import org.kie.dmn.core.api.DMNExpressionEvaluator;
 import org.kie.dmn.core.api.EvaluatorResult;
@@ -568,7 +570,25 @@ public class DMNEvaluatorCompiler {
             // need to break this statement down and check for nulls
             parameterNames.addAll( ((BusinessKnowledgeModelNode) node).getBusinessKnowledModel().getEncapsulatedLogic().getFormalParameter().stream().map( f -> f.getName() ).collect( toList() ) );
         } else {
-            parameterNames.addAll( node.getDependencies().keySet() );
+            for (Entry<String, DMNNode> depEntry : node.getDependencies().entrySet()) { // DROOLS-1663: dependencies names must be prefixed with "alias." for those not coming from this model but DMN Imports instead.
+                if (depEntry.getValue().getModelNamespace().equals(node.getModelNamespace())) {
+                    parameterNames.add(depEntry.getKey()); // this dependency is from this model, adding parameter name as-is.
+                } else {
+                    Optional<String> importAlias = model.getImportAliasFor(depEntry.getValue().getModelNamespace(), depEntry.getValue().getModelName());
+                    if (!importAlias.isPresent()) {
+                        MsgUtil.reportMessage(logger,
+                                              DMNMessage.Severity.ERROR,
+                                              dt.getParent(),
+                                              model,
+                                              null,
+                                              null,
+                                              Msg.IMPORT_NOT_FOUND_FOR_NODE_MISSING_ALIAS,
+                                              new QName(depEntry.getValue().getModelNamespace(), depEntry.getValue().getModelName()),
+                                              node);
+                    }
+                    parameterNames.add(importAlias.get() + "." + depEntry.getKey()); // this dependency is from an imported model, need to add parameter with "alias." DMN Import name prefix.
+                }
+            }
         }
 
         // creates a FEEL instance which will be used by the invoker/impl (s)

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -6,6 +6,7 @@ public final class Msg {
     // consolidated
     public static final Message2 UNSUPPORTED_ELEMENT                                 = new Message2( DMNMessageType.UNSUPPORTED_ELEMENT, "Element %s with type='%s' is not supported." );
     public static final Message2 IMPORT_NOT_FOUND_FOR_NODE                           = new Message2( DMNMessageType.IMPORT_NOT_FOUND, "Required import not found: %s for node '%s' " );
+    public static final Message2 IMPORT_NOT_FOUND_FOR_NODE_MISSING_ALIAS             = new Message2(DMNMessageType.IMPORT_NOT_FOUND, "Required import not found: %s for node '%s'; missing DMN Import name alias.");
     public static final Message2 REQ_INPUT_NOT_FOUND_FOR_NODE                        = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required input '%s' not found on node '%s'" );
     public static final Message2 REQ_DECISION_NOT_FOUND_FOR_NODE                     = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required Decision '%s' not found on node '%s'" );
     public static final Message2 REQ_BKM_NOT_FOUND_FOR_NODE                          = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required Business Knowledge Model '%s' not found on node '%s'" );

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -6,7 +6,7 @@ public final class Msg {
     // consolidated
     public static final Message2 UNSUPPORTED_ELEMENT                                 = new Message2( DMNMessageType.UNSUPPORTED_ELEMENT, "Element %s with type='%s' is not supported." );
     public static final Message2 IMPORT_NOT_FOUND_FOR_NODE                           = new Message2( DMNMessageType.IMPORT_NOT_FOUND, "Required import not found: %s for node '%s' " );
-    public static final Message2 IMPORT_NOT_FOUND_FOR_NODE_MISSING_ALIAS             = new Message2(DMNMessageType.IMPORT_NOT_FOUND, "Required import not found: %s for node '%s'; missing DMN Import name alias.");
+    public static final Message2 IMPORT_NOT_FOUND_FOR_NODE_MISSING_ALIAS             = new Message2( DMNMessageType.IMPORT_NOT_FOUND, "Required import not found: %s for node '%s'; missing DMN Import name alias." );
     public static final Message2 REQ_INPUT_NOT_FOUND_FOR_NODE                        = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required input '%s' not found on node '%s'" );
     public static final Message2 REQ_DECISION_NOT_FOUND_FOR_NODE                     = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required Decision '%s' not found on node '%s'" );
     public static final Message2 REQ_BKM_NOT_FOUND_FOR_NODE                          = new Message2( DMNMessageType.REQ_NOT_FOUND, "Required Business Knowledge Model '%s' not found on node '%s'" );

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.imports;
 
 import org.junit.Test;

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/imports/ImportsTest.java
@@ -1,0 +1,54 @@
+package org.kie.dmn.core.imports;
+
+import org.junit.Test;
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.core.util.DMNRuntimeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
+import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
+
+public class ImportsTest {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ImportsTest.class);
+
+    @Test
+    public void testImportDependenciesForDTInAContext() {
+        DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Imported_Model.dmn",
+                                                                                 this.getClass(),
+                                                                                 "Import_BKM_and_have_a_Decision_Ctx_with_DT.dmn");
+
+        DMNModel importedModel = runtime.getModel("http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36",
+                                                  "Imported Model");
+        assertThat(importedModel, notNullValue());
+        for (DMNMessage message : importedModel.getMessages()) {
+            LOG.debug("1 {}", message);
+        }
+
+        DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_c3e08836-7973-4e4d-af2b-d46b23725c13",
+                                             "Import BKM and have a Decision Ctx with DT");
+        assertThat(dmnModel, notNullValue());
+        for (DMNMessage message : dmnModel.getMessages()) {
+            LOG.debug("2 {}", message);
+        }
+
+        DMNContext context = runtime.newContext();
+        context.set("A Person", mapOf(entry("name", "John"), entry("age", 47)));
+
+        DMNResult evaluateAll = runtime.evaluateAll(dmnModel, context);
+        for (DMNMessage message : evaluateAll.getMessages()) {
+            LOG.debug("e {}", message);
+        }
+        LOG.debug("{}", evaluateAll);
+        assertThat(evaluateAll.getDecisionResultByName("A Decision Ctx with DT").getResult(), is("Respectfully, Hello John!"));
+    }
+
+}

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/imports/Import_BKM_and_have_a_Decision_Ctx_with_DT.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/imports/Import_BKM_and_have_a_Decision_Ctx_with_DT.dmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns="http://www.trisotech.com/definitions/_c3e08836-7973-4e4d-af2b-d46b23725c13" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:include1="http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.0.6.201804192120" id="_c3e08836-7973-4e4d-af2b-d46b23725c13" name="Import BKM and have a Decision Ctx with DT" namespace="http://www.trisotech.com/definitions/_c3e08836-7973-4e4d-af2b-d46b23725c13" triso:logoChoice="Default">
+  <semantic:extensionElements/>
+  <semantic:import xmlns:drools="http://www.drools.org/kie/dmn/1.1" drools:modelName="Imported Model" drools:name="myimport" importType="http://www.omg.org/spec/DMN1-2Alpha/20160929/MODEL" namespace="http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36" triso:fileId="eyJmIjp7InNrdSI6IjBmMzNjZmVhLTZkYTQtNDJjNS04MDM3LTRiYjJmNWJkYzc0YiIsIm5hbWUiOiJJbXBvcnRlZCBNb2RlbCJ9fQ==" triso:fileName="Matteo Mortari/Imported Model"/>
+  <semantic:inputData id="_9df2ca89-d100-4ba3-9a44-6a71cae5c001" name="A Person">
+    <semantic:variable id="_9e1f6cbc-584f-41f6-8748-97f579a3df43" name="A Person" typeRef="myimport.tPerson"/>
+  </semantic:inputData>
+  <semantic:decision id="_2d131943-c513-416b-acc6-6efe8fe01ba4" name="A Decision Ctx with DT">
+    <semantic:variable id="_1a9b6949-afac-4c9e-afcd-178d9f720f29" name="A Decision Ctx with DT"/>
+    <semantic:informationRequirement>
+      <semantic:requiredInput href="#_9df2ca89-d100-4ba3-9a44-6a71cae5c001"/>
+    </semantic:informationRequirement>
+    <semantic:knowledgeRequirement>
+      <semantic:requiredKnowledge href="http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36#_32543811-b499-4608-b784-6c6f294b1c58"/>
+    </semantic:knowledgeRequirement>
+    <semantic:context id="_6bffe0cf-17b5-4372-afeb-161d2378dfc6">
+      <semantic:contextEntry>
+        <semantic:variable id="_5459fb02-6003-4c75-9660-bd5dc8111e92" name="normal greeting"/>
+        <semantic:literalExpression id="_c6977a3f-f3e0-411f-a1fc-590db1b97958">
+          <semantic:text>myimport.Say Hello(A Person)</semantic:text>
+        </semantic:literalExpression>
+      </semantic:contextEntry>
+      <semantic:contextEntry>
+        <semantic:variable id="_2e57804f-68d1-4613-9cd5-2f9aa04c5d84" name="override greeting" typeRef="feel:string"/>
+        <semantic:decisionTable hitPolicy="UNIQUE" id="_beebc5ac-ba03-4330-b01a-9ced32ef17fe" outputLabel="override greeting">
+          <semantic:input id="_d7a3e1e5-15c6-4b83-9fe6-f4ab8ce4be1c">
+            <semantic:inputExpression typeRef="feel:number">
+              <semantic:text>A Person.age</semantic:text>
+            </semantic:inputExpression>
+          </semantic:input>
+          <semantic:output id="_22740ea7-5a3a-45a2-ba08-95f0f0d98eea"/>
+          <semantic:rule id="_5f3dad91-e3b0-483f-a259-c855a0e6d7d6">
+            <semantic:inputEntry id="_6fe43313-b225-4b78-aac1-bf90794b80fd">
+              <semantic:text>&lt;=30</semantic:text>
+            </semantic:inputEntry>
+            <semantic:outputEntry id="_25a3221c-9ee1-4b01-9b80-1553d376527e">
+              <semantic:text>normal greeting</semantic:text>
+            </semantic:outputEntry>
+          </semantic:rule>
+          <semantic:rule id="_b73ea436-a867-43c7-b164-222bc5d65ae3">
+            <semantic:inputEntry id="_c4f6a141-36c6-4e4c-b737-3dcafee8c60b">
+              <semantic:text>&gt;30</semantic:text>
+            </semantic:inputEntry>
+            <semantic:outputEntry id="_28977b5a-e0ba-4266-957d-dad963e4c7cf">
+              <semantic:text>"Respectfully, "+normal greeting</semantic:text>
+            </semantic:outputEntry>
+          </semantic:rule>
+        </semantic:decisionTable>
+      </semantic:contextEntry>
+      <semantic:contextEntry>
+        <semantic:literalExpression id="_67c0a864-cbb6-4fa7-a516-687778423717">
+          <semantic:text>override greeting</semantic:text>
+        </semantic:literalExpression>
+      </semantic:contextEntry>
+    </semantic:context>
+  </semantic:decision>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/imports/Imported_Model.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/imports/Imported_Model.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns="http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.0.3.201802231629" id="_f27bb64b-6fc7-4e1f-9848-11ba35e0df36" name="Imported Model" namespace="http://www.trisotech.com/definitions/_f27bb64b-6fc7-4e1f-9848-11ba35e0df36" triso:logoChoice="Default">
+  <semantic:extensionElements>
+    <drools:decisionServices xmlns:drools="http://www.drools.org/kie/dmn/1.1"/>
+  </semantic:extensionElements>
+  <semantic:itemDefinition label="tPerson" name="tPerson">
+    <semantic:itemComponent id="_9bb0759c-b3c1-482f-87f5-c047dc65cef0" name="name">
+      <semantic:typeRef>feel:string</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_929acc15-101c-4e49-9b11-494fff411e50" name="age">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+  </semantic:itemDefinition>
+  <semantic:businessKnowledgeModel id="_32543811-b499-4608-b784-6c6f294b1c58" name="Say Hello">
+    <semantic:encapsulatedLogic xmlns:drools="http://www.drools.org/kie/dmn/1.1" drools:kind="F" id="_acbb96c9-34a3-4628-8179-dfc5f583e695">
+      <semantic:formalParameter id="_4a626f74-2ecc-4759-b76a-04baec6b795d" name="Person" typeRef="tPerson"/>
+      <semantic:literalExpression id="_c173a894-3719-4d2f-a365-25850e217310">
+        <semantic:text>"Hello " + Person.name + "!"</semantic:text>
+      </semantic:literalExpression>
+    </semantic:encapsulatedLogic>
+    <semantic:variable id="_a8eb10e1-30e6-40d8-a564-a868f4e0af34" name="Say Hello" typeRef="feel:string"/>
+  </semantic:businessKnowledgeModel>
+</semantic:definitions>


### PR DESCRIPTION
node dependencies which are not coming from the same model, but from an
imported model, needs to be prefixed in the dependency-name with the
"alias." prefix with the DMN Import name used during import.

@etirelli : this should fix the problem reported by Simon.

/cc @baldimir @kurobako @winklerm