### PR TITLE
[DROOLS-2495] NullPointerException in Declaration.getHashCode() when …

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/AccessorKey.java
+++ b/drools-core/src/main/java/org/drools/core/base/AccessorKey.java
@@ -44,7 +44,7 @@ public class AccessorKey
         final int PRIME = 31;
         int result = 1;
         result = PRIME * result + className.hashCode();
-        result = PRIME * result + ( (fieldName == null) ? 0 : fieldName.hashCode() );
+        result = PRIME * result + ( (this.fieldName == null) ? 0 : this.fieldName.hashCode() );
         result = PRIME * result + type.name().hashCode();
         this.hashCode = result;
     }


### PR DESCRIPTION
…getter in LHS and serialize/deserialize package
- Unit test and fix

The issue is caused by wrong AccessorKey.hashCode calculation (e.g. "Name" vs "name") so ReadAccessor is not found in ClassFieldAccessorStore.lookup during deserialization.
. 