### PR TITLE
[DROOLS-2517] NullPointerException in BaseClassFieldReader.writeExter…

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/MyUtil.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/MyUtil.java
@@ -1,0 +1,8 @@
+package org.drools.compiler;
+
+public class MyUtil {
+
+    public String transform(Object o) {
+        return o.toString() + "-san";
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/base/BaseClassFieldReader.java
+++ b/drools-core/src/main/java/org/drools/core/base/BaseClassFieldReader.java
@@ -193,7 +193,11 @@ abstract public class BaseClassFieldReader
     public void writeExternal(ObjectOutput out) throws IOException {
         out.writeInt( index );
         out.writeObject( valueType );
-        out.writeUTF( fieldType.getName() );
+        if (fieldType == null) {
+            out.writeUTF( "" );
+        } else {
+            out.writeUTF( fieldType.getName() );
+        }
     }
 
     public void readExternal(ObjectInput in) throws IOException,
@@ -202,12 +206,14 @@ abstract public class BaseClassFieldReader
         valueType = (ValueType) in.readObject();
         String clsName = in.readUTF();
 
-        try {
-            fieldType = in instanceof DroolsObjectInput ?
-                        ClassUtils.getClassFromName( clsName, false, ( (DroolsObjectInput) in ).getClassLoader() ) :
-                        ClassUtils.getClassFromName( clsName );
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException( e );
+        if (!clsName.isEmpty()) {
+            try {
+                fieldType = in instanceof DroolsObjectInput ?
+                            ClassUtils.getClassFromName( clsName, false, ( (DroolsObjectInput) in ).getClassLoader() ) :
+                            ClassUtils.getClassFromName( clsName );
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException( e );
+            }
         }
     }
 }


### PR DESCRIPTION
…nal() when a global method is used in LHS and serialize package
- Unit test and a fix candidate which doesn't look intrusive

The NPE is thrown because fieldType is null when MVELObjectClassFieldReader is created.