### PR TITLE
RHPAM-795 RHPAM-55 Register project classloaders as parallel capable

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
@@ -348,6 +348,10 @@ public class ProjectClassLoader extends ClassLoader implements KieTypeResolver {
         }
     }
 
+    protected void setInternalClassLoader(InternalTypesClassLoader classLoader) {
+        typesClassLoader = classLoader;
+    }
+
     public void setResourceProvider(ResourceProvider resourceProvider) {
         this.resourceProvider = resourceProvider;
     }
@@ -362,7 +366,7 @@ public class ProjectClassLoader extends ClassLoader implements KieTypeResolver {
         nonExistingClasses.addAll(other.nonExistingClasses);
     }
 
-    private InternalTypesClassLoader makeClassLoader() {
+    protected InternalTypesClassLoader makeClassLoader() {
         return ClassUtils.isAndroid() ?
                 (InternalTypesClassLoader) ClassUtils.instantiateObject(
                         "org.drools.android.DexInternalTypesClassLoader", null, this) :

--- a/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
+++ b/drools-core/src/main/java/org/drools/core/common/ProjectClassLoader.java
@@ -44,6 +44,10 @@ public class ProjectClassLoader extends ClassLoader implements KieTypeResolver {
 
     private static boolean isIBM_JVM = System.getProperty("java.vendor").toLowerCase().contains("ibm");
 
+    static {
+        registerAsParallelCapable();
+    }
+
     private Map<String, byte[]> store;
 
     private Map<String, ClassBytecode> definedTypes;
@@ -348,7 +352,10 @@ public class ProjectClassLoader extends ClassLoader implements KieTypeResolver {
         }
     }
 
-    protected void setInternalClassLoader(InternalTypesClassLoader classLoader) {
+    // WARNING: This is and should be used just for testing purposes.
+    // If not, dragons will come to the Earth, eat all cookies and
+    // hijack all kittens and puppies.
+    void setInternalClassLoader(InternalTypesClassLoader classLoader) {
         typesClassLoader = classLoader;
     }
 
@@ -366,7 +373,7 @@ public class ProjectClassLoader extends ClassLoader implements KieTypeResolver {
         nonExistingClasses.addAll(other.nonExistingClasses);
     }
 
-    protected InternalTypesClassLoader makeClassLoader() {
+    InternalTypesClassLoader makeClassLoader() {
         return ClassUtils.isAndroid() ?
                 (InternalTypesClassLoader) ClassUtils.instantiateObject(
                         "org.drools.android.DexInternalTypesClassLoader", null, this) :
@@ -409,6 +416,10 @@ public class ProjectClassLoader extends ClassLoader implements KieTypeResolver {
     }
 
     private static class DefaultInternalTypesClassLoader extends ClassLoader implements InternalTypesClassLoader {
+
+        static {
+            registerAsParallelCapable();
+        }
 
         private final ProjectClassLoader projectClassLoader;
 

--- a/drools-core/src/test/java/org/drools/core/common/ClassLoaderTest.java
+++ b/drools-core/src/test/java/org/drools/core/common/ClassLoaderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+public class ClassLoaderTest {
+
+    @Test
+    public void testParallelClassloading() {
+
+        final Integer THREAD_COUNT = 2;
+
+        final ClassLoader projectClassLoader = ProjectClassLoader.createProjectClassLoader();
+        final ClassLoader internalTypesClassLoader = (ClassLoader) ((ProjectClassLoader) projectClassLoader).makeClassLoader();
+
+        ((ProjectClassLoader) projectClassLoader).setInternalClassLoader((ProjectClassLoader.InternalTypesClassLoader) internalTypesClassLoader);
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        final List<Future> futures = new ArrayList<>();
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            if (i % 2 == 0) {
+                futures.add(executorService.submit(() -> {
+                    try {
+                        Class.forName("nonexistant", true, projectClassLoader);
+                    } catch (ClassNotFoundException e) {
+                        //
+                    }
+                }));
+            } else {
+                futures.add(executorService.submit(() -> {
+                    try {
+                        Class.forName("nonexistant", true, internalTypesClassLoader);
+                    } catch (ClassNotFoundException e) {
+                        //
+                    }
+                }));
+            }
+        }
+
+        for (int i = 1; i <= THREAD_COUNT; i++) {
+            System.out.println("Thread no: " + i);
+            try {
+                futures.get(i - 1).get();
+            } catch (final InterruptedException | ExecutionException e) {
+//
+            }
+        }
+    }
+
+}

--- a/drools-core/src/test/java/org/drools/core/common/ClassLoaderTest.java
+++ b/drools-core/src/test/java/org/drools/core/common/ClassLoaderTest.java
@@ -27,10 +27,10 @@ import org.junit.Test;
 
 public class ClassLoaderTest {
 
-    @Test
-    public void testParallelClassloading() {
+    @Test(timeout = 20000)
+    public void testParallelClassLoading() {
 
-        final Integer THREAD_COUNT = 2;
+        final Integer THREAD_COUNT = 100;
 
         final ClassLoader projectClassLoader = ProjectClassLoader.createProjectClassLoader();
         final ClassLoader internalTypesClassLoader = (ClassLoader) ((ProjectClassLoader) projectClassLoader).makeClassLoader();
@@ -61,11 +61,10 @@ public class ClassLoaderTest {
         }
 
         for (int i = 1; i <= THREAD_COUNT; i++) {
-            System.out.println("Thread no: " + i);
             try {
                 futures.get(i - 1).get();
             } catch (final InterruptedException | ExecutionException e) {
-//
+                // Nothing
             }
         }
     }


### PR DESCRIPTION
- This avoids the deadlock mentioned in https://issues.jboss.org/browse/RHPAM-795 and probably also the deadlock from RHPAM-55. 

@mariofusco @DuncanDoyle could you please review? 