### PR TITLE
DROOLS-2520 Fix executors and threads handling in drools-compiler tests

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/factmodel/traits/TraitTest.java
@@ -4940,16 +4940,18 @@ public class TraitTest extends CommonTestMethodBase {
         int MAX_WAIT_SECONDS = 60;
 
         final ExecutorService executorService = Executors.newFixedThreadPool( MAX_THREADS );
-        for (int threadIndex = 0; threadIndex < MAX_THREADS; threadIndex++) {
-            executorService.execute(new TraitRulesThread(threadIndex, MAX_REPETITIONS, kbase.newKieSession()));
+        try {
+            for (int threadIndex = 0; threadIndex < MAX_THREADS; threadIndex++) {
+                executorService.execute(new TraitRulesThread(threadIndex, MAX_REPETITIONS, kbase.newKieSession()));
+            }
+        } finally {
+            executorService.shutdown();
+            executorService.awaitTermination(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
+            final List<Runnable> queuedTasks = executorService.shutdownNow();
+
+            assertEquals(0, queuedTasks.size());
+            assertEquals(true, executorService.isTerminated());
         }
-
-        executorService.shutdown();
-        executorService.awaitTermination(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
-        final List<Runnable> queuedTasks = executorService.shutdownNow();
-
-        assertEquals(0, queuedTasks.size());
-        assertEquals(true, executorService.isTerminated());
     }
 
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CalendarTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CalendarTest.java
@@ -73,17 +73,20 @@ public class CalendarTest {
         KieBase kbase = ks.newKieContainer(kbuilder.getKieModule().getReleaseId()).getKieBase();
 
         KieSession ksession = ks.newKieContainer(kbuilder.getKieModule().getReleaseId()).newKieSession();
+        try {
+            ArrayList<String> list = new ArrayList<>();
 
-        ArrayList<String> list = new ArrayList<String>();
+            ksession.getCalendars().set("weekend", WEEKEND);
+            ksession.getCalendars().set("weekday", WEEKDAY);
+            ksession.setGlobal("list", list);
 
-        ksession.getCalendars().set("weekend", WEEKEND);
-        ksession.getCalendars().set("weekday", WEEKDAY);
-        ksession.setGlobal("list", list);
+            ksession.fireAllRules();
+            ksession.dispose();
 
-        ksession.fireAllRules();
-        ksession.dispose();
-
-        assertEquals(1, list.size());
+            assertEquals(1, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     private static final org.kie.api.time.Calendar WEEKEND = new org.kie.api.time.Calendar() {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -138,20 +138,23 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString( rule );
         KieSession ksession = createKnowledgeSession(kbase);
-        Message msg = new Message();
-        Properties props = new Properties();
-        props.put("timestamp",
-                  new Integer(99));
-        props.put( "duration",
-                   new Integer( 52 ) );
-        msg.setProperties(props);
+        try {
+            Message msg = new Message();
+            Properties props = new Properties();
+            props.put("timestamp",
+                      new Integer(99));
+            props.put( "duration",
+                       new Integer( 52 ) );
+            msg.setProperties(props);
 
-        EventFactHandle efh = (EventFactHandle) ksession.insert( msg );
-        assertEquals( 98,
-                      efh.getStartTimestamp() );
-        assertEquals( 53,
-                      efh.getDuration() );
-
+            EventFactHandle efh = (EventFactHandle) ksession.insert( msg );
+            assertEquals( 98,
+                          efh.getStartTimestamp() );
+            assertEquals( 53,
+                          efh.getDuration() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -166,135 +169,147 @@ public class CepEspTest extends CommonTestMethodBase {
         
         KieBase kbase = loadKnowledgeBaseFromString( rule );
         KieSession ksession = createKnowledgeSession(kbase);
-        Message msg = new Message();
-        msg.setStartTime( new Timestamp( 10000 ) );
-        msg.setDuration( 1000l );
+        try {
+            Message msg = new Message();
+            msg.setStartTime( new Timestamp( 10000 ) );
+            msg.setDuration( 1000l );
 
-        EventFactHandle efh = (EventFactHandle) ksession.insert( msg );
-        assertEquals( 10000,
-                      efh.getStartTimestamp() );
-        assertEquals( 1000,
-                      efh.getDuration() );
+            EventFactHandle efh = (EventFactHandle) ksession.insert( msg );
+            assertEquals( 10000,
+                          efh.getStartTimestamp() );
+            assertEquals( 1000,
+                          efh.getDuration() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEventAssertion() throws Exception {
+    public void testEventAssertion() {
         KieBase kbase = loadKnowledgeBase( "test_CEP_SimpleEventAssertion.drl" );
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get("pseudo") );
         KieSession session = createKnowledgeSession(kbase, conf);
 
-        SessionPseudoClock clock = (SessionPseudoClock) session.<SessionClock>getSessionClock();
+        try {
+            SessionPseudoClock clock = session.getSessionClock();
 
-        final List results = new ArrayList();
+            final List results = new ArrayList();
 
-        session.setGlobal( "results",
-                           results );
+            session.setGlobal( "results",
+                               results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  10000 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  10010 );
-        StockTickInterface tick3 = new StockTick( 3,
-                                                  "ACME",
-                                                  10,
-                                                  10100 );
-        StockTickInterface tick4 = new StockTick( 4,
-                                                  "DROO",
-                                                  50,
-                                                  11000 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      10000 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      10010 );
+            StockTickInterface tick3 = new StockTick( 3,
+                                                      "ACME",
+                                                      10,
+                                                      10100 );
+            StockTickInterface tick4 = new StockTick( 4,
+                                                      "DROO",
+                                                      50,
+                                                      11000 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
-        clock.advanceTime( 30,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
-        clock.advanceTime( 20,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            clock.advanceTime( 30,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
+            clock.advanceTime( 20,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
-        assertNotNull( handle3 );
-        assertNotNull( handle4 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
+            assertNotNull( handle3 );
+            assertNotNull( handle4 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
 
-        session.fireAllRules();
+            session.fireAllRules();
 
-        assertEquals( 2,
-                      ((List) session.getGlobal( "results" )).size() );
+            assertEquals( 2,
+                          ((List) session.getGlobal( "results" )).size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testAnnotatedEventAssertion() throws Exception {
+    public void testAnnotatedEventAssertion() {
         KieBase kbase = loadKnowledgeBase( "test_CEP_SimpleAnnotatedEventAssertion.drl" );
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get("pseudo") );
         KieSession session = createKnowledgeSession(kbase, conf);
 
-        SessionPseudoClock clock = (SessionPseudoClock) session.<SessionClock>getSessionClock();
+        try {
+            SessionPseudoClock clock = session.getSessionClock();
 
-        final List results = new ArrayList();
+            final List results = new ArrayList();
 
-        session.setGlobal( "results",
-                           results );
+            session.setGlobal( "results",
+                               results );
 
-        StockTickInterface tick1 = new StockTickEvent( 1,
-                                                      "DROO",
-                                                      50,
-                                                      10000 );
-        StockTickInterface tick2 = new StockTickEvent( 2,
-                                                      "ACME",
-                                                      10,
-                                                      10010 );
-        StockTickInterface tick3 = new StockTickEvent( 3,
-                                                      "ACME",
-                                                      10,
-                                                      10100 );
-        StockTickInterface tick4 = new StockTickEvent( 4,
-                                                      "DROO",
-                                                      50,
-                                                      11000 );
+            StockTickInterface tick1 = new StockTickEvent( 1,
+                                                           "DROO",
+                                                           50,
+                                                           10000 );
+            StockTickInterface tick2 = new StockTickEvent( 2,
+                                                           "ACME",
+                                                           10,
+                                                           10010 );
+            StockTickInterface tick3 = new StockTickEvent( 3,
+                                                           "ACME",
+                                                           10,
+                                                           10100 );
+            StockTickInterface tick4 = new StockTickEvent( 4,
+                                                           "DROO",
+                                                           50,
+                                                           11000 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
-        clock.advanceTime( 30,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
-        clock.advanceTime( 20,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            clock.advanceTime( 30,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
+            clock.advanceTime( 20,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
-        assertNotNull( handle3 );
-        assertNotNull( handle4 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
+            assertNotNull( handle3 );
+            assertNotNull( handle4 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
 
-        session.fireAllRules();
+            session.fireAllRules();
 
-        assertEquals( 2,
-                      ((List) session.getGlobal( "results" )).size() );
+            assertEquals( 2,
+                          ((List) session.getGlobal( "results" )).size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -322,187 +337,196 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         KieSession session = createKnowledgeSession(kbase, conf);
 
-        final List<StockTick> results = new ArrayList<StockTick>();
+        try {
+            final List<StockTick> results = new ArrayList<StockTick>();
 
-        session.setGlobal( "results",
-                           results );
+            session.setGlobal( "results",
+                               results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  10000 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  10010 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      10000 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      10010 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
 
-        session.fireAllRules();
+            session.fireAllRules();
 
-        assertEquals( 1,
-                      results.size() );
-        assertEquals( tick2,
-                      results.get( 0 ) );
-
+            assertEquals( 1,
+                          results.size() );
+            assertEquals( tick2,
+                          results.get( 0 ) );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEventAssertionWithDuration() throws Exception {
+    public void testEventAssertionWithDuration() {
         KieBase kbase = loadKnowledgeBase( "test_CEP_SimpleEventAssertionWithDuration.drl" );
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession session = createKnowledgeSession(kbase, conf);
 
-        final List results = new ArrayList();
+        try {
+            final List results = new ArrayList();
 
-        session.setGlobal( "results",
-                      results );
+            session.setGlobal( "results",
+                               results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  10000,
-                                                  5 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  11000,
-                                                  10 );
-        StockTickInterface tick3 = new StockTick( 3,
-                                                  "ACME",
-                                                  10,
-                                                  12000,
-                                                  8 );
-        StockTickInterface tick4 = new StockTick( 4,
-                                                  "DROO",
-                                                  50,
-                                                  13000,
-                                                  7 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      10000,
+                                                      5 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      11000,
+                                                      10 );
+            StockTickInterface tick3 = new StockTick( 3,
+                                                      "ACME",
+                                                      10,
+                                                      12000,
+                                                      8 );
+            StockTickInterface tick4 = new StockTick( 4,
+                                                      "DROO",
+                                                      50,
+                                                      13000,
+                                                      7 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
-        assertNotNull( handle3 );
-        assertNotNull( handle4 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
+            assertNotNull( handle3 );
+            assertNotNull( handle4 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
 
-        EventFactHandle eh1 = (EventFactHandle) handle1;
-        EventFactHandle eh2 = (EventFactHandle) handle2;
-        EventFactHandle eh3 = (EventFactHandle) handle3;
-        EventFactHandle eh4 = (EventFactHandle) handle4;
+            EventFactHandle eh1 = (EventFactHandle) handle1;
+            EventFactHandle eh2 = (EventFactHandle) handle2;
+            EventFactHandle eh3 = (EventFactHandle) handle3;
+            EventFactHandle eh4 = (EventFactHandle) handle4;
 
-        assertEquals( tick1.getTime(),
-                      eh1.getStartTimestamp() );
-        assertEquals( tick2.getTime(),
-                      eh2.getStartTimestamp() );
-        assertEquals( tick3.getTime(),
-                      eh3.getStartTimestamp() );
-        assertEquals( tick4.getTime(),
-                      eh4.getStartTimestamp() );
+            assertEquals( tick1.getTime(),
+                          eh1.getStartTimestamp() );
+            assertEquals( tick2.getTime(),
+                          eh2.getStartTimestamp() );
+            assertEquals( tick3.getTime(),
+                          eh3.getStartTimestamp() );
+            assertEquals( tick4.getTime(),
+                          eh4.getStartTimestamp() );
 
-        assertEquals( tick1.getDuration(),
-                      eh1.getDuration() );
-        assertEquals( tick2.getDuration(),
-                      eh2.getDuration() );
-        assertEquals( tick3.getDuration(),
-                      eh3.getDuration() );
-        assertEquals( tick4.getDuration(),
-                      eh4.getDuration() );
+            assertEquals( tick1.getDuration(),
+                          eh1.getDuration() );
+            assertEquals( tick2.getDuration(),
+                          eh2.getDuration() );
+            assertEquals( tick3.getDuration(),
+                          eh3.getDuration() );
+            assertEquals( tick4.getDuration(),
+                          eh4.getDuration() );
 
-        session.fireAllRules();
+            session.fireAllRules();
 
-        assertEquals( 2,
-                      results.size() );
-
+            assertEquals( 2,
+                          results.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEventAssertionWithDateTimestamp() throws Exception {
+    public void testEventAssertionWithDateTimestamp() {
         KieBase kbase = loadKnowledgeBase( "test_CEP_SimpleEventAssertionWithDateTimestamp.drl" );
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession session = createKnowledgeSession(kbase, conf);
 
-        final List results = new ArrayList();
+        try {
+            final List results = new ArrayList();
 
-        session.setGlobal( "results",
-                      results );
+            session.setGlobal( "results",
+                               results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  10000,
-                                                  5 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  11000,
-                                                  10 );
-        StockTickInterface tick3 = new StockTick( 3,
-                                                  "ACME",
-                                                  10,
-                                                  12000,
-                                                  8 );
-        StockTickInterface tick4 = new StockTick( 4,
-                                                  "DROO",
-                                                  50,
-                                                  13000,
-                                                  7 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      10000,
+                                                      5 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      11000,
+                                                      10 );
+            StockTickInterface tick3 = new StockTick( 3,
+                                                      "ACME",
+                                                      10,
+                                                      12000,
+                                                      8 );
+            StockTickInterface tick4 = new StockTick( 4,
+                                                      "DROO",
+                                                      50,
+                                                      13000,
+                                                      7 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
-        assertNotNull( handle3 );
-        assertNotNull( handle4 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
+            assertNotNull( handle3 );
+            assertNotNull( handle4 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
 
-        EventFactHandle eh1 = (EventFactHandle) handle1;
-        EventFactHandle eh2 = (EventFactHandle) handle2;
-        EventFactHandle eh3 = (EventFactHandle) handle3;
-        EventFactHandle eh4 = (EventFactHandle) handle4;
+            EventFactHandle eh1 = (EventFactHandle) handle1;
+            EventFactHandle eh2 = (EventFactHandle) handle2;
+            EventFactHandle eh3 = (EventFactHandle) handle3;
+            EventFactHandle eh4 = (EventFactHandle) handle4;
 
-        assertEquals( tick1.getTime(),
-                      eh1.getStartTimestamp() );
-        assertEquals( tick2.getTime(),
-                      eh2.getStartTimestamp() );
-        assertEquals( tick3.getTime(),
-                      eh3.getStartTimestamp() );
-        assertEquals( tick4.getTime(),
-                      eh4.getStartTimestamp() );
+            assertEquals( tick1.getTime(),
+                          eh1.getStartTimestamp() );
+            assertEquals( tick2.getTime(),
+                          eh2.getStartTimestamp() );
+            assertEquals( tick3.getTime(),
+                          eh3.getStartTimestamp() );
+            assertEquals( tick4.getTime(),
+                          eh4.getStartTimestamp() );
 
-        session.fireAllRules();
+            session.fireAllRules();
 
-        assertEquals( 2,
-                      results.size() );
-
+            assertEquals( 2,
+                          results.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEventExpiration() throws Exception {
+    public void testEventExpiration() {
         KieBase kbase = loadKnowledgeBase( "test_CEP_EventExpiration.drl" );
 
         // read in the source
@@ -513,7 +537,7 @@ public class CepEspTest extends CommonTestMethodBase {
     }
 
     @Test(timeout=10000)
-    public void testEventExpiration2() throws Exception {
+    public void testEventExpiration2() {
         // read in the source
         KieBaseConfiguration kbc = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         kbc.setOption( EventProcessingOption.STREAM );
@@ -531,7 +555,7 @@ public class CepEspTest extends CommonTestMethodBase {
     }
 
     @Test(timeout=10000)
-    public void testEventExpiration3() throws Exception {
+    public void testEventExpiration3() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -548,7 +572,7 @@ public class CepEspTest extends CommonTestMethodBase {
     }
 
     @Test(timeout=10000)
-    public void testEventExpiration4() throws Exception {
+    public void testEventExpiration4() {
         // read in the source
         final KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -559,37 +583,41 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieSession ksession = createKnowledgeSession(kbase, sconf);
 
-        EntryPoint eventStream = ksession.getEntryPoint( "Event Stream" );
+        try {
+            EntryPoint eventStream = ksession.getEntryPoint( "Event Stream" );
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        final List results = new ArrayList();
-        ksession.setGlobal( "results",
-                            results );
+            final List results = new ArrayList();
+            ksession.setGlobal( "results",
+                                results );
 
-        EventFactHandle handle1 = (EventFactHandle) eventStream.insert( new StockTick( 1,
-                                                                                       "ACME",
-                                                                                       50,
-                                                                                       System.currentTimeMillis(),
-                                                                                       3 ) );
+            EventFactHandle handle1 = (EventFactHandle) eventStream.insert( new StockTick( 1,
+                                                                                           "ACME",
+                                                                                           50,
+                                                                                           System.currentTimeMillis(),
+                                                                                           3 ) );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        clock.advanceTime( 11,
-                           TimeUnit.SECONDS );
-        /** clock.advance() will put the event expiration in the queue to be executed, 
-            but it has to wait for a "thread" to do that
-            so we fire rules again here to get that
-            alternative could run fireUntilHalt() **/
-        ksession.fireAllRules();
+            clock.advanceTime( 11,
+                               TimeUnit.SECONDS );
+            /** clock.advance() will put the event expiration in the queue to be executed,
+             but it has to wait for a "thread" to do that
+             so we fire rules again here to get that
+             alternative could run fireUntilHalt() **/
+            ksession.fireAllRules();
 
-        assertTrue( results.size() == 1 );
-        assertTrue( handle1.isExpired() );
-        assertFalse( ksession.getFactHandles().contains( handle1 ) );
+            assertTrue( results.size() == 1 );
+            assertTrue( handle1.isExpired() );
+            assertFalse( ksession.getFactHandles().contains( handle1 ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testTimeRelationalOperators() throws Exception {
+    public void testTimeRelationalOperators() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -598,205 +626,207 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration sconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
-        
-        final PseudoClockScheduler clock = (PseudoClockScheduler) wm.getSessionClock();
 
-        clock.setStartupTime( 1000 );
-        final List results_coincides = new ArrayList();
-        final List results_before = new ArrayList();
-        final List results_after = new ArrayList();
-        final List results_meets = new ArrayList();
-        final List results_met_by = new ArrayList();
-        final List results_overlaps = new ArrayList();
-        final List results_overlapped_by = new ArrayList();
-        final List results_during = new ArrayList();
-        final List results_includes = new ArrayList();
-        final List results_starts = new ArrayList();
-        final List results_started_by = new ArrayList();
-        final List results_finishes = new ArrayList();
-        final List results_finished_by = new ArrayList();
+        try {
+            final PseudoClockScheduler clock = wm.getSessionClock();
 
-        wm.setGlobal( "results_coincides",
-                      results_coincides );
-        wm.setGlobal( "results_before",
-                      results_before );
-        wm.setGlobal( "results_after",
-                      results_after );
-        wm.setGlobal( "results_meets",
-                      results_meets );
-        wm.setGlobal( "results_met_by",
-                      results_met_by );
-        wm.setGlobal( "results_overlaps",
-                      results_overlaps );
-        wm.setGlobal( "results_overlapped_by",
-                      results_overlapped_by );
-        wm.setGlobal( "results_during",
-                      results_during );
-        wm.setGlobal( "results_includes",
-                      results_includes );
-        wm.setGlobal( "results_starts",
-                      results_starts );
-        wm.setGlobal( "results_started_by",
-                      results_started_by );
-        wm.setGlobal( "results_finishes",
-                      results_finishes );
-        wm.setGlobal( "results_finished_by",
-                      results_finished_by );
+            clock.setStartupTime( 1000 );
+            final List results_coincides = new ArrayList();
+            final List results_before = new ArrayList();
+            final List results_after = new ArrayList();
+            final List results_meets = new ArrayList();
+            final List results_met_by = new ArrayList();
+            final List results_overlaps = new ArrayList();
+            final List results_overlapped_by = new ArrayList();
+            final List results_during = new ArrayList();
+            final List results_includes = new ArrayList();
+            final List results_starts = new ArrayList();
+            final List results_started_by = new ArrayList();
+            final List results_finishes = new ArrayList();
+            final List results_finished_by = new ArrayList();
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  System.currentTimeMillis(),
-                                                  3 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis(),
-                                                  3 );
-        StockTickInterface tick3 = new StockTick( 3,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis(),
-                                                  3 );
-        StockTickInterface tick4 = new StockTick( 4,
-                                                  "DROO",
-                                                  50,
-                                                  System.currentTimeMillis(),
-                                                  5 );
-        StockTickInterface tick5 = new StockTick( 5,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis(),
-                                                  5 );
-        StockTickInterface tick6 = new StockTick( 6,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis(),
-                                                  3 );
-        StockTickInterface tick7 = new StockTick( 7,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis(),
-                                                  5 );
-        StockTickInterface tick8 = new StockTick( 8,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis(),
-                                                  3 );
+            wm.setGlobal( "results_coincides",
+                          results_coincides );
+            wm.setGlobal( "results_before",
+                          results_before );
+            wm.setGlobal( "results_after",
+                          results_after );
+            wm.setGlobal( "results_meets",
+                          results_meets );
+            wm.setGlobal( "results_met_by",
+                          results_met_by );
+            wm.setGlobal( "results_overlaps",
+                          results_overlaps );
+            wm.setGlobal( "results_overlapped_by",
+                          results_overlapped_by );
+            wm.setGlobal( "results_during",
+                          results_during );
+            wm.setGlobal( "results_includes",
+                          results_includes );
+            wm.setGlobal( "results_starts",
+                          results_starts );
+            wm.setGlobal( "results_started_by",
+                          results_started_by );
+            wm.setGlobal( "results_finishes",
+                          results_finishes );
+            wm.setGlobal( "results_finished_by",
+                          results_finished_by );
 
-        InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        InternalFactHandle handle3 = (InternalFactHandle) wm.insert( tick3 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        InternalFactHandle handle4 = (InternalFactHandle) wm.insert( tick4 );
-        InternalFactHandle handle5 = (InternalFactHandle) wm.insert( tick5 );
-        clock.advanceTime( 1,
-                           TimeUnit.MILLISECONDS );
-        InternalFactHandle handle6 = (InternalFactHandle) wm.insert( tick6 );
-        InternalFactHandle handle7 = (InternalFactHandle) wm.insert( tick7 );
-        clock.advanceTime( 2,
-                           TimeUnit.MILLISECONDS );
-        InternalFactHandle handle8 = (InternalFactHandle) wm.insert( tick8 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      System.currentTimeMillis(),
+                                                      3 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis(),
+                                                      3 );
+            StockTickInterface tick3 = new StockTick( 3,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis(),
+                                                      3 );
+            StockTickInterface tick4 = new StockTick( 4,
+                                                      "DROO",
+                                                      50,
+                                                      System.currentTimeMillis(),
+                                                      5 );
+            StockTickInterface tick5 = new StockTick( 5,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis(),
+                                                      5 );
+            StockTickInterface tick6 = new StockTick( 6,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis(),
+                                                      3 );
+            StockTickInterface tick7 = new StockTick( 7,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis(),
+                                                      5 );
+            StockTickInterface tick8 = new StockTick( 8,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis(),
+                                                      3 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
-        assertNotNull( handle3 );
-        assertNotNull( handle4 );
-        assertNotNull( handle5 );
-        assertNotNull( handle6 );
-        assertNotNull( handle7 );
-        assertNotNull( handle8 );
+            InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            InternalFactHandle handle3 = (InternalFactHandle) wm.insert( tick3 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            InternalFactHandle handle4 = (InternalFactHandle) wm.insert( tick4 );
+            InternalFactHandle handle5 = (InternalFactHandle) wm.insert( tick5 );
+            clock.advanceTime( 1,
+                               TimeUnit.MILLISECONDS );
+            InternalFactHandle handle6 = (InternalFactHandle) wm.insert( tick6 );
+            InternalFactHandle handle7 = (InternalFactHandle) wm.insert( tick7 );
+            clock.advanceTime( 2,
+                               TimeUnit.MILLISECONDS );
+            InternalFactHandle handle8 = (InternalFactHandle) wm.insert( tick8 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
-        assertTrue( handle6.isEvent() );
-        assertTrue( handle7.isEvent() );
-        assertTrue( handle8.isEvent() );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
+            assertNotNull( handle3 );
+            assertNotNull( handle4 );
+            assertNotNull( handle5 );
+            assertNotNull( handle6 );
+            assertNotNull( handle7 );
+            assertNotNull( handle8 );
 
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
+            assertTrue( handle6.isEvent() );
+            assertTrue( handle7.isEvent() );
+            assertTrue( handle8.isEvent() );
 
-        assertEquals( 1,
-                      results_coincides.size() );
-        assertEquals( tick5,
-                      results_coincides.get( 0 ) );
+            wm.fireAllRules();
 
-        assertEquals( 1,
-                      results_before.size() );
-        assertEquals( tick2,
-                      results_before.get( 0 ) );
+            assertEquals( 1,
+                          results_coincides.size() );
+            assertEquals( tick5,
+                          results_coincides.get( 0 ) );
 
-        assertEquals( 1,
-                      results_after.size() );
-        assertEquals( tick3,
-                      results_after.get( 0 ) );
+            assertEquals( 1,
+                          results_before.size() );
+            assertEquals( tick2,
+                          results_before.get( 0 ) );
 
-        assertEquals( 1,
-                      results_meets.size() );
-        assertEquals( tick3,
-                      results_meets.get( 0 ) );
+            assertEquals( 1,
+                          results_after.size() );
+            assertEquals( tick3,
+                          results_after.get( 0 ) );
 
-        assertEquals( 1,
-                      results_met_by.size() );
-        assertEquals( tick2,
-                      results_met_by.get( 0 ) );
+            assertEquals( 1,
+                          results_meets.size() );
+            assertEquals( tick3,
+                          results_meets.get( 0 ) );
 
-        assertEquals( 1,
-                      results_met_by.size() );
-        assertEquals( tick2,
-                      results_met_by.get( 0 ) );
+            assertEquals( 1,
+                          results_met_by.size() );
+            assertEquals( tick2,
+                          results_met_by.get( 0 ) );
 
-        assertEquals( 1,
-                      results_overlaps.size() );
-        assertEquals( tick4,
-                      results_overlaps.get( 0 ) );
+            assertEquals( 1,
+                          results_met_by.size() );
+            assertEquals( tick2,
+                          results_met_by.get( 0 ) );
 
-        assertEquals( 1,
-                      results_overlapped_by.size() );
-        assertEquals( tick8,
-                      results_overlapped_by.get( 0 ) );
+            assertEquals( 1,
+                          results_overlaps.size() );
+            assertEquals( tick4,
+                          results_overlaps.get( 0 ) );
 
-        assertEquals( 1,
-                      results_during.size() );
-        assertEquals( tick6,
-                      results_during.get( 0 ) );
+            assertEquals( 1,
+                          results_overlapped_by.size() );
+            assertEquals( tick8,
+                          results_overlapped_by.get( 0 ) );
 
-        assertEquals( 1,
-                      results_includes.size() );
-        assertEquals( tick4,
-                      results_includes.get( 0 ) );
+            assertEquals( 1,
+                          results_during.size() );
+            assertEquals( tick6,
+                          results_during.get( 0 ) );
 
-        assertEquals( 1,
-                      results_starts.size() );
-        assertEquals( tick6,
-                      results_starts.get( 0 ) );
+            assertEquals( 1,
+                          results_includes.size() );
+            assertEquals( tick4,
+                          results_includes.get( 0 ) );
 
-        assertEquals( 1,
-                      results_started_by.size() );
-        assertEquals( tick7,
-                      results_started_by.get( 0 ) );
+            assertEquals( 1,
+                          results_starts.size() );
+            assertEquals( tick6,
+                          results_starts.get( 0 ) );
 
-        assertEquals( 1,
-                      results_finishes.size() );
-        assertEquals( tick8,
-                      results_finishes.get( 0 ) );
+            assertEquals( 1,
+                          results_started_by.size() );
+            assertEquals( tick7,
+                          results_started_by.get( 0 ) );
 
-        assertEquals( 1,
-                      results_finished_by.size() );
-        assertEquals( tick7,
-                      results_finished_by.get( 0 ) );
+            assertEquals( 1,
+                          results_finishes.size() );
+            assertEquals( tick8,
+                          results_finishes.get( 0 ) );
 
+            assertEquals( 1,
+                          results_finished_by.size() );
+            assertEquals( tick7,
+                          results_finished_by.get( 0 ) );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testBeforeOperator() throws Exception {
+    public void testBeforeOperator() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -806,51 +836,55 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = createKnowledgeSession( kbase, sconf );
 
-        final PseudoClockScheduler clock = (PseudoClockScheduler) ksession.<SessionClock>getSessionClock();
-        clock.setStartupTime( 1000 );
+        try {
+            final PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.setStartupTime( 1000 );
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        StockTickInterface tick1 = new StockTick( 1, "DROO", 50, System.currentTimeMillis(), 3 );        
-        StockTickInterface tick2 = new StockTick( 2, "ACME", 10, System.currentTimeMillis(), 3 );
-        StockTickInterface tick3 = new StockTick( 3, "ACME", 10, System.currentTimeMillis(), 3 );
-        StockTickInterface tick4 = new StockTick( 4, "DROO", 50, System.currentTimeMillis(), 5 );
-        StockTickInterface tick5 = new StockTick( 5, "ACME", 10, System.currentTimeMillis(), 5 );
-        StockTickInterface tick6 = new StockTick( 6, "ACME", 10, System.currentTimeMillis(), 3 );
-        StockTickInterface tick7 = new StockTick( 7, "ACME", 10, System.currentTimeMillis(), 5 );
-        StockTickInterface tick8 = new StockTick( 8, "ACME", 10, System.currentTimeMillis(), 3 );
-        
+            StockTickInterface tick1 = new StockTick( 1, "DROO", 50, System.currentTimeMillis(), 3 );
+            StockTickInterface tick2 = new StockTick( 2, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick3 = new StockTick( 3, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick4 = new StockTick( 4, "DROO", 50, System.currentTimeMillis(), 5 );
+            StockTickInterface tick5 = new StockTick( 5, "ACME", 10, System.currentTimeMillis(), 5 );
+            StockTickInterface tick6 = new StockTick( 6, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick7 = new StockTick( 7, "ACME", 10, System.currentTimeMillis(), 5 );
+            StockTickInterface tick8 = new StockTick( 8, "ACME", 10, System.currentTimeMillis(), 3 );
 
-        ksession.insert( tick1 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick2 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick3 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick4 );
-        ksession.insert( tick5 );
-        clock.advanceTime( 1,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick6 );
-        ksession.insert( tick7 );
-        clock.advanceTime( 2,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick8 );
 
-        ksession.fireAllRules();
+            ksession.insert( tick1 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick2 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick3 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick4 );
+            ksession.insert( tick5 );
+            clock.advanceTime( 1,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick6 );
+            ksession.insert( tick7 );
+            clock.advanceTime( 2,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick8 );
 
-        assertEquals( 1, list.size() );
-        StockTick[] stocks = ( StockTick[] ) list.get(0);
-        assertSame( tick4, stocks[0]);
-        assertSame( tick2, stocks[1]);
+            ksession.fireAllRules();
+
+            assertEquals( 1, list.size() );
+            StockTick[] stocks = ( StockTick[] ) list.get(0);
+            assertSame( tick4, stocks[0]);
+            assertSame( tick2, stocks[1]);
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testComplexOperator() throws Exception {
+    public void testComplexOperator() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -860,43 +894,47 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = createKnowledgeSession( kbase, sconf );
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        final PseudoClockScheduler clock = (PseudoClockScheduler) ksession.<SessionClock>getSessionClock();
-        clock.setStartupTime( 1000 );
+            final PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.setStartupTime( 1000 );
 
-        AgendaEventListener ael = mock( AgendaEventListener.class );
-        ksession.addEventListener( ael );
+            AgendaEventListener ael = mock( AgendaEventListener.class );
+            ksession.addEventListener( ael );
 
-        StockTickInterface tick1 = new StockTick( 1, "DROO", 50, 0, 3 );
-        StockTickInterface tick2 = new StockTick( 2, "ACME", 10, 4, 3 );
-        StockTickInterface tick3 = new StockTick( 3, "ACME", 10, 8, 3 );
-        StockTickInterface tick4 = new StockTick( 4, "DROO", 50, 12, 5 );
-        StockTickInterface tick5 = new StockTick( 5, "ACME", 10, 12, 5 );
-        StockTickInterface tick6 = new StockTick( 6, "ACME", 10, 13, 3 );
-        StockTickInterface tick7 = new StockTick( 7, "ACME", 10, 13, 5 );
-        StockTickInterface tick8 = new StockTick( 8, "ACME", 10, 15, 3 );
+            StockTickInterface tick1 = new StockTick( 1, "DROO", 50, 0, 3 );
+            StockTickInterface tick2 = new StockTick( 2, "ACME", 10, 4, 3 );
+            StockTickInterface tick3 = new StockTick( 3, "ACME", 10, 8, 3 );
+            StockTickInterface tick4 = new StockTick( 4, "DROO", 50, 12, 5 );
+            StockTickInterface tick5 = new StockTick( 5, "ACME", 10, 12, 5 );
+            StockTickInterface tick6 = new StockTick( 6, "ACME", 10, 13, 3 );
+            StockTickInterface tick7 = new StockTick( 7, "ACME", 10, 13, 5 );
+            StockTickInterface tick8 = new StockTick( 8, "ACME", 10, 15, 3 );
 
-        ksession.insert( tick1 );
-        ksession.insert( tick2 );
-        ksession.insert( tick3 );
-        ksession.insert( tick4 );
-        ksession.insert( tick5 );
-        ksession.insert( tick6 );
-        ksession.insert( tick7 );
-        ksession.insert( tick8 );
+            ksession.insert( tick1 );
+            ksession.insert( tick2 );
+            ksession.insert( tick3 );
+            ksession.insert( tick4 );
+            ksession.insert( tick5 );
+            ksession.insert( tick6 );
+            ksession.insert( tick7 );
+            ksession.insert( tick8 );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        StockTick[] stocks = ( StockTick[] ) list.get(0);
-        assertSame( tick4, stocks[0]);
-        assertSame( tick2, stocks[1]);
+            assertEquals( 1, list.size() );
+            StockTick[] stocks = ( StockTick[] ) list.get(0);
+            assertSame( tick4, stocks[0]);
+            assertSame( tick2, stocks[1]);
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testMetByOperator() throws Exception {
+    public void testMetByOperator() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -906,50 +944,54 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = createKnowledgeSession( kbase, sconf );
 
-        final PseudoClockScheduler clock = (PseudoClockScheduler) ksession.<PseudoClockScheduler>getSessionClock();
-        clock.setStartupTime( 1000 );
+        try {
+            final PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.setStartupTime( 1000 );
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        StockTickInterface tick1 = new StockTick( 1, "DROO", 50, System.currentTimeMillis(), 3 );
-        StockTickInterface tick2 = new StockTick( 2, "ACME", 10, System.currentTimeMillis(), 3 );
-        StockTickInterface tick3 = new StockTick( 3, "ACME", 10, System.currentTimeMillis(), 3 );
-        StockTickInterface tick4 = new StockTick( 4, "DROO", 50, System.currentTimeMillis(), 5 );
-        StockTickInterface tick5 = new StockTick( 5, "ACME", 10, System.currentTimeMillis(), 5 );
-        StockTickInterface tick6 = new StockTick( 6, "ACME", 10, System.currentTimeMillis(), 3 );
-        StockTickInterface tick7 = new StockTick( 7, "ACME", 10, System.currentTimeMillis(), 5 );
-        StockTickInterface tick8 = new StockTick( 8, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick1 = new StockTick( 1, "DROO", 50, System.currentTimeMillis(), 3 );
+            StockTickInterface tick2 = new StockTick( 2, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick3 = new StockTick( 3, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick4 = new StockTick( 4, "DROO", 50, System.currentTimeMillis(), 5 );
+            StockTickInterface tick5 = new StockTick( 5, "ACME", 10, System.currentTimeMillis(), 5 );
+            StockTickInterface tick6 = new StockTick( 6, "ACME", 10, System.currentTimeMillis(), 3 );
+            StockTickInterface tick7 = new StockTick( 7, "ACME", 10, System.currentTimeMillis(), 5 );
+            StockTickInterface tick8 = new StockTick( 8, "ACME", 10, System.currentTimeMillis(), 3 );
 
-        InternalFactHandle fh1 = (InternalFactHandle) ksession.insert( tick1 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        InternalFactHandle fh2 = (InternalFactHandle) ksession.insert( tick2 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick3 );
-        clock.advanceTime( 4,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick4 );
-        ksession.insert( tick5 );
-        clock.advanceTime( 1,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick6 );
-        ksession.insert( tick7 );
-        clock.advanceTime( 2,
-                           TimeUnit.MILLISECONDS );
-        ksession.insert( tick8 );
+            InternalFactHandle fh1 = (InternalFactHandle) ksession.insert( tick1 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            InternalFactHandle fh2 = (InternalFactHandle) ksession.insert( tick2 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick3 );
+            clock.advanceTime( 4,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick4 );
+            ksession.insert( tick5 );
+            clock.advanceTime( 1,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick6 );
+            ksession.insert( tick7 );
+            clock.advanceTime( 2,
+                               TimeUnit.MILLISECONDS );
+            ksession.insert( tick8 );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        StockTick[] stocks = ( StockTick[] ) list.get(0);
-        assertSame( tick1, stocks[0]);
-        assertSame( tick2, stocks[1]);
+            assertEquals( 1, list.size() );
+            StockTick[] stocks = ( StockTick[] ) list.get(0);
+            assertSame( tick1, stocks[0]);
+            assertSame( tick2, stocks[1]);
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testAfterOnArbitraryDates() throws Exception {
+    public void testAfterOnArbitraryDates() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -959,49 +1001,53 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
 
-        final List< ? > results = new ArrayList<Object>();
+        try {
+            final List< ? > results = new ArrayList<Object>();
 
-        wm.setGlobal( "results",
-                      results );
+            wm.setGlobal( "results",
+                          results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  100000, // arbitrary timestamp
-                                                  3 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  104000, // 4 seconds after DROO
-                                                  3 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      100000, // arbitrary timestamp
+                                                      3 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      104000, // 4 seconds after DROO
+                                                      3 );
 
-        InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
-        InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
-        
+            InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
+            InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
 
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
 
-        assertEquals( 4,
-                      results.size() );
-        assertEquals( tick1,
-                      results.get( 0 ) );
-        assertEquals( tick2,
-                      results.get( 1 ) );
-        assertEquals( tick1,
-                      results.get( 2 ) );
-        assertEquals( tick2,
-                      results.get( 3 ) );
+            //        wm  = SerializationHelper.serializeObject(wm);
+            wm.fireAllRules();
+
+            assertEquals( 4,
+                          results.size() );
+            assertEquals( tick1,
+                          results.get( 0 ) );
+            assertEquals( tick2,
+                          results.get( 1 ) );
+            assertEquals( tick1,
+                          results.get( 2 ) );
+            assertEquals( tick2,
+                          results.get( 3 ) );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testBeforeOnArbitraryDates() throws Exception {
+    public void testBeforeOnArbitraryDates() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -1011,48 +1057,52 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
 
-        final List< ? > results = new ArrayList<Object>();
+        try {
+            final List< ? > results = new ArrayList<Object>();
 
-        wm.setGlobal( "results",
-                      results );
+            wm.setGlobal( "results",
+                          results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  104000, // arbitrary timestamp
-                                                  3 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  100000, // 4 seconds after DROO
-                                                  3 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      104000, // arbitrary timestamp
+                                                      3 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      100000, // 4 seconds after DROO
+                                                      3 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
-        InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
+            InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
+            InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
 
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            //        wm  = SerializationHelper.serializeObject(wm);
+            wm.fireAllRules();
 
-        assertEquals( 4,
-                      results.size() );
-        assertEquals( tick1,
-                      results.get( 0 ) );
-        assertEquals( tick2,
-                      results.get( 1 ) );
-        assertEquals( tick1,
-                      results.get( 2 ) );
-        assertEquals( tick2,
-                      results.get( 3 ) );
+            assertEquals( 4,
+                          results.size() );
+            assertEquals( tick1,
+                          results.get( 0 ) );
+            assertEquals( tick2,
+                          results.get( 1 ) );
+            assertEquals( tick1,
+                          results.get( 2 ) );
+            assertEquals( tick2,
+                          results.get( 3 ) );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testCoincidesOnArbitraryDates() throws Exception {
+    public void testCoincidesOnArbitraryDates() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -1062,48 +1112,52 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
 
-        final List< ? > results = new ArrayList<Object>();
+        try {
+            final List< ? > results = new ArrayList<Object>();
 
-        wm.setGlobal( "results",
-                      results );
+            wm.setGlobal( "results",
+                          results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  100000, // arbitrary timestamp
-                                                  3 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  100050, // 50 milliseconds after DROO
-                                                  3 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      100000, // arbitrary timestamp
+                                                      3 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      100050, // 50 milliseconds after DROO
+                                                      3 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
-        InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
+            InternalFactHandle handle1 = (InternalFactHandle) wm.insert( tick1 );
+            InternalFactHandle handle2 = (InternalFactHandle) wm.insert( tick2 );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
 
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            //        wm  = SerializationHelper.serializeObject(wm);
+            wm.fireAllRules();
 
-        assertEquals( 4,
-                      results.size() );
-        assertEquals( tick1,
-                      results.get( 0 ) );
-        assertEquals( tick2,
-                      results.get( 1 ) );
-        assertEquals( tick1,
-                      results.get( 2 ) );
-        assertEquals( tick2,
-                      results.get( 3 ) );
+            assertEquals( 4,
+                          results.size() );
+            assertEquals( tick1,
+                          results.get( 0 ) );
+            assertEquals( tick2,
+                          results.get( 1 ) );
+            assertEquals( tick1,
+                          results.get( 2 ) );
+            assertEquals( tick2,
+                          results.get( 3 ) );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testSimpleTimeWindow() throws Exception {
+    public void testSimpleTimeWindow() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -1113,129 +1167,132 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
 
-        List results = new ArrayList();
+        try {
+            List results = new ArrayList();
 
-        wm.setGlobal( "results",
-                      results );
+            wm.setGlobal( "results",
+                          results );
 
-        // how to initialize the clock?
-        // how to configure the clock?
-        SessionPseudoClock clock = (SessionPseudoClock) wm.getSessionClock();
+            // how to initialize the clock?
+            // how to configure the clock?
+            SessionPseudoClock clock = wm.getSessionClock();
 
-        clock.advanceTime( 5,
-                           TimeUnit.SECONDS ); // 5 seconds
-        EventFactHandle handle1 = (EventFactHandle) wm.insert( new OrderEvent( "1",
-                                                                               "customer A",
-                                                                               70 ) );
-        assertEquals( 5000,
-                      handle1.getStartTimestamp() );
-        assertEquals( 0,
-                      handle1.getDuration() );
+            clock.advanceTime( 5,
+                               TimeUnit.SECONDS ); // 5 seconds
+            EventFactHandle handle1 = (EventFactHandle) wm.insert( new OrderEvent( "1",
+                                                                                   "customer A",
+                                                                                   70 ) );
+            assertEquals( 5000,
+                          handle1.getStartTimestamp() );
+            assertEquals( 0,
+                          handle1.getDuration() );
 
-        //        wm  = SerializationHelper.getSerialisedStatefulSession( wm );
-        //        results = (List) wm.getGlobal( "results" );
-        //        clock = (SessionPseudoClock) wm.getSessionClock();
+            //        wm  = SerializationHelper.getSerialisedStatefulSession( wm );
+            //        results = (List) wm.getGlobal( "results" );
+            //        clock = (SessionPseudoClock) wm.getSessionClock();
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        assertEquals( 1,
-                      results.size() );
-        assertEquals( 70,
-                      ((Number) results.get( 0 )).intValue() );
+            assertEquals( 1,
+                          results.size() );
+            assertEquals( 70,
+                          ((Number) results.get( 0 )).intValue() );
 
-        // advance clock and assert new data
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS ); // 10 seconds
-        EventFactHandle handle2 = (EventFactHandle) wm.insert( new OrderEvent( "2",
-                                                                               "customer A",
-                                                                               60 ) );
-        assertEquals( 15000,
-                      handle2.getStartTimestamp() );
-        assertEquals( 0,
-                      handle2.getDuration() );
+            // advance clock and assert new data
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS ); // 10 seconds
+            EventFactHandle handle2 = (EventFactHandle) wm.insert( new OrderEvent( "2",
+                                                                                   "customer A",
+                                                                                   60 ) );
+            assertEquals( 15000,
+                          handle2.getStartTimestamp() );
+            assertEquals( 0,
+                          handle2.getDuration() );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        assertEquals( 2,
-                      results.size() );
-        assertEquals( 65,
-                      ((Number) results.get( 1 )).intValue() );
+            assertEquals( 2,
+                          results.size() );
+            assertEquals( 65,
+                          ((Number) results.get( 1 )).intValue() );
 
-        // advance clock and assert new data
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS ); // 10 seconds
-        EventFactHandle handle3 = (EventFactHandle) wm.insert( new OrderEvent( "3",
-                                                                               "customer A",
-                                                                               50 ) );
-        assertEquals( 25000,
-                      handle3.getStartTimestamp() );
-        assertEquals( 0,
-                      handle3.getDuration() );
+            // advance clock and assert new data
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS ); // 10 seconds
+            EventFactHandle handle3 = (EventFactHandle) wm.insert( new OrderEvent( "3",
+                                                                                   "customer A",
+                                                                                   50 ) );
+            assertEquals( 25000,
+                          handle3.getStartTimestamp() );
+            assertEquals( 0,
+                          handle3.getDuration() );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        assertEquals( 3,
-                      results.size() );
-        assertEquals( 60,
-                      ((Number) results.get( 2 )).intValue() );
+            assertEquals( 3,
+                          results.size() );
+            assertEquals( 60,
+                          ((Number) results.get( 2 )).intValue() );
 
-        // advance clock and assert new data
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS ); // 10 seconds
-        EventFactHandle handle4 = (EventFactHandle) wm.insert( new OrderEvent( "4",
-                                                                               "customer A",
-                                                                               25 ) );
-        assertEquals( 35000,
-                      handle4.getStartTimestamp() );
-        assertEquals( 0,
-                      handle4.getDuration() );
+            // advance clock and assert new data
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS ); // 10 seconds
+            EventFactHandle handle4 = (EventFactHandle) wm.insert( new OrderEvent( "4",
+                                                                                   "customer A",
+                                                                                   25 ) );
+            assertEquals( 35000,
+                          handle4.getStartTimestamp() );
+            assertEquals( 0,
+                          handle4.getDuration() );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        // first event should have expired, making average under the rule threshold, so no additional rule fire
-        assertEquals( 3,
-                      results.size() );
+            // first event should have expired, making average under the rule threshold, so no additional rule fire
+            assertEquals( 3,
+                          results.size() );
 
-        // advance clock and assert new data
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS ); // 10 seconds
-        EventFactHandle handle5 = (EventFactHandle) wm.insert( new OrderEvent( "5",
-                                                                               "customer A",
-                                                                               70 ) );
-        assertEquals( 45000,
-                      handle5.getStartTimestamp() );
-        assertEquals( 0,
-                      handle5.getDuration() );
+            // advance clock and assert new data
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS ); // 10 seconds
+            EventFactHandle handle5 = (EventFactHandle) wm.insert( new OrderEvent( "5",
+                                                                                   "customer A",
+                                                                                   70 ) );
+            assertEquals( 45000,
+                          handle5.getStartTimestamp() );
+            assertEquals( 0,
+                          handle5.getDuration() );
 
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            //        wm  = SerializationHelper.serializeObject(wm);
+            wm.fireAllRules();
 
-        // still under the threshold, so no fire
-        assertEquals( 3,
-                      results.size() );
+            // still under the threshold, so no fire
+            assertEquals( 3,
+                          results.size() );
 
-        // advance clock and assert new data
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS ); // 10 seconds
-        EventFactHandle handle6 = (EventFactHandle) wm.insert( new OrderEvent( "6",
-                                                                               "customer A",
-                                                                               115 ) );
-        assertEquals( 55000,
-                      handle6.getStartTimestamp() );
-        assertEquals( 0,
-                      handle6.getDuration() );
+            // advance clock and assert new data
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS ); // 10 seconds
+            EventFactHandle handle6 = (EventFactHandle) wm.insert( new OrderEvent( "6",
+                                                                                   "customer A",
+                                                                                   115 ) );
+            assertEquals( 55000,
+                          handle6.getStartTimestamp() );
+            assertEquals( 0,
+                          handle6.getDuration() );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        assertEquals( 4,
-                      results.size() );
-        assertEquals( 70,
-                      ((Number) results.get( 3 )).intValue() );
-
+            assertEquals( 4,
+                          results.size() );
+            assertEquals( 70,
+                          ((Number) results.get( 3 )).intValue() );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test (timeout=10000)
-    public void testSimpleLengthWindow() throws Exception {
+    public void testSimpleLengthWindow() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -1245,77 +1302,80 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
 
-        final List results = new ArrayList();
+        try {
+            final List results = new ArrayList();
 
-        wm.setGlobal( "results",
-                      results );
+            wm.setGlobal( "results",
+                          results );
 
-        EventFactHandle handle1 = (EventFactHandle) wm.insert( new OrderEvent( "1",
-                                                                               "customer A",
-                                                                               70 ) );
+            EventFactHandle handle1 = (EventFactHandle) wm.insert( new OrderEvent( "1",
+                                                                                   "customer A",
+                                                                                   70 ) );
 
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            //        wm  = SerializationHelper.serializeObject(wm);
+            wm.fireAllRules();
 
-        assertEquals( 1,
-                      results.size() );
-        assertEquals( 70,
-                      ((Number) results.get( 0 )).intValue() );
+            assertEquals( 1,
+                          results.size() );
+            assertEquals( 70,
+                          ((Number) results.get( 0 )).intValue() );
 
-        // assert new data
-        EventFactHandle handle2 = (EventFactHandle) wm.insert( new OrderEvent( "2",
-                                                                               "customer A",
-                                                                               60 ) );
-        wm.fireAllRules();
+            // assert new data
+            EventFactHandle handle2 = (EventFactHandle) wm.insert( new OrderEvent( "2",
+                                                                                   "customer A",
+                                                                                   60 ) );
+            wm.fireAllRules();
 
-        assertEquals( 2,
-                      results.size() );
-        assertEquals( 65,
-                      ((Number) results.get( 1 )).intValue() );
+            assertEquals( 2,
+                          results.size() );
+            assertEquals( 65,
+                          ((Number) results.get( 1 )).intValue() );
 
-        // assert new data
-        EventFactHandle handle3 = (EventFactHandle) wm.insert( new OrderEvent( "3",
-                                                                               "customer A",
-                                                                               50 ) );
-        wm.fireAllRules();
+            // assert new data
+            EventFactHandle handle3 = (EventFactHandle) wm.insert( new OrderEvent( "3",
+                                                                                   "customer A",
+                                                                                   50 ) );
+            wm.fireAllRules();
 
-        assertEquals( 3,
-                      results.size() );
-        assertEquals( 60,
-                      ((Number) results.get( 2 )).intValue() );
+            assertEquals( 3,
+                          results.size() );
+            assertEquals( 60,
+                          ((Number) results.get( 2 )).intValue() );
 
-        // assert new data
-        EventFactHandle handle4 = (EventFactHandle) wm.insert( new OrderEvent( "4",
-                                                                               "customer A",
-                                                                               25 ) );
-        wm.fireAllRules();
+            // assert new data
+            EventFactHandle handle4 = (EventFactHandle) wm.insert( new OrderEvent( "4",
+                                                                                   "customer A",
+                                                                                   25 ) );
+            wm.fireAllRules();
 
-        // first event should have expired, making average under the rule threshold, so no additional rule fire
-        assertEquals( 3,
-                      results.size() );
+            // first event should have expired, making average under the rule threshold, so no additional rule fire
+            assertEquals( 3,
+                          results.size() );
 
-        // assert new data
-        EventFactHandle handle5 = (EventFactHandle) wm.insert( new OrderEvent( "5",
-                                                                               "customer A",
-                                                                               70 ) );
-        //        wm  = SerializationHelper.serializeObject(wm);
-        wm.fireAllRules();
+            // assert new data
+            EventFactHandle handle5 = (EventFactHandle) wm.insert( new OrderEvent( "5",
+                                                                                   "customer A",
+                                                                                   70 ) );
+            //        wm  = SerializationHelper.serializeObject(wm);
+            wm.fireAllRules();
 
-        // still under the threshold, so no fire
-        assertEquals( 3,
-                      results.size() );
+            // still under the threshold, so no fire
+            assertEquals( 3,
+                          results.size() );
 
-        // assert new data
-        EventFactHandle handle6 = (EventFactHandle) wm.insert( new OrderEvent( "6",
-                                                                               "customer A",
-                                                                               115 ) );
-        wm.fireAllRules();
+            // assert new data
+            EventFactHandle handle6 = (EventFactHandle) wm.insert( new OrderEvent( "6",
+                                                                                   "customer A",
+                                                                                   115 ) );
+            wm.fireAllRules();
 
-        assertEquals( 4,
-                      results.size() );
-        assertEquals( 70,
-                      ((Number) results.get( 3 )).intValue() );
-
+            assertEquals( 4,
+                          results.size() );
+            assertEquals( 70,
+                          ((Number) results.get( 3 )).intValue() );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1329,58 +1389,61 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = createKnowledgeSession( kbase, sconf );
 
-        final List results = new ArrayList();
+        try {
+            final List results = new ArrayList();
 
-        ksession.setGlobal("results",
-                           results);
+            ksession.setGlobal("results",
+                               results);
 
-        EventFactHandle handle1 = (EventFactHandle) ksession.insert( new OrderEvent( "1", "customer A", 80 ) );
-        ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            EventFactHandle handle1 = (EventFactHandle) ksession.insert( new OrderEvent( "1", "customer A", 80 ) );
+            ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
 
-        // assert new data
-        EventFactHandle handle2 = (EventFactHandle) ksession.insert( new OrderEvent( "2", "customer A", 70 ) );
-        ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            // assert new data
+            EventFactHandle handle2 = (EventFactHandle) ksession.insert( new OrderEvent( "2", "customer A", 70 ) );
+            ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
-        // assert new data
-        EventFactHandle handle3 = (EventFactHandle) ksession.insert( new OrderEvent( "3", "customer A", 60 ) );
-        ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            // assert new data
+            EventFactHandle handle3 = (EventFactHandle) ksession.insert( new OrderEvent( "3", "customer A", 60 ) );
+            ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
-        // assert new data
-        EventFactHandle handle4 = (EventFactHandle) ksession.insert( new OrderEvent( "4", "customer A", 50 ) );
-        ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            // assert new data
+            EventFactHandle handle4 = (EventFactHandle) ksession.insert( new OrderEvent( "4", "customer A", 50 ) );
+            ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1,
-                      results.size() );
+            assertEquals( 1,
+                          results.size() );
 
-        assertEquals(60,
-                     ((Number) results.get(0)).intValue());
+            assertEquals(60,
+                         ((Number) results.get(0)).intValue());
 
-        // assert new data
-        EventFactHandle handle5 = (EventFactHandle) ksession.insert( new OrderEvent( "5", "customer A", 10 ) );
-        ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
+            // assert new data
+            EventFactHandle handle5 = (EventFactHandle) ksession.insert( new OrderEvent( "5", "customer A", 10 ) );
+            ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
 
-        assertEquals( 1,
-                      results.size() );
+            assertEquals( 1,
+                          results.size() );
 
-        EventFactHandle handle6 = (EventFactHandle) ksession.insert( new OrderEvent( "6", "customer A", 90 ) );
-        ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
+            EventFactHandle handle6 = (EventFactHandle) ksession.insert( new OrderEvent( "6", "customer A", 90 ) );
+            ksession  = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
 
-        assertEquals( 2,
-                      results.size() );
-        assertEquals( 50,
-                      ((Number) results.get( 1 )).intValue() );
-
+            assertEquals( 2,
+                          results.size() );
+            assertEquals( 50,
+                          ((Number) results.get( 1 )).intValue() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
 
 
     @Test(timeout=10000)
-    public void testDelayingNot() throws Exception {
+    public void testDelayingNot() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -1390,65 +1453,68 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
 
-        final RuleImpl rule = (RuleImpl) kbase.getRule( "org.drools.compiler", "Delaying Not" );
-        assertEquals( 10000,
-                      ((DurationTimer) rule.getTimer()).getDuration() );
+        try {
+            final RuleImpl rule = (RuleImpl) kbase.getRule( "org.drools.compiler", "Delaying Not" );
+            assertEquals( 10000,
+                          ((DurationTimer) rule.getTimer()).getDuration() );
 
-        final List results = new ArrayList();
+            final List results = new ArrayList();
 
-        wm.setGlobal( "results",
-                      results );
+            wm.setGlobal( "results",
+                          results );
 
-        SessionPseudoClock clock = (SessionPseudoClock) wm.getSessionClock();
+            SessionPseudoClock clock = wm.getSessionClock();
 
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
 
-        StockTickInterface st1O = new StockTick( 1,
-                                                 "DROO",
-                                                 100,
-                                                 clock.getCurrentTime() );
+            StockTickInterface st1O = new StockTick( 1,
+                                                     "DROO",
+                                                     100,
+                                                     clock.getCurrentTime() );
 
-        EventFactHandle st1 = (EventFactHandle) wm.insert( st1O );
+            EventFactHandle st1 = (EventFactHandle) wm.insert( st1O );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        // should not fire, because it must wait 10 seconds
-        assertEquals( 0,
-                      results.size() );
+            // should not fire, because it must wait 10 seconds
+            assertEquals( 0,
+                          results.size() );
 
-        clock.advanceTime( 5,
-                           TimeUnit.SECONDS );
+            clock.advanceTime( 5,
+                               TimeUnit.SECONDS );
 
-        EventFactHandle st2 = (EventFactHandle) wm.insert( new StockTick( 1,
-                                                                          "DROO",
-                                                                          80,
-                                                                          clock.getCurrentTime() ) );
+            EventFactHandle st2 = (EventFactHandle) wm.insert( new StockTick( 1,
+                                                                              "DROO",
+                                                                              80,
+                                                                              clock.getCurrentTime() ) );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        // should still not fire, because it must wait 5 more seconds, and st2 has lower price (80)
-        assertEquals( 0,
-                      results.size() );
-        // assert new data
-        wm.fireAllRules();
+            // should still not fire, because it must wait 5 more seconds, and st2 has lower price (80)
+            assertEquals( 0,
+                          results.size() );
+            // assert new data
+            wm.fireAllRules();
 
-        clock.advanceTime( 6,
-                           TimeUnit.SECONDS );
+            clock.advanceTime( 6,
+                               TimeUnit.SECONDS );
 
-        wm.fireAllRules();
+            wm.fireAllRules();
 
-        // should fire, because waited for 10 seconds and no other event arrived with a price increase
-        assertEquals( 1,
-                      results.size() );
+            // should fire, because waited for 10 seconds and no other event arrived with a price increase
+            assertEquals( 1,
+                          results.size() );
 
-        assertEquals( st1O,
-                      results.get( 0 ) );
-
+            assertEquals( st1O,
+                          results.get( 0 ) );
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testDelayingNot2() throws Exception {
+    public void testDelayingNot2() {
         String str = "package org.drools.compiler\n" +
                 "declare A @role(event) symbol : String end\n" +
                 "declare B @role(event) symbol : String end\n" +
@@ -1467,14 +1533,18 @@ public class CepEspTest extends CommonTestMethodBase {
         final KieBase kbase = loadKnowledgeBaseFromString( conf, str );
         
         KieSession ksession = createKnowledgeSession(kbase);
-        // rule X should not be delayed as the delay would be infinite
-        int rules = ksession.fireAllRules();
-        assertEquals( 2, rules );
+        try {
+            // rule X should not be delayed as the delay would be infinite
+            int rules = ksession.fireAllRules();
+            assertEquals( 2, rules );
+        } finally {
+            ksession.dispose();
+        }
         
     }
     
     @Test(timeout=10000)
-    public void testDelayingNotWithPreEpochClock() throws Exception {
+    public void testDelayingNotWithPreEpochClock() {
         String str = "package org.drools.compiler\n" +
                 "declare A @role(event) symbol : String end\n" +
                 "declare B @role(event) symbol : String end\n" +
@@ -1495,38 +1565,26 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = createKnowledgeSession(kbase, ksconf);
-        
-        // Getting a pre-epoch date (i.e., before 1970) 
-        Calendar ts = Calendar.getInstance();
-        ts.set( 1900, 1, 1 );
-        
-        // Initializing the clock to that date
-        SessionPseudoClock clock = ksession.getSessionClock();
-        clock.advanceTime( ts.getTimeInMillis(), TimeUnit.MILLISECONDS );
-        
-        // rule X should not be delayed as the delay would be infinite
-        int rules = ksession.fireAllRules();
-        assertEquals( 2, rules );
-        
+
+        try {
+            // Getting a pre-epoch date (i.e., before 1970)
+            Calendar ts = Calendar.getInstance();
+            ts.set( 1900, 1, 1 );
+
+            // Initializing the clock to that date
+            SessionPseudoClock clock = ksession.getSessionClock();
+            clock.advanceTime( ts.getTimeInMillis(), TimeUnit.MILLISECONDS );
+
+            // rule X should not be delayed as the delay would be infinite
+            int rules = ksession.fireAllRules();
+            assertEquals( 2, rules );
+        } finally {
+            ksession.dispose();
+        }
     }
-    
-    //    @Test(timeout=10000) @Ignore
-    //    public void testTransactionCorrelation() throws Exception {
-    //        // read in the source
-    //        final Reader reader = new InputStreamReader( getClass().getResourceAsStream( "test_TransactionCorrelation.drl" ) );
-    //        final RuleBase ruleBase = loadRuleBase( reader );
-    //
-    //        final WorkingMemory wm = ruleBase.newStatefulSession();
-    //        final List results = new ArrayList();
-    //
-    //        wm.setGlobal( "results",
-    //                      results );
-    //
-    //
-    //    }
 
     @Test(timeout=10000)
-    public void testIdleTime() throws Exception {
+    public void testIdleTime() {
         // read in the source
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( ResourceFactory.newInputStreamResource( getClass().getResourceAsStream( "test_CEP_SimpleEventAssertion.drl" ) ),
@@ -1538,80 +1596,83 @@ public class CepEspTest extends CommonTestMethodBase {
         conf.setOption( ClockTypeOption.get( "pseudo" ) );
         StatefulKnowledgeSessionImpl session = (StatefulKnowledgeSessionImpl)createKnowledgeSession(kbase, conf);
 
-        SessionPseudoClock clock = (SessionPseudoClock) session.getSessionClock();
+        try {
+            SessionPseudoClock clock = (SessionPseudoClock) session.getSessionClock();
 
-        final List results = new ArrayList();
+            final List results = new ArrayList();
 
-        session.setGlobal( "results",
-                           results );
+            session.setGlobal( "results",
+                               results );
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  10000 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  10010 );
-        StockTickInterface tick3 = new StockTick( 3,
-                                                  "ACME",
-                                                  10,
-                                                  10100 );
-        StockTickInterface tick4 = new StockTick( 4,
-                                                  "DROO",
-                                                  50,
-                                                  11000 );
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      10000 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      10010 );
+            StockTickInterface tick3 = new StockTick( 3,
+                                                      "ACME",
+                                                      10,
+                                                      10100 );
+            StockTickInterface tick4 = new StockTick( 4,
+                                                      "DROO",
+                                                      50,
+                                                      11000 );
 
-        assertEquals( 0,
-                      session.getIdleTime() );
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
-        assertEquals( 10000,
-                      session.getIdleTime() );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
-        assertEquals( 0,
-                      session.getIdleTime() );
-        clock.advanceTime( 15,
-                           TimeUnit.SECONDS );
-        assertEquals( 15000,
-                      session.getIdleTime() );
-        clock.advanceTime( 15,
-                           TimeUnit.SECONDS );
-        assertEquals( 30000,
-                      session.getIdleTime() );
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
-        assertEquals( 0,
-                      session.getIdleTime() );
-        clock.advanceTime( 20,
-                           TimeUnit.SECONDS );
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
-        clock.advanceTime( 10,
-                           TimeUnit.SECONDS );
+            assertEquals( 0,
+                          session.getIdleTime() );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
+            assertEquals( 10000,
+                          session.getIdleTime() );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            assertEquals( 0,
+                          session.getIdleTime() );
+            clock.advanceTime( 15,
+                               TimeUnit.SECONDS );
+            assertEquals( 15000,
+                          session.getIdleTime() );
+            clock.advanceTime( 15,
+                               TimeUnit.SECONDS );
+            assertEquals( 30000,
+                          session.getIdleTime() );
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
+            assertEquals( 0,
+                          session.getIdleTime() );
+            clock.advanceTime( 20,
+                               TimeUnit.SECONDS );
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
+            clock.advanceTime( 10,
+                               TimeUnit.SECONDS );
 
-        assertNotNull( handle1 );
-        assertNotNull( handle2 );
-        assertNotNull( handle3 );
-        assertNotNull( handle4 );
+            assertNotNull( handle1 );
+            assertNotNull( handle2 );
+            assertNotNull( handle3 );
+            assertNotNull( handle4 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
 
-        assertEquals( 10000,
-                      session.getIdleTime() );
-        session.fireAllRules();
-        assertEquals( 0,
-                      session.getIdleTime() );
+            assertEquals( 10000,
+                          session.getIdleTime() );
+            session.fireAllRules();
+            assertEquals( 0,
+                          session.getIdleTime() );
 
-        assertEquals( 2,
-                      ((List) session.getGlobal( "results" )).size() );
-
+            assertEquals( 2,
+                          ((List) session.getGlobal( "results" )).size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testIdleTimeAndTimeToNextJob() throws Exception {
+    public void testIdleTimeAndTimeToNextJob() {
         // read in the source
         KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         conf.setOption( EventProcessingOption.STREAM );
@@ -1621,116 +1682,120 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         StatefulKnowledgeSessionImpl wm = (StatefulKnowledgeSessionImpl)createKnowledgeSession( kbase, sconf );
 
-        WorkingMemoryFileLogger logger = new WorkingMemoryFileLogger( (WorkingMemory) wm );
-        File testTmpDir = new File( "target/test-tmp/" );
-        testTmpDir.mkdirs();
-        logger.setFileName( "target/test-tmp/testIdleTimeAndTimeToNextJob-audit" );
-
         try {
-            List results = new ArrayList();
+            WorkingMemoryFileLogger logger = new WorkingMemoryFileLogger( (WorkingMemory) wm );
+            File testTmpDir = new File( "target/test-tmp/" );
+            testTmpDir.mkdirs();
+            logger.setFileName( "target/test-tmp/testIdleTimeAndTimeToNextJob-audit" );
 
-            wm.setGlobal( "results",
-                          results );
+            try {
+                List results = new ArrayList();
 
-            // how to initialize the clock?
-            // how to configure the clock?
-            SessionPseudoClock clock = (SessionPseudoClock) wm.getSessionClock();
-            clock.advanceTime( 5,
-                               TimeUnit.SECONDS ); // 5 seconds
+                wm.setGlobal( "results",
+                              results );
 
-            // there is no next job, so returns -1
-            assertEquals( -1,
-                          wm.getTimeToNextJob() );
-            wm.insert( new OrderEvent( "1",
-                                       "customer A",
-                                       70 ) );
-            wm.fireAllRules();
-            assertEquals( 0,
-                          wm.getIdleTime() );
-            // now, there is a next job in 30 seconds: expire the event
-            assertEquals( 30000,
-                          wm.getTimeToNextJob() );
+                // how to initialize the clock?
+                // how to configure the clock?
+                SessionPseudoClock clock = (SessionPseudoClock) wm.getSessionClock();
+                clock.advanceTime( 5,
+                                   TimeUnit.SECONDS ); // 5 seconds
 
-            wm.fireAllRules();
-            assertEquals( 1,
-                          results.size() );
-            assertEquals( 70,
-                          ((Number) results.get( 0 )).intValue() );
+                // there is no next job, so returns -1
+                assertEquals( -1,
+                              wm.getTimeToNextJob() );
+                wm.insert( new OrderEvent( "1",
+                                           "customer A",
+                                           70 ) );
+                wm.fireAllRules();
+                assertEquals( 0,
+                              wm.getIdleTime() );
+                // now, there is a next job in 30 seconds: expire the event
+                assertEquals( 30000,
+                              wm.getTimeToNextJob() );
 
-            // advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
-            // next job is in 20 seconds: expire the event
-            assertEquals( 20000,
-                          wm.getTimeToNextJob() );
+                wm.fireAllRules();
+                assertEquals( 1,
+                              results.size() );
+                assertEquals( 70,
+                              ((Number) results.get( 0 )).intValue() );
 
-            wm.insert( new OrderEvent( "2",
-                                       "customer A",
-                                       60 ) );
-            wm.fireAllRules();
+                // advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                // next job is in 20 seconds: expire the event
+                assertEquals( 20000,
+                              wm.getTimeToNextJob() );
 
-            assertEquals( 2,
-                          results.size() );
-            assertEquals( 65,
-                          ((Number) results.get( 1 )).intValue() );
+                wm.insert( new OrderEvent( "2",
+                                           "customer A",
+                                           60 ) );
+                wm.fireAllRules();
 
-            // advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
-            // next job is in 10 seconds: expire the event
-            assertEquals( 10000,
-                          wm.getTimeToNextJob() );
+                assertEquals( 2,
+                              results.size() );
+                assertEquals( 65,
+                              ((Number) results.get( 1 )).intValue() );
 
-            wm.insert( new OrderEvent( "3",
-                                       "customer A",
-                                       50 ) );
-            wm.fireAllRules();
-            assertEquals( 3,
-                          results.size() );
-            assertEquals( 60,
-                          ((Number) results.get( 2 )).intValue() );
+                // advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                // next job is in 10 seconds: expire the event
+                assertEquals( 10000,
+                              wm.getTimeToNextJob() );
 
-            // advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
-            // advancing clock time will cause events to expire
-            assertEquals( 0,
-                          wm.getIdleTime() );
-            // next job is in 10 seconds: expire another event
-            //assertEquals( 10000, iwm.getTimeToNextJob());
+                wm.insert( new OrderEvent( "3",
+                                           "customer A",
+                                           50 ) );
+                wm.fireAllRules();
+                assertEquals( 3,
+                              results.size() );
+                assertEquals( 60,
+                              ((Number) results.get( 2 )).intValue() );
 
-            wm.insert( new OrderEvent( "4",
-                                       "customer A",
-                                       25 ) );
-            wm.fireAllRules();
+                // advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                // advancing clock time will cause events to expire
+                assertEquals( 0,
+                              wm.getIdleTime() );
+                // next job is in 10 seconds: expire another event
+                //assertEquals( 10000, iwm.getTimeToNextJob());
 
-            // first event should have expired, making average under the rule threshold, so no additional rule fire
-            assertEquals( 3,
-                          results.size() );
+                wm.insert( new OrderEvent( "4",
+                                           "customer A",
+                                           25 ) );
+                wm.fireAllRules();
 
-            // advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
+                // first event should have expired, making average under the rule threshold, so no additional rule fire
+                assertEquals( 3,
+                              results.size() );
 
-            wm.insert( new OrderEvent( "5",
-                                       "customer A",
-                                       70 ) );
-            assertEquals( 0,
-                          wm.getIdleTime() );
+                // advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
 
-            //        wm  = SerializationHelper.serializeObject(wm);
-            wm.fireAllRules();
+                wm.insert( new OrderEvent( "5",
+                                           "customer A",
+                                           70 ) );
+                assertEquals( 0,
+                              wm.getIdleTime() );
 
-            // still under the threshold, so no fire
-            assertEquals( 3,
-                          results.size() );
+                //        wm  = SerializationHelper.serializeObject(wm);
+                wm.fireAllRules();
+
+                // still under the threshold, so no fire
+                assertEquals( 3,
+                              results.size() );
+            } finally {
+                logger.writeToDisk();
+            }
         } finally {
-            logger.writeToDisk();
+            wm.dispose();
         }
     }
 
     @Test(timeout=10000)
-    public void testCollectWithWindows() throws Exception {
+    public void testCollectWithWindows() {
         final KieBaseConfiguration kbconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         kbconf.setOption( EventProcessingOption.STREAM );
         final KieBase kbase = loadKnowledgeBase( kbconf, "test_CEP_CollectWithWindows.drl" );
@@ -1739,112 +1804,116 @@ public class CepEspTest extends CommonTestMethodBase {
         ksconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         KieSession ksession = createKnowledgeSession(kbase, ksconf);
-        WorkingMemoryFileLogger logger = new WorkingMemoryFileLogger( ksession );
-        File testTmpDir = new File( "target/test-tmp/" );
-        testTmpDir.mkdirs();
-        logger.setFileName( "target/test-tmp/testCollectWithWindows-audit" );
-
-        List<Number> timeResults = new ArrayList<Number>();
-        List<Number> lengthResults = new ArrayList<Number>();
-
-        ksession.setGlobal( "timeResults",
-                            timeResults );
-        ksession.setGlobal( "lengthResults",
-                            lengthResults );
-
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
 
         try {
-            // First interaction
-            clock.advanceTime( 5,
-                               TimeUnit.SECONDS ); // 5 seconds
-            ksession.insert( new OrderEvent( "1",
-                                             "customer A",
-                                             70 ) );
+            WorkingMemoryFileLogger logger = new WorkingMemoryFileLogger( ksession );
+            File testTmpDir = new File( "target/test-tmp/" );
+            testTmpDir.mkdirs();
+            logger.setFileName( "target/test-tmp/testCollectWithWindows-audit" );
 
-            ksession.fireAllRules();
+            List<Number> timeResults = new ArrayList<Number>();
+            List<Number> lengthResults = new ArrayList<Number>();
 
-            assertEquals( 1,
-                          timeResults.size() );
-            assertEquals( 1,
-                          timeResults.get( 0 ).intValue() );
-            assertEquals( 1,
-                          lengthResults.size() );
-            assertEquals( 1,
-                          lengthResults.get( 0 ).intValue() );
+            ksession.setGlobal( "timeResults",
+                                timeResults );
+            ksession.setGlobal( "lengthResults",
+                                lengthResults );
 
-            // Second interaction: advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
-            ksession.insert( new OrderEvent( "2",
-                                             "customer A",
-                                             60 ) );
-            ksession.fireAllRules();
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-            assertEquals( 2,
-                          timeResults.size() );
-            assertEquals( 2,
-                          timeResults.get( 1 ).intValue() );
-            assertEquals( 2,
-                          lengthResults.size() );
-            assertEquals( 2,
-                          lengthResults.get( 1 ).intValue() );
+            try {
+                // First interaction
+                clock.advanceTime( 5,
+                                   TimeUnit.SECONDS ); // 5 seconds
+                ksession.insert( new OrderEvent( "1",
+                                                 "customer A",
+                                                 70 ) );
 
-            // Third interaction: advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
-            ksession.insert( new OrderEvent( "3",
-                                             "customer A",
-                                             50 ) );
-            ksession.fireAllRules();
+                ksession.fireAllRules();
 
-            assertEquals( 3,
-                          timeResults.size() );
-            assertEquals( 3,
-                          timeResults.get( 2 ).intValue() );
-            assertEquals( 3,
-                          lengthResults.size() );
-            assertEquals( 3,
-                          lengthResults.get( 2 ).intValue() );
+                assertEquals( 1,
+                              timeResults.size() );
+                assertEquals( 1,
+                              timeResults.get( 0 ).intValue() );
+                assertEquals( 1,
+                              lengthResults.size() );
+                assertEquals( 1,
+                              lengthResults.get( 0 ).intValue() );
 
-            // Fourth interaction: advance clock and assert new data
-            clock.advanceTime( 10,
-                               TimeUnit.SECONDS ); // 10 seconds
-            ksession.insert( new OrderEvent( "4",
-                                             "customer A",
-                                             25 ) );
-            ksession.fireAllRules();
+                // Second interaction: advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                ksession.insert( new OrderEvent( "2",
+                                                 "customer A",
+                                                 60 ) );
+                ksession.fireAllRules();
 
-            // first event should have expired now
-            assertEquals( 4,
-                          timeResults.size() );
-            assertEquals( 3,
-                          timeResults.get( 3 ).intValue() );
-            assertEquals( 4,
-                          lengthResults.size() );
-            assertEquals( 3,
-                          lengthResults.get( 3 ).intValue() );
+                assertEquals( 2,
+                              timeResults.size() );
+                assertEquals( 2,
+                              timeResults.get( 1 ).intValue() );
+                assertEquals( 2,
+                              lengthResults.size() );
+                assertEquals( 2,
+                              lengthResults.get( 1 ).intValue() );
 
-            // Fifth interaction: advance clock and assert new data
-            clock.advanceTime( 5,
-                               TimeUnit.SECONDS ); // 10 seconds
-            ksession.insert( new OrderEvent( "5",
-                                             "customer A",
-                                             70 ) );
-            ksession.fireAllRules();
+                // Third interaction: advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                ksession.insert( new OrderEvent( "3",
+                                                 "customer A",
+                                                 50 ) );
+                ksession.fireAllRules();
 
-            assertEquals( 5,
-                          timeResults.size() );
-            assertEquals( 4,
-                          timeResults.get( 4 ).intValue() );
-            assertEquals( 5,
-                          lengthResults.size() );
-            assertEquals( 3,
-                          lengthResults.get( 4 ).intValue() );
+                assertEquals( 3,
+                              timeResults.size() );
+                assertEquals( 3,
+                              timeResults.get( 2 ).intValue() );
+                assertEquals( 3,
+                              lengthResults.size() );
+                assertEquals( 3,
+                              lengthResults.get( 2 ).intValue() );
+
+                // Fourth interaction: advance clock and assert new data
+                clock.advanceTime( 10,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                ksession.insert( new OrderEvent( "4",
+                                                 "customer A",
+                                                 25 ) );
+                ksession.fireAllRules();
+
+                // first event should have expired now
+                assertEquals( 4,
+                              timeResults.size() );
+                assertEquals( 3,
+                              timeResults.get( 3 ).intValue() );
+                assertEquals( 4,
+                              lengthResults.size() );
+                assertEquals( 3,
+                              lengthResults.get( 3 ).intValue() );
+
+                // Fifth interaction: advance clock and assert new data
+                clock.advanceTime( 5,
+                                   TimeUnit.SECONDS ); // 10 seconds
+                ksession.insert( new OrderEvent( "5",
+                                                 "customer A",
+                                                 70 ) );
+                ksession.fireAllRules();
+
+                assertEquals( 5,
+                              timeResults.size() );
+                assertEquals( 4,
+                              timeResults.get( 4 ).intValue() );
+                assertEquals( 5,
+                              lengthResults.size() );
+                assertEquals( 3,
+                              lengthResults.get( 4 ).intValue() );
+            } finally {
+                logger.writeToDisk();
+            }
         } finally {
-            logger.writeToDisk();
+            ksession.dispose();
         }
-
     }
 
     @Test(timeout=10000)
@@ -1873,10 +1942,13 @@ public class CepEspTest extends CommonTestMethodBase {
         InternalKnowledgeBase knowledgeBase = KnowledgeBaseFactory.newKnowledgeBase( config );
         knowledgeBase.addPackages( kbuilder.getKnowledgePackages() );
         KieSession ksession = knowledgeBase.newKieSession( sessionConfig, KieServices.get().newEnvironment() );
-        PseudoClockScheduler pseudoClock = ksession.<PseudoClockScheduler>getSessionClock();
 
-        FactHandle h = ksession.insert( new A() );
-        ksession.retract( h );
+        try {
+            FactHandle h = ksession.insert( new A() );
+            ksession.delete( h );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     public static class A
@@ -1925,81 +1997,84 @@ public class CepEspTest extends CommonTestMethodBase {
                                                                            null );
 
         final KieSession ksession1 = kbase1.newKieSession();
-        AgendaEventListener ael1 = mock( AgendaEventListener.class );
-        ksession1.addEventListener( ael1 );
-
         final KieSession ksession2 = kbase2.newKieSession();
-        AgendaEventListener ael2 = mock( AgendaEventListener.class );
-        ksession2.addEventListener( ael2 );
+        try {
+            AgendaEventListener ael1 = mock( AgendaEventListener.class );
+            ksession1.addEventListener( ael1 );
 
-        // -------------
-        // first, check the non-serialized session
-        // -------------
-        ksession1.insert( new Sensor( 10,
-                                      10 ) );
-        ksession1.fireAllRules();
+            AgendaEventListener ael2 = mock( AgendaEventListener.class );
+            ksession2.addEventListener( ael2 );
+            try {
+                // -------------
+                // first, check the non-serialized session
+                // -------------
+                ksession1.insert( new Sensor( 10,
+                                              10 ) );
+                ksession1.fireAllRules();
 
-        ArgumentCaptor<AfterMatchFiredEvent> aafe1 = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
-        verify( ael1,
-                times( 1 ) ).afterMatchFired(aafe1.capture());
-        List<AfterMatchFiredEvent> events1 = aafe1.getAllValues();
-        assertThat( events1.get( 0 ).getMatch().getDeclarationValue( "$avg" ),
-                    is( (Object) 10 ) );
+                ArgumentCaptor<AfterMatchFiredEvent> aafe1 = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
+                verify( ael1,
+                        times( 1 ) ).afterMatchFired(aafe1.capture());
+                List<AfterMatchFiredEvent> events1 = aafe1.getAllValues();
+                assertThat( events1.get( 0 ).getMatch().getDeclarationValue( "$avg" ),
+                            is(10) );
 
-        ksession1.insert( new Sensor( 20,
-                                      20 ) );
-        ksession1.fireAllRules();
-        verify( ael1,
-                times( 2 ) ).afterMatchFired(aafe1.capture());
-        events1 = aafe1.getAllValues();
-        assertThat( events1.get( 1 ).getMatch().getDeclarationValue( "$avg" ),
-                    is( (Object) 15 ) );
-        ksession1.insert( new Sensor( 30,
-                                      30 ) );
-        ksession1.fireAllRules();
-        verify( ael1,
-                times( 3 ) ).afterMatchFired(aafe1.capture());
-        assertThat( events1.get( 2 ).getMatch().getDeclarationValue( "$avg" ),
-                    is( (Object) 25 ) );
+                ksession1.insert( new Sensor( 20,
+                                              20 ) );
+                ksession1.fireAllRules();
+                verify( ael1,
+                        times( 2 ) ).afterMatchFired(aafe1.capture());
+                events1 = aafe1.getAllValues();
+                assertThat( events1.get( 1 ).getMatch().getDeclarationValue( "$avg" ),
+                            is(15) );
+                ksession1.insert( new Sensor( 30,
+                                              30 ) );
+                ksession1.fireAllRules();
+                verify( ael1,
+                        times( 3 ) ).afterMatchFired(aafe1.capture());
+                assertThat( events1.get( 2 ).getMatch().getDeclarationValue( "$avg" ),
+                            is(25) );
+            } finally {
+                ksession1.dispose();
+            }
 
-        ksession1.dispose();
+            // -------------
+            // now we check the serialized session
+            // -------------
+            ArgumentCaptor<AfterMatchFiredEvent> aafe2 = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
 
-        // -------------
-        // now we check the serialized session
-        // -------------
-        ArgumentCaptor<AfterMatchFiredEvent> aafe2 = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
+            ksession2.insert( new Sensor( 10,
+                                          10 ) );
+            ksession2.fireAllRules();
+            verify( ael2,
+                    times( 1 ) ).afterMatchFired(aafe2.capture());
+            List<AfterMatchFiredEvent> events2 = aafe2.getAllValues();
+            assertThat( events2.get( 0 ).getMatch().getDeclarationValue( "$avg" ),
+                        is(10) );
 
-        ksession2.insert( new Sensor( 10,
-                                      10 ) );
-        ksession2.fireAllRules();
-        verify( ael2,
-                times( 1 ) ).afterMatchFired(aafe2.capture());
-        List<AfterMatchFiredEvent> events2 = aafe2.getAllValues();
-        assertThat( events2.get( 0 ).getMatch().getDeclarationValue( "$avg" ),
-                    is( (Object) 10 ) );
+            ksession2.insert( new Sensor( 20,
+                                          20 ) );
+            ksession2.fireAllRules();
+            verify( ael2,
+                    times( 2 ) ).afterMatchFired(aafe2.capture());
+            events2 = aafe2.getAllValues();
+            assertThat( events2.get( 1 ).getMatch().getDeclarationValue( "$avg" ),
+                        is(15) );
 
-        ksession2.insert( new Sensor( 20,
-                                      20 ) );
-        ksession2.fireAllRules();
-        verify( ael2,
-                times( 2 ) ).afterMatchFired(aafe2.capture());
-        events2 = aafe2.getAllValues();
-        assertThat( events2.get( 1 ).getMatch().getDeclarationValue( "$avg" ),
-                    is( (Object) 15 ) );
-
-        ksession2.insert( new Sensor( 30,
-                                      30 ) );
-        ksession2.fireAllRules();
-        verify( ael2,
-                times( 3 ) ).afterMatchFired(aafe2.capture());
-        assertThat( events2.get( 2 ).getMatch().getDeclarationValue( "$avg" ),
-                    is( (Object) 25 ) );
-        ksession2.dispose();
+            ksession2.insert( new Sensor( 30,
+                                          30 ) );
+            ksession2.fireAllRules();
+            verify( ael2,
+                    times( 3 ) ).afterMatchFired(aafe2.capture());
+            assertThat( events2.get( 2 ).getMatch().getDeclarationValue( "$avg" ),
+                        is(25) );
+        } finally {
+            ksession2.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testIdentityAssertBehaviorOnEntryPoints() throws IOException,
-                                                         ClassNotFoundException {
+    public void testIdentityAssertBehaviorOnEntryPoints() {
         StockTickInterface st1 = new StockTick( 1,
                                                 "RHT",
                                                 10,
@@ -2019,35 +2094,36 @@ public class CepEspTest extends CommonTestMethodBase {
         final KieBase kbase1 = loadKnowledgeBase( kbconf, "test_CEP_AssertBehaviorOnEntryPoints.drl" );
 
         final KieSession ksession = kbase1.newKieSession();
-        AgendaEventListener ael1 = mock( AgendaEventListener.class );
-        ksession.addEventListener( ael1 );
-        EntryPoint ep1 = ksession.getEntryPoint( "stocktick stream" );
+        try {
+            AgendaEventListener ael1 = mock( AgendaEventListener.class );
+            ksession.addEventListener( ael1 );
+            EntryPoint ep1 = ksession.getEntryPoint( "stocktick stream" );
 
-        FactHandle fh1 = ep1.insert( st1 );
-        FactHandle fh1_2 = ep1.insert( st1 );
-        FactHandle fh2 = ep1.insert( st2 );
-        FactHandle fh3 = ep1.insert( st3 );
+            FactHandle fh1 = ep1.insert( st1 );
+            FactHandle fh1_2 = ep1.insert( st1 );
+            FactHandle fh2 = ep1.insert( st2 );
+            FactHandle fh3 = ep1.insert( st3 );
 
-        assertSame( fh1,
-                    fh1_2 );
-        assertNotSame( fh1,
-                       fh2 );
-        assertNotSame( fh1,
-                       fh3 );
-        assertNotSame( fh2,
-                       fh3 );
+            assertSame( fh1,
+                        fh1_2 );
+            assertNotSame( fh1,
+                           fh2 );
+            assertNotSame( fh1,
+                           fh3 );
+            assertNotSame( fh2,
+                           fh3 );
 
-        ksession.fireAllRules();
-        // must have fired 3 times, one for each event identity
-        verify( ael1,
-                times( 3 ) ).afterMatchFired(any(AfterMatchFiredEvent.class));
-
-        ksession.dispose();
+            ksession.fireAllRules();
+            // must have fired 3 times, one for each event identity
+            verify( ael1,
+                    times( 3 ) ).afterMatchFired(any(AfterMatchFiredEvent.class));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEqualityAssertBehaviorOnEntryPoints() throws IOException,
-                                                         ClassNotFoundException {
+    public void testEqualityAssertBehaviorOnEntryPoints() {
         StockTickInterface st1 = new StockTick( 1,
                                                 "RHT",
                                                 10,
@@ -2067,82 +2143,92 @@ public class CepEspTest extends CommonTestMethodBase {
         final KieBase kbase1 = loadKnowledgeBase( kbconf, "test_CEP_AssertBehaviorOnEntryPoints.drl" );
 
         final KieSession ksession1 = kbase1.newKieSession();
-        AgendaEventListener ael1 = mock( AgendaEventListener.class );
-        ksession1.addEventListener( ael1 );
-        EntryPoint ep1 = ksession1.getEntryPoint( "stocktick stream" );
 
-        FactHandle fh1 = ep1.insert( st1 );
-        FactHandle fh1_2 = ep1.insert( st1 );
-        FactHandle fh2 = ep1.insert( st2 );
-        FactHandle fh3 = ep1.insert( st3 );
+        try {
+            AgendaEventListener ael1 = mock( AgendaEventListener.class );
+            ksession1.addEventListener( ael1 );
+            EntryPoint ep1 = ksession1.getEntryPoint( "stocktick stream" );
 
-        assertSame( fh1,
-                    fh1_2 );
-        assertSame( fh1,
-                    fh2 );
-        assertNotSame( fh1,
-                       fh3 );
+            FactHandle fh1 = ep1.insert( st1 );
+            FactHandle fh1_2 = ep1.insert( st1 );
+            FactHandle fh2 = ep1.insert( st2 );
+            FactHandle fh3 = ep1.insert( st3 );
 
-        ksession1.fireAllRules();
-        // must have fired 2 times, one for each event equality
-        verify( ael1,
-                times( 2 ) ).afterMatchFired(any(AfterMatchFiredEvent.class));
+            assertSame( fh1,
+                        fh1_2 );
+            assertSame( fh1,
+                        fh2 );
+            assertNotSame( fh1,
+                           fh3 );
 
-        ksession1.dispose();
+            ksession1.fireAllRules();
+            // must have fired 2 times, one for each event equality
+            verify( ael1,
+                    times( 2 ) ).afterMatchFired(any(AfterMatchFiredEvent.class));
+        } finally {
+            ksession1.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEventDeclarationForInterfaces() throws Exception {
+    public void testEventDeclarationForInterfaces() {
         // read in the source
         final KieBase kbase = loadKnowledgeBase( "test_CEP_EventInterfaces.drl" );
 
         KieSession session = createKnowledgeSession(kbase);
 
-        StockTickInterface tick1 = new StockTick( 1,
-                                                  "DROO",
-                                                  50,
-                                                  10000 );
-        StockTickInterface tick2 = new StockTick( 2,
-                                                  "ACME",
-                                                  10,
-                                                  10010 );
-        StockTickInterface tick3 = new StockTick( 3,
-                                                  "ACME",
-                                                  10,
-                                                  10100 );
-        StockTickInterface tick4 = new StockTick( 4,
-                                                  "DROO",
-                                                  50,
-                                                  11000 );
+        try {
+            StockTickInterface tick1 = new StockTick( 1,
+                                                      "DROO",
+                                                      50,
+                                                      10000 );
+            StockTickInterface tick2 = new StockTick( 2,
+                                                      "ACME",
+                                                      10,
+                                                      10010 );
+            StockTickInterface tick3 = new StockTick( 3,
+                                                      "ACME",
+                                                      10,
+                                                      10100 );
+            StockTickInterface tick4 = new StockTick( 4,
+                                                      "DROO",
+                                                      50,
+                                                      11000 );
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert( tick1 );
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert( tick2 );
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert( tick3 );
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert( tick4 );
 
-        assertTrue( handle1.isEvent() );
-        assertTrue( handle2.isEvent() );
-        assertTrue( handle3.isEvent() );
-        assertTrue( handle4.isEvent() );
+            assertTrue( handle1.isEvent() );
+            assertTrue( handle2.isEvent() );
+            assertTrue( handle3.isEvent() );
+            assertTrue( handle4.isEvent() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testTemporalOperators() throws Exception {
+    public void testTemporalOperators() {
         // read in the source
         final RuleBaseConfiguration kbconf = new RuleBaseConfiguration();
         kbconf.setEventProcessingMode( EventProcessingOption.STREAM );
         KieBase kbase = loadKnowledgeBase( kbconf, "test_CEP_TemporalOperators.drl" );
 
         KieSession ksession = createKnowledgeSession(kbase);
-
-        ksession.insert( new StockTick( 1,
-                                        "A",
-                                        10,
-                                        1000 ) );
+        try {
+            ksession.insert( new StockTick( 1,
+                                            "A",
+                                            10,
+                                            1000 ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testTemporalOperators2() throws Exception {
+    public void testTemporalOperators2() {
         // read in the source
         final RuleBaseConfiguration kbconf = new RuleBaseConfiguration();
         kbconf.setEventProcessingMode( EventProcessingOption.STREAM );
@@ -2152,40 +2238,36 @@ public class CepEspTest extends CommonTestMethodBase {
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         KieSession ksession = createKnowledgeSession(kbase, sconf);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+            EntryPoint ep = ksession.getEntryPoint( "X" );
 
-        EntryPoint ep = ksession.getEntryPoint( "X" );
+            clock.advanceTime( 1000,
+                               TimeUnit.SECONDS );
+            ep.insert( new StockTick( 1, "A", 10, clock.getCurrentTime() ) );
 
-        clock.advanceTime( 1000,
-                           TimeUnit.SECONDS );
-        ep.insert( new StockTick( 1, "A", 10, clock.getCurrentTime() ) );
+            clock.advanceTime( 8,
+                               TimeUnit.SECONDS );
+            ep.insert( new StockTick( 2, "B", 10, clock.getCurrentTime() ) );
 
-        clock.advanceTime( 8,
-                           TimeUnit.SECONDS );
-        ep.insert( new StockTick( 2, "B", 10, clock.getCurrentTime() ) );
+            clock.advanceTime( 8,
+                               TimeUnit.SECONDS );
+            ep.insert( new StockTick( 3, "B", 10, clock.getCurrentTime() ) );
 
-        clock.advanceTime( 8,
-                           TimeUnit.SECONDS );
-        ep.insert( new StockTick( 3, "B", 10, clock.getCurrentTime() ) );
-
-        clock.advanceTime( 8,
-                           TimeUnit.SECONDS );
-        int rules = ksession.fireAllRules();
-//        assertEquals( 2,
-//                      rules );
-
-//        assertEquals( 1, list.size() );
-//        StockTick[] stocks = ( StockTick[] ) list.get(0);
-//        assertSame( tick4, stocks[0]);
-//        assertSame( tick2, stocks[1]);
+            clock.advanceTime( 8,
+                               TimeUnit.SECONDS );
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testTemporalOperatorsInfinity() throws Exception {
+    public void testTemporalOperatorsInfinity() {
         // read in the source
         final RuleBaseConfiguration kbconf = new RuleBaseConfiguration();
         kbconf.setEventProcessingMode( EventProcessingOption.STREAM );
@@ -2194,40 +2276,42 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration sconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        KieSession ksession = kbase.newKieSession( sconf,
-                                                                               null );
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+        KieSession ksession = kbase.newKieSession( sconf, null );
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        EntryPoint ep = ksession.getEntryPoint( "X" );
+            EntryPoint ep = ksession.getEntryPoint( "X" );
 
-        clock.advanceTime( 1000, TimeUnit.SECONDS );
+            clock.advanceTime( 1000, TimeUnit.SECONDS );
 
-        int rules = 0;
-        ep.insert( new StockTick( 1, "A", 10, clock.getCurrentTime() ) );
-        clock.advanceTime( 8, TimeUnit.SECONDS );
-        //int rules = ksession.fireAllRules();
-        System.out.println( list );
+            int rules = 0;
+            ep.insert( new StockTick( 1, "A", 10, clock.getCurrentTime() ) );
+            clock.advanceTime( 8, TimeUnit.SECONDS );
+            //int rules = ksession.fireAllRules();
+            System.out.println( list );
 
-        ep.insert( new StockTick( 2, "B", 10, clock.getCurrentTime() ) );
-        clock.advanceTime( 8, TimeUnit.SECONDS );
-        //rules = ksession.fireAllRules();
-        System.out.println( list );
+            ep.insert( new StockTick( 2, "B", 10, clock.getCurrentTime() ) );
+            clock.advanceTime( 8, TimeUnit.SECONDS );
+            //rules = ksession.fireAllRules();
+            System.out.println( list );
 
-        ep.insert( new StockTick( 3, "B", 10, clock.getCurrentTime() ) );
-        clock.advanceTime( 8, TimeUnit.SECONDS );
-        rules = ksession.fireAllRules();
-        System.out.println( list );
+            ep.insert( new StockTick( 3, "B", 10, clock.getCurrentTime() ) );
+            clock.advanceTime( 8, TimeUnit.SECONDS );
+            rules = ksession.fireAllRules();
+            System.out.println( list );
 
-        assertEquals( 3,
-                      rules );
+            assertEquals( 3,
+                          rules );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test (timeout=10000)
-    public void testMultipleSlidingWindows() throws IOException,
-                                            ClassNotFoundException {
+    public void testMultipleSlidingWindows() {
         String str = "declare A\n" +
                      "    @role( event )\n" +
                      "    id : int\n" +
@@ -2265,46 +2349,46 @@ public class CepEspTest extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( config, str );
         KieSession ksession = createKnowledgeSession(kbase);
 
-        AgendaEventListener ael = mock( AgendaEventListener.class );
-        ksession.addEventListener( ael );
+        try {
+            AgendaEventListener ael = mock( AgendaEventListener.class );
+            ksession.addEventListener( ael );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        ArgumentCaptor<AfterMatchFiredEvent> captor = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
-        verify( ael,
-                times( 3 ) ).afterMatchFired(captor.capture());
+            ArgumentCaptor<AfterMatchFiredEvent> captor = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
+            verify( ael,
+                    times( 3 ) ).afterMatchFired(captor.capture());
 
-        List<AfterMatchFiredEvent> values = captor.getAllValues();
-        // first rule
-        Match act = values.get( 0 ).getMatch();
-        assertThat( act.getRule().getName(),
-                    is( "launch" ) );
+            List<AfterMatchFiredEvent> values = captor.getAllValues();
+            // first rule
+            Match act = values.get( 0 ).getMatch();
+            assertThat( act.getRule().getName(),
+                        is( "launch" ) );
 
-        // second rule
-        act = values.get( 1 ).getMatch();
-        assertThat( act.getRule().getName(),
-                    is( "ba" ) );
-        assertThat( ((Number) act.getDeclarationValue( "$a" )).intValue(),
-                    is( 3 ) );
-        assertThat( ((Number) act.getDeclarationValue( "$b" )).intValue(),
-                    is( 2 ) );
+            // second rule
+            act = values.get( 1 ).getMatch();
+            assertThat( act.getRule().getName(),
+                        is( "ba" ) );
+            assertThat( ((Number) act.getDeclarationValue( "$a" )).intValue(),
+                        is( 3 ) );
+            assertThat( ((Number) act.getDeclarationValue( "$b" )).intValue(),
+                        is( 2 ) );
 
-        // third rule
-        act = values.get( 2 ).getMatch();
-        assertThat( act.getRule().getName(),
-                    is( "ab" ) );
-        assertThat( ((Number) act.getDeclarationValue( "$a" )).intValue(),
-                    is( 3 ) );
-        assertThat( ((Number) act.getDeclarationValue( "$b" )).intValue(),
-                    is( 2 ) );
+            // third rule
+            act = values.get( 2 ).getMatch();
+            assertThat( act.getRule().getName(),
+                        is( "ab" ) );
+            assertThat( ((Number) act.getDeclarationValue( "$a" )).intValue(),
+                        is( 3 ) );
+            assertThat( ((Number) act.getDeclarationValue( "$b" )).intValue(),
+                        is( 2 ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testCloudModeExpiration() throws IOException,
-                                            ClassNotFoundException,
-                                         InstantiationException,
-                                         IllegalAccessException,
-                                         InterruptedException {
+    public void testCloudModeExpiration() throws InstantiationException, IllegalAccessException, InterruptedException {
         String str = "package org.drools.cloud\n" +
                      "import org.drools.compiler.*\n" +
                      "declare Event\n" +
@@ -2332,42 +2416,45 @@ public class CepEspTest extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( config, str );
         KieSession ksession = createKnowledgeSession(kbase);
 
-        EntryPoint ep = ksession.getEntryPoint( "X" );
+        try {
+            EntryPoint ep = ksession.getEntryPoint( "X" );
 
-        ep.insert( new StockTick( 1,
-                                  "RHT",
-                                  10,
-                                  1000 ) );
-        int rulesFired = ksession.fireAllRules();
-        assertEquals( 0,
-                      rulesFired );
+            ep.insert( new StockTick( 1,
+                                      "RHT",
+                                      10,
+                                      1000 ) );
+            int rulesFired = ksession.fireAllRules();
+            assertEquals( 0,
+                          rulesFired );
 
-        org.kie.api.definition.type.FactType event = kbase.getFactType( "org.drools.cloud",
-                                                                       "Event" );
-        Object e1 = event.newInstance();
-        event.set( e1,
-                   "name",
-                   "someKey" );
-        event.set( e1,
-                   "value",
-                   "someValue" );
+            org.kie.api.definition.type.FactType event = kbase.getFactType( "org.drools.cloud",
+                                                                            "Event" );
+            Object e1 = event.newInstance();
+            event.set( e1,
+                       "name",
+                       "someKey" );
+            event.set( e1,
+                       "value",
+                       "someValue" );
 
-        ep.insert( e1 );
-        rulesFired = ksession.fireAllRules();
-        assertEquals( 1,
-                      rulesFired );
+            ep.insert( e1 );
+            rulesFired = ksession.fireAllRules();
+            assertEquals( 1,
+                          rulesFired );
 
-        // let some time be spent
-        Thread.currentThread().sleep( 1000 );
+            // let some time be spent
+            Thread.sleep(1000 );
 
-        // check both events are still in memory as we are running in CLOUD mode
-        assertEquals( 2,
-                      ep.getFactCount() );
+            // check both events are still in memory as we are running in CLOUD mode
+            assertEquals( 2,
+                          ep.getFactCount() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testSalienceWithEventsPseudoClock() throws IOException,
-                                                   ClassNotFoundException {
+    public void testSalienceWithEventsPseudoClock() {
         String str = "package org.drools.compiler\n" +
                      "import " + StockTick.class.getName() + "\n" +
                      "declare StockTick\n" +
@@ -2396,62 +2483,64 @@ public class CepEspTest extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( config, str );
         KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
-        KieSession ksession = kbase.newKieSession( ksconf,
-                                                                               null );
+        KieSession ksession = kbase.newKieSession( ksconf, null );
+        try {
+            AgendaEventListener ael = mock( AgendaEventListener.class );
+            ksession.addEventListener( ael );
 
-        AgendaEventListener ael = mock( AgendaEventListener.class );
-        ksession.addEventListener( ael );
+            SessionPseudoClock clock = ksession.getSessionClock();
+            clock.advanceTime( 1000000,
+                               TimeUnit.MILLISECONDS );
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
-        clock.advanceTime( 1000000,
-                           TimeUnit.MILLISECONDS );
+            ksession.insert( new StockTick( 1,
+                                            "RHT",
+                                            10,
+                                            1000 ) );
+            clock.advanceTime( 5,
+                               TimeUnit.SECONDS );
+            ksession.insert( new StockTick( 2,
+                                            "RHT",
+                                            10,
+                                            1000 ) );
+            clock.advanceTime( 5,
+                               TimeUnit.SECONDS );
+            ksession.insert( new StockTick( 3,
+                                            "RHT",
+                                            10,
+                                            1000 ) );
+            clock.advanceTime( 5,
+                               TimeUnit.SECONDS );
+            ksession.insert( new StockTick( 4,
+                                            "ACME",
+                                            10,
+                                            1000 ) );
+            clock.advanceTime( 5,
+                               TimeUnit.SECONDS );
+            int rulesFired = ksession.fireAllRules();
+            assertEquals( 4,
+                          rulesFired );
 
-        ksession.insert( new StockTick( 1,
-                                        "RHT",
-                                        10,
-                                        1000 ) );
-        clock.advanceTime( 5,
-                           TimeUnit.SECONDS );
-        ksession.insert( new StockTick( 2,
-                                        "RHT",
-                                        10,
-                                        1000 ) );
-        clock.advanceTime( 5,
-                           TimeUnit.SECONDS );
-        ksession.insert( new StockTick( 3,
-                                        "RHT",
-                                        10,
-                                        1000 ) );
-        clock.advanceTime( 5,
-                           TimeUnit.SECONDS );
-        ksession.insert( new StockTick( 4,
-                                        "ACME",
-                                        10,
-                                        1000 ) );
-        clock.advanceTime( 5,
-                           TimeUnit.SECONDS );
-        int rulesFired = ksession.fireAllRules();
-        assertEquals( 4,
-                      rulesFired );
+            ArgumentCaptor<AfterMatchFiredEvent> captor = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
+            verify( ael,
+                    times( 4 ) ).afterMatchFired(captor.capture());
+            List<AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        ArgumentCaptor<AfterMatchFiredEvent> captor = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
-        verify( ael,
-                times( 4 ) ).afterMatchFired(captor.capture());
-        List<AfterMatchFiredEvent> aafe = captor.getAllValues();
-
-        assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
-                           is( "R1" ) );
-        assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
-                           is( "R1" ) );
-        assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
-                           is( "R1" ) );
-        assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
-                           is( "R3" ) );
+            assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
+                        is( "R1" ) );
+            assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
+                        is( "R1" ) );
+            assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
+                        is( "R1" ) );
+            assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
+                        is( "R3" ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testSalienceWithEventsRealtimeClock() throws IOException,
-                                                     ClassNotFoundException, InterruptedException {
+    public void testSalienceWithEventsRealtimeClock() throws
+            InterruptedException {
         String str = "package org.drools.compiler\n" +
                      "import " + StockTick.class.getName() + "\n" +
                      "declare StockTick\n" +
@@ -2480,53 +2569,55 @@ public class CepEspTest extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( config, str );
         KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksconf.setOption( ClockTypeOption.get( ClockType.REALTIME_CLOCK.getId() ) );
-        KieSession ksession = kbase.newKieSession( ksconf,
-                                                                               null );
+        KieSession ksession = kbase.newKieSession( ksconf, null );
+        try {
+            AgendaEventListener ael = mock( AgendaEventListener.class );
+            ksession.addEventListener( ael );
 
-        AgendaEventListener ael = mock( AgendaEventListener.class );
-        ksession.addEventListener( ael );
+            ksession.insert( new StockTick( 1,
+                                            "RHT",
+                                            10,
+                                            1000 ) );
+            ksession.insert( new StockTick( 2,
+                                            "RHT",
+                                            10,
+                                            1000 ) );
+            ksession.insert( new StockTick( 3,
+                                            "RHT",
+                                            10,
+                                            1000 ) );
+            // sleep for 2 secs
+            Thread.sleep(2000 );
+            ksession.insert( new StockTick( 4,
+                                            "ACME",
+                                            10,
+                                            1000 ) );
+            // sleep for 1 sec
+            Thread.sleep(1000 );
+            int rulesFired = ksession.fireAllRules();
+            assertEquals( 4,
+                          rulesFired );
 
-        ksession.insert( new StockTick( 1,
-                                        "RHT",
-                                        10,
-                                        1000 ) );
-        ksession.insert( new StockTick( 2,
-                                        "RHT",
-                                        10,
-                                        1000 ) );
-        ksession.insert( new StockTick( 3,
-                                        "RHT",
-                                        10,
-                                        1000 ) );
-        // sleep for 2 secs
-        Thread.currentThread().sleep( 2000 );
-        ksession.insert( new StockTick( 4,
-                                        "ACME",
-                                        10,
-                                        1000 ) );
-        // sleep for 1 sec
-        Thread.currentThread().sleep( 1000 );
-        int rulesFired = ksession.fireAllRules();
-        assertEquals( 4,
-                      rulesFired );
+            ArgumentCaptor<AfterMatchFiredEvent> captor = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
+            verify( ael,
+                    times( 4 ) ).afterMatchFired(captor.capture());
+            List<AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        ArgumentCaptor<AfterMatchFiredEvent> captor = ArgumentCaptor.forClass( AfterMatchFiredEvent.class );
-        verify( ael,
-                times( 4 ) ).afterMatchFired(captor.capture());
-        List<AfterMatchFiredEvent> aafe = captor.getAllValues();
-
-        assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
-                           is( "R1" ) );
-        assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
-                           is( "R1" ) );
-        assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
-                           is( "R1" ) );
-        assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
-                           is( "R3" ) );
+            assertThat( aafe.get( 0 ).getMatch().getRule().getName(),
+                        is( "R1" ) );
+            assertThat( aafe.get( 1 ).getMatch().getRule().getName(),
+                        is( "R1" ) );
+            assertThat( aafe.get( 2 ).getMatch().getRule().getName(),
+                        is( "R1" ) );
+            assertThat( aafe.get( 3 ).getMatch().getRule().getName(),
+                        is( "R3" ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testExpireEventOnEndTimestamp() throws Exception {
+    public void testExpireEventOnEndTimestamp() {
         // DROOLS-40
         String str =
                 "package org.drools.compiler;\n" +
@@ -2555,23 +2646,26 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = kbase.newKieSession(conf, null);
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
 
-        PseudoClockScheduler clock = (PseudoClockScheduler) ksession.getSessionClock();
+            List<StockTick> resultsAfter = new ArrayList<StockTick>();
+            ksession.setGlobal("resultsAfter", resultsAfter);
 
-        List<StockTick> resultsAfter = new ArrayList<StockTick>();
-        ksession.setGlobal("resultsAfter", resultsAfter);
+            // inserting new StockTick with duration 30 at time 0 => rule
+            // after[60,80] should fire when ACME lasts at 100-120
+            ksession.insert(new StockTick(1, "DROO", 0, 0, 30));
 
-        // inserting new StockTick with duration 30 at time 0 => rule
-        // after[60,80] should fire when ACME lasts at 100-120
-        ksession.insert(new StockTick(1, "DROO", 0, 0, 30));
+            clock.advanceTime(100, TimeUnit.MILLISECONDS);
 
-        clock.advanceTime(100, TimeUnit.MILLISECONDS);
+            ksession.insert(new StockTick(2, "ACME", 0, 0, 20));
 
-        ksession.insert(new StockTick(2, "ACME", 0, 0, 20));
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-
-        assertEquals(1, resultsAfter.size());
+            assertEquals(1, resultsAfter.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -2605,29 +2699,28 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         final KieSession ksession = kbase.newKieSession(conf, null);
-
-        final StockFactory stockFactory = new StockFactory(kbase);
-
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final Future sessionFuture = executor.submit(new Runnable() {
-
-            @Override
-            public void run() {
-                ksession.fireUntilHalt();
-            }
-        });
-
         try {
-            for (int iteration = 0; iteration < 100; iteration++) {
-                this.populateSessionWithStocks(ksession, stockFactory);
-            }
-            // let the engine finish its job
-            Thread.sleep(2000);
+            final StockFactory stockFactory = new StockFactory(kbase);
+            final ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                final Future sessionFuture = executor.submit((Runnable) ksession::fireUntilHalt);
+                try {
+                    for (int iteration = 0; iteration < 100; iteration++) {
+                        this.populateSessionWithStocks(ksession, stockFactory);
+                    }
+                    // let the engine finish its job
+                    Thread.sleep(2000);
 
+                } finally {
+                    ksession.halt();
+                    // not to swallow possible exception
+                    sessionFuture.get();
+                    ksession.dispose();
+                }
+            } finally {
+                executor.shutdownNow();
+            }
         } finally {
-            ksession.halt();
-            // not to swallow possible exception
-            sessionFuture.get();
             ksession.dispose();
         }
     }
@@ -2717,30 +2810,28 @@ public class CepEspTest extends CommonTestMethodBase {
         final StockFactory stockFactory = new StockFactory(kbase);
 
         final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final Future sessionFuture = executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                ksession.fireUntilHalt();
-            }
-        });
-
         try {
-            for (int iteration = 0; iteration < 100; iteration++) {
-                this.populateSessionWithStocks(ksession, stockFactory);
-            }
-            // let the engine finish its job
-            Thread.sleep(2000);
+            final Future sessionFuture = executor.submit((Runnable) ksession::fireUntilHalt);
+            try {
+                for (int iteration = 0; iteration < 100; iteration++) {
+                    this.populateSessionWithStocks(ksession, stockFactory);
+                }
+                // let the engine finish its job
+                Thread.sleep(2000);
 
+            } finally {
+                ksession.halt();
+                // not to swallow possible exception
+                sessionFuture.get();
+                ksession.dispose();
+            }
         } finally {
-            ksession.halt();
-            // not to swallow possible exception
-            sessionFuture.get();
-            ksession.dispose();
+            executor.shutdownNow();
         }
     }
 
     @Test(timeout=10000)
-    public void testSlidingWindowsAccumulateExternalJoin() throws Exception {
+    public void testSlidingWindowsAccumulateExternalJoin() {
         // DROOLS-106
         // The logic may not be optimal, but was used to detect a WM corruption
         String str =
@@ -2776,40 +2867,42 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession ksession = kbase.newKieSession(conf, null);
+        try {
+            int seq = 0;
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        int seq = 0;
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+            ksession.insert( new StockTick( seq++, "AAA", 10.0, 10L ) );
+            ksession.fireAllRules();
+            assertEquals(list, Arrays.asList(1));
 
-        ksession.insert( new StockTick( seq++, "AAA", 10.0, 10L ) );
-        ksession.fireAllRules();
-        assertEquals(list, Arrays.asList(1));
+            ksession.insert(new StockTick(seq++, "AAA", 15.0, 10L));
+            ksession.fireAllRules();
+            assertEquals( list, Arrays.asList( 1, 2 ) );
 
-        ksession.insert(new StockTick(seq++, "AAA", 15.0, 10L));
-        ksession.fireAllRules();
-        assertEquals( list, Arrays.asList( 1, 2 ) );
+            ksession.insert( new StockTick( seq++, "CCC", 10.0, 10L ) );
+            ksession.fireAllRules();
+            assertEquals( list, Arrays.asList( 1, 2, 1 ) );
 
-        ksession.insert( new StockTick( seq++, "CCC", 10.0, 10L ) );
-        ksession.fireAllRules();
-        assertEquals( list, Arrays.asList( 1, 2, 1 ) );
+            System.out.println(" ___________________________________- ");
 
-        System.out.println(" ___________________________________- ");
+            ksession.insert( new StockTick( seq++, "DDD", 13.0, 20L ) );
+            ksession.fireAllRules();
+            assertEquals( list, Arrays.asList( 1, 2, 1, 1 ) );
 
-        ksession.insert( new StockTick( seq++, "DDD", 13.0, 20L ) );
-        ksession.fireAllRules();
-        assertEquals( list, Arrays.asList( 1, 2, 1, 1 ) );
+            ksession.insert( new StockTick( seq++, "AAA", 11.0, 20L ) );
+            ksession.fireAllRules();
+            assertEquals(list, Arrays.asList(1, 2, 1, 1, 3));
 
-        ksession.insert( new StockTick( seq++, "AAA", 11.0, 20L ) );
-        ksession.fireAllRules();
-        assertEquals(list, Arrays.asList(1, 2, 1, 1, 3));
-
-        // NPE Here
-        ksession.fireAllRules();
-
+            // NPE Here
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test (timeout=10000)
-    public void testTimeAndLengthWindowConflict() throws Exception {
+    public void testTimeAndLengthWindowConflict() {
         // JBRULES-3671
         String drl = "package org.drools.compiler;\n" +
                      "\n" +
@@ -2847,47 +2940,47 @@ public class CepEspTest extends CommonTestMethodBase {
         ksconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         KieSession ksession = createKnowledgeSession(kbase, ksconf);
+        try {
+            List<Number> timeResults = new ArrayList<Number>();
+            List<Number> lengthResults = new ArrayList<Number>();
 
-        List<Number> timeResults = new ArrayList<Number>();
-        List<Number> lengthResults = new ArrayList<Number>();
+            ksession.setGlobal( "timeResults",
+                                timeResults );
+            ksession.setGlobal( "lengthResults",
+                                lengthResults );
 
-        ksession.setGlobal( "timeResults",
-                            timeResults );
-        ksession.setGlobal( "lengthResults",
-                            lengthResults );
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+            clock.advanceTime( 5, TimeUnit.SECONDS ); // 5 seconds
+            ksession.insert( new OrderEvent( "1", "customer A", 70 ) );
+            ksession.fireAllRules();
+            System.out.println( lengthResults );
+            assertTrue( lengthResults.contains( 70.0 ) );
 
-        clock.advanceTime( 5, TimeUnit.SECONDS ); // 5 seconds
-        ksession.insert( new OrderEvent( "1", "customer A", 70 ) );
-        ksession.fireAllRules();
-        System.out.println( lengthResults );
-        assertTrue( lengthResults.contains( 70.0 ) );
+            clock.advanceTime( 10, TimeUnit.SECONDS ); // 10 seconds
+            ksession.insert( new OrderEvent( "2", "customer A", 60 ) );
+            ksession.fireAllRules();
+            System.out.println( lengthResults );
+            assertTrue( lengthResults.contains( 65.0 ) );
 
-        clock.advanceTime( 10, TimeUnit.SECONDS ); // 10 seconds
-        ksession.insert( new OrderEvent( "2", "customer A", 60 ) );
-        ksession.fireAllRules();
-        System.out.println( lengthResults );
-        assertTrue( lengthResults.contains( 65.0 ) );
+            // Third interaction: advance clock and assert new data
+            clock.advanceTime( 10, TimeUnit.SECONDS ); // 10 seconds
+            ksession.insert( new OrderEvent( "3", "customer A", 50 ) );
+            ksession.fireAllRules();
+            System.out.println( lengthResults );
+            assertTrue( lengthResults.contains( 60.0 ) );
 
-        // Third interaction: advance clock and assert new data
-        clock.advanceTime( 10, TimeUnit.SECONDS ); // 10 seconds
-        ksession.insert( new OrderEvent( "3", "customer A", 50 ) );
-        ksession.fireAllRules();
-        System.out.println( lengthResults );
-        assertTrue( lengthResults.contains( 60.0 ) );
-
-        // Fourth interaction: advance clock and assert new data
-        clock.advanceTime( 60, TimeUnit.SECONDS ); // 60 seconds
-        ksession.insert( new OrderEvent( "4", "customer A", 25 ) );
-        ksession.fireAllRules();
-        System.out.println( lengthResults );
-        // assertTrue( lengthResults.contains( 45 ) );
-
+            // Fourth interaction: advance clock and assert new data
+            clock.advanceTime( 60, TimeUnit.SECONDS ); // 60 seconds
+            ksession.insert( new OrderEvent( "4", "customer A", 25 ) );
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testTimeStampOnNonExistingField() throws Exception {
+    public void testTimeStampOnNonExistingField() {
         // BZ-985942
         String drl = "package org.drools.compiler;\n" +
                      "\n" +
@@ -2904,7 +2997,7 @@ public class CepEspTest extends CommonTestMethodBase {
     }
 
     @Test (timeout=10000)
-    public void testTimeWindowWithPastEvents() throws Exception {
+    public void testTimeWindowWithPastEvents() {
         // JBRULES-2258 
         String drl = "package org.drools.compiler;\n" +
                      "\n" +
@@ -2936,44 +3029,46 @@ public class CepEspTest extends CommonTestMethodBase {
         ksconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         KieSession ksession = createKnowledgeSession(kbase, ksconf);
+        try {
+            List<Number> timeResults = new ArrayList<Number>();
 
-        List<Number> timeResults = new ArrayList<Number>();
+            ksession.setGlobal( "timeResults",
+                                timeResults );
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        ksession.setGlobal( "timeResults",
-                            timeResults );
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+            int count = 0;
+            StockTick tick1 = new StockTick( count++, "X", 0.0, 1 );
+            StockTick tick2 = new StockTick( count++, "X", 0.0, 3 );
+            StockTick tick3 = new StockTick( count++, "X", 0.0, 7 );
+            StockTick tick4 = new StockTick( count++, "X", 0.0, 9 );
+            StockTick tick5 = new StockTick( count++, "X", 0.0, 15 );
 
-        int count = 0;
-        StockTick tick1 = new StockTick( count++, "X", 0.0, 1 );
-        StockTick tick2 = new StockTick( count++, "X", 0.0, 3 );
-        StockTick tick3 = new StockTick( count++, "X", 0.0, 7 );
-        StockTick tick4 = new StockTick( count++, "X", 0.0, 9 );
-        StockTick tick5 = new StockTick( count++, "X", 0.0, 15 );
+            clock.advanceTime( 30, TimeUnit.MILLISECONDS );
 
-        clock.advanceTime( 30, TimeUnit.MILLISECONDS );
+            ksession.insert( tick1 );
+            ksession.insert( tick2 );
+            ksession.insert( tick3 );
+            ksession.insert( tick4 );
+            ksession.insert( tick5 );
 
-        ksession.insert( tick1 );
-        ksession.insert( tick2 );
-        ksession.insert( tick3 );
-        ksession.insert( tick4 );
-        ksession.insert( tick5 );
+            ksession.fireAllRules();
+            System.out.println(timeResults);
+            assertTrue(timeResults.isEmpty());
 
-        ksession.fireAllRules();
-        System.out.println(timeResults);
-        assertTrue(timeResults.isEmpty());
+            clock.advanceTime( 0, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertTrue( timeResults.isEmpty() );
 
-        clock.advanceTime( 0, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertTrue( timeResults.isEmpty() );
+            clock.advanceTime( 3, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertTrue( timeResults.isEmpty() );
 
-        clock.advanceTime( 3, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertTrue( timeResults.isEmpty() );
-
-        clock.advanceTime( 10, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertTrue( timeResults.isEmpty() );
-
+            clock.advanceTime( 10, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertTrue( timeResults.isEmpty() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -3020,25 +3115,27 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksconf.setOption( ClockTypeOption.get( ClockType.REALTIME_CLOCK.getId() ) );
         KieSession ksession = createKnowledgeSession(kbase, ksconf);
+        try {
+            List<Number> list = new ArrayList<Number>();
 
-        List<Number> list = new ArrayList<Number>();
+            ksession.setGlobal( "list", list );
 
-        ksession.setGlobal( "list", list );
+            ksession.insert( new Long( 1000 ) );
+            ksession.insert( new Long( 1001 ) );
+            ksession.insert( new Long( 1002 ) );
 
-        ksession.insert( new Long( 1000 ) );
-        ksession.insert( new Long( 1001 ) );
-        ksession.insert( new Long( 1002 ) );
+            Thread.sleep(1000);
 
-        Thread.sleep(1000);
-
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
 
     @Test(timeout=10000)
-    public void testTwoWindowsInsideCEAndOut() throws Exception {
+    public void testTwoWindowsInsideCEAndOut() {
         String drl = "package org.drools.compiler;\n" +
                      "\n" +
                      "import java.util.List\n" +
@@ -3065,21 +3162,22 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration sconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
         KieSession wm = createKnowledgeSession( kbase, sconf );
-
-
-
-        wm.insert( new OrderEvent( "1", "customer A", 70 ) );
-        wm.insert( new OrderEvent( "2", "customer A", 60 ) );
-        wm.insert( new OrderEvent( "3", "customer A", 50 ) );
-        wm.insert( new OrderEvent( "4", "customer A", 40 ) );
-        wm.insert( new OrderEvent( "5", "customer A", 30 ) );
-        wm.insert( new OrderEvent( "6", "customer A", 20 ) );
-        wm.insert( new OrderEvent( "7", "customer A", 10 ) );
-        wm.fireAllRules();
+        try {
+            wm.insert( new OrderEvent( "1", "customer A", 70 ) );
+            wm.insert( new OrderEvent( "2", "customer A", 60 ) );
+            wm.insert( new OrderEvent( "3", "customer A", 50 ) );
+            wm.insert( new OrderEvent( "4", "customer A", 40 ) );
+            wm.insert( new OrderEvent( "5", "customer A", 30 ) );
+            wm.insert( new OrderEvent( "6", "customer A", 20 ) );
+            wm.insert( new OrderEvent( "7", "customer A", 10 ) );
+            wm.fireAllRules();
+        } finally {
+            wm.dispose();
+        }
     }
 
     @Test
-    public void testUpdateEventThroughEntryPoint() throws Exception {
+    public void testUpdateEventThroughEntryPoint() {
         String drl = "import org.drools.compiler.integrationtests.CepEspTest.TestEvent\n" +
                      "\n" +
                      "declare TestEvent\n" +
@@ -3112,21 +3210,22 @@ public class CepEspTest extends CommonTestMethodBase {
         assertEquals(0, builder.getResults().getMessages().size());
 
         KieSession kieSession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
+        try {
+            EntryPoint entryPoint = kieSession.getEntryPoint("EventStream");
 
-        EntryPoint entryPoint = kieSession.getEntryPoint("EventStream");
+            TestEvent event = new TestEvent("testEvent1");
+            FactHandle handle = entryPoint.insert(event);
 
-        TestEvent event = new TestEvent("testEvent1");
-        FactHandle handle = entryPoint.insert(event);
+            TestEvent event2 = new TestEvent("testEvent2");
+            entryPoint.update(handle, event2);
 
-        TestEvent event2 = new TestEvent("testEvent2");
-        entryPoint.update(handle, event2);
-
-        // make sure the event is in the entry-point
-        assertFalse(entryPoint.getObjects().contains(event));
-        assertTrue(entryPoint.getObjects().contains(event2));
-        assertEquals(entryPoint.getObject(handle), event2);
-
-        kieSession.dispose();
+            // make sure the event is in the entry-point
+            assertFalse(entryPoint.getObjects().contains(event));
+            assertTrue(entryPoint.getObjects().contains(event2));
+            assertEquals(entryPoint.getObject(handle), event2);
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     public static class TestEvent implements Serializable {
@@ -3232,11 +3331,14 @@ public class CepEspTest extends CommonTestMethodBase {
         assertEquals(res.toString(), 0, res.size());
 
         KieSession ksession = ks.newKieContainer(kbuilder.getKieModule().getReleaseId()).newKieSession();
-
-        ArrayList<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
-        ksession.fireAllRules();
-        assertEquals(1, list.size());
+        try {
+            ArrayList<String> list = new ArrayList<String>();
+            ksession.setGlobal("list", list);
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     public static class Event {
@@ -3326,41 +3428,43 @@ public class CepEspTest extends CommonTestMethodBase {
 
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        ArrayList list = new ArrayList( );
-        ksession.setGlobal( "list", list );
+        try {
+            ArrayList list = new ArrayList( );
+            ksession.setGlobal( "list", list );
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
-        ksession.setGlobal( "clock", clock );
+            SessionPseudoClock clock = ksession.getSessionClock();
+            ksession.setGlobal( "clock", clock );
 
-        ksession.insert( new Event( 1, -1, clock.getCurrentTime() ) ); // 0
-        clock.advanceTime(600, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 600
-        clock.advanceTime(100, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 700
-        clock.advanceTime(300, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 1000
-        clock.advanceTime(100, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        ksession.insert( new Event( 2, 1, clock.getCurrentTime() ) ); // 1100
-        clock.advanceTime(100, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        clock.advanceTime(100, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 1300
+            ksession.insert( new Event( 1, -1, clock.getCurrentTime() ) ); // 0
+            clock.advanceTime(600, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 600
+            clock.advanceTime(100, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 700
+            clock.advanceTime(300, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 1000
+            clock.advanceTime(100, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            ksession.insert( new Event( 2, 1, clock.getCurrentTime() ) ); // 1100
+            clock.advanceTime(100, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            clock.advanceTime(100, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) ); // 1300
 
-        clock.advanceTime(1000, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
+            clock.advanceTime(1000, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
 
-        assertFalse( list.isEmpty() );
-        assertEquals( 1, list.size() );
-        Long time = (Long) list.get( 0 );
+            assertFalse( list.isEmpty() );
+            assertEquals( 1, list.size() );
+            Long time = (Long) list.get( 0 );
 
-        assertTrue( time > 1000 && time < 1500 );
-
-        ksession.dispose();
+            assertTrue( time > 1000 && time < 1500 );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -3404,31 +3508,33 @@ public class CepEspTest extends CommonTestMethodBase {
 
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        ArrayList list = new ArrayList( );
-        ksession.setGlobal( "list", list );
+        try {
+            ArrayList list = new ArrayList( );
+            ksession.setGlobal( "list", list );
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
-        ksession.setGlobal( "clock", clock );
+            SessionPseudoClock clock = ksession.getSessionClock();
+            ksession.setGlobal( "clock", clock );
 
-        ksession.insert( new Event( 0, 0, clock.getCurrentTime() ) );
-        clock.advanceTime(100, TimeUnit.MILLISECONDS);
+            ksession.insert( new Event( 0, 0, clock.getCurrentTime() ) );
+            clock.advanceTime(100, TimeUnit.MILLISECONDS);
 
-        ksession.insert( new Event( 1, 0, clock.getCurrentTime() ) );
-        clock.advanceTime(600, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
+            ksession.insert( new Event( 1, 0, clock.getCurrentTime() ) );
+            clock.advanceTime(600, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
 
-        ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) );
-        clock.advanceTime(600, TimeUnit.MILLISECONDS);
-        ksession.insert( new Event( 3, 0, clock.getCurrentTime() ) );
-        ksession.fireAllRules();
+            ksession.insert( new Event( 2, 0, clock.getCurrentTime() ) );
+            clock.advanceTime(600, TimeUnit.MILLISECONDS);
+            ksession.insert( new Event( 3, 0, clock.getCurrentTime() ) );
+            ksession.fireAllRules();
 
-        assertFalse( list.isEmpty() );
-        assertEquals( 1, list.size() );
-        long time = (Long) list.get( 0 );
+            assertFalse( list.isEmpty() );
+            assertEquals( 1, list.size() );
+            long time = (Long) list.get( 0 );
 
-        assertEquals( 1300, time );
-
-        ksession.dispose();
+            assertEquals( 1300, time );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -3455,15 +3561,18 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(kconf, drl);
         KieSession ksession = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
-
-        SimpleFact fact = new SimpleFact("id1");
-        ksession.insert(fact);
-        ksession.fireAllRules();
-        assertEquals(1, list.size());
-        assertEquals("OK", fact.getStatus());
+            SimpleFact fact = new SimpleFact("id1");
+            ksession.insert(fact);
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+            assertEquals("OK", fact.getStatus());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -3500,16 +3609,19 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(kconf, drl);
         KieSession ksession = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+            ksession.insert(new SimpleFact("id1"));
+            ksession.insert(new SimpleFact("id2"));
+            ksession.insert(new SimpleFact("id3"));
 
-        ksession.insert(new SimpleFact("id1"));
-        ksession.insert(new SimpleFact("id2"));
-        ksession.insert(new SimpleFact("id3"));
-
-        ksession.fireAllRules();
-        assertEquals(0, list.size());
+            ksession.fireAllRules();
+            assertEquals(0, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -3547,16 +3659,19 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(kconf, drl);
         KieSession ksession = kbase.newKieSession();
+        try {
+            for (int i = 0; i < 4; i++) {
+                ksession.insert(new SimpleFact("id" + i));
+            }
+            ksession.fireAllRules();
+            assertEquals("all events should be in WM", 4, ksession.getFactCount());
 
-        for (int i = 0; i < 4; i++) {
-            ksession.insert(new SimpleFact("id" + i));
+            ksession.insert(new SimpleFact("last"));
+            ksession.fireAllRules();
+            assertEquals("only one event should be still in WM", 1, ksession.getFactCount());
+        } finally {
+            ksession.dispose();
         }
-        ksession.fireAllRules();
-        assertEquals("all events should be in WM", 4, ksession.getFactCount());
-
-        ksession.insert(new SimpleFact("last"));
-        ksession.fireAllRules();
-        assertEquals("only one event should be still in WM", 1, ksession.getFactCount());
     }
 
     public static class SimpleFact {
@@ -3617,22 +3732,23 @@ public class CepEspTest extends CommonTestMethodBase {
         ksconfig.setOption(ClockTypeOption.get("pseudo"));
 
         KieSession ksession = kbase.newKieSession(ksconfig, null);
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        SessionPseudoClock clock = ksession.getSessionClock();
+            EntryPoint ePoint = ksession.getEntryPoint("EStream");
+            EntryPoint entryPoint = ksession.getEntryPoint("EventStream");
 
-        EntryPoint ePoint = ksession.getEntryPoint("EStream");
-        EntryPoint entryPoint = ksession.getEntryPoint("EventStream");
-
-        ePoint.insert(new TestEvent("zero"));
-        entryPoint.insert(new TestEvent("one"));
-        clock.advanceTime( 10, TimeUnit.SECONDS );
-        entryPoint.insert(new TestEvent("two"));
-        clock.advanceTime( 10, TimeUnit.SECONDS );
-        entryPoint.insert(new TestEvent("three"));
-        QueryResults results = ksession.getQueryResults("EventsBeforeNineSeconds");
-        assertEquals(1, results.size());
-
-        ksession.dispose();
+            ePoint.insert(new TestEvent("zero"));
+            entryPoint.insert(new TestEvent("one"));
+            clock.advanceTime( 10, TimeUnit.SECONDS );
+            entryPoint.insert(new TestEvent("two"));
+            clock.advanceTime( 10, TimeUnit.SECONDS );
+            entryPoint.insert(new TestEvent("three"));
+            QueryResults results = ksession.getQueryResults("EventsBeforeNineSeconds");
+            assertEquals(1, results.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
 
@@ -3649,9 +3765,7 @@ public class CepEspTest extends CommonTestMethodBase {
 
             ProbeEvent that = (ProbeEvent) o;
 
-            if (value != that.value) return false;
-
-            return true;
+            return value == that.value;
         }
 
         @Override
@@ -3675,7 +3789,7 @@ public class CepEspTest extends CommonTestMethodBase {
 
     @Test
     @Ignore
-    public void testExpirationAtHighRates() throws InterruptedException {
+    public void testExpirationAtHighRates() {
         // DROOLS-130
         String drl = "package droolsfusioneval\n" +
                      "" +
@@ -3778,37 +3892,38 @@ public class CepEspTest extends CommonTestMethodBase {
         ksconf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         KieSession ksession = createKnowledgeSession(kbase, ksconf);
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
+            EntryPoint ePoint = ksession.getEntryPoint("EStream");
+            EntryPoint entryPoint = ksession.getEntryPoint("EventStream");
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
-        EntryPoint ePoint = ksession.getEntryPoint("EStream");
-        EntryPoint entryPoint = ksession.getEntryPoint("EventStream");
 
+            ePoint.insert(new StockTick(0L, "zero", 0.0, 0));
 
-        ePoint.insert(new StockTick(0L, "zero", 0.0, 0));
+            entryPoint.insert(new StockTick(1L, "one", 0.0, 0));
 
-        entryPoint.insert(new StockTick(1L, "one", 0.0, 0));
+            clock.advanceTime(10, TimeUnit.SECONDS);
 
-        clock.advanceTime(10, TimeUnit.SECONDS);
+            entryPoint.insert(new StockTick(2L, "two",0.0,  0));
 
-        entryPoint.insert(new StockTick(2L, "two",0.0,  0));
+            clock.advanceTime(10, TimeUnit.SECONDS);
 
-        clock.advanceTime(10, TimeUnit.SECONDS);
+            entryPoint.insert(new StockTick(3L, "three", 0.0, 0));
 
-        entryPoint.insert(new StockTick(3L, "three", 0.0, 0));
+            QueryResults results = ksession.getQueryResults("EventsBeforeNineSeconds");
 
-        QueryResults results = ksession.getQueryResults("EventsBeforeNineSeconds");
+            assertEquals( 0, results.size());
 
-        assertEquals( 0, results.size());
+            results = ksession.getQueryResults("EventsBeforeNineteenSeconds");
 
-        results = ksession.getQueryResults("EventsBeforeNineteenSeconds");
+            assertEquals( 0, results.size() );
 
-        assertEquals( 0, results.size() );
+            results = ksession.getQueryResults("EventsBeforeHundredSeconds");
 
-        results = ksession.getQueryResults("EventsBeforeHundredSeconds");
-
-        assertEquals( 1, results.size() );
-
-        ksession.dispose();
+            assertEquals( 1, results.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -3853,11 +3968,14 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kb = loadKnowledgeBaseFromString( drl );
         KieSession ks = kb.newKieSession();
-
-        ArrayList list = new ArrayList( 1 );
-        ks.setGlobal( "list", list );
-        ks.fireAllRules();
-        assertEquals( Arrays.asList( 1 ), list );
+        try {
+            ArrayList list = new ArrayList( 1 );
+            ks.setGlobal( "list", list );
+            ks.fireAllRules();
+            assertEquals( Arrays.asList( 1 ), list );
+        } finally {
+            ks.dispose();
+        }
     }
 
     @Test
@@ -3893,28 +4011,31 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kb = loadKnowledgeBaseFromString( kbconf, drl );
         KieSession ks = kb.newKieSession( knowledgeSessionConfiguration, null );
-
-        ks.insert( new StockTick( 2, "BBB", 1.0, 0 ) );
-        Thread.sleep( 1100 );
-
         try {
-            ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            ks.insert( new StockTick( 2, "BBB", 1.0, 0 ) );
+            Thread.sleep( 1100 );
+
+            try {
+                ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+            ks.addEventListener( new DebugAgendaEventListener(  ) );
+
+            ArrayList list = new ArrayList();
+            ks.setGlobal( "list", list );
+
+            ks.fireAllRules();
+
+            ks.insert( new StockTick( 3, "BBB", 1.0, 0 ) );
+            ks.fireAllRules();
+
+            assertEquals( 2, list.size() );
+            assertEquals( Arrays.asList( 2L, 3L ), list );
+        } finally {
+            ks.dispose();
         }
-        ks.addEventListener( new DebugAgendaEventListener(  ) );
-
-        ArrayList list = new ArrayList();
-        ks.setGlobal( "list", list );
-
-        ks.fireAllRules();
-
-        ks.insert( new StockTick( 3, "BBB", 1.0, 0 ) );
-        ks.fireAllRules();
-
-        assertEquals( 2, list.size() );
-        assertEquals( Arrays.asList( 2L, 3L ), list );
     }
 
     @Test
@@ -3943,33 +4064,36 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kb = loadKnowledgeBaseFromString( kbconf, drl );
         KieSession ks = kb.newKieSession( knowledgeSessionConfiguration, null );
-
-        ks.insert( new StockTick( 1, "BBB", 1.0, 0 ) );
-        Thread.sleep( 1000 );
-        ks.insert(new StockTick(2, "BBB", 2.0, 0));
-        Thread.sleep( 100 );
-
         try {
-            ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            ks.insert( new StockTick( 1, "BBB", 1.0, 0 ) );
+            Thread.sleep( 1000 );
+            ks.insert(new StockTick(2, "BBB", 2.0, 0));
+            Thread.sleep( 100 );
+
+            try {
+                ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+
+            List<Double> list = new ArrayList<Double>();
+            ks.setGlobal( "list", list );
+
+            ks.fireAllRules();
+
+            ks.insert(new StockTick(3, "BBB", 3.0, 0));
+            ks.fireAllRules();
+
+            assertEquals( 2, list.size() );
+            assertEquals( Arrays.asList( 2.0, 5.0 ), list );
+        } finally {
+            ks.dispose();
         }
-
-        List<Double> list = new ArrayList<Double>();
-        ks.setGlobal( "list", list );
-
-        ks.fireAllRules();
-
-        ks.insert(new StockTick(3, "BBB", 3.0, 0));
-        ks.fireAllRules();
-
-        assertEquals( 2, list.size() );
-        assertEquals( Arrays.asList( 2.0, 5.0 ), list );
     }
 
     @Test
-    public void testDeserializationWithCompositeTrigger() throws InterruptedException {
+    public void testDeserializationWithCompositeTrigger() {
         String drl = "package org.drools.test;\n" +
                      "import org.drools.compiler.StockTick; \n" +
                      "global java.util.List list;\n" +
@@ -3995,14 +4119,17 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kb = loadKnowledgeBaseFromString( kbconf, drl );
         KieSession ks = kb.newKieSession( knowledgeSessionConfiguration, null );
-
-        ks.insert( new StockTick( 2, "AAA", 1.0, 0 ) );
-
         try {
-            ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            ks.insert( new StockTick( 2, "AAA", 1.0, 0 ) );
+
+            try {
+                ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+        } finally {
+            ks.dispose();
         }
     }
 
@@ -4028,33 +4155,33 @@ public class CepEspTest extends CommonTestMethodBase {
         kbconf.setOption( EventProcessingOption.STREAM );
         KieBase kb = loadKnowledgeBaseFromString( kbconf, drl );
         KieSession ks = kb.newKieSession( );
-
-        ks.insert( new StockTick( 2, "BBB", 1.0, 0 ) );
-        Thread.sleep( 1500 );
-
         try {
-            ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            ks.insert( new StockTick( 2, "BBB", 1.0, 0 ) );
+            Thread.sleep( 1500 );
+
+            try {
+                ks = SerializationHelper.getSerialisedStatefulKnowledgeSession( ks, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+            ArrayList list = new ArrayList();
+            ks.setGlobal( "list", list );
+
+            ks.fireAllRules();
+
+            ks.insert( new StockTick( 3, "BBB", 1.0, 0 ) );
+            ks.fireAllRules();
+
+            assertEquals( 1, list.size() );
+            assertEquals( Arrays.asList( 3L ), list );
+        } finally {
+            ks.dispose();
         }
-        ArrayList list = new ArrayList();
-        ks.setGlobal( "list", list );
-
-        ks.fireAllRules();
-
-        ks.insert( new StockTick( 3, "BBB", 1.0, 0 ) );
-        ks.fireAllRules();
-
-        System.out.print( list );
-        assertEquals( 1, list.size() );
-        assertEquals( Arrays.asList( 3L ), list );
-
-
     }
 
     @Test
-    public void testDuplicateFiring1() throws InterruptedException {
+    public void testDuplicateFiring1() {
 
         String drl = "package org.test;\n" +
                      "import org.drools.compiler.StockTick;\n " +
@@ -4102,38 +4229,40 @@ public class CepEspTest extends CommonTestMethodBase {
         sessionConfig.setOption( ClockTypeOption.get("pseudo") );
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession(sessionConfig, null);
-        SessionPseudoClock clock = ksession.getSessionClock();
-        ArrayList list = new ArrayList(  );
-        ksession.setGlobal( "list", list );
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
+            ArrayList list = new ArrayList(  );
+            ksession.setGlobal( "list", list );
 
-        //entry point for sensor events
-        EntryPoint sensorEventStream = ksession.getEntryPoint( "SensorEventStream" );
+            //entry point for sensor events
+            EntryPoint sensorEventStream = ksession.getEntryPoint( "SensorEventStream" );
 
-        ksession.insert( "Go" );
-        System.out.println("1. fireAllRules()");
+            ksession.insert( "Go" );
+            System.out.println("1. fireAllRules()");
 
-        //insert events
-        for(int i=2;i<8;i++){
-            StockTick event = new StockTick( (i-1), "XXX", 1.0, 0 );
-            sensorEventStream.insert( event );
+            //insert events
+            for(int i=2;i<8;i++){
+                StockTick event = new StockTick( (i-1), "XXX", 1.0, 0 );
+                sensorEventStream.insert( event );
 
-            System.out.println(i + ". fireAllRules()");
+                System.out.println(i + ". fireAllRules()");
+                ksession.fireAllRules();
+
+                clock.advanceTime(105, TimeUnit.MILLISECONDS);
+            }
+
+            //let thread sleep for another 1m to see if dereffered rules fire (timers, (not) after rules)
+            clock.advanceTime(100*40*1, TimeUnit.MILLISECONDS);
             ksession.fireAllRules();
 
-            clock.advanceTime(105, TimeUnit.MILLISECONDS);
+            assertEquals( Arrays.asList( 1L, 2L, 3L, 3L, 3L, 3L, -1 ), list );
+        } finally {
+            ksession.dispose();
         }
-
-        //let thread sleep for another 1m to see if dereffered rules fire (timers, (not) after rules)
-        clock.advanceTime(100*40*1, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-
-        assertEquals( Arrays.asList( 1L, 2L, 3L, 3L, 3L, 3L, -1 ), list );
-
-        ksession.dispose();
     }
 
     @Test
-    public void testDuplicateFiring2() throws InterruptedException {
+    public void testDuplicateFiring2() {
 
         String drl = "package org.test;\n" +
                      "import org.drools.compiler.StockTick;\n " +
@@ -4171,42 +4300,42 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get("pseudo") );
         //init stateful knowledge session
-        KieSession ksession = kbase.newKieSession(sessionConfig, null);
-        SessionPseudoClock clock = ksession.getSessionClock();
         ArrayList list = new ArrayList(  );
-        ksession.setGlobal( "list", list );
+        KieSession ksession = kbase.newKieSession(sessionConfig, null);
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
+            ksession.setGlobal( "list", list );
 
+            //insert events
+            for(int i=1;i<3;i++){
+                StockTick event = new StockTick( (i-1), "XXX", 1.0, 0 );
+                clock.advanceTime( 1001, TimeUnit.MILLISECONDS );
+                ksession.insert( event );
 
-        //insert events
-        for(int i=1;i<3;i++){
-            StockTick event = new StockTick( (i-1), "XXX", 1.0, 0 );
-            clock.advanceTime( 1001, TimeUnit.MILLISECONDS );
+                System.out.println(i + ". rule invocation");
+                ksession.fireAllRules();
+            }
+
+            clock.advanceTime( 3001, TimeUnit.MILLISECONDS );
+            StockTick event = new StockTick( 3, "XXX", 1.0, 0 );
+            System.out.println("3. rule invocation");
             ksession.insert( event );
-
-            System.out.println(i + ". rule invocation");
             ksession.fireAllRules();
+
+            clock.advanceTime( 3001, TimeUnit.MILLISECONDS );
+            StockTick event2 = new StockTick( 3, "XXX", 1.0, 0 );
+            System.out.println("4. rule invocation");
+            ksession.insert( event2 );
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+            assertEquals( Arrays.asList( 1L, 2L, 1L, 1L ), list );
         }
-
-        clock.advanceTime( 3001, TimeUnit.MILLISECONDS );
-        StockTick event = new StockTick( 3, "XXX", 1.0, 0 );
-        System.out.println("3. rule invocation");
-        ksession.insert( event );
-        ksession.fireAllRules();
-
-        clock.advanceTime( 3001, TimeUnit.MILLISECONDS );
-        StockTick event2 = new StockTick( 3, "XXX", 1.0, 0 );
-        System.out.println("4. rule invocation");
-        ksession.insert( event2 );
-        ksession.fireAllRules();
-
-        ksession.dispose();
-
-        assertEquals( Arrays.asList( 1L, 2L, 1L, 1L ), list );
     }
 
 
     @Test
-    public void testPastEventExipration() throws InterruptedException {
+    public void testPastEventExipration() {
         //DROOLS-257
         String drl = "package org.test;\n" +
                      "import org.drools.compiler.StockTick;\n " +
@@ -4238,31 +4367,35 @@ public class CepEspTest extends CommonTestMethodBase {
         sessionConfig.setOption( ClockTypeOption.get("pseudo") );
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        SessionPseudoClock clock = ksession.getSessionClock();
-        ArrayList list = new ArrayList(  );
-        ksession.setGlobal( "list", list );
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
+            ArrayList list = new ArrayList(  );
+            ksession.setGlobal( "list", list );
 
-        long now = 0;
+            long now = 0;
 
-        StockTick event1 = new StockTick( 1, "XXX", 1.0, now );
-        StockTick event2 = new StockTick( 2, "XXX", 1.0, now + 240 );
-        StockTick event3 = new StockTick( 2, "XXX", 1.0, now + 380 );
-        StockTick event4 = new StockTick( 2, "XXX", 1.0, now + 500 );
+            StockTick event1 = new StockTick( 1, "XXX", 1.0, now );
+            StockTick event2 = new StockTick( 2, "XXX", 1.0, now + 240 );
+            StockTick event3 = new StockTick( 2, "XXX", 1.0, now + 380 );
+            StockTick event4 = new StockTick( 2, "XXX", 1.0, now + 500 );
 
-        ksession.insert( event1 );
-        ksession.insert( event2 );
-        ksession.insert( event3 );
-        ksession.insert( event4 );
+            ksession.insert( event1 );
+            ksession.insert( event2 );
+            ksession.insert( event3 );
+            ksession.insert( event4 );
 
-        clock.advanceTime( 220, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 220, TimeUnit.MILLISECONDS );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        clock.advanceTime( 400, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 400, TimeUnit.MILLISECONDS );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( Arrays.asList( 3L, 1L ), list );
+            assertEquals( Arrays.asList( 3L, 1L ), list );
+        } finally {
+            ksession.dispose();
+        }
     }
 
 
@@ -4275,7 +4408,7 @@ public class CepEspTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testEventStreamWithEPsAndDefaultPseudo() throws InterruptedException {
+    public void testEventStreamWithEPsAndDefaultPseudo() {
         //DROOLS-286
         String drl = "\n" +
                      "import java.util.*;\n" +
@@ -4358,43 +4491,45 @@ public class CepEspTest extends CommonTestMethodBase {
 
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        SessionPseudoClock clock = ksession.getSessionClock();
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        ArrayList list = new ArrayList( );
-        ksession.setGlobal( "list", list );
+            ArrayList list = new ArrayList( );
+            ksession.setGlobal( "list", list );
 
-        ksession.fireAllRules();
-        list.clear();
-
-        for ( int j = 0; j < 5; j++ ) {
-            clock.advanceTime(500, TimeUnit.MILLISECONDS );
-            ksession.insert(new MyEvent(clock.getCurrentTime() ) );
-            ksession.getEntryPoint( "stream" ).insert(new MyEvent(clock.getCurrentTime() ) );
-            clock.advanceTime( 500, TimeUnit.MILLISECONDS );
             ksession.fireAllRules();
-
-            System.out.println( list );
-            switch ( j ) {
-                case 0 : assertEquals( Arrays.asList( "r6:1", "r5:1", "r3:1", "r2:1" ), list );
-                    break;
-                case 1 : assertEquals( Arrays.asList( "r6:2", "r5:1", "r3:2", "r2:1" ), list );
-                    break;
-                case 2 :
-                case 3 :
-                case 4 : assertEquals( Arrays.asList( "r6:3", "r5:1", "r3:3", "r2:1" ), list );
-                    break;
-                default: fail();
-            }
             list.clear();
 
-            System.out.println( "-------------- SLEEP ------------" );
-        }
+            for ( int j = 0; j < 5; j++ ) {
+                clock.advanceTime(500, TimeUnit.MILLISECONDS );
+                ksession.insert(new MyEvent(clock.getCurrentTime() ) );
+                ksession.getEntryPoint( "stream" ).insert(new MyEvent(clock.getCurrentTime() ) );
+                clock.advanceTime( 500, TimeUnit.MILLISECONDS );
+                ksession.fireAllRules();
 
-        ksession.dispose();
+                System.out.println( list );
+                switch ( j ) {
+                    case 0 : assertEquals( Arrays.asList( "r6:1", "r5:1", "r3:1", "r2:1" ), list );
+                        break;
+                    case 1 : assertEquals( Arrays.asList( "r6:2", "r5:1", "r3:2", "r2:1" ), list );
+                        break;
+                    case 2 :
+                    case 3 :
+                    case 4 : assertEquals( Arrays.asList( "r6:3", "r5:1", "r3:3", "r2:1" ), list );
+                        break;
+                    default: fail();
+                }
+                list.clear();
+
+                System.out.println( "-------------- SLEEP ------------" );
+            }
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testExpirationOnModification() throws InterruptedException {
+    public void testExpirationOnModification() {
         //DROOLS-374
         String drl = "\n" +
                      "import java.util.*;\n" +
@@ -4443,33 +4578,33 @@ public class CepEspTest extends CommonTestMethodBase {
 
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        SessionPseudoClock clock = ksession.getSessionClock();
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        ArrayList list = new ArrayList( );
-        ksession.setGlobal( "list", list );
+            ArrayList list = new ArrayList( );
+            ksession.setGlobal( "list", list );
 
-        ksession.insert( "go" );
-        ksession.fireAllRules();
+            ksession.insert( "go" );
+            ksession.fireAllRules();
 
-        clock.advanceTime( 100, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 100, TimeUnit.MILLISECONDS );
 
-        ksession.insert( "go" );
-        ksession.fireAllRules();
+            ksession.insert( "go" );
+            ksession.fireAllRules();
 
-        clock.advanceTime( 500, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 500, TimeUnit.MILLISECONDS );
 
-        ksession.insert( "go" );
-        ksession.fireAllRules();
+            ksession.insert( "go" );
+            ksession.fireAllRules();
 
-        assertEquals( Arrays.asList( 1L, 2L, 1L ), list );
-
-        ksession.dispose();
+            assertEquals( Arrays.asList( 1L, 2L, 1L ), list );
+        } finally {
+            ksession.dispose();
+        }
     }
 
-
-
     @Test
-    public void testTemporalEvaluatorsWithEventsFromNode() throws InterruptedException {
+    public void testTemporalEvaluatorsWithEventsFromNode() {
         //DROOLS-421
         String drl = "\n" +
                      "import java.util.*; " +
@@ -4517,20 +4652,22 @@ public class CepEspTest extends CommonTestMethodBase {
         assertEquals( 0, kbuilder.getResults().getMessages().size() );
 
         KieSession ksession = ks.newKieContainer( kbuilder.getKieModule().getReleaseId() ).newKieSession();
-        assertNotNull( ksession );
+        try {
+            assertNotNull( ksession );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        ksession.dispose();
-
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testTemporalEvaluatorsUsingRawDateFields() throws InterruptedException {
+    public void testTemporalEvaluatorsUsingRawDateFields() {
         //DROOLS-421
         String drl = "\n" +
                      "import java.util.*; " +
@@ -4575,21 +4712,22 @@ public class CepEspTest extends CommonTestMethodBase {
         assertEquals( 0, kbuilder.getResults().getMessages().size() );
 
         KieSession ksession = ks.newKieContainer( kbuilder.getKieModule().getReleaseId() ).newKieSession();
-        assertNotNull( ksession );
+        try {
+            assertNotNull( ksession );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        ksession.dispose();
-
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
-
     @Test
-    public void testTemporalEvaluatorsUsingRawDateFieldsFromFrom() throws InterruptedException {
+    public void testTemporalEvaluatorsUsingRawDateFieldsFromFrom() {
         //DROOLS-421
         String drl = "\n" +
                      "import java.util.*; " +
@@ -4623,20 +4761,22 @@ public class CepEspTest extends CommonTestMethodBase {
         assertEquals( 0, kbuilder.getResults().getMessages().size() );
 
         KieSession ksession = ks.newKieContainer( kbuilder.getKieModule().getReleaseId() ).newKieSession();
-        assertNotNull( ksession );
+        try {
+            assertNotNull( ksession );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        ksession.dispose();
-
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testTemporalEvaluatorsUsingSelfDates() throws InterruptedException {
+    public void testTemporalEvaluatorsUsingSelfDates() {
         //DROOLS-421
         String drl = "\n" +
                      "import java.util.*; " +
@@ -4668,16 +4808,18 @@ public class CepEspTest extends CommonTestMethodBase {
         assertEquals( 0, kbuilder.getResults().getMessages().size() );
 
         KieSession ksession = ks.newKieContainer( kbuilder.getKieModule().getReleaseId() ).newKieSession();
-        assertNotNull( ksession );
+        try {
+            assertNotNull( ksession );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        ksession.dispose();
-
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -4723,22 +4865,23 @@ public class CepEspTest extends CommonTestMethodBase {
 
         //init stateful knowledge session
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
+            // generate the event
+            ksession.fireAllRules();
 
-        // generate the event
-        ksession.fireAllRules();
+            // move on..
+            clock.advanceTime( 10, TimeUnit.SECONDS );
 
-        // move on..
-        clock.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
+            // The event should still be there...
 
-        // The event should still be there...
-
-        assertEquals( 1, ksession.getObjects().size() );
-
-        ksession.dispose();
+            assertEquals( 1, ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test @Ignore("Cannot reproduce with pseudoclock and takes too long with system clock")
@@ -4875,13 +5018,17 @@ public class CepEspTest extends CommonTestMethodBase {
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         final KieSession ksession = kbase.newKieSession(sessionConfig, null);
-        PseudoClockScheduler clock = ksession.getSessionClock();
-        clock.setStartupTime(System.currentTimeMillis());
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.setStartupTime(System.currentTimeMillis());
 
-        SimpleEvent event = new SimpleEvent("code1");
-        event.setDateEvt(System.currentTimeMillis() - (2 * 60 * 60 * 1000));
-        ksession.insert(event);
-        ksession.fireAllRules();
+            SimpleEvent event = new SimpleEvent("code1");
+            event.setDateEvt(System.currentTimeMillis() - (2 * 60 * 60 * 1000));
+            ksession.insert(event);
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     public static class SimpleEvent {
@@ -4953,18 +5100,22 @@ public class CepEspTest extends CommonTestMethodBase {
         kbase.addPackages( kbuilder.getKnowledgePackages() );
 
         KieSession ksession = kbase.newKieSession();
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        SimpleEvent event = new SimpleEvent("code1", DateUtils.parseDate("18-Mar-2014").getTime());
-        ksession.insert(event);
-        ksession.fireAllRules();
+            SimpleEvent event = new SimpleEvent("code1", DateUtils.parseDate("18-Mar-2014").getTime());
+            ksession.insert(event);
+            ksession.fireAllRules();
 
-        assertEquals(1, list.size());
+            assertEquals(1, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testTemporalOperatorWithConstantAndJoin() throws Exception {
+    public void testTemporalOperatorWithConstantAndJoin() {
         // BZ 1096243
         String drl = "import " + SimpleEvent.class.getCanonicalName() + "\n" +
                      "import java.util.Date\n" +
@@ -4996,20 +5147,24 @@ public class CepEspTest extends CommonTestMethodBase {
         kbase.addPackages( kbuilder.getKnowledgePackages() );
 
         KieSession ksession = kbase.newKieSession();
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        SimpleEvent event1 = new SimpleEvent("code1", DateUtils.parseDate("18-Mar-2014").getTime());
-        ksession.insert(event1);
-        SimpleEvent event2 = new SimpleEvent("code2", DateUtils.parseDate("19-Mar-2014").getTime());
-        ksession.insert(event2);
-        ksession.fireAllRules();
+            SimpleEvent event1 = new SimpleEvent("code1", DateUtils.parseDate("18-Mar-2014").getTime());
+            ksession.insert(event1);
+            SimpleEvent event2 = new SimpleEvent("code2", DateUtils.parseDate("19-Mar-2014").getTime());
+            ksession.insert(event2);
+            ksession.fireAllRules();
 
-        assertEquals(1, list.size());
+            assertEquals(1, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testDynamicSalienceInStreamMode() throws Exception {
+    public void testDynamicSalienceInStreamMode() {
         // DROOLS-526
         String drl =
                 "import java.util.concurrent.atomic.AtomicInteger;\n" +
@@ -5054,17 +5209,21 @@ public class CepEspTest extends CommonTestMethodBase {
         kbase.addPackages( kbuilder.getKnowledgePackages() );
 
         KieSession ksession = kbase.newKieSession();
-        List<Integer> list = new ArrayList<Integer>();
-        ksession.setGlobal("list", list);
-        ksession.setGlobal("salience1", new AtomicInteger(9));
-        ksession.setGlobal("salience2", new AtomicInteger(10));
+        try {
+            List<Integer> list = new ArrayList<Integer>();
+            ksession.setGlobal("list", list);
+            ksession.setGlobal("salience1", new AtomicInteger(9));
+            ksession.setGlobal("salience2", new AtomicInteger(10));
 
-        for (int i = 0; i < 10; i++) {
-            ksession.insert(i);
-            ksession.fireAllRules();
+            for (int i = 0; i < 10; i++) {
+                ksession.insert(i);
+                ksession.fireAllRules();
+            }
+
+            assertEquals(list, Arrays.asList(2, 1, 2, 1, 2, 1, 2, 1, 2, 1));
+        } finally {
+            ksession.dispose();
         }
-
-        assertEquals(list, Arrays.asList(2, 1, 2, 1, 2, 1, 2, 1, 2, 1));
     }
 
     @Test
@@ -5107,18 +5266,22 @@ public class CepEspTest extends CommonTestMethodBase {
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
         final KieSession ksession = kbase.newKieSession(sessionConfig, null);
-        PseudoClockScheduler clock = ksession.getSessionClock();
-        clock.setStartupTime(System.currentTimeMillis());
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.setStartupTime(System.currentTimeMillis());
 
-        SimpleEvent event = new SimpleEvent("code1");
-        event.setDateEvt(System.currentTimeMillis() - (2 * 60 * 60 * 1000));
-        ksession.insert(event);
-        ksession.fireAllRules();
-        assertEquals("code2", event.getCode());
+            SimpleEvent event = new SimpleEvent("code1");
+            event.setDateEvt(System.currentTimeMillis() - (2 * 60 * 60 * 1000));
+            ksession.insert(event);
+            ksession.fireAllRules();
+            assertEquals("code2", event.getCode());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testRetractFromWindow() throws Exception {
+    public void testRetractFromWindow() {
         // DROOLS-636
         String drl =
                 "import org.drools.compiler.StockTick;\n " +
@@ -5140,14 +5303,17 @@ public class CepEspTest extends CommonTestMethodBase {
         KieHelper helper = new KieHelper();
         helper.addContent(drl, ResourceType.DRL);
         KieSession ksession = helper.build(EventProcessingOption.STREAM).newKieSession();
-
-        ksession.insert(42);
-        ksession.insert(new StockTick(1L, "DROOLS", 20));
-        ksession.fireAllRules();
+        try {
+            ksession.insert(42);
+            ksession.insert(new StockTick(1L, "DROOLS", 20));
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testCEPNamedCons() throws InterruptedException {
+    public void testCEPNamedCons() {
 
         String drl = "package org.drools " +
 
@@ -5204,30 +5370,31 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSession ksession = helper.build(
                 EventProcessingOption.STREAM
         ).newKieSession( sessionConfig, null );
+        try {
+            List list = new ArrayList(  );
+            ksession.setGlobal( "list", list );
 
+            ksession.insert("John");
+            ksession.fireAllRules();
 
-        List list = new ArrayList(  );
-        ksession.setGlobal( "list", list );
+            System.out.println("--------------------");
+            (( PseudoClockScheduler )ksession.getSessionClock()).advanceTime( 10, TimeUnit.MILLISECONDS );
+            ksession.insert( "Peter" );
+            ksession.fireAllRules();
 
-        ksession.insert("John");
-        ksession.fireAllRules();
-
-        System.out.println("--------------------");
-        (( PseudoClockScheduler )ksession.getSessionClock()).advanceTime( 10, TimeUnit.MILLISECONDS );
-        ksession.insert( "Peter" );
-        ksession.fireAllRules();
-
-        System.out.println( list );
-        assertTrue( list.contains( 0 ) );
-        assertTrue( list.contains( 1 ) );
-        assertTrue(list.contains(2));
-        assertFalse(list.contains(-1));
-        assertFalse(list.contains(-2));
-
+            System.out.println( list );
+            assertTrue( list.contains( 0 ) );
+            assertTrue( list.contains( 1 ) );
+            assertTrue(list.contains(2));
+            assertFalse(list.contains(-1));
+            assertFalse(list.contains(-2));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testCEPNamedConsTimers() throws InterruptedException {
+    public void testCEPNamedConsTimers() {
 
         String drl = "package org.drools " +
 
@@ -5264,24 +5431,26 @@ public class CepEspTest extends CommonTestMethodBase {
         KieHelper helper = new KieHelper();
         helper.addContent(drl, ResourceType.DRL);
         KieSession ksession = helper.build(EventProcessingOption.STREAM).newKieSession( sessionConfig, null );
+        try {
+            List list = new ArrayList(  );
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList(  );
-        ksession.setGlobal( "list", list );
+            ksession.insert("John");
+            ksession.fireAllRules();
+            assertTrue(list.isEmpty());
 
-        ksession.insert("John");
-        ksession.fireAllRules();
-        assertTrue(list.isEmpty());
+            (( PseudoClockScheduler )ksession.getSessionClock()).advanceTime(1000, TimeUnit.MILLISECONDS);
 
-        (( PseudoClockScheduler )ksession.getSessionClock()).advanceTime(1000, TimeUnit.MILLISECONDS);
-
-        ksession.fireAllRules();
-        assertTrue(list.contains(-2));
-        assertTrue(list.contains(0));
-
+            ksession.fireAllRules();
+            assertTrue(list.contains(-2));
+            assertTrue(list.contains(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void test2TimersWithNamedCons() throws InterruptedException {
+    public void test2TimersWithNamedCons() {
         String drl = "package org.drools " +
 
                      "global java.util.List list; " +
@@ -5314,23 +5483,26 @@ public class CepEspTest extends CommonTestMethodBase {
         KieHelper helper = new KieHelper();
         helper.addContent(drl, ResourceType.DRL);
         KieSession ksession = helper.build(EventProcessingOption.STREAM).newKieSession(sessionConfig, null);
+        try {
+            List<Integer> list = new ArrayList<Integer>();
+            ksession.setGlobal("list", list);
 
-        List<Integer> list = new ArrayList<Integer>();
-        ksession.setGlobal("list", list);
+            ksession.insert("Alice");
+            ksession.fireAllRules();
+            assertTrue(list.isEmpty());
 
-        ksession.insert("Alice");
-        ksession.fireAllRules();
-        assertTrue(list.isEmpty());
+            ((PseudoClockScheduler) ksession.getSessionClock()).advanceTime(150, TimeUnit.MILLISECONDS);
 
-        ((PseudoClockScheduler) ksession.getSessionClock()).advanceTime(150, TimeUnit.MILLISECONDS);
-
-        ksession.fireAllRules();
-        assertEquals(1, list.size());
-        assertEquals(1, (int) list.get(0));
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+            assertEquals(1, (int) list.get(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void test2TimersWith2Rules() throws InterruptedException {
+    public void test2TimersWith2Rules() {
         String drl = "package org.drools " +
 
                      "global java.util.List list; " +
@@ -5367,23 +5539,26 @@ public class CepEspTest extends CommonTestMethodBase {
         KieHelper helper = new KieHelper();
         helper.addContent(drl, ResourceType.DRL);
         KieSession ksession = helper.build(EventProcessingOption.STREAM).newKieSession(sessionConfig, null);
+        try {
+            List<Integer> list = new ArrayList<Integer>();
+            ksession.setGlobal("list", list);
 
-        List<Integer> list = new ArrayList<Integer>();
-        ksession.setGlobal("list", list);
+            ksession.insert("Alice");
+            ksession.fireAllRules();
+            assertTrue(list.isEmpty());
 
-        ksession.insert("Alice");
-        ksession.fireAllRules();
-        assertTrue(list.isEmpty());
+            ((PseudoClockScheduler) ksession.getSessionClock()).advanceTime(150, TimeUnit.MILLISECONDS);
 
-        ((PseudoClockScheduler) ksession.getSessionClock()).advanceTime(150, TimeUnit.MILLISECONDS);
-
-        ksession.fireAllRules();
-        assertEquals(1, list.size());
-        assertEquals(1, (int) list.get(0));
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+            assertEquals(1, (int) list.get(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testCEPWith2NamedConsAndEagerRule() throws InterruptedException {
+    public void testCEPWith2NamedConsAndEagerRule() {
         String drl = "package org.drools " +
 
                      "global java.util.List list; " +
@@ -5425,22 +5600,24 @@ public class CepEspTest extends CommonTestMethodBase {
         KieHelper helper = new KieHelper();
         helper.addContent(drl, ResourceType.DRL);
         KieSession ksession = helper.build(EventProcessingOption.STREAM).newKieSession(sessionConfig, null);
+        try {
+            List<Integer> list = new ArrayList<Integer>();
+            ksession.setGlobal("list", list);
 
-        List<Integer> list = new ArrayList<Integer>();
-        ksession.setGlobal("list", list);
+            ksession.insert("Alice");
+            ksession.fireAllRules();
+            assertTrue(list.isEmpty());
 
-        ksession.insert("Alice");
-        ksession.fireAllRules();
-        assertTrue(list.isEmpty());
+            ((PseudoClockScheduler) ksession.getSessionClock()).advanceTime(150, TimeUnit.MILLISECONDS);
 
-        ((PseudoClockScheduler) ksession.getSessionClock()).advanceTime(150, TimeUnit.MILLISECONDS);
-
-        ksession.fireAllRules();
-        System.out.println(list);
-        assertEquals(3, list.size());
-        assertTrue(list.contains(0));
-        assertTrue(list.contains(1));
-        assertTrue(list.contains(2));
+            ksession.fireAllRules();
+            assertEquals(3, list.size());
+            assertTrue(list.contains(0));
+            assertTrue(list.contains(1));
+            assertTrue(list.contains(2));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -5465,13 +5642,16 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSession ksession = helper.build(
                 EventProcessingOption.STREAM
         ).newKieSession( sessionConfig, null );
+        try {
+            ksession.fireAllRules();
+            ((PseudoClockScheduler)ksession.getSessionClock()).advanceTime( 1, TimeUnit.SECONDS );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-        ((PseudoClockScheduler)ksession.getSessionClock()).advanceTime( 1, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-
-        assertEquals( 0, ksession.getObjects().size() );
-        assertEquals( 0, ( (NamedEntryPoint) ksession.getEntryPoint( EntryPointId.DEFAULT.getEntryPointId() ) ).getTruthMaintenanceSystem().getEqualityKeyMap().size() );
+            assertEquals( 0, ksession.getObjects().size() );
+            assertEquals( 0, ( (NamedEntryPoint) ksession.getEntryPoint( EntryPointId.DEFAULT.getEntryPointId() ) ).getTruthMaintenanceSystem().getEqualityKeyMap().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -5501,17 +5681,20 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent(drl, ResourceType.DRL);
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession(sessionConfig, null);
+        try {
+            ksession.insert(new Event1("id1", 0));
 
-        ksession.insert(new Event1("id1", 0));
+            PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.advanceTime(2, TimeUnit.HOURS);
+            ksession.fireAllRules();
 
-        PseudoClockScheduler clock = ksession.getSessionClock();
-        clock.advanceTime(2, TimeUnit.HOURS);
-        ksession.fireAllRules();
+            ksession = marshallAndUnmarshall(KieServices.Factory.get(), kbase, ksession, sessionConfig);
 
-        ksession = marshallAndUnmarshall(KieServices.Factory.get(), kbase, ksession, sessionConfig);
-
-        ksession.insert(new Event1("id2", 0));
-        ksession.fireAllRules();
+            ksession.insert(new Event1("id2", 0));
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     public static class Event1 implements Serializable {
@@ -5564,9 +5747,12 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-
-        ksession.insert( new HashMap<String, Object>() );
-        ksession.fireAllRules();
+        try {
+            ksession.insert( new HashMap<String, Object>() );
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -5580,23 +5766,26 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            DefaultFactHandle helloHandle = (DefaultFactHandle) ksession.insert( "hello" );
+            DefaultFactHandle goodbyeHandle = (DefaultFactHandle) ksession.insert( "goodbye" );
 
-        DefaultFactHandle helloHandle = (DefaultFactHandle) ksession.insert( "hello" );
-        DefaultFactHandle goodbyeHandle = (DefaultFactHandle) ksession.insert( "goodbye" );
+            FactHandle key = DefaultFactHandle.createFromExternalFormat( helloHandle.toExternalForm() );
+            assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
+            assertEquals( "hello",
+                          ksession.getObject( key ) );
 
-        FactHandle key = DefaultFactHandle.createFromExternalFormat( helloHandle.toExternalForm() );
-        assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
-        assertEquals( "hello",
-                      ksession.getObject( key ) );
-
-        key = DefaultFactHandle.createFromExternalFormat( goodbyeHandle.toExternalForm() );
-        assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
-        assertEquals( "goodbye",
-                      ksession.getObject( key ) );
+            key = DefaultFactHandle.createFromExternalFormat( goodbyeHandle.toExternalForm() );
+            assertTrue("FactHandle not deserialized as EventFactHandle", key instanceof EventFactHandle);
+            assertEquals( "goodbye",
+                          ksession.getObject( key ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testEventWithShortExpiration() throws InterruptedException {
+    public void testEventWithShortExpiration() {
         // DROOLS-921
         String drl = "declare String\n" +
                      "  @expires( 1ms )\n" +
@@ -5611,22 +5800,25 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build( EventProcessingOption.STREAM )
                                              .newKieSession();
-
-        ksession.insert( "test" );
-        assertEquals( 1, ksession.fireAllRules() );
-        waitBusy(2L);
-        assertEquals( 0, ksession.fireAllRules() );
-        waitBusy(30L);
-        // Expire action is put into propagation queue by timer job, so there
-        // can be a race condition where it puts it there right after previous fireAllRules
-        // flushes the queue. So there needs to be another flush -> another fireAllRules
-        // to flush the queue.
-        assertEquals( 0, ksession.fireAllRules() );
-        assertEquals( 0, ksession.getObjects().size() );
+        try {
+            ksession.insert( "test" );
+            assertEquals( 1, ksession.fireAllRules() );
+            waitBusy(2L);
+            assertEquals( 0, ksession.fireAllRules() );
+            waitBusy(30L);
+            // Expire action is put into propagation queue by timer job, so there
+            // can be a race condition where it puts it there right after previous fireAllRules
+            // flushes the queue. So there needs to be another flush -> another fireAllRules
+            // to flush the queue.
+            assertEquals( 0, ksession.fireAllRules() );
+            assertEquals( 0, ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testDeleteExpiredEvent() throws Exception {
+    public void testDeleteExpiredEvent() {
         // BZ-1274696
         String drl =
                 "import " + StockTick.class.getCanonicalName() + "\n" +
@@ -5650,21 +5842,25 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
 
-        EventFactHandle handle1 = (EventFactHandle) ksession.insert( new StockTick( 1, "ACME", 50 ) );
+            EventFactHandle handle1 = (EventFactHandle) ksession.insert( new StockTick( 1, "ACME", 50 ) );
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        clock.advanceTime( 2, TimeUnit.SECONDS );
-        ksession.fireAllRules();
+            clock.advanceTime( 2, TimeUnit.SECONDS );
+            ksession.fireAllRules();
 
-        assertTrue( handle1.isExpired() );
-        assertFalse( ksession.getFactHandles().contains( handle1 ) );
+            assertTrue( handle1.isExpired() );
+            assertFalse( ksession.getFactHandles().contains( handle1 ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testDeleteExpiredEventWithTimestampAndEqualityKey() throws Exception {
+    public void testDeleteExpiredEventWithTimestampAndEqualityKey() {
         // DROOLS-1017
         String drl =
                 "import " + StockTick.class.getCanonicalName() + "\n" +
@@ -5688,21 +5884,24 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM, EqualityBehaviorOption.EQUALITY );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
+            clock.setStartupTime(5000L);
 
-        PseudoClockScheduler clock = ksession.getSessionClock();
-        clock.setStartupTime(5000L);
+            EventFactHandle handle1 = (EventFactHandle) ksession.insert( new StockTick( 1, "ACME", 50, 0L ) );
 
-        EventFactHandle handle1 = (EventFactHandle) ksession.insert( new StockTick( 1, "ACME", 50, 0L ) );
+            clock.advanceTime( 2, TimeUnit.SECONDS );
+            ksession.fireAllRules();
 
-        clock.advanceTime( 2, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-
-        assertTrue( handle1.isExpired() );
-        assertFalse( ksession.getFactHandles().contains( handle1 ) );
+            assertTrue( handle1.isExpired() );
+            assertFalse( ksession.getFactHandles().contains( handle1 ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testSerializationWithWindowLength() throws Exception {
+    public void testSerializationWithWindowLength() {
         // DROOLS-953
         String drl =
                 "import " + StockTick.class.getCanonicalName() + "\n" +
@@ -5724,36 +5923,39 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
-
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-
-        ksession.insert( new StockTick( 1, "ACME", 50 ) );
-        ksession.insert( new StockTick( 2, "DROO", 50 ) );
-        ksession.insert( new StockTick( 3, "JBPM", 50 ) );
-        ksession.fireAllRules();
-
-        assertEquals(1, list.size());
-        assertEquals("JBPM", list.get(0));
-
         try {
-            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            PseudoClockScheduler clock = ksession.getSessionClock();
+
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+
+            ksession.insert( new StockTick( 1, "ACME", 50 ) );
+            ksession.insert( new StockTick( 2, "DROO", 50 ) );
+            ksession.insert( new StockTick( 3, "JBPM", 50 ) );
+            ksession.fireAllRules();
+
+            assertEquals(1, list.size());
+            assertEquals("JBPM", list.get(0));
+
+            try {
+                ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+
+            list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            assertEquals(0, list.size());
+        } finally {
+            ksession.dispose();
         }
-
-        list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-
-        ksession.fireAllRules();
-        System.out.println(list);
-        assertEquals(0, list.size());
     }
 
     @Test
-    public void testSerializationWithWindowLengthAndLiaSharing() throws Exception {
+    public void testSerializationWithWindowLengthAndLiaSharing() {
         // DROOLS-953
         String drl =
                 "import " + StockTick.class.getCanonicalName() + "\n" +
@@ -5781,36 +5983,39 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
-
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-
-        ksession.insert( new StockTick( 1, "ACME", 50 ) );
-        ksession.insert( new StockTick( 2, "DROO", 50 ) );
-        ksession.insert( new StockTick( 3, "JBPM", 50 ) );
-        ksession.fireAllRules();
-
-        assertEquals(1, list.size());
-        assertEquals("JBPM", list.get(0));
-
         try {
-            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            PseudoClockScheduler clock = ksession.getSessionClock();
+
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+
+            ksession.insert( new StockTick( 1, "ACME", 50 ) );
+            ksession.insert( new StockTick( 2, "DROO", 50 ) );
+            ksession.insert( new StockTick( 3, "JBPM", 50 ) );
+            ksession.fireAllRules();
+
+            assertEquals(1, list.size());
+            assertEquals("JBPM", list.get(0));
+
+            try {
+                ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+
+            list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            assertEquals(0, list.size());
+        } finally {
+            ksession.dispose();
         }
-
-        list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-
-        ksession.fireAllRules();
-        System.out.println(list);
-        assertEquals(0, list.size());
     }
 
     @Test
-    public void testSerializationBeforeFireWithWindowLength() throws Exception {
+    public void testSerializationBeforeFireWithWindowLength() {
         // DROOLS-953
         String drl =
                 "import " + StockTick.class.getCanonicalName() + "\n" +
@@ -5832,33 +6037,36 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
-
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-
-        ksession.insert( new StockTick( 1, "ACME", 50 ) );
-        ksession.insert( new StockTick( 2, "DROO", 50 ) );
-        ksession.insert( new StockTick( 3, "JBPM", 50 ) );
-
         try {
-            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            PseudoClockScheduler clock = ksession.getSessionClock();
+
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+
+            ksession.insert( new StockTick( 1, "ACME", 50 ) );
+            ksession.insert( new StockTick( 2, "DROO", 50 ) );
+            ksession.insert( new StockTick( 3, "JBPM", 50 ) );
+
+            try {
+                ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+
+            list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+            assertEquals("JBPM", list.get(0));
+        } finally {
+            ksession.dispose();
         }
-
-        list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-
-        ksession.fireAllRules();
-        System.out.println(list);
-        assertEquals(1, list.size());
-        assertEquals("JBPM", list.get(0));
     }
 
     @Test
-    public void testSubclassWithLongerExpirationThanSuper() throws Exception {
+    public void testSubclassWithLongerExpirationThanSuper() {
         // DROOLS-983
         String drl =
                 "import " + SuperClass.class.getCanonicalName() + "\n" +
@@ -5881,24 +6089,28 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
 
-        EventFactHandle handle1 = (EventFactHandle) ksession.insert(new SubClass());
-        ksession.fireAllRules();
+            EventFactHandle handle1 = (EventFactHandle) ksession.insert(new SubClass());
+            ksession.fireAllRules();
 
-        clock.advanceTime(15, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertFalse(handle1.isExpired());
-        assertEquals( 1, ksession.getObjects().size() );
+            clock.advanceTime(15, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertFalse(handle1.isExpired());
+            assertEquals( 1, ksession.getObjects().size() );
 
-        clock.advanceTime(10, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertTrue(handle1.isExpired());
-        assertEquals( 0, ksession.getObjects().size() );
+            clock.advanceTime(10, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertTrue(handle1.isExpired());
+            assertEquals( 0, ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testSubclassWithLongerExpirationThanSuperWithSerialization() throws Exception {
+    public void testSubclassWithLongerExpirationThanSuperWithSerialization() {
         // DROOLS-983
         String drl =
                 "import " + SuperClass.class.getCanonicalName() + "\n" +
@@ -5921,27 +6133,31 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
-
-        EventFactHandle handle1 = (EventFactHandle) ksession.insert(new SubClass());
-        ksession.fireAllRules();
-
-        clock.advanceTime(15, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertFalse(handle1.isExpired());
-        assertEquals( 1, ksession.getObjects().size() );
-
         try {
-            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
-        }
+            PseudoClockScheduler clock = ksession.getSessionClock();
 
-        clock = ksession.getSessionClock();
-        clock.advanceTime(10, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals( 0, ksession.getObjects().size() );
+            EventFactHandle handle1 = (EventFactHandle) ksession.insert(new SubClass());
+            ksession.fireAllRules();
+
+            clock.advanceTime(15, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertFalse(handle1.isExpired());
+            assertEquals( 1, ksession.getObjects().size() );
+
+            try {
+                ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+
+            clock = ksession.getSessionClock();
+            clock.advanceTime(10, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals( 0, ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Role(Role.Type.EVENT)
@@ -5979,17 +6195,20 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal("list", list);
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
+            ksession.setGlobal("baseEvent", new SimpleEvent("1", 15000L));
 
-        ksession.setGlobal("baseEvent", new SimpleEvent("1", 15000L));
+            SimpleEvent event1 = new SimpleEvent("1", 0L);
+            ksession.insert(event1);
+            ksession.fireAllRules();
 
-        SimpleEvent event1 = new SimpleEvent("1", 0L);
-        ksession.insert(event1);
-        ksession.fireAllRules();
-
-        assertEquals( 1, list.size() );
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6031,22 +6250,24 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-        PseudoClockScheduler clock = ksession.getSessionClock();
+        try {
+            PseudoClockScheduler clock = ksession.getSessionClock();
 
-        SimpleEvent event1 = new SimpleEvent("1", 0L);
-        ksession.insert(event1);
-        ksession.fireAllRules();
+            SimpleEvent event1 = new SimpleEvent("1", 0L);
+            ksession.insert(event1);
+            ksession.fireAllRules();
 
-        //Session should only contain the fact we just inserted.
-        assertEquals( 1, ksession.getFactCount() );
+            //Session should only contain the fact we just inserted.
+            assertEquals( 1, ksession.getFactCount() );
 
-        clock.advanceTime( 60000, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
+            clock.advanceTime( 60000, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
 
-        //We've disabled expiration, so fact should still be in WorkingMemory.
-        assertEquals( 1, ksession.getFactCount() );
-
-        ksession.dispose();
+            //We've disabled expiration, so fact should still be in WorkingMemory.
+            assertEquals( 1, ksession.getFactCount() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6079,28 +6300,31 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            long now = System.currentTimeMillis();
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            sessionClock.setStartupTime(now - 10000);
 
-        long now = System.currentTimeMillis();
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
-        sessionClock.setStartupTime(now - 10000);
+            AtomicInteger counter = new AtomicInteger( 1 );
+            MyEvent event1 = new MyEvent(now - 8000);
+            MyEvent event2 = new MyEvent(now - 7000);
+            MyEvent event3 = new MyEvent(now - 6000);
 
-        AtomicInteger counter = new AtomicInteger( 1 );
-        MyEvent event1 = new MyEvent(now - 8000);
-        MyEvent event2 = new MyEvent(now - 7000);
-        MyEvent event3 = new MyEvent(now - 6000);
+            ksession.insert(counter);
+            ksession.insert(event1);
+            ksession.insert(event2);
+            ksession.insert(event3);
 
-        ksession.insert(counter);
-        ksession.insert(event1);
-        ksession.insert(event2);
-        ksession.insert(event3);
+            ksession.fireAllRules(); // Nothing Happens
+            assertEquals(1, counter.get());
 
-        ksession.fireAllRules(); // Nothing Happens
-        assertEquals(1, counter.get());
+            sessionClock.advanceTime(10000, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
 
-        sessionClock.advanceTime(10000, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-
-        assertEquals(0, counter.get());
+            assertEquals(0, counter.get());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6131,26 +6355,29 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            sessionClock.setStartupTime(0);
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
-        sessionClock.setStartupTime(0);
+            AtomicInteger counter = new AtomicInteger( 0 );
+            ksession.setGlobal( "counter", counter );
 
-        AtomicInteger counter = new AtomicInteger( 0 );
-        ksession.setGlobal( "counter", counter );
+            ksession.insert("test");
+            ksession.insert(true);
+            ksession.insert(new MyEvent(0));
+            ksession.insert(new MyEvent(15));
 
-        ksession.insert("test");
-        ksession.insert(true);
-        ksession.insert(new MyEvent(0));
-        ksession.insert(new MyEvent(15));
+            ksession.fireAllRules();
+            assertEquals(0, counter.get());
 
-        ksession.fireAllRules();
-        assertEquals(0, counter.get());
+            sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
+            ksession.insert( 1 );
+            ksession.fireAllRules(); // MyEvent is expired
 
-        sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
-        ksession.insert( 1 );
-        ksession.fireAllRules(); // MyEvent is expired
-
-        assertEquals(1, counter.get());
+            assertEquals(1, counter.get());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6180,25 +6407,28 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            sessionClock.setStartupTime(0);
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
-        sessionClock.setStartupTime(0);
+            AtomicInteger counter = new AtomicInteger( 0 );
+            ksession.setGlobal( "counter", counter );
 
-        AtomicInteger counter = new AtomicInteger( 0 );
-        ksession.setGlobal( "counter", counter );
+            ksession.insert(true);
+            ksession.insert(new MyEvent(0));
+            ksession.insert(new MyEvent(15));
 
-        ksession.insert(true);
-        ksession.insert(new MyEvent(0));
-        ksession.insert(new MyEvent(15));
+            ksession.fireAllRules();
+            assertEquals(0, counter.get());
 
-        ksession.fireAllRules();
-        assertEquals(0, counter.get());
+            sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
+            ksession.insert( 1 );
+            ksession.fireAllRules(); // MyEvent is expired
 
-        sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
-        ksession.insert( 1 );
-        ksession.fireAllRules(); // MyEvent is expired
-
-        assertEquals(1, counter.get());
+            assertEquals(1, counter.get());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6228,26 +6458,29 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            sessionClock.setStartupTime(0);
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
-        sessionClock.setStartupTime(0);
+            AtomicInteger counter = new AtomicInteger( 0 );
+            ksession.setGlobal( "counter", counter );
 
-        AtomicInteger counter = new AtomicInteger( 0 );
-        ksession.setGlobal( "counter", counter );
+            ksession.insert(true);
+            FactHandle iFh = ksession.insert( 1 );
+            ksession.insert(new MyEvent(0));
+            ksession.insert(new MyEvent(15));
 
-        ksession.insert(true);
-        FactHandle iFh = ksession.insert( 1 );
-        ksession.insert(new MyEvent(0));
-        ksession.insert(new MyEvent(15));
+            ksession.fireAllRules();
+            assertEquals(0, counter.get());
 
-        ksession.fireAllRules();
-        assertEquals(0, counter.get());
+            sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
+            ksession.delete( iFh );
+            ksession.fireAllRules(); // MyEvent is expired
 
-        sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
-        ksession.delete( iFh );
-        ksession.fireAllRules(); // MyEvent is expired
-
-        assertEquals(1, counter.get());
+            assertEquals(1, counter.get());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6273,19 +6506,22 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            sessionClock.setStartupTime(0);
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
-        sessionClock.setStartupTime(0);
+            ksession.insert(new MyEvent(0));
+            assertEquals( 1L, ksession.getFactCount() );
 
-        ksession.insert(new MyEvent(0));
-        assertEquals( 1L, ksession.getFactCount() );
+            ksession.fireAllRules();
+            assertEquals( 2L, ksession.getFactCount() );
 
-        ksession.fireAllRules();
-        assertEquals( 2L, ksession.getFactCount() );
-
-        sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-        assertEquals( 0L, ksession.getFactCount() );
+            sessionClock.advanceTime(20, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
+            assertEquals( 0L, ksession.getFactCount() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6354,52 +6590,56 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSessionConfiguration config = kieServices.newKieSessionConfiguration();
         config.setOption( ClockTypeOption.get("pseudo") );
         KieSession session = kieBase.newKieSession(config, null);
-        SessionPseudoClock clock = session.getSessionClock();
+        try {
+            SessionPseudoClock clock = session.getSessionClock();
 
-        FactType time_VarType = kieBase.getFactType( "org.drools.drools_usage_pZB7GRxZp64", "time_Var" );
+            FactType time_VarType = kieBase.getFactType( "org.drools.drools_usage_pZB7GRxZp64", "time_Var" );
 
-        clock.advanceTime(1472057509000L, TimeUnit.MILLISECONDS);
+            clock.advanceTime(1472057509000L, TimeUnit.MILLISECONDS);
 
-        Object time_Var = time_VarType.newInstance();
-        time_VarType.set( time_Var, "value",  1472057509000L );
+            Object time_Var = time_VarType.newInstance();
+            time_VarType.set( time_Var, "value",  1472057509000L );
 
-        session.insert(time_Var);
-        session.fireAllRules();
+            session.insert(time_Var);
+            session.fireAllRules();
 
-        for (int i=0; i<10; i++) {
+            for (int i=0; i<10; i++) {
+                clock.advanceTime(1, TimeUnit.SECONDS);
+
+                Object time_VarP1 = time_VarType.newInstance();
+                time_VarType.set( time_VarP1, "value",  clock.getCurrentTime() );
+
+                session.insert(time_VarP1);
+                session.fireAllRules();
+            }
+
             clock.advanceTime(1, TimeUnit.SECONDS);
+            session.fireAllRules();
 
+            clock.advanceTime(1, TimeUnit.HOURS);
             Object time_VarP1 = time_VarType.newInstance();
             time_VarType.set( time_VarP1, "value",  clock.getCurrentTime() );
-
             session.insert(time_VarP1);
             session.fireAllRules();
-        }
 
-        clock.advanceTime(1, TimeUnit.SECONDS);
-        session.fireAllRules();
+            clock.advanceTime(1, TimeUnit.HOURS);
+            Object time_VarP2 = time_VarType.newInstance();
+            time_VarType.set( time_VarP2, "value",  clock.getCurrentTime() );
+            session.insert(time_VarP2);
+            session.fireAllRules();
 
-        clock.advanceTime(1, TimeUnit.HOURS);
-        Object time_VarP1 = time_VarType.newInstance();
-        time_VarType.set( time_VarP1, "value",  clock.getCurrentTime() );
-        session.insert(time_VarP1);
-        session.fireAllRules();
+            clock.advanceTime(1, TimeUnit.HOURS);
+            session.fireAllRules();
 
-        clock.advanceTime(1, TimeUnit.HOURS);
-        Object time_VarP2 = time_VarType.newInstance();
-        time_VarType.set( time_VarP2, "value",  clock.getCurrentTime() );
-        session.insert(time_VarP2);
-        session.fireAllRules();
-
-        clock.advanceTime(1, TimeUnit.HOURS);
-        session.fireAllRules();
-
-        // actually should be empty..
-        for ( Object o : session.getFactHandles() ) {
-            if (o instanceof EventFactHandle) {
-                EventFactHandle eventFactHandle = (EventFactHandle)o;
-                assertFalse(eventFactHandle.isExpired());
+            // actually should be empty..
+            for ( Object o : session.getFactHandles() ) {
+                if (o instanceof EventFactHandle) {
+                    EventFactHandle eventFactHandle = (EventFactHandle)o;
+                    assertFalse(eventFactHandle.isExpired());
+                }
             }
+        } finally {
+            session.dispose();
         }
     }
 
@@ -6433,28 +6673,31 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            long now = 1000;
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            sessionClock.setStartupTime(now - 10);
 
-        long now = 1000; //System.currentTimeMillis();
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
-        sessionClock.setStartupTime(now - 10);
+            AtomicInteger counter = new AtomicInteger( 1 );
+            MyEvent event1 = new MyEvent(now - 8);
+            MyEvent event2 = new MyEvent(now - 7);
+            MyEvent event3 = new MyEvent(now - 6);
 
-        AtomicInteger counter = new AtomicInteger( 1 );
-        MyEvent event1 = new MyEvent(now - 8);
-        MyEvent event2 = new MyEvent(now - 7);
-        MyEvent event3 = new MyEvent(now - 6);
+            ksession.insert(counter);
+            ksession.insert(event1);
+            ksession.insert(event2);
+            ksession.insert(event3);
 
-        ksession.insert(counter);
-        ksession.insert(event1);
-        ksession.insert(event2);
-        ksession.insert(event3);
+            ksession.fireAllRules(); // Nothing Happens
+            assertEquals(1, counter.get());
 
-        ksession.fireAllRules(); // Nothing Happens
-        assertEquals(1, counter.get());
+            sessionClock.advanceTime(10, TimeUnit.MILLISECONDS);
+            ksession.fireAllRules();
 
-        sessionClock.advanceTime(10, TimeUnit.MILLISECONDS);
-        ksession.fireAllRules();
-
-        assertEquals(0, counter.get());
+            assertEquals(0, counter.get());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -6481,23 +6724,22 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
-
-
-        ksession.insert(new TestEvent("test1"));
-        ksession.fireAllRules();
-
         KieSession kieSessionDeserialized = null;
         try {
-            kieSessionDeserialized = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            fail( e.getMessage() );
+            ksession.insert(new TestEvent("test1"));
+            ksession.fireAllRules();
+
+            try {
+                kieSessionDeserialized = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
+        } finally {
+            ksession.dispose();
+            kieSessionDeserialized.insert(new TestEvent("test2"));
+            kieSessionDeserialized.fireAllRules();
         }
-
-        ksession.dispose();
-
-        kieSessionDeserialized.insert(new TestEvent("test2"));
-        kieSessionDeserialized.fireAllRules();
     }
 
     @Test
@@ -6514,19 +6756,22 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSession kieSession = new KieHelper().addContent( drl, ResourceType.DRL )
                                                .build( EventProcessingOption.STREAM )
                                                .newKieSession();
+        try {
+            FactHandle fhA = kieSession.insert("A");
+            FactHandle fhB = kieSession.insert("B");
+            FactHandle fh1 = kieSession.insert(1);
 
-        FactHandle fhA = kieSession.insert("A");
-        FactHandle fhB = kieSession.insert("B");
-        FactHandle fh1 = kieSession.insert(1);
+            assertEquals( 0, kieSession.fireAllRules() );
 
-        assertEquals( 0, kieSession.fireAllRules() );
+            kieSession.delete( fh1 );
+            kieSession.update(fhA, "A");
+            kieSession.update(fhB, "B");
+            FactHandle fh2 = kieSession.insert(2);
 
-        kieSession.delete( fh1 );
-        kieSession.update(fhA, "A");
-        kieSession.update(fhB, "B");
-        FactHandle fh2 = kieSession.insert(2);
-
-        assertEquals( 0, kieSession.fireAllRules() );
+            assertEquals( 0, kieSession.fireAllRules() );
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     @Test
@@ -6556,14 +6801,18 @@ public class CepEspTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                           .build( EventProcessingOption.STREAM )
                                           .newKieSession();
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
 
-        ksession.insert(new AtomicBoolean( false ));
-        ksession.fireAllRules();
+            ksession.insert(new AtomicBoolean( false ));
+            ksession.fireAllRules();
 
-        assertEquals( 1, list.size() );
-        assertEquals( "R2", list.get(0) );
+            assertEquals( 1, list.size() );
+            assertEquals( "R2", list.get(0) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6586,19 +6835,22 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            ksession.insert("test");
+            ksession.insert(1);
 
-        ksession.insert("test");
-        ksession.insert(1);
+            assertEquals(2, ksession.getFactCount());
 
-        assertEquals(2, ksession.getFactCount());
+            ksession.fireAllRules();
+            sessionClock.advanceTime(11, TimeUnit.SECONDS);
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-        sessionClock.advanceTime(11, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-
-        assertEquals(0, ksession.getFactCount());
+            assertEquals(0, ksession.getFactCount());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6621,22 +6873,25 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            ksession.insert(1);
 
-        ksession.insert(1);
+            assertEquals(1, ksession.getFactCount());
 
-        assertEquals(1, ksession.getFactCount());
+            ksession.fireAllRules();
+            sessionClock.advanceTime(11, TimeUnit.SECONDS);
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-        sessionClock.advanceTime(11, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-
-        assertEquals(0, ksession.getFactCount());
+            assertEquals(0, ksession.getFactCount());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testFireExpiredEventOnInactiveGroup() throws Exception {
+    public void testFireExpiredEventOnInactiveGroup() {
         // DROOLS-1523
         String DRL = "global java.util.List list;\n" +
                      "declare String  @role(event) @expires( 6d ) end\n" +
@@ -6670,35 +6925,38 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( DRL, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession kieSession = kbase.newKieSession( sessionConfig, null );
-
-        kieSession.addEventListener(new DefaultAgendaEventListener() {
-            public void agendaGroupPopped(AgendaGroupPoppedEvent event ) {
-                if (event.getAgendaGroup().getName().equals("rf-grp0")) {
-                    event.getKieRuntime().getAgenda().getAgendaGroup("rf-grp1").setFocus();
+        try {
+            kieSession.addEventListener(new DefaultAgendaEventListener() {
+                public void agendaGroupPopped(AgendaGroupPoppedEvent event ) {
+                    if (event.getAgendaGroup().getName().equals("rf-grp0")) {
+                        event.getKieRuntime().getAgenda().getAgendaGroup("rf-grp1").setFocus();
+                    }
                 }
-            }
-        });
+            });
 
-        List<String> list = new ArrayList<>();
-        kieSession.setGlobal("list", list);
+            List<String> list = new ArrayList<>();
+            kieSession.setGlobal("list", list);
 
-        PseudoClockScheduler sessionClock = kieSession.getSessionClock();
+            PseudoClockScheduler sessionClock = kieSession.getSessionClock();
 
-        kieSession.insert("DummyEvent");
-        kieSession.insert(1); //<- OtherDummyEvent
-        kieSession.getAgenda().getAgendaGroup( "rf-grp0" ).setFocus();
-        kieSession.fireAllRules(); // OK nothing happens
+            kieSession.insert("DummyEvent");
+            kieSession.insert(1); //<- OtherDummyEvent
+            kieSession.getAgenda().getAgendaGroup( "rf-grp0" ).setFocus();
+            kieSession.fireAllRules(); // OK nothing happens
 
-        assertEquals(2, kieSession.getFactCount());
+            assertEquals(2, kieSession.getFactCount());
 
-        sessionClock.advanceTime(145, TimeUnit.HOURS);
-        kieSession.getAgenda().getAgendaGroup( "rf-grp0" ).setFocus();
-        kieSession.fireAllRules();
+            sessionClock.advanceTime(145, TimeUnit.HOURS);
+            kieSession.getAgenda().getAgendaGroup( "rf-grp0" ).setFocus();
+            kieSession.fireAllRules();
 
-        assertEquals("Expiration occured => no more fact in WM", 0, kieSession.getFactCount());
+            assertEquals("Expiration occured => no more fact in WM", 0, kieSession.getFactCount());
 
-        assertEquals("RG_1 should fire once", 1, list.stream().filter(r->r.equals("RG_1")).count());
-        assertEquals("RG_2 should fire once", 1, list.stream().filter(r->r.equals("RG_2")).count());
+            assertEquals("RG_1 should fire once", 1, list.stream().filter(r->r.equals("RG_1")).count());
+            assertEquals("RG_2 should fire once", 1, list.stream().filter(r->r.equals("RG_2")).count());
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     @Test
@@ -6718,22 +6976,25 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            ksession.insert("test");
 
-        ksession.insert("test");
+            ksession.fireAllRules();
+            assertEquals(1, ksession.getFactCount());
 
-        ksession.fireAllRules();
-        assertEquals(1, ksession.getFactCount());
+            sessionClock.advanceTime(2, TimeUnit.SECONDS);
+            ksession.fireAllRules();
 
-        sessionClock.advanceTime(2, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-
-        assertEquals(0, ksession.getFactCount());
+            assertEquals(0, ksession.getFactCount());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testExpireUnusedDeclaredTypeClass() throws Exception {
+    public void testExpireUnusedDeclaredTypeClass() {
         // DROOLS-1524
         String drl = "rule R when\n"
                      + "then\n"
@@ -6747,16 +7008,18 @@ public class CepEspTest extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieBase kbase = helper.build( EventProcessingOption.STREAM );
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
+        try {
+            PseudoClockScheduler sessionClock = ksession.getSessionClock();
 
-        PseudoClockScheduler sessionClock = ksession.getSessionClock();
+            ksession.insert(new EventWithoutRule());
+            ksession.fireAllRules();
+            sessionClock.advanceTime(2, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals(0, ksession.getFactCount());
 
-        ksession.insert(new EventWithoutRule());
-        ksession.fireAllRules();
-        sessionClock.advanceTime(2, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals(0, ksession.getFactCount());
-
-        ksession.dispose();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Role(Role.Type.EVENT)
@@ -6764,9 +7027,9 @@ public class CepEspTest extends CommonTestMethodBase {
     public class EventWithoutRule { }
 
     public static class EventA implements Serializable {
-        private String time;
-        private int value;
-        private Date timestamp;
+        private final String time;
+        private final int value;
+        private final Date timestamp;
 
         public EventA(String time, int value) {
             this.time = time;
@@ -6800,7 +7063,7 @@ public class CepEspTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testDeleteOfDeserializedJob() throws Exception {
+    public void testDeleteOfDeserializedJob() {
         // DROOLS-1660
         String drl =
                 "import " + EventA.class.getCanonicalName() + "\n" +
@@ -6825,84 +7088,87 @@ public class CepEspTest extends CommonTestMethodBase {
         sessionConfig.setOption(ClockTypeOption.get("pseudo"));
 
         KieSession ksession = kieBase.newKieSession(sessionConfig, null);
-
-        List<String> list = new ArrayList<>();
-
-        List<EventA> events = new ArrayList<>();
-        events.add(new EventA("2010-01-01 02:00:00", 0));
-        events.add(new EventA("2010-01-01 03:00:00", 1));
-        events.add(new EventA("2010-01-01 03:01:00", 0));
-        events.add(new EventA("2010-01-01 03:02:00", 1));
-        events.add(new EventA("2010-01-01 03:03:00", 0));
-        events.add(new EventA("2010-01-01 03:04:00", 0));
-        events.add(new EventA("2010-01-01 03:05:00", 0));
-        events.add(new EventA("2010-01-01 03:06:00", 0));
-        events.add(new EventA("2010-01-01 03:07:00", 0));
-
-        // set clock reference
-        SessionPseudoClock clock = ksession.getSessionClock();
-        clock.advanceTime(events.get(0).getTimestamp().getTime(), TimeUnit.MILLISECONDS);
-
-        byte[] serializedSession = null;
-
         try {
-            Marshaller marshaller = KieServices.Factory.get().getMarshallers().newMarshaller(kieBase);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            marshaller.marshall(baos, ksession);
+            List<String> list = new ArrayList<>();
 
-            serializedSession = baos.toByteArray();
-        } catch (IOException e2) {
-            e2.printStackTrace();
-        }
+            List<EventA> events = new ArrayList<>();
+            events.add(new EventA("2010-01-01 02:00:00", 0));
+            events.add(new EventA("2010-01-01 03:00:00", 1));
+            events.add(new EventA("2010-01-01 03:01:00", 0));
+            events.add(new EventA("2010-01-01 03:02:00", 1));
+            events.add(new EventA("2010-01-01 03:03:00", 0));
+            events.add(new EventA("2010-01-01 03:04:00", 0));
+            events.add(new EventA("2010-01-01 03:05:00", 0));
+            events.add(new EventA("2010-01-01 03:06:00", 0));
+            events.add(new EventA("2010-01-01 03:07:00", 0));
 
-        for (EventA current : events) {
+            // set clock reference
+            SessionPseudoClock clock = ksession.getSessionClock();
+            clock.advanceTime(events.get(0).getTimestamp().getTime(), TimeUnit.MILLISECONDS);
 
-            KieSession ksession2 = null;
-
-            Marshaller marshaller = KieServices.Factory.get().getMarshallers().newMarshaller( kieBase );
+            byte[] serializedSession = null;
 
             try {
-                ByteArrayInputStream bais = new ByteArrayInputStream(serializedSession);
-                ksession2 = marshaller.unmarshall(bais, sessionConfig, null);
-                ksession2.setGlobal( "list", list );
-                clock = ksession2.getSessionClock();
-                bais.close();
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+                Marshaller marshaller = KieServices.Factory.get().getMarshallers().newMarshaller(kieBase);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                marshaller.marshall(baos, ksession);
 
-            long currTime = clock.getCurrentTime();
-            long nextTime = current.getTimestamp().getTime();
-
-            while (currTime <= (nextTime - 1000)) {
-                clock.advanceTime(1000, TimeUnit.MILLISECONDS);
-                ksession2.fireAllRules();
-                currTime += 1000;
-            }
-
-            long diff = nextTime - currTime;
-            if (diff > 0) {
-                clock.advanceTime(diff, TimeUnit.MILLISECONDS);
-            }
-
-            ksession2.insert(current);
-            ksession2.fireAllRules();
-
-            // serialize knowledge session
-            try {
-                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                marshaller.marshall(baos, ksession2);
                 serializedSession = baos.toByteArray();
             } catch (IOException e2) {
                 e2.printStackTrace();
             }
-            ksession2.dispose();
-        }
 
-        assertEquals( 1, list.size() );
-        assertEquals( "Fired EventA at 2010-01-01 03:02:00", list.get(0) );
+            for (EventA current : events) {
+
+                KieSession ksession2 = null;
+
+                Marshaller marshaller = KieServices.Factory.get().getMarshallers().newMarshaller( kieBase );
+
+                try {
+                    ByteArrayInputStream bais = new ByteArrayInputStream(serializedSession);
+                    ksession2 = marshaller.unmarshall(bais, sessionConfig, null);
+                    ksession2.setGlobal( "list", list );
+                    clock = ksession2.getSessionClock();
+                    bais.close();
+                } catch (ClassNotFoundException e) {
+                    e.printStackTrace();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+                long currTime = clock.getCurrentTime();
+                long nextTime = current.getTimestamp().getTime();
+
+                while (currTime <= (nextTime - 1000)) {
+                    clock.advanceTime(1000, TimeUnit.MILLISECONDS);
+                    ksession2.fireAllRules();
+                    currTime += 1000;
+                }
+
+                long diff = nextTime - currTime;
+                if (diff > 0) {
+                    clock.advanceTime(diff, TimeUnit.MILLISECONDS);
+                }
+
+                ksession2.insert(current);
+                ksession2.fireAllRules();
+
+                // serialize knowledge session
+                try {
+                    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    marshaller.marshall(baos, ksession2);
+                    serializedSession = baos.toByteArray();
+                } catch (IOException e2) {
+                    e2.printStackTrace();
+                }
+                ksession2.dispose();
+            }
+
+            assertEquals( 1, list.size() );
+            assertEquals( "Fired EventA at 2010-01-01 03:02:00", list.get(0) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6931,7 +7197,12 @@ public class CepEspTest extends CommonTestMethodBase {
                 "rule Insert when then " +
                 "   insertLogical( new ExpiringEventD() ); end ";
 
-        new KieHelper().addContent( drl, ResourceType.DRL ).build(  ).newKieSession().fireAllRules();
+        final KieSession kieSession = new KieHelper().addContent( drl, ResourceType.DRL ).build(  ).newKieSession();
+        try {
+            kieSession.fireAllRules();
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     @Test
@@ -6969,12 +7240,15 @@ public class CepEspTest extends CommonTestMethodBase {
         sessionConfig.setOption(ClockTypeOption.get("pseudo"));
 
         KieSession ksession = kieBase.newKieSession(sessionConfig, null);
+        try {
+            assertEquals( 1, ksession.fireAllRules( ) );
 
-        assertEquals( 1, ksession.fireAllRules( ) );
+            ((SessionPseudoClock ) ksession.getSessionClock() ).advanceTime( 200, TimeUnit.MILLISECONDS );
 
-        ((SessionPseudoClock ) ksession.getSessionClock() ).advanceTime( 200, TimeUnit.MILLISECONDS );
-
-        assertEquals( 1, ksession.fireAllRules( 10 ) );
+            assertEquals( 1, ksession.fireAllRules( 10 ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -6999,6 +7273,10 @@ public class CepEspTest extends CommonTestMethodBase {
 
         KieBase kieBase = new KieHelper().addContent(drl, ResourceType.DRL).build(EventProcessingOption.STREAM);
         KieSession ksession = kieBase.newKieSession();
-        assertEquals( 1, ksession.fireAllRules() );
+        try {
+            assertEquals( 1, ksession.fireAllRules() );
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepFireUntilHaltTimerTest.java
@@ -118,14 +118,8 @@ public class CepFireUntilHaltTimerTest {
     }
 
     private void performTest() throws Exception {
-        ExecutorService thread = Executors.newSingleThreadExecutor();
-        final Future fireUntilHaltResult = thread.submit(new Runnable() {
-            @Override
-            public void run() {
-                ksession.fireUntilHalt();
-            }
-        });
-
+        final ExecutorService thread = Executors.newSingleThreadExecutor();
+        final Future fireUntilHaltResult = thread.submit(() -> ksession.fireUntilHalt());
         try {
 
             final int ITEMS = 10;
@@ -154,7 +148,7 @@ public class CepFireUntilHaltTimerTest {
             // wait for the engine to finish and throw exception if any was thrown
             // in engine's thread
             fireUntilHaltResult.get(60000, TimeUnit.SECONDS);
-            thread.shutdown();
+            thread.shutdownNow();
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CepJavaTypeTest.java
@@ -127,17 +127,20 @@ public class CepJavaTypeTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build( EventProcessingOption.STREAM )
                                              .newKieSession();
-
-        ksession.insert(new MyMessage("ATrigger" ) );
-        assertEquals( 1, ksession.fireAllRules() );
-        waitBusy(2L);
-        assertEquals( 0, ksession.fireAllRules() );
-        waitBusy(30L);
-        // Expire action is put into propagation queue by timer job, so there
-        // can be a race condition where it puts it there right after previous fireAllRules
-        // flushes the queue. So there needs to be another flush -> another fireAllRules
-        // to flush the queue.
-        assertEquals( 0, ksession.fireAllRules() );
-        assertEquals( 0, ksession.getObjects().size() );
+        try {
+            ksession.insert(new MyMessage("ATrigger" ) );
+            assertEquals( 1, ksession.fireAllRules() );
+            waitBusy(2L);
+            assertEquals( 0, ksession.fireAllRules() );
+            waitBusy(30L);
+            // Expire action is put into propagation queue by timer job, so there
+            // can be a race condition where it puts it there right after previous fireAllRules
+            // flushes the queue. So there needs to be another flush -> another fireAllRules
+            // to flush the queue.
+            assertEquals( 0, ksession.fireAllRules() );
+            assertEquals( 0, ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CompositeAgendaTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/CompositeAgendaTest.java
@@ -100,7 +100,7 @@ public class CompositeAgendaTest {
         kieSession.setGlobal("firings", firingCounter);
 
         final ExecutorService executor = Executors.newFixedThreadPool(2);
-        executor.submit(() -> kieSession.fireUntilHalt());
+        executor.submit((Runnable) kieSession::fireUntilHalt);
         try {
             final EventInsertThread eventInsertThread = new EventInsertThread(kieSession);
             executor.submit(eventInsertThread);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesChangesTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/DynamicRulesChangesTest.java
@@ -19,6 +19,7 @@ import org.drools.compiler.CommonTestMethodBase;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.command.Command;
@@ -43,14 +44,20 @@ import static org.junit.Assert.assertEquals;
 public class DynamicRulesChangesTest extends CommonTestMethodBase {
 
     private static final int PARALLEL_THREADS = 1;
-    private static final ExecutorService executor = Executors.newFixedThreadPool(PARALLEL_THREADS);
 
     private static InternalKnowledgeBase kbase;
+    private ExecutorService executor;
 
     @Before
     public void setUp() throws Exception {
+        executor = Executors.newFixedThreadPool(PARALLEL_THREADS);
         kbase = KnowledgeBaseFactory.newKnowledgeBase();
         addRule("raiseAlarm");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
     }
 
     @Test(timeout=10000)

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MTEntryPointsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MTEntryPointsTest.java
@@ -115,25 +115,23 @@ public class MTEntryPointsTest {
     public void testOneEntryPoint() throws Exception {
         final EntryPoint firstThreadEntryPoint = kieSession.getEntryPoint("FirstStream");
 
-        int numInsertersInEachEntryPoint = 10;
-        int numThreadPoolCapacity = numInsertersInEachEntryPoint;
-
-        ExecutorService executorService = Executors.newFixedThreadPool(numThreadPoolCapacity);
-        List<Future<?>> futures = new ArrayList<Future<?>>();
-
-        for (int i = 0; i < numInsertersInEachEntryPoint; i++) {
-            // future for exception watching
-            Future<?> futureForFirstThread = executorService.submit(
-                    new TestInserter(kieSession, firstThreadEntryPoint));
-            futures.add(futureForFirstThread);
-        }
-
+        final int numInsertersInEachEntryPoint = 10;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numInsertersInEachEntryPoint);
         try {
-            for (Future<?> f : futures) {
+            final List<Future<?>> futures = new ArrayList<>();
+
+            for (int i = 0; i < numInsertersInEachEntryPoint; i++) {
+                // future for exception watching
+                final Future<?> futureForFirstThread = executorService.submit(
+                        new TestInserter(kieSession, firstThreadEntryPoint));
+                futures.add(futureForFirstThread);
+            }
+
+            for (final Future<?> f : futures) {
                 f.get(30, TimeUnit.SECONDS);
             }
-        } catch (ExecutionException ex) {
-            throw ex;
+        } finally {
+            executorService.shutdownNow();
         }
     }
 
@@ -147,30 +145,30 @@ public class MTEntryPointsTest {
         final EntryPoint firstThreadEntryPoint = kieSession.getEntryPoint("FirstStream");
         final EntryPoint secondThreadEntryPoint = kieSession.getEntryPoint("SecondStream");
 
-        int numInsertersInEachEntryPoint = 10;
-        int numThreadPoolCapacity = numInsertersInEachEntryPoint * 2;
+        final int numInsertersInEachEntryPoint = 10;
+        final int numThreadPoolCapacity = numInsertersInEachEntryPoint * 2;
 
-        ExecutorService executorService = Executors.newFixedThreadPool(numThreadPoolCapacity);
-        List<Future<?>> futures = new ArrayList<Future<?>>();
-
-        for (int i = 0; i < numInsertersInEachEntryPoint; i++) {
-            // working only with first stream, future for exception watching
-            Future<?> futureForFirstThread = executorService.submit(new TestInserter(kieSession,
-                                                                                     firstThreadEntryPoint));
-            futures.add(futureForFirstThread);
-
-            // working only with second stream, future for exception watching
-            Future<?> futureForSecondThread = executorService.submit(new TestInserter(kieSession,
-                                                                                      secondThreadEntryPoint));
-            futures.add(futureForSecondThread);
-        }
-
+        final ExecutorService executorService = Executors.newFixedThreadPool(numThreadPoolCapacity);
         try {
-            for (Future<?> f : futures) {
+            final List<Future<?>> futures = new ArrayList<>();
+
+            for (int i = 0; i < numInsertersInEachEntryPoint; i++) {
+                // working only with first stream, future for exception watching
+                final Future<?> futureForFirstThread = executorService.submit(new TestInserter(kieSession,
+                                                                                         firstThreadEntryPoint));
+                futures.add(futureForFirstThread);
+
+                // working only with second stream, future for exception watching
+                final Future<?> futureForSecondThread = executorService.submit(new TestInserter(kieSession,
+                                                                                          secondThreadEntryPoint));
+                futures.add(futureForSecondThread);
+            }
+
+            for (final Future<?> f : futures) {
                 f.get(30, TimeUnit.SECONDS);
             }
-        } catch (ExecutionException ex) {
-            throw ex;
+        } finally {
+            executorService.shutdownNow();
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Misc2Test.java
@@ -238,7 +238,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieSession ksession = ks.newKieContainer( kbuilder.getKieModule().getReleaseId() ).newKieSession();
         assertNotNull( ksession );
 
-        List<String> context = new ArrayList<String>();
+        List<String> context = new ArrayList<>();
         ksession.setGlobal( "context", context );
 
         FactHandle b = ksession.insert( new Message( "b" ) );
@@ -414,7 +414,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         final KieSession ksession = kbase.newKieSession();
 
-        List<String> res = new ArrayList<String>();
+        List<String> res = new ArrayList<>();
         ksession.setGlobal( "results", res );
 
         AgendaEventListener agendaEventListener = new AgendaEventListener() {
@@ -598,7 +598,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( 5 );
@@ -630,7 +630,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( 3 );
@@ -987,7 +987,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        Map<Parameter, Double> values = new EnumMap<Parameter, Double>( Parameter.class );
+        Map<Parameter, Double> values = new EnumMap<>(Parameter.class);
         values.put( Parameter.PARAM_A, 4.0 );
         DataSample data = new DataSample();
         data.setValues( values );
@@ -1048,7 +1048,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
     @PropertyReactive
     public static class DataSample {
-        private Map<Parameter, Double> values = new EnumMap<Parameter, Double>( Parameter.class );
+        private Map<Parameter, Double> values = new EnumMap<>(Parameter.class);
 
         public Map<Parameter, Double> getValues() {
             return values;
@@ -1665,7 +1665,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         list.add( 1 );
@@ -1736,7 +1736,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         ksession.setGlobal( "l", l );
 
         ksession.fireAllRules();
@@ -1998,7 +1998,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         Person p1 = new Person( "AAA", 31 );
@@ -2515,7 +2515,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Conversation> conversations = new ArrayList<Conversation>();
+        List<Conversation> conversations = new ArrayList<>();
         ksession.setGlobal( "list", conversations );
 
         Conversation c0 = new Conversation( 0, "Fusco", 2 );
@@ -2569,7 +2569,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
     @Test
     public void testNamedConsequence() {
-        List<String> firedRules = new ArrayList<String>();
+        List<String> firedRules = new ArrayList<>();
         String str =
                 "import " + Foo.class.getCanonicalName() + "\n" +
                 "import " + Foo2.class.getCanonicalName() + "\n" +
@@ -2600,7 +2600,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
     @Test
     public void testNamedConsequenceWithNot() {
-        List<String> firedRules = new ArrayList<String>();
+        List<String> firedRules = new ArrayList<>();
         String str =
                 "import " + Foo.class.getCanonicalName() + "\n" +
                 "import " + Foo2.class.getCanonicalName() + "\n" +
@@ -2781,7 +2781,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         StatelessKieSession ksession = kbase.newStatelessKieSession();
 
-        final List<String> firings = new ArrayList<String>();
+        final List<String> firings = new ArrayList<>();
 
         AgendaEventListener agendaEventListener = new AgendaEventListener() {
             public void matchCreated( org.kie.api.event.rule.MatchCreatedEvent event ) {
@@ -2832,7 +2832,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
     @Test
     public void testKsessionSerializationWithInsertLogical() {
-        List<String> firedRules = new ArrayList<String>();
+        List<String> firedRules = new ArrayList<>();
         String str =
                 "import java.util.Date;\n" +
                 "import org.drools.compiler.integrationtests.Misc2Test.Promotion;\n" +
@@ -2979,7 +2979,7 @@ public class Misc2Test extends CommonTestMethodBase {
         ArrayList list = new ArrayList();
         ksession.setGlobal( "list", list );
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put( "x", "Test" );
         ksession.insert( map );
 
@@ -3006,7 +3006,7 @@ public class Misc2Test extends CommonTestMethodBase {
         ArrayList list = new ArrayList();
         ksession.setGlobal( "list", list );
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put( "x", "Test" );
         ksession.insert( map );
 
@@ -3051,7 +3051,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
         KieSession ksession = kbase.newKieSession();
 
-        ArrayList<String> ruleList = new ArrayList<String>();
+        ArrayList<String> ruleList = new ArrayList<>();
         ksession.setGlobal( "ruleList", ruleList );
 
         ksession.insert( "fireRules" );
@@ -3253,7 +3253,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kb = loadKnowledgeBaseFromString( drl );
         KieSession ks = kb.newKieSession();
 
-        Map<String, String> context = new HashMap<String, String>();
+        Map<String, String> context = new HashMap<>();
         context.put( "key", "value" );
         ks.setGlobal( "context", context );
 
@@ -4200,7 +4200,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( kbConf, drl );
 
         KieSession ksession = kbase.newKieSession();
-        List<Long> list = new ArrayList<Long>();
+        List<Long> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.fireAllRules();
@@ -5160,9 +5160,9 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<String> allList = new ArrayList<String>();
+        List<String> allList = new ArrayList<>();
         ksession.setGlobal( "allList", allList );
-        List<String> anyList = new ArrayList<String>();
+        List<String> anyList = new ArrayList<>();
         ksession.setGlobal( "anyList", anyList );
 
         ksession.insert( new Strings( "1", "2", "3" ) );
@@ -5236,7 +5236,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( "1234" );
@@ -5302,7 +5302,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
         ksession.setGlobal( "evaller", new Evaller() );
 
@@ -5333,7 +5333,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.fireAllRules();
@@ -5357,7 +5357,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
         ksession.setGlobal( "evaller", new Evaller() );
 
@@ -5384,7 +5384,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new Evaller() );
@@ -5409,7 +5409,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( "abcde" );
@@ -5438,7 +5438,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( "abcde" );
@@ -5471,7 +5471,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession ksession = kbase.newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
         ksession.setGlobal( "tat", new Date( 2000 ) );
 
@@ -5700,7 +5700,7 @@ public class Misc2Test extends CommonTestMethodBase {
         ks.newKieBuilder( kfs ).buildAll();
         KieSession ksession = ks.newKieContainer( ks.getRepository().getDefaultReleaseId() ).newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( 0 );
@@ -5899,7 +5899,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession ksession = helper.build().newKieSession();
 
-        ArrayList<Trailer> trailerList = new ArrayList<Trailer>();
+        ArrayList<Trailer> trailerList = new ArrayList<>();
         ksession.setGlobal( "trailerList", trailerList );
 
         Trailer trailer1 = new Trailer( Trailer.TypeStatus.WAITING );
@@ -6436,7 +6436,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession ksession = helper.build().newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.fireAllRules();
@@ -6492,7 +6492,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession ksession = helper.build().newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.fireAllRules();
@@ -6528,7 +6528,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession kieSession = helper.build().newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         kieSession.setGlobal( "list", list );
 
         kieSession.insert( 10 );
@@ -6601,7 +6601,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession session = helper.build().newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         session.setGlobal( "list", list );
 
         for ( Rule r : session.getKieBase().getKiePackage( "org.drools.test" ).getRules() ) {
@@ -6723,7 +6723,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession kieSession = helper.build().newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         kieSession.setGlobal( "list", list );
 
         FactHandle handle = kieSession.insert( 42 );
@@ -6792,7 +6792,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession kieSession = helper.build().newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         kieSession.setGlobal( "list", list );
 
         FactHandle iFH = kieSession.insert( 42 );
@@ -6861,7 +6861,7 @@ public class Misc2Test extends CommonTestMethodBase {
         helper.addContent( drl, ResourceType.DRL );
         KieSession kieSession = helper.build().newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         kieSession.setGlobal( "list", list );
 
         kieSession.insert( 3 );
@@ -6962,7 +6962,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<Class> list = new ArrayList<Class>();
+        List<Class> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.fireAllRules();
@@ -7322,7 +7322,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( 18 );
@@ -7349,7 +7349,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( 1 );
@@ -7458,7 +7458,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new $X.$Y( 42 ) );
@@ -7534,17 +7534,17 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<Object> globalList = new ArrayList<Object>();
+        List<Object> globalList = new ArrayList<>();
         ksession.setGlobal( "list", globalList );
 
         NonStringConstructorClass simpleTestObject = new NonStringConstructorClass();
         simpleTestObject.setSomething( "simpleTestObject" );
 
-        Map<Object, Object> map = new HashMap<Object, Object>();
+        Map<Object, Object> map = new HashMap<>();
         map.put( "someOtherValue", "someOtherValue" );
         map.put( simpleTestObject, "someValue" );
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         ksession.insert( map );
         ksession.insert( simpleTestObject );
 
@@ -7590,14 +7590,14 @@ public class Misc2Test extends CommonTestMethodBase {
         final Integer monitor = 42;
         int factsNr = 5;
 
-        List<String> list = new NotifyingList<String>( factsNr, new Runnable() {
+        List<String> list = new NotifyingList<>(factsNr, new Runnable() {
             @Override
             public void run() {
                 synchronized (monitor) {
                     monitor.notifyAll();
                 }
             }
-        } );
+        });
 
         ksession.setGlobal( "list", list );
 
@@ -7681,7 +7681,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new A1() );
@@ -7760,7 +7760,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( "mario.fusco@test.org" );
@@ -7834,7 +7834,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( "a" );
@@ -7861,7 +7861,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( "a" );
@@ -7924,7 +7924,7 @@ public class Misc2Test extends CommonTestMethodBase {
     @Test
     public void testFunctionInvokingFunction() throws Exception {
         // DROOLS-926
-        String drl =
+        final String drl =
                 "function boolean isOdd(int i) {\n" +
                 "    return i % 2 == 1;\n" +
                 "}\n" +
@@ -7943,33 +7943,37 @@ public class Misc2Test extends CommonTestMethodBase {
 
         final KieBase kbase = new KieHelper().addContent( drl, ResourceType.DRL ).build();
 
-        int parallelThreads = 10;
-        ExecutorService executor = Executors.newFixedThreadPool( parallelThreads );
+        final int parallelThreads = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool( parallelThreads );
+        try {
+            final Collection<Callable<Boolean>> solvers = new ArrayList<>();
+            for ( int i = 0; i < parallelThreads; ++i ) {
+                solvers.add(() -> {
+                    final KieSession ksession = kbase.newKieSession();
+                    try {
+                        final List<Integer> list = new ArrayList<>();
+                        ksession.setGlobal( "list", list );
 
-        Collection<Callable<Boolean>> solvers = new ArrayList<Callable<Boolean>>();
-        for ( int i = 0; i < parallelThreads; ++i ) {
-            solvers.add( new Callable<Boolean>() {
-                @Override
-                public Boolean call() throws Exception {
-                    KieSession ksession = kbase.newKieSession();
-                    List<Integer> list = new ArrayList<Integer>();
-                    ksession.setGlobal( "list", list );
-
-                    for ( int i = 0; i < 100; i++ ) {
-                        ksession.insert( i );
+                        for ( int i1 = 0; i1 < 100; i1++ ) {
+                            ksession.insert(i1);
+                        }
+                        ksession.fireAllRules();
+                        return list.size() == 50;
+                    } finally {
+                        ksession.dispose();
                     }
-                    ksession.fireAllRules();
-                    return list.size() == 50;
-                }
-            } );
-        }
+                });
+            }
 
-        CompletionService<Boolean> ecs = new ExecutorCompletionService<Boolean>( executor );
-        for ( Callable<Boolean> s : solvers ) {
-            ecs.submit( s );
-        }
-        for ( int i = 0; i < parallelThreads; ++i ) {
-            assertTrue( ecs.take().get() );
+            final CompletionService<Boolean> ecs = new ExecutorCompletionService<>(executor);
+            for ( final Callable<Boolean> s : solvers ) {
+                ecs.submit( s );
+            }
+            for ( int i = 0; i < parallelThreads; ++i ) {
+                assertTrue( ecs.take().get() );
+            }
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -8006,7 +8010,7 @@ public class Misc2Test extends CommonTestMethodBase {
     }
 
     public static class Container {
-        private Map<String, Object> objects = new HashMap<String, Object>();
+        private Map<String, Object> objects = new HashMap<>();
 
         public Map<String, Object> getObjects() {
             return objects;
@@ -8078,7 +8082,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
         ksession.fireAllRules();
         assertEquals( 4, list.size() );
@@ -8102,7 +8106,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new StringWrapper("aaa") );
@@ -8154,7 +8158,7 @@ public class Misc2Test extends CommonTestMethodBase {
                                              .build()
                                              .newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new Person("Bob") );
@@ -8563,7 +8567,7 @@ public class Misc2Test extends CommonTestMethodBase {
         KieContainer kcontainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         KieSession kSession = kcontainer.newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         kSession.setGlobal( "list", list );
         kSession.fireAllRules();
 
@@ -8911,7 +8915,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
         KieSession kSession = new KieHelper().addContent(drl, ResourceType.DRL).build().newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         kSession.setGlobal( "list", list );
 
         kSession.insert(new TestObject(null));
@@ -8945,7 +8949,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
         KieSession ksession = new KieHelper().addContent(str, ResourceType.DRL).build().newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new Cheese( "gauda", 42 ) );
@@ -9021,7 +9025,7 @@ public class Misc2Test extends CommonTestMethodBase {
 
         KieSession ksession = new KieHelper().addContent( str, ResourceType.DRL ).build().newKieSession();
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
 
         ksession.insert( new ElementOperation( new MyElement() ) );
@@ -9082,13 +9086,13 @@ public class Misc2Test extends CommonTestMethodBase {
         Collection<KiePackage> knowledgePackages2 = kbuilder2.getKnowledgePackages();
 
         InternalKnowledgeBase kbase1 = KnowledgeBaseFactory.newKnowledgeBase();
-        Collection<KiePackage> combinedPackages1 = new ArrayList<KiePackage>();
+        Collection<KiePackage> combinedPackages1 = new ArrayList<>();
         combinedPackages1.addAll(knowledgePackages1);
         combinedPackages1.addAll(knowledgePackages2);
         kbase1.addPackages(combinedPackages1); // Add once to make inUse=true
 
         InternalKnowledgeBase kbase2 = KnowledgeBaseFactory.newKnowledgeBase();
-        Collection<KiePackage> combinedPackages2 = new ArrayList<KiePackage>();
+        Collection<KiePackage> combinedPackages2 = new ArrayList<>();
         combinedPackages2.addAll(knowledgePackages1);
         combinedPackages2.addAll(knowledgePackages2);
         kbase2.addPackages(combinedPackages2); // this will cause package deepClone

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParallelCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParallelCompilationTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderConfiguration;
@@ -38,10 +40,19 @@ import org.kie.api.io.ResourceType;
 
 public class ParallelCompilationTest {
     private static final int PARALLEL_THREADS = 5;
-    private static final ExecutorService executor = Executors.newFixedThreadPool(PARALLEL_THREADS);
-
     private static final String DRL_FILE = "parallel_compilation.drl";
-    private List<User> users;
+
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        executor = Executors.newFixedThreadPool(PARALLEL_THREADS);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+    }
 
     @Test(timeout=10000)
     public void testConcurrentRuleAdditions() throws Exception {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParallelEvaluationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ParallelEvaluationTest.java
@@ -1022,7 +1022,7 @@ public class ParallelEvaluationTest {
         return fhs;
     }
 
-    private void runTasksInParallel(List<Callable<Void>> tasks) throws InterruptedException, TimeoutException, ExecutionException {
+    private void runTasksInParallel(List<Callable<Void>> tasks) throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(tasks.size());
         try {
             List<Future<Void>> futures = executorService.invokeAll(tasks);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PseudoClockEventsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/PseudoClockEventsTest.java
@@ -76,7 +76,7 @@ public class PseudoClockEventsTest extends CommonTestMethodBase {
             "";
     int evalFirePseudoClockStockCount = 5;
 
-    @Test(timeout = 6000)
+    @Test(timeout = 10000)
     public void testEvenFirePseudoClockRuleA() throws Exception {
 
         AgendaEventListener ael = mock(AgendaEventListener.class);
@@ -89,7 +89,7 @@ public class PseudoClockEventsTest extends CommonTestMethodBase {
                 any(AfterMatchFiredEvent.class));
     }
 
-    @Test(timeout = 6000)
+    @Test(timeout = 10000)
     public void testEvenFirePseudoClockRuleB() throws Exception {
 
         AgendaEventListener ael = mock(AgendaEventListener.class);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepFireUntilHaltTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/QueryCepFireUntilHaltTest.java
@@ -95,7 +95,7 @@ public class QueryCepFireUntilHaltTest {
 
     private void stopEngine() {
         ksession.halt();
-        executorService.shutdown();
+        executorService.shutdownNow();
     }
 
     @Test(timeout = 10000L)

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTest.java
@@ -175,15 +175,17 @@ public class SerializedPackageMergeTest {
         knowledgeBase2.addPackages(deserializedPackages);
 
         KieSession ksession = knowledgeBase2.newKieSession();
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-        ksession.insert(new org.drools.compiler.Person("John"));
-        ksession.insert(new org.drools.compiler.Person("Paul"));
-        ksession.fireAllRules();
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+            ksession.insert(new org.drools.compiler.Person("John"));
+            ksession.insert(new org.drools.compiler.Person("Paul"));
+            ksession.fireAllRules();
 
-        assertEquals(2, list.size());
-
-        ksession.dispose();
+            assertEquals(2, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -216,10 +218,13 @@ public class SerializedPackageMergeTest {
         KieBase kbase = builder2.newKieBase();
 
         KieSession ksession = kbase.newKieSession();
-        ksession.insert(new org.drools.compiler.Person("aaa"));
-        ksession.insert(new org.drools.compiler.Cheese("aaa"));
-        ksession.fireAllRules();
-        ksession.dispose();
+        try {
+            ksession.insert(new org.drools.compiler.Person("aaa"));
+            ksession.insert(new org.drools.compiler.Cheese("aaa"));
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -251,11 +256,13 @@ public class SerializedPackageMergeTest {
         KieBase kbase = builder2.newKieBase();
 
         KieSession ksession = kbase.newKieSession();
-        ksession.setGlobal("myUtil", new org.drools.compiler.MyUtil());
-        ksession.insert(new org.drools.compiler.Person("John"));
-        int fired = ksession.fireAllRules();
-        assertEquals(1, fired);
-
-        ksession.dispose();
+        try {
+            ksession.setGlobal("myUtil", new org.drools.compiler.MyUtil());
+            ksession.insert(new org.drools.compiler.Person("John"));
+            int fired = ksession.fireAllRules();
+            assertEquals(1, fired);
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTwoSteps1Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTwoSteps1Test.java
@@ -33,7 +33,7 @@ public class SerializedPackageMergeTwoSteps1Test {
 			System.getProperty( "java.io.tmpdir" ) + File.separator + "SerializedPackageMergeTwoSteps_2.bin" };
 
 	@Test
-	public void testBuildAndSerializePackagesInTwoSteps1() throws IOException, ClassNotFoundException    {        
+	public void testBuildAndSerializePackagesInTwoSteps1() {
 		String str1 =
 				"package com.sample.packageA\n" +
 						"import org.drools.compiler.Person\n" +

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTwoSteps2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTwoSteps2Test.java
@@ -88,15 +88,17 @@ public class SerializedPackageMergeTwoSteps2Test {
         kbase2.addPackages(deserializedPackages);
 
         KieSession ksession = kbase2.newKieSession();
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
-        ksession.insert(new org.drools.compiler.Person("John"));
-        ksession.fireAllRules();
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
+            ksession.insert(new org.drools.compiler.Person("John"));
+            ksession.fireAllRules();
 
-        assertEquals(2, list.size());
-
-        ksession.dispose();              
-    }   
+            assertEquals(2, list.size());
+        } finally {
+            ksession.dispose();
+        }
+    }
     
   	private Collection<KiePackage>  _deserializeFromBytes(byte [] byteCode){
 		Collection<KiePackage> ret = null;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ShadowProxyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/ShadowProxyTest.java
@@ -35,50 +35,59 @@ public class ShadowProxyTest extends CommonTestMethodBase {
     public void testShadowProxyInHierarchies() throws Exception {
         final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_ShadowProxyInHierarchies.drl"));
         final KieSession ksession = createKnowledgeSession(kbase);
-
-        ksession.insert(new Child("gp"));
-        ksession.fireAllRules();
+        try {
+            ksession.insert(new Child("gp"));
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
     public void testShadowProxyOnCollections() throws Exception {
         final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_ShadowProxyOnCollections.drl"));
         final KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            final List results = new ArrayList();
+            ksession.setGlobal("results", results);
 
-        final List results = new ArrayList();
-        ksession.setGlobal("results", results);
+            final Cheesery cheesery = new Cheesery();
+            ksession.insert(cheesery);
 
-        final Cheesery cheesery = new Cheesery();
-        ksession.insert(cheesery);
-
-        ksession.fireAllRules();
-        assertEquals(1, results.size());
-        assertEquals(1, cheesery.getCheeses().size());
-        assertEquals(results.get(0), cheesery.getCheeses().get(0));
+            ksession.fireAllRules();
+            assertEquals(1, results.size());
+            assertEquals(1, cheesery.getCheeses().size());
+            assertEquals(results.get(0), cheesery.getCheeses().get(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
     public void testShadowProxyOnCollections2() throws Exception {
         final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_ShadowProxyOnCollections2.drl"));
         final KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            final List results = new ArrayList();
+            ksession.setGlobal("results", results);
 
-        final List results = new ArrayList();
-        ksession.setGlobal("results", results);
+            final List list = new ArrayList();
+            list.add("example1");
+            list.add("example2");
 
-        final List list = new ArrayList();
-        list.add("example1");
-        list.add("example2");
+            final MockPersistentSet mockPersistentSet = new MockPersistentSet(false);
+            mockPersistentSet.addAll(list);
+            final ObjectWithSet objectWithSet = new ObjectWithSet();
+            objectWithSet.setSet(mockPersistentSet);
 
-        final MockPersistentSet mockPersistentSet = new MockPersistentSet(false);
-        mockPersistentSet.addAll(list);
-        final ObjectWithSet objectWithSet = new ObjectWithSet();
-        objectWithSet.setSet(mockPersistentSet);
+            ksession.insert(objectWithSet);
 
-        ksession.insert(objectWithSet);
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-
-        assertEquals(1, results.size());
-        assertEquals("show", objectWithSet.getMessage());
+            assertEquals(1, results.size());
+            assertEquals("show", objectWithSet.getMessage());
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
@@ -126,10 +126,12 @@ public class SharingTest extends CommonTestMethodBase {
                 .addContent( drl1, ResourceType.DRL )
                 .addContent(drl2, ResourceType.DRL)
                 .build().newKieSession();
-
-        kieSession.insert(new Misc2Test.TestObject( 1) );
-
-        assertEquals(2, kieSession.fireAllRules() );
+        try {
+            kieSession.insert(new Misc2Test.TestObject( 1) );
+            assertEquals(2, kieSession.fireAllRules() );
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     @Test
@@ -158,10 +160,12 @@ public class SharingTest extends CommonTestMethodBase {
                 .addContent(drl1, ResourceType.DRL)
                 .addContent(drl2, ResourceType.DRL)
                 .build().newKieSession();
-
-        kieSession.insert(new Misc2Test.TestObject( 1) );
-
-        assertEquals(2, kieSession.fireAllRules() );
+        try {
+            kieSession.insert(new Misc2Test.TestObject( 1) );
+            assertEquals(2, kieSession.fireAllRules() );
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     @Test
@@ -191,11 +195,14 @@ public class SharingTest extends CommonTestMethodBase {
                 .addContent(drl1, ResourceType.DRL)
                 .addContent(drl2, ResourceType.DRL)
                 .build().newKieSession();
+        try {
+            final FactWithList factWithList = new FactWithList("test");
+            kieSession.insert(factWithList);
 
-        final FactWithList factWithList = new FactWithList("test");
-        kieSession.insert(factWithList);
-
-        assertEquals(2, kieSession.fireAllRules() );
+            assertEquals(2, kieSession.fireAllRules() );
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     @Test
@@ -236,22 +243,25 @@ public class SharingTest extends CommonTestMethodBase {
         KieSession kieSession = new KieHelper()
                 .addContent(drl1, ResourceType.DRL)
                 .build().newKieSession();
+        try {
+            List<String> list = new ArrayList<>();
+            kieSession.setGlobal( "list", list );
 
-        List<String> list = new ArrayList<>();
-        kieSession.setGlobal( "list", list );
+            kieSession.insert( new A(1) );
+            kieSession.insert( new B(1) );
 
-        kieSession.insert( new A(1) );
-        kieSession.insert( new B(1) );
+            final Agenda agenda = kieSession.getAgenda();
+            agenda.getAgendaGroup("G2").setFocus();
+            agenda.getAgendaGroup("G1").setFocus();
 
-        final Agenda agenda = kieSession.getAgenda();
-        agenda.getAgendaGroup("G2").setFocus();
-        agenda.getAgendaGroup("G1").setFocus();
+            kieSession.fireAllRules();
 
-        kieSession.fireAllRules();
-
-        assertEquals( 2, list.size() );
-        assertTrue( list.contains( "R1" ) );
-        assertTrue( list.contains( "R2" ) );
+            assertEquals( 2, list.size() );
+            assertTrue( list.contains( "R1" ) );
+            assertTrue( list.contains( "R2" ) );
+        } finally {
+            kieSession.dispose();
+        }
     }
 
     public static class A {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StarImportTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StarImportTest.java
@@ -50,9 +50,7 @@ public class StarImportTest extends CommonTestMethodBase {
 
     @After
     public void cleanup() {
-        if (this.ksession != null) {
-            this.ksession.dispose();
-        }
+        this.ksession.dispose();
     }
 
     /**

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StatelessStressTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StatelessStressTest.java
@@ -34,7 +34,8 @@ import org.kie.api.runtime.StatelessKieSession;
  */
 public class StatelessStressTest extends CommonTestMethodBase {
 
-    @Test @Ignore
+    @Ignore
+    @Test
     public void testLotsOfStateless() throws Exception {
         final KieBase kbase = loadKnowledgeBase("thread_class_test.drl");
 
@@ -43,44 +44,40 @@ public class StatelessStressTest extends CommonTestMethodBase {
         
         
             for (int i=0; i<numThreads; i++) {
-                Runnable run = new Runnable() {
-    
-                    public void run() {
-                        
-                        long start = 0;
-                        long previous = 0;
-                        
-                        while (true) {
-                            start = System.currentTimeMillis();
-                            StatelessKieSession sess = kbase.newStatelessKieSession();
-                            try {
-                                sess    = SerializationHelper.serializeObject(sess);
-                            } catch (Exception ex) {
-                                throw new RuntimeException(ex);
-                            }
-                            Person p = new Person();
-                            p.setName( "Michael" );
-                            Address add1 = new Address();
-                            add1.setStreet( "High" );
-                            Address add2 = new Address();
-                            add2.setStreet( "Low" );
-                            List l = new ArrayList();
-                            l.add( add1 ); l.add( add2 );
-                            p.setAddresses( l );
-                            sess.execute( p );
-                            
-                            long current = System.currentTimeMillis() - start;
-                            if (previous != 0) {
-                                float f = current/previous;
-                                if (f > 1) {
-                                    System.err.println("SLOWDOWN");
-                                }
-                            }
-                            
-                            previous = current;
+                Runnable run = () -> {
+
+                    long start = 0;
+                    long previous = 0;
+
+                    while (true) {
+                        start = System.currentTimeMillis();
+                        StatelessKieSession sess = kbase.newStatelessKieSession();
+                        try {
+                            sess    = SerializationHelper.serializeObject(sess);
+                        } catch (Exception ex) {
+                            throw new RuntimeException(ex);
                         }
+                        Person p = new Person();
+                        p.setName( "Michael" );
+                        Address add1 = new Address();
+                        add1.setStreet( "High" );
+                        Address add2 = new Address();
+                        add2.setStreet( "Low" );
+                        List l = new ArrayList();
+                        l.add( add1 ); l.add( add2 );
+                        p.setAddresses( l );
+                        sess.execute( p );
+
+                        long current = System.currentTimeMillis() - start;
+                        if (previous != 0) {
+                            float f = current/previous;
+                            if (f > 1) {
+                                System.err.println("SLOWDOWN");
+                            }
+                        }
+
+                        previous = current;
                     }
-                    
                 };
                 
                 Thread t = new Thread(run);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrEvaluatorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrEvaluatorTest.java
@@ -40,121 +40,136 @@ import static org.junit.Assert.assertTrue;
 public class StrEvaluatorTest extends CommonTestMethodBase {
 
     @Test
-    public void testStrStartsWith() throws Exception {
+    public void testStrStartsWith() {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            RoutingMessage m = new RoutingMessage();
+            m.setRoutingValue("R1:messageBody");
 
-        RoutingMessage m = new RoutingMessage();
-        m.setRoutingValue("R1:messageBody");
+            ksession.insert(m);
+            ksession.fireAllRules();
+            assertTrue(list.size() == 4);
 
-        ksession.insert(m);
-        ksession.fireAllRules();
-        assertTrue(list.size() == 4);
-
-        assertTrue( ((String) list.get(0)).equals("Message starts with R1") );
-        assertTrue( ((String) list.get(1)).equals("Message length is not 17") );
-        assertTrue( ((String) list.get(2)).equals("Message does not start with R2") );
-        assertTrue( ((String) list.get(3)).equals("Message does not end with R1") );
-
+            assertTrue( list.get(0).equals("Message starts with R1") );
+            assertTrue( list.get(1).equals("Message length is not 17") );
+            assertTrue( list.get(2).equals("Message does not start with R2") );
+            assertTrue( list.get(3).equals("Message does not end with R1") );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testStrEndsWith() throws Exception {
+    public void testStrEndsWith() {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            RoutingMessage m = new RoutingMessage();
+            m.setRoutingValue("messageBody:R2");
 
-        RoutingMessage m = new RoutingMessage();
-        m.setRoutingValue("messageBody:R2");
+            ksession.insert(m);
+            ksession.fireAllRules();
+            assertTrue(list.size() == 4);
 
-        ksession.insert(m);
-        ksession.fireAllRules();
-        assertTrue(list.size() == 4);
-
-        assertTrue( ((String) list.get(0)).equals("Message ends with R2") );
-        assertTrue( ((String) list.get(1)).equals("Message length is not 17") );
-        assertTrue( ((String) list.get(2)).equals("Message does not start with R2") );
-        assertTrue( ((String) list.get(3)).equals("Message does not end with R1") );
-
+            assertTrue( list.get(0).equals("Message ends with R2") );
+            assertTrue( list.get(1).equals("Message length is not 17") );
+            assertTrue( list.get(2).equals("Message does not start with R2") );
+            assertTrue( list.get(3).equals("Message does not end with R1") );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testStrLengthEquals() throws Exception {
+    public void testStrLengthEquals() {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            RoutingMessage m = new RoutingMessage();
+            m.setRoutingValue( "R1:messageBody:R2" );
 
-        RoutingMessage m = new RoutingMessage();
-        m.setRoutingValue( "R1:messageBody:R2" );
-
-        ksession.insert( m );
-        ksession.fireAllRules();
-        assertEquals( 6, list.size() );
-        assertTrue(list.contains( "Message length is 17" ));
-
+            ksession.insert( m );
+            ksession.fireAllRules();
+            assertEquals( 6, list.size() );
+            assertTrue(list.contains( "Message length is 17" ));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testStrNotStartsWith() throws Exception {
+    public void testStrNotStartsWith() {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            RoutingMessage m = new RoutingMessage();
+            m.setRoutingValue("messageBody");
 
-        RoutingMessage m = new RoutingMessage();
-        m.setRoutingValue("messageBody");
-
-        ksession.insert(m);
-        ksession.fireAllRules();
-        assertTrue( list.size() == 3 );
-        assertTrue( ((String) list.get(1)).equals( "Message does not start with R2" ) );
+            ksession.insert(m);
+            ksession.fireAllRules();
+            assertTrue( list.size() == 3 );
+            assertTrue( list.get(1).equals("Message does not start with R2" ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testStrNotEndsWith() throws Exception {
+    public void testStrNotEndsWith() {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            RoutingMessage m = new RoutingMessage();
+            m.setRoutingValue("messageBody");
 
-        RoutingMessage m = new RoutingMessage();
-        m.setRoutingValue("messageBody");
-
-        ksession.insert(m);
-        ksession.fireAllRules();
-        assertTrue( list.size() == 3 );
-        assertTrue( ( (String) list.get( 0 ) ).equals( "Message length is not 17" ) );
-        assertTrue( ((String) list.get(1)).equals("Message does not start with R2") );
-        assertTrue(((String) list.get(2)).equals("Message does not end with R1"));
+            ksession.insert(m);
+            ksession.fireAllRules();
+            assertTrue( list.size() == 3 );
+            assertTrue( list.get( 0 ).equals("Message length is not 17" ) );
+            assertTrue( list.get(1).equals("Message does not start with R2") );
+            assertTrue(list.get(2).equals("Message does not end with R1"));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testStrLengthNoEquals() throws Exception {
+    public void testStrLengthNoEquals() {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            RoutingMessage m = new RoutingMessage();
+            m.setRoutingValue("messageBody");
 
-        RoutingMessage m = new RoutingMessage();
-        m.setRoutingValue("messageBody");
+            ksession.insert(m);
+            ksession.fireAllRules();
+            assertTrue(list.size() == 3);
 
-        ksession.insert(m);
-        ksession.fireAllRules();
-        assertTrue(list.size() == 3);
-
-        assertTrue( ((String) list.get(0)).equals("Message length is not 17") );
-        assertTrue( ((String) list.get(1)).equals("Message does not start with R2") );
-        assertTrue( ((String) list.get(2)).equals("Message does not end with R1") );
+            assertTrue( list.get(0).equals("Message length is not 17") );
+            assertTrue( list.get(1).equals("Message does not start with R2") );
+            assertTrue( list.get(2).equals("Message does not end with R1") );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -223,7 +238,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
         }
     }
 
-    private KieBase readKnowledgeBase() throws Exception {
+    private KieBase readKnowledgeBase() {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( ResourceFactory.newInputStreamResource(getClass().getResourceAsStream("strevaluator_test.drl")),
                 ResourceType.DRL );

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StreamsTest.java
@@ -76,16 +76,13 @@ import static org.mockito.Mockito.*;
  */
 public class StreamsTest extends CommonTestMethodBase {
 
-    private KieBase loadKnowledgeBase( final String fileName ) throws IOException,
-            DroolsParserException,
-            Exception {
+    private KieBase loadKnowledgeBase( final String fileName ) throws Exception {
         return loadKnowledgeBase( fileName,
                                   KnowledgeBaseFactory.newKnowledgeBaseConfiguration() );
     }
 
     private KieBase loadKnowledgeBase( final String fileName,
-            KieBaseConfiguration kconf ) throws IOException,
-            DroolsParserException,
+            KieBaseConfiguration kconf ) throws
             Exception {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add(ResourceFactory.newClassPathResource(fileName,
@@ -100,7 +97,6 @@ public class StreamsTest extends CommonTestMethodBase {
         kbase.addPackages(kbuilder.getKnowledgePackages());
 
         return SerializationHelper.serializeObject(kbase);
-        //return kbase;
     }
 
     @Test(timeout=10000)
@@ -112,143 +108,147 @@ public class StreamsTest extends CommonTestMethodBase {
         KieSessionConfiguration conf = SessionConfiguration.newInstance();
         ( (SessionConfiguration) conf ).setClockType( ClockType.PSEUDO_CLOCK );
         KieSession session = kbase.newKieSession( conf, null );
+        try {
+            final List results = new ArrayList();
 
-        final List results = new ArrayList();
+            session.setGlobal("results",
+                              results);
 
-        session.setGlobal("results",
-                          results);
+            StockTickInterface tick1 = new StockTick(1,
+                                                     "DROO",
+                                                     50,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick2 = new StockTick(2,
+                                                     "ACME",
+                                                     10,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick3 = new StockTick(3,
+                                                     "ACME",
+                                                     10,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick4 = new StockTick(4,
+                                                     "DROO",
+                                                     50,
+                                                     System.currentTimeMillis());
 
-        StockTickInterface tick1 = new StockTick(1,
-                                                 "DROO",
-                                                 50,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick2 = new StockTick(2,
-                                                 "ACME",
-                                                 10,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick3 = new StockTick(3,
-                                                 "ACME",
-                                                 10,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick4 = new StockTick(4,
-                                                 "DROO",
-                                                 50,
-                                                 System.currentTimeMillis());
+            InternalFactHandle handle1 = (InternalFactHandle) session.insert(tick1);
+            InternalFactHandle handle2 = (InternalFactHandle) session.insert(tick2);
+            InternalFactHandle handle3 = (InternalFactHandle) session.insert(tick3);
+            InternalFactHandle handle4 = (InternalFactHandle) session.insert(tick4);
 
-        InternalFactHandle handle1 = (InternalFactHandle) session.insert(tick1);
-        InternalFactHandle handle2 = (InternalFactHandle) session.insert(tick2);
-        InternalFactHandle handle3 = (InternalFactHandle) session.insert(tick3);
-        InternalFactHandle handle4 = (InternalFactHandle) session.insert(tick4);
+            assertNotNull(handle1);
+            assertNotNull(handle2);
+            assertNotNull(handle3);
+            assertNotNull(handle4);
 
-        assertNotNull(handle1);
-        assertNotNull(handle2);
-        assertNotNull(handle3);
-        assertNotNull(handle4);
+            assertTrue(handle1.isEvent());
+            assertTrue(handle2.isEvent());
+            assertTrue(handle3.isEvent());
+            assertTrue(handle4.isEvent());
 
-        assertTrue(handle1.isEvent());
-        assertTrue(handle2.isEvent());
-        assertTrue(handle3.isEvent());
-        assertTrue(handle4.isEvent());
+            session.fireAllRules();
 
-        session.fireAllRules();
+            assertEquals(0,
+                         results.size());
 
-        assertEquals(0,
-                     results.size());
+            StockTickInterface tick5 = new StockTick(5,
+                                                     "DROO",
+                                                     50,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick6 = new StockTick(6,
+                                                     "ACME",
+                                                     10,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick7 = new StockTick(7,
+                                                     "ACME",
+                                                     15,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick8 = new StockTick(8,
+                                                     "DROO",
+                                                     50,
+                                                     System.currentTimeMillis());
 
-        StockTickInterface tick5 = new StockTick(5,
-                                                 "DROO",
-                                                 50,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick6 = new StockTick(6,
-                                                 "ACME",
-                                                 10,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick7 = new StockTick(7,
-                                                 "ACME",
-                                                 15,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick8 = new StockTick(8,
-                                                 "DROO",
-                                                 50,
-                                                 System.currentTimeMillis());
+            EntryPoint entry = session.getEntryPoint("StockStream");
 
-        EntryPoint entry = session.getEntryPoint("StockStream");
+            InternalFactHandle handle5 = (InternalFactHandle) entry.insert(tick5);
+            InternalFactHandle handle6 = (InternalFactHandle) entry.insert(tick6);
+            InternalFactHandle handle7 = (InternalFactHandle) entry.insert(tick7);
+            InternalFactHandle handle8 = (InternalFactHandle) entry.insert(tick8);
 
-        InternalFactHandle handle5 = (InternalFactHandle) entry.insert(tick5);
-        InternalFactHandle handle6 = (InternalFactHandle) entry.insert(tick6);
-        InternalFactHandle handle7 = (InternalFactHandle) entry.insert(tick7);
-        InternalFactHandle handle8 = (InternalFactHandle) entry.insert(tick8);
+            assertNotNull(handle5);
+            assertNotNull(handle6);
+            assertNotNull(handle7);
+            assertNotNull(handle8);
 
-        assertNotNull(handle5);
-        assertNotNull(handle6);
-        assertNotNull(handle7);
-        assertNotNull(handle8);
+            assertTrue(handle5.isEvent());
+            assertTrue(handle6.isEvent());
+            assertTrue(handle7.isEvent());
+            assertTrue(handle8.isEvent());
 
-        assertTrue(handle5.isEvent());
-        assertTrue(handle6.isEvent());
-        assertTrue(handle7.isEvent());
-        assertTrue(handle8.isEvent());
+            session.fireAllRules();
 
-        session.fireAllRules();
-
-        assertEquals(1,
-                     results.size());
-        assertSame(tick7,
-                   results.get(0));
-
+            assertEquals(1,
+                         results.size());
+            assertSame(tick7,
+                       results.get(0));
+        } finally {
+            session.dispose();
+        }
     }
 
-    @Test//(timeout=10000)
+    @Test
     public void testEntryPointReference() throws Exception {
         // read in the source
         KieBase kbase = loadKnowledgeBase("test_EntryPointReference.drl");
         KieSession session = kbase.newKieSession();
+        try {
+            final List<StockTick> results = new ArrayList<StockTick>();
+            session.setGlobal("results",
+                              results);
 
-        final List<StockTick> results = new ArrayList<StockTick>();
-        session.setGlobal("results",
-                          results);
+            StockTickInterface tick5 = new StockTick(5,
+                                                     "DROO",
+                                                     50,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick6 = new StockTick(6,
+                                                     "ACME",
+                                                     10,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick7 = new StockTick(7,
+                                                     "ACME",
+                                                     30,
+                                                     System.currentTimeMillis());
+            StockTickInterface tick8 = new StockTick(8,
+                                                     "DROO",
+                                                     50,
+                                                     System.currentTimeMillis());
 
-        StockTickInterface tick5 = new StockTick(5,
-                                                 "DROO",
-                                                 50,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick6 = new StockTick(6,
-                                                 "ACME",
-                                                 10,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick7 = new StockTick(7,
-                                                 "ACME",
-                                                 30,
-                                                 System.currentTimeMillis());
-        StockTickInterface tick8 = new StockTick(8,
-                                                 "DROO",
-                                                 50,
-                                                 System.currentTimeMillis());
+            EntryPoint entry = session.getEntryPoint("stream1");
 
-        EntryPoint entry = session.getEntryPoint("stream1");
+            InternalFactHandle handle5 = (InternalFactHandle) entry.insert(tick5);
+            InternalFactHandle handle6 = (InternalFactHandle) entry.insert(tick6);
+            InternalFactHandle handle7 = (InternalFactHandle) entry.insert(tick7);
+            InternalFactHandle handle8 = (InternalFactHandle) entry.insert(tick8);
 
-        InternalFactHandle handle5 = (InternalFactHandle) entry.insert(tick5);
-        InternalFactHandle handle6 = (InternalFactHandle) entry.insert(tick6);
-        InternalFactHandle handle7 = (InternalFactHandle) entry.insert(tick7);
-        InternalFactHandle handle8 = (InternalFactHandle) entry.insert(tick8);
+            assertNotNull(handle5);
+            assertNotNull(handle6);
+            assertNotNull(handle7);
+            assertNotNull(handle8);
 
-        assertNotNull(handle5);
-        assertNotNull(handle6);
-        assertNotNull(handle7);
-        assertNotNull(handle8);
+            assertTrue(handle5.isEvent());
+            assertTrue(handle6.isEvent());
+            assertTrue(handle7.isEvent());
+            assertTrue(handle8.isEvent());
 
-        assertTrue(handle5.isEvent());
-        assertTrue(handle6.isEvent());
-        assertTrue(handle7.isEvent());
-        assertTrue(handle8.isEvent());
+            session.fireAllRules();
 
-        session.fireAllRules();
-
-        assertEquals(1,
-                     results.size());
-        assertSame(tick7,
-                   results.get(0));
-
+            assertEquals(1,
+                         results.size());
+            assertSame(tick7,
+                       results.get(0));
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -256,66 +256,67 @@ public class StreamsTest extends CommonTestMethodBase {
         // read in the source
         KieBase kbase = loadKnowledgeBase("test_modifyRetractEntryPoint.drl");
         KieSession session = kbase.newKieSession();
+        try {
+            final List<? extends Number> results = new ArrayList<Number>();
+            session.setGlobal( "results",
+                               results );
 
-        final List<? extends Number> results = new ArrayList<Number>();
-        session.setGlobal( "results",
-                           results );
+            StockTickInterface tick5 = new StockTick( 5,
+                                                      "DROO",
+                                                      50,
+                                                      System.currentTimeMillis() );
+            StockTickInterface tick6 = new StockTick( 6,
+                                                      "ACME",
+                                                      10,
+                                                      System.currentTimeMillis() );
+            StockTickInterface tick7 = new StockTick( 7,
+                                                      "ACME",
+                                                      30,
+                                                      System.currentTimeMillis() );
+            StockTickInterface tick8 = new StockTick( 8,
+                                                      "DROO",
+                                                      50,
+                                                      System.currentTimeMillis() );
 
-        StockTickInterface tick5 = new StockTick( 5,
-                                                  "DROO",
-                                                  50,
-                                                  System.currentTimeMillis() );
-        StockTickInterface tick6 = new StockTick( 6,
-                                                  "ACME",
-                                                  10,
-                                                  System.currentTimeMillis() );
-        StockTickInterface tick7 = new StockTick( 7,
-                                                  "ACME",
-                                                  30,
-                                                  System.currentTimeMillis() );
-        StockTickInterface tick8 = new StockTick( 8,
-                                                  "DROO",
-                                                  50,
-                                                  System.currentTimeMillis() );
+            EntryPoint entry = session.getEntryPoint( "stream1" );
 
-        EntryPoint entry = session.getEntryPoint( "stream1" );
+            InternalFactHandle handle5 = (InternalFactHandle) entry.insert( tick5 );
+            InternalFactHandle handle6 = (InternalFactHandle) entry.insert( tick6 );
+            InternalFactHandle handle7 = (InternalFactHandle) entry.insert( tick7 );
+            InternalFactHandle handle8 = (InternalFactHandle) entry.insert( tick8 );
 
-       InternalFactHandle handle5 = (InternalFactHandle) entry.insert( tick5 );
-        InternalFactHandle handle6 = (InternalFactHandle) entry.insert( tick6 );
-        InternalFactHandle handle7 = (InternalFactHandle) entry.insert( tick7 );
-        InternalFactHandle handle8 = (InternalFactHandle) entry.insert( tick8 );
+            assertNotNull( handle5 );
+            assertNotNull( handle6 );
+            assertNotNull( handle7 );
+            assertNotNull( handle8 );
 
-        assertNotNull( handle5 );
-        assertNotNull( handle6 );
-        assertNotNull( handle7 );
-        assertNotNull( handle8 );
+            assertTrue( handle5.isEvent() );
+            assertTrue( handle6.isEvent() );
+            assertTrue( handle7.isEvent() );
+            assertTrue( handle8.isEvent() );
 
-        assertTrue( handle5.isEvent() );
-        assertTrue( handle6.isEvent() );
-        assertTrue( handle7.isEvent() );
-        assertTrue( handle8.isEvent() );
+            session.fireAllRules();
 
-        session.fireAllRules();
+            assertEquals( 2,
+                          results.size() );
+            assertEquals( 30,
+                          results.get( 0 ).intValue() );
+            assertEquals( 110,
+                          results.get( 1 ).intValue() );
 
-        System.out.println(results);
-        assertEquals( 2,
-                      results.size() );
-        assertEquals( 30,
-                      ( (Number) results.get( 0 ) ).intValue() );
-        assertEquals( 110,
-                      ( (Number) results.get( 1 ) ).intValue() );
-
-        // the 3 non-matched facts continue to exist in the entry point
-        assertEquals(3,
-                     entry.getObjects().size());
-        // but no fact was inserted into the main session
-        assertEquals(0,
-                session.getObjects().size());
-
+            // the 3 non-matched facts continue to exist in the entry point
+            assertEquals(3,
+                         entry.getObjects().size());
+            // but no fact was inserted into the main session
+            assertEquals(0,
+                         session.getObjects().size());
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test //(timeout=10000)
-    public void testModifyOnEntryPointFacts() throws Exception {
+    public void testModifyOnEntryPointFacts() {
         String str = "package org.drools.compiler\n" +
                      "declare StockTick\n" +
                      "        @role ( event )\n" +
@@ -345,45 +346,48 @@ public class StreamsTest extends CommonTestMethodBase {
         // read in the source
         KieBase kbase = loadKnowledgeBaseFromString( (KieBaseConfiguration)null, str );
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            org.kie.api.event.rule.AgendaEventListener ael = mock(org.kie.api.event.rule.AgendaEventListener.class);
+            ksession.addEventListener(ael);
 
-        org.kie.api.event.rule.AgendaEventListener ael = mock(org.kie.api.event.rule.AgendaEventListener.class);
-        ksession.addEventListener(ael);
+            EntryPoint ep1 = ksession.getEntryPoint("ep1");
+            EntryPoint ep2 = ksession.getEntryPoint("ep2");
+            EntryPoint ep3 = ksession.getEntryPoint("ep3");
 
-        EntryPoint ep1 = ksession.getEntryPoint("ep1");
-        EntryPoint ep2 = ksession.getEntryPoint("ep2");
-        EntryPoint ep3 = ksession.getEntryPoint("ep3");
+            ep1.insert(new StockTick(1,
+                                     "RHT",
+                                     10,
+                                     1000));
+            ep2.insert(new StockTick(1,
+                                     "RHT",
+                                     10,
+                                     1000));
+            ep3.insert(new StockTick(1,
+                                     "RHT",
+                                     10,
+                                     1000));
+            int rulesFired = ksession.fireAllRules();
+            assertEquals(3,
+                         rulesFired);
 
-        ep1.insert(new StockTick(1,
-                                 "RHT",
-                                 10,
-                                 1000));
-        ep2.insert(new StockTick(1,
-                                 "RHT",
-                                 10,
-                                 1000));
-        ep3.insert(new StockTick(1,
-                                 "RHT",
-                                 10,
-                                 1000));
-        int rulesFired = ksession.fireAllRules();
-        assertEquals(3,
-                     rulesFired);
+            ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
+            verify(ael,
+                   times(3)).afterMatchFired(captor.capture());
+            List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
-        verify(ael,
-               times(3)).afterMatchFired(captor.capture());
-        List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
-
-        assertThat(aafe.get(0).getMatch().getRule().getName(),
-                          is("R1"));
-        assertThat(aafe.get(1).getMatch().getRule().getName(),
-                          is("R2"));
-        assertThat(aafe.get(2).getMatch().getRule().getName(),
-                          is("R3"));
+            assertThat(aafe.get(0).getMatch().getRule().getName(),
+                       is("R1"));
+            assertThat(aafe.get(1).getMatch().getRule().getName(),
+                       is("R2"));
+            assertThat(aafe.get(2).getMatch().getRule().getName(),
+                       is("R3"));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEntryPointWithAccumulateAndMVEL() throws Exception {
+    public void testEntryPointWithAccumulateAndMVEL() {
         String str = "package org.drools.compiler\n" +
                 "rule R1 dialect 'mvel'\n" +
                 "    when\n" +
@@ -396,27 +400,30 @@ public class StreamsTest extends CommonTestMethodBase {
         // read in the source
         KieBase kbase = loadKnowledgeBaseFromString( (KieBaseConfiguration)null, str );
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            org.kie.api.event.rule.AgendaEventListener ael = mock(org.kie.api.event.rule.AgendaEventListener.class);
+            ksession.addEventListener(ael);
 
-        org.kie.api.event.rule.AgendaEventListener ael = mock(org.kie.api.event.rule.AgendaEventListener.class);
-        ksession.addEventListener(ael);
+            EntryPoint ep1 = ksession.getEntryPoint("ep1");
 
-        EntryPoint ep1 = ksession.getEntryPoint("ep1");
+            ep1.insert(new StockTick(1,
+                                     "RHT",
+                                     10,
+                                     1000));
+            int rulesFired = ksession.fireAllRules();
+            assertEquals(1,
+                         rulesFired);
 
-        ep1.insert(new StockTick(1,
-                "RHT",
-                10,
-                1000));
-        int rulesFired = ksession.fireAllRules();
-        assertEquals(1,
-                rulesFired);
+            ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
+            verify(ael,
+                   times(1)).afterMatchFired(captor.capture());
+            List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
 
-        ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
-        verify(ael,
-                times(1)).afterMatchFired(captor.capture());
-        List<org.kie.api.event.rule.AfterMatchFiredEvent> aafe = captor.getAllValues();
-
-        assertThat(aafe.get(0).getMatch().getRule().getName(),
-                is("R1"));
+            assertThat(aafe.get(0).getMatch().getRule().getName(),
+                       is("R1"));
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -424,19 +431,22 @@ public class StreamsTest extends CommonTestMethodBase {
         // read in the source
         KieBase kbase = loadKnowledgeBase("test_EntryPointReference.drl");
         KieSession session = kbase.newKieSession();
+        try {
+            EntryPoint def = session.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId());
+            EntryPoint s1 = session.getEntryPoint("stream1");
+            EntryPoint s2 = session.getEntryPoint( "stream2" );
+            EntryPoint s3 = session.getEntryPoint( "stream3" );
+            Collection<? extends EntryPoint> eps = session.getEntryPoints();
 
-        EntryPoint def = session.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId());
-        EntryPoint s1 = session.getEntryPoint("stream1");
-        EntryPoint s2 = session.getEntryPoint( "stream2" );
-        EntryPoint s3 = session.getEntryPoint( "stream3" );
-        Collection<? extends EntryPoint> eps = session.getEntryPoints();
-
-        assertEquals( 4,
-                      eps.size() );
-        assertTrue(eps.contains(def));
-        assertTrue(eps.contains(s1));
-        assertTrue(eps.contains(s2));
-        assertTrue(eps.contains(s3));
+            assertEquals( 4,
+                          eps.size() );
+            assertTrue(eps.contains(def));
+            assertTrue(eps.contains(s1));
+            assertTrue(eps.contains(s2));
+            assertTrue(eps.contains(s3));
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -448,41 +458,43 @@ public class StreamsTest extends CommonTestMethodBase {
 
         KieSessionConfiguration ksessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksessionConfig.setOption(ClockTypeOption.get("pseudo"));
-        KieSession ksession = kbase.newKieSession(ksessionConfig,
-                null);
+        KieSession ksession = kbase.newKieSession(ksessionConfig, null);
+        try {
+            RuleRuntimeEventListener wml = mock(RuleRuntimeEventListener.class);
+            ksession.addEventListener(wml);
 
-        RuleRuntimeEventListener wml = mock(RuleRuntimeEventListener.class);
-        ksession.addEventListener(wml);
+            PseudoClockScheduler clock = (PseudoClockScheduler) ksession.getSessionClock();
 
-        PseudoClockScheduler clock = (PseudoClockScheduler) ksession.<SessionClock> getSessionClock();
+            final StockTickInterface st1 = new StockTick(1,
+                                                         "RHT",
+                                                         100,
+                                                         1000);
+            final StockTickInterface st2 = new StockTick(2,
+                                                         "RHT",
+                                                         100,
+                                                         1000);
 
-        final StockTickInterface st1 = new StockTick(1,
-                                                     "RHT",
-                                                     100,
-                                                     1000);
-        final StockTickInterface st2 = new StockTick(2,
-                                                     "RHT",
-                                                     100,
-                                                     1000);
+            ksession.insert(st1);
+            ksession.insert(st2);
 
-        ksession.insert(st1);
-        ksession.insert(st2);
+            verify(wml,
+                   times(2)).objectInserted(any(org.kie.api.event.rule.ObjectInsertedEvent.class));
+            assertThat(ksession.getObjects().size(),
+                       equalTo(2));
+            assertThat((Collection<Object>) ksession.getObjects(),
+                       hasItems(st1, st2));
 
-        verify(wml,
-               times(2)).objectInserted(any(org.kie.api.event.rule.ObjectInsertedEvent.class));
-        assertThat(ksession.getObjects().size(),
-                   equalTo(2));
-        assertThat((Collection<Object>) ksession.getObjects(),
-                   hasItems((Object) st1, st2));
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
+            clock.advanceTime(3,
+                              TimeUnit.SECONDS);
+            ksession.fireAllRules();
 
-        clock.advanceTime(3,
-                          TimeUnit.SECONDS);
-        ksession.fireAllRules();
-
-        assertThat(ksession.getObjects().size(),
-                equalTo(0));
+            assertThat(ksession.getObjects().size(),
+                       equalTo(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -494,51 +506,53 @@ public class StreamsTest extends CommonTestMethodBase {
 
         KieSessionConfiguration ksessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksessionConfig.setOption(ClockTypeOption.get("pseudo"));
-        KieSession ksession = kbase.newKieSession(ksessionConfig,
-                                                                              null);
+        KieSession ksession = kbase.newKieSession(ksessionConfig, null);
+        try {
+            RuleRuntimeEventListener wml = mock(RuleRuntimeEventListener.class);
+            ksession.addEventListener(wml);
+            AgendaEventListener ael = mock(AgendaEventListener.class);
+            ksession.addEventListener(ael);
 
-        RuleRuntimeEventListener wml = mock(RuleRuntimeEventListener.class);
-        ksession.addEventListener(wml);
-        AgendaEventListener ael = mock(AgendaEventListener.class);
-        ksession.addEventListener(ael);
+            PseudoClockScheduler clock = (PseudoClockScheduler) ksession.getSessionClock();
 
-        PseudoClockScheduler clock = (PseudoClockScheduler) ksession.<SessionClock> getSessionClock();
+            final StockTickInterface st1 = new StockTick(1,
+                                                         "RHT",
+                                                         100,
+                                                         1000);
+            final StockTickInterface st2 = new StockTick(2,
+                                                         "RHT",
+                                                         100,
+                                                         1000);
 
-        final StockTickInterface st1 = new StockTick(1,
-                                                     "RHT",
-                                                     100,
-                                                     1000);
-        final StockTickInterface st2 = new StockTick(2,
-                                                     "RHT",
-                                                     100,
-                                                     1000);
+            ksession.insert(st1);
+            ksession.insert(st2);
 
-        ksession.insert(st1);
-        ksession.insert(st2);
+            assertThat(ksession.fireAllRules(),
+                       equalTo(2));
 
-        assertThat(ksession.fireAllRules(),
-                   equalTo(2));
+            verify(wml,
+                   times(2)).objectInserted(any(org.kie.api.event.rule.ObjectInsertedEvent.class));
+            verify(ael,
+                   times(2)).matchCreated(any(MatchCreatedEvent.class));
+            assertThat(ksession.getObjects().size(),
+                       equalTo(2));
+            assertThat((Collection<Object>) ksession.getObjects(),
+                       hasItems(st1,
+                                st2));
 
-        verify(wml,
-               times(2)).objectInserted(any(org.kie.api.event.rule.ObjectInsertedEvent.class));
-        verify(ael,
-               times(2)).matchCreated(any(MatchCreatedEvent.class));
-        assertThat(ksession.getObjects().size(),
-                   equalTo(2));
-        assertThat((Collection<Object>) ksession.getObjects(),
-                   hasItems((Object) st1,
-                            st2));
+            clock.advanceTime(3,
+                              TimeUnit.SECONDS);
+            ksession.fireAllRules();
 
-        clock.advanceTime(3,
-                          TimeUnit.SECONDS);
-        ksession.fireAllRules();
-
-        assertThat(ksession.getObjects().size(),
-                   equalTo(0));
+            assertThat(ksession.getObjects().size(),
+                       equalTo(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testEventExpirationValue() throws Exception {
+    public void testEventExpirationValue() {
         String drl1 = "package org.drools.pkg1\n" +
                       "import org.drools.compiler.StockTick\n" +
                       "declare StockTick\n" +
@@ -571,7 +585,7 @@ public class StreamsTest extends CommonTestMethodBase {
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase( kconf );
         kbase.addPackages( kbuilder.getKnowledgePackages() );
 
-        List<ObjectTypeNode> otns = ( (KnowledgeBaseImpl) kbase ).getRete().getObjectTypeNodes();
+        List<ObjectTypeNode> otns = kbase.getRete().getObjectTypeNodes();
         ObjectType stot = new ClassObjectType( StockTick.class );
         for (ObjectTypeNode otn : otns) {
             if (otn.getObjectType().isAssignableFrom( stot )) {
@@ -595,14 +609,16 @@ public class StreamsTest extends CommonTestMethodBase {
         
         KieBase kbase = loadKnowledgeBaseFromString( (KieBaseConfiguration)null, drl );
         KieSession ksession = kbase.newKieSession();
-
-        assertNotNull(ksession.getEntryPoint("UsedEntryPoint"));
-        assertNotNull(ksession.getEntryPoint("UnusedEntryPoint"));
-
-        ksession.dispose();
+        try {
+            assertNotNull(ksession.getEntryPoint("UsedEntryPoint"));
+            assertNotNull(ksession.getEntryPoint("UnusedEntryPoint"));
+        } finally {
+            ksession.dispose();
+        }
     }
 
-    public void testWindowDeclaration() throws Exception {
+    @Test
+    public void testWindowDeclaration() {
         String drl = "package org.drools.compiler\n" +
                      "declare StockTick\n" +
                      "    @role(event)\n" +
@@ -625,35 +641,38 @@ public class StreamsTest extends CommonTestMethodBase {
                                                           drl);
 
         KieSession ksession = kbase.newKieSession();
-        AgendaEventListener ael = mock(AgendaEventListener.class);
-        ksession.addEventListener(ael);
+        try {
+            AgendaEventListener ael = mock(AgendaEventListener.class);
+            ksession.addEventListener(ael);
 
-        EntryPoint ep = ksession.getEntryPoint("ticks");
-        ep.insert(new StockTick(1, "ACME", 20, 1000)); // not in the window
-        ep.insert(new StockTick(2, "RHT", 20, 1000)); // not > 20
-        ep.insert(new StockTick(3, "RHT", 30, 1000));
-        ep.insert(new StockTick(4, "ACME", 30, 1000)); // not in the window
-        ep.insert(new StockTick(5, "RHT", 25, 1000));
-        ep.insert(new StockTick(6, "ACME", 10, 1000)); // not in the window
-        ep.insert(new StockTick(7, "RHT", 10, 1000)); // not > 20
-        ep.insert(new StockTick(8, "RHT", 40, 1000));
+            EntryPoint ep = ksession.getEntryPoint("ticks");
+            ep.insert(new StockTick(1, "ACME", 20, 1000)); // not in the window
+            ep.insert(new StockTick(2, "RHT", 20, 1000)); // not > 20
+            ep.insert(new StockTick(3, "RHT", 30, 1000));
+            ep.insert(new StockTick(4, "ACME", 30, 1000)); // not in the window
+            ep.insert(new StockTick(5, "RHT", 25, 1000));
+            ep.insert(new StockTick(6, "ACME", 10, 1000)); // not in the window
+            ep.insert(new StockTick(7, "RHT", 10, 1000)); // not > 20
+            ep.insert(new StockTick(8, "RHT", 40, 1000));
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
-        verify(ael,
-               times(1)).afterMatchFired(captor.capture());
+            ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
+            verify(ael,
+                   times(1)).afterMatchFired(captor.capture());
 
-        AfterMatchFiredEvent aafe = captor.getValue();
-        assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
-                          is(95));
-        assertThat(((Number) aafe.getMatch().getDeclarationValue("$cnt")).intValue(),
-                          is(3));
-
+            AfterMatchFiredEvent aafe = captor.getValue();
+            assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
+                       is(95));
+            assertThat(((Number) aafe.getMatch().getDeclarationValue("$cnt")).intValue(),
+                       is(3));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testWindowDeclaration2() throws Exception {
+    public void testWindowDeclaration2() {
         String drl = "package org.drools.compiler\n" +
                      "declare Double\n" + 
                      "    @role(event)\n" + 
@@ -676,27 +695,31 @@ public class StreamsTest extends CommonTestMethodBase {
                                                           drl);
 
         KieSession ksession = kbase.newKieSession();
-        AgendaEventListener ael = mock(AgendaEventListener.class);
-        ksession.addEventListener(ael);
+        try {
+            AgendaEventListener ael = mock(AgendaEventListener.class);
+            ksession.addEventListener(ael);
 
-        EntryPoint ep = ksession.getEntryPoint("data");
-        ep.insert(Double.valueOf( 10 )); 
-        ep.insert(Double.valueOf( 11 )); 
-        ep.insert(Double.valueOf( 12 )); 
+            EntryPoint ep = ksession.getEntryPoint("data");
+            ep.insert(Double.valueOf( 10 ));
+            ep.insert(Double.valueOf( 11 ));
+            ep.insert(Double.valueOf( 12 ));
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
-        verify(ael,
-               times(1)).afterMatchFired(captor.capture());
+            ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
+            verify(ael,
+                   times(1)).afterMatchFired(captor.capture());
 
-        AfterMatchFiredEvent aafe = captor.getValue();
-        assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
-                          is(33));
+            AfterMatchFiredEvent aafe = captor.getValue();
+            assertThat(((Number) aafe.getMatch().getDeclarationValue("$sum")).intValue(),
+                       is(33));
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test (timeout=10000)
-    public void testMultipleWindows() throws Exception {
+    public void testMultipleWindows() {
         String drl = "package org.drools.compiler\n" +
                      "declare StockTick\n" + 
                      "    @role(event)\n" + 
@@ -709,29 +732,31 @@ public class StreamsTest extends CommonTestMethodBase {
                      "end";
         KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
         kconf.setOption(EventProcessingOption.STREAM);
-        KieBase kbase = loadKnowledgeBaseFromString(kconf,
-                                                          drl);
-
+        KieBase kbase = loadKnowledgeBaseFromString(kconf, drl);
         KieSession ksession = kbase.newKieSession();
-        AgendaEventListener ael = mock(AgendaEventListener.class);
-        ksession.addEventListener(ael);
-        
-        StockTick st1 = new StockTick(1, "RHT", 10, 1000);
-        ksession.insert( st1 );
-        StockTick st2 = new StockTick(2, "JBW", 10, 1000);
-        ksession.insert( st2 );
-        
-        ksession.fireAllRules();
+        try {
+            AgendaEventListener ael = mock(AgendaEventListener.class);
+            ksession.addEventListener(ael);
 
-        ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
-        verify(ael,
-               times(1)).afterMatchFired(captor.capture());
+            StockTick st1 = new StockTick(1, "RHT", 10, 1000);
+            ksession.insert( st1 );
+            StockTick st2 = new StockTick(2, "JBW", 10, 1000);
+            ksession.insert( st2 );
 
-        AfterMatchFiredEvent aafe = captor.getValue();
-        assertThat( (StockTick) aafe.getMatch().getDeclarationValue("f1"),
-                           is(st1));
-        assertThat( (StockTick) aafe.getMatch().getDeclarationValue("f2"),
-                           is(st2));
+            ksession.fireAllRules();
+
+            ArgumentCaptor<org.kie.api.event.rule.AfterMatchFiredEvent> captor = ArgumentCaptor.forClass(org.kie.api.event.rule.AfterMatchFiredEvent.class);
+            verify(ael,
+                   times(1)).afterMatchFired(captor.capture());
+
+            AfterMatchFiredEvent aafe = captor.getValue();
+            assertThat(aafe.getMatch().getDeclarationValue("f1"),
+                       is(st1));
+            assertThat(aafe.getMatch().getDeclarationValue("f2"),
+                       is(st2));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -799,15 +824,18 @@ public class StreamsTest extends CommonTestMethodBase {
         kBaseConfig.setOption(EventProcessingOption.STREAM);
         KieBase kbase = loadKnowledgeBaseFromString(kBaseConfig, str);
         KieSession ksession = createKnowledgeSession( kbase );
-        
-        ksession.addEventListener(new org.kie.api.event.rule.DebugAgendaEventListener());
+        try {
+            ksession.addEventListener(new org.kie.api.event.rule.DebugAgendaEventListener());
 
-        FactType eventType = kbase.getFactType("org.drools.compiler.test", "Event");
+            FactType eventType = kbase.getFactType("org.drools.compiler.test", "Event");
 
-        Object event = eventType.newInstance();
-        eventType.set(event, "name", "myName");
-        ksession.insert( event );
+            Object event = eventType.newInstance();
+            eventType.set(event, "name", "myName");
+            ksession.insert( event );
 
-        ksession.fireUntilHalt();
+            ksession.fireUntilHalt();
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrictAnnotationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/StrictAnnotationTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 public class StrictAnnotationTest extends CommonTestMethodBase {
 
     @Test
-    public void testUnknownAnnotation() throws Exception {
+    public void testUnknownAnnotation() {
         String str =
                 "package org.simple \n" +
                 "@Xyz rule yyy \n" +
@@ -69,7 +69,7 @@ public class StrictAnnotationTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testImportedAnnotation() throws Exception {
+    public void testImportedAnnotation() {
         String str =
                 "package org.simple \n" +
                 "import " + Xyz.class.getCanonicalName() + " \n" +
@@ -91,7 +91,7 @@ public class StrictAnnotationTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testEagerEvaluation() throws Exception {
+    public void testEagerEvaluation() {
         String str =
                 "package org.simple \n" +
                 "@Propagation(EAGER) rule xxx \n" +
@@ -117,22 +117,25 @@ public class StrictAnnotationTest extends CommonTestMethodBase {
                 .addContent(str, ResourceType.DRL)
                 .build()
                 .newKieSession(conf, null);
+        try {
+            final List list = new ArrayList();
 
-        final List list = new ArrayList();
+            AgendaEventListener agendaEventListener = new DefaultAgendaEventListener() {
+                public void matchCreated(org.kie.api.event.rule.MatchCreatedEvent event) {
+                    list.add("activated");
+                }
+            };
+            ksession.addEventListener(agendaEventListener);
 
-        AgendaEventListener agendaEventListener = new DefaultAgendaEventListener() {
-            public void matchCreated(org.kie.api.event.rule.MatchCreatedEvent event) {
-                list.add("activated");
-            }
-        };
-        ksession.addEventListener(agendaEventListener);
-
-        ksession.insert("test");
-        assertEquals(2, list.size());
+            ksession.insert("test");
+            assertEquals(2, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testWatch() throws Exception {
+    public void testWatch() {
         String str =
                 "package com.sample;\n" +
                 "import " + MyClass.class.getCanonicalName() + ";\n" +
@@ -149,15 +152,18 @@ public class StrictAnnotationTest extends CommonTestMethodBase {
                 .addContent(str, ResourceType.DRL)
                 .build()
                 .newKieSession();
-
-        MyClass myClass = new MyClass("test", 1);
-        ksession.insert(myClass);
-        ksession.fireAllRules();
-        assertEquals(2, myClass.getValue());
+        try {
+            MyClass myClass = new MyClass("test", 1);
+            ksession.insert(myClass);
+            ksession.fireAllRules();
+            assertEquals(2, myClass.getValue());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testStirctWatchWithoutQuotes() throws Exception {
+    public void testStirctWatchWithoutQuotes() {
         String str =
                 "package com.sample;\n" +
                 "import " + MyClass.class.getCanonicalName() + ";\n" +
@@ -206,13 +212,17 @@ public class StrictAnnotationTest extends CommonTestMethodBase {
 
         List<String> names = new ArrayList<String>();
         KieSession ksession = kieBase.newKieSession();
-        ksession.setGlobal("names", names);
+        try {
+            ksession.setGlobal("names", names);
 
-        ksession.insert(instance);
-        ksession.fireAllRules();
+            ksession.insert(instance);
+            ksession.fireAllRules();
 
-        assertEquals(1, names.size());
-        assertEquals("Mark", names.get(0));
+            assertEquals(1, names.size());
+            assertEquals("Mark", names.get(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -230,16 +240,19 @@ public class StrictAnnotationTest extends CommonTestMethodBase {
                 .addContent(str, ResourceType.DRL)
                 .build()
                 .newKieSession();
+        try {
+            Message msg = new Message();
+            msg.setStartTime( new Timestamp( 10000 ) );
+            msg.setDuration( 1000l );
 
-        Message msg = new Message();
-        msg.setStartTime( new Timestamp( 10000 ) );
-        msg.setDuration( 1000l );
-
-        EventFactHandle efh = (EventFactHandle) ksession.insert( msg );
-        assertEquals( 10000,
-                      efh.getStartTimestamp() );
-        assertEquals( 1000,
-                      efh.getDuration() );
+            EventFactHandle efh = (EventFactHandle) ksession.insert( msg );
+            assertEquals( 10000,
+                          efh.getStartTimestamp() );
+            assertEquals( 1000,
+                          efh.getDuration() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @PropertyReactive

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TemporalOperatorTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TemporalOperatorTest.java
@@ -70,18 +70,21 @@ public class TemporalOperatorTest {
         KieSession ksession = new KieHelper().addContent( str, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
+            TimestampedObject t1 = new TimestampedObject( "t1", LocalDateTime.now() );
+            TimestampedObject t2 = new TimestampedObject( "t2", LocalDateTime.now().plusHours( 1 ) );
 
-        TimestampedObject t1 = new TimestampedObject( "t1", LocalDateTime.now() );
-        TimestampedObject t2 = new TimestampedObject( "t2", LocalDateTime.now().plusHours( 1 ) );
+            ksession.insert( t1 );
+            ksession.insert( t2 );
+            ksession.fireAllRules();
 
-        ksession.insert( t1 );
-        ksession.insert( t2 );
-        ksession.fireAllRules();
-
-        assertEquals(t2.getName(), list.get(0));
+            assertEquals(t2.getName(), list.get(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 
     public static class TimestampedObject {
@@ -139,15 +142,18 @@ public class TemporalOperatorTest {
         KieSession ksession = new KieHelper().addContent( str, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
+            TimestampedObject t1 = new TimestampedObject( "t1", LocalDateTime.now() );
 
-        TimestampedObject t1 = new TimestampedObject( "t1", LocalDateTime.now() );
+            ksession.insert( t1 );
+            ksession.fireAllRules();
 
-        ksession.insert( t1 );
-        ksession.fireAllRules();
-
-        assertEquals(t1.getName(), list.get(0));
+            assertEquals(t1.getName(), list.get(0));
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TimerAndCalendarTest.java
@@ -70,61 +70,67 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
     public void testDuration() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_Duration.drl");
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            final List list = new ArrayList();
+            ksession.setGlobal( "list",
+                                list );
 
-        final List list = new ArrayList();
-        ksession.setGlobal( "list",
-                                 list );
+            final Cheese brie = new Cheese( "brie",
+                                            12 );
+            final FactHandle brieHandle = ksession.insert(brie );
 
-        final Cheese brie = new Cheese( "brie",
-                                        12 );
-        final FactHandle brieHandle = (FactHandle) ksession.insert( brie );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
+            // now check for update
+            assertEquals( 0,
+                          list.size() );
 
-        // now check for update
-        assertEquals( 0,
-                      list.size() );
-
-        // sleep for 500ms
-        Thread.sleep( 500 );
+            // sleep for 500ms
+            Thread.sleep( 500 );
 
 
-        ksession.fireAllRules();
-        // now check for update
-        assertEquals( 1,
-                      list.size() );
+            ksession.fireAllRules();
+            // now check for update
+            assertEquals( 1,
+                          list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
     public void testDurationWithNoLoop() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_Duration_with_NoLoop.drl");
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            final List list = new ArrayList();
+            ksession.setGlobal( "list",
+                                list );
 
-        final List list = new ArrayList();
-        ksession.setGlobal( "list",
-                                 list );
+            final Cheese brie = new Cheese( "brie",
+                                            12 );
+            final FactHandle brieHandle = ksession.insert(brie );
 
-        final Cheese brie = new Cheese( "brie",
-                                        12 );
-        final FactHandle brieHandle = (FactHandle) ksession.insert( brie );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
+            // now check for update
+            assertEquals( 0,
+                          list.size() );
 
-        // now check for update
-        assertEquals( 0,
-                      list.size() );
+            // sleep for 300ms
+            Thread.sleep( 300 );
 
-        // sleep for 300ms
-        Thread.sleep( 300 );
-
-        ksession.fireAllRules();
-        // now check for update
-        assertEquals( 1,
-                      list.size() );
+            ksession.fireAllRules();
+            // now check for update
+            assertEquals( 1,
+                          list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testDurationMemoryLeakonRepeatedUpdate() throws Exception {
+    public void testDurationMemoryLeakonRepeatedUpdate() {
         String str = "";
         str += "package org.drools.compiler.test\n";
         str += "import org.drools.compiler.Alarm\n";
@@ -144,57 +150,63 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
+        try {
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list",
-                            list );
-        ksession.insert( new Alarm() );
+            List list = new ArrayList();
+            ksession.setGlobal( "list",
+                                list );
+            ksession.insert( new Alarm() );
 
-        ksession.fireAllRules();
-
-        for ( int i = 0; i < 6; i++ ) {
-            timeService.advanceTime( 55, TimeUnit.SECONDS );
             ksession.fireAllRules();
-        }
 
-        assertEquals(5,
-                     list.size() );
+            for ( int i = 0; i < 6; i++ ) {
+                timeService.advanceTime( 55, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+            }
+
+            assertEquals(5,
+                         list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
     public void testFireRuleAfterDuration() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_FireRuleAfterDuration.drl");
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            final List list = new ArrayList();
+            ksession.setGlobal( "list",
+                                list );
 
-        final List list = new ArrayList();
-        ksession.setGlobal( "list",
-                                 list );
+            final Cheese brie = new Cheese( "brie",
+                                            12 );
+            final FactHandle brieHandle = ksession.insert(brie );
 
-        final Cheese brie = new Cheese( "brie",
-                                        12 );
-        final FactHandle brieHandle = (FactHandle) ksession.insert( brie );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
+            // now check for update
+            assertEquals( 0,
+                          list.size() );
 
-        // now check for update
-        assertEquals( 0,
-                      list.size() );
+            // sleep for 300ms
+            Thread.sleep( 300 );
 
-        // sleep for 300ms
-        Thread.sleep( 300 );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-
-        // now check for update
-        assertEquals( 2,
-                      list.size() );
-
+            // now check for update
+            assertEquals( 2,
+                          list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
-    public void testNoProtocolIntervalTimer() throws Exception {
+    public void testNoProtocolIntervalTimer() {
         String str = "";
         str += "package org.simple \n";
         str += "global java.util.List list \n";
@@ -210,39 +222,42 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
 
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
-        
-        ksession.setGlobal( "list", list );
-        
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-        
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-        
-        timeService.advanceTime( 15, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        
-        timeService.advanceTime( 3, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        
-        timeService.advanceTime( 2, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( 15, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 3, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 2, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
-    public void testIntervalTimer() throws Exception {
+    public void testIntervalTimer() {
         String str = "";
         str += "package org.simple \n";
         str += "global java.util.List list \n";
@@ -258,40 +273,43 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
+        try {
+            List list = new ArrayList();
 
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime(new Date().getTime(), TimeUnit.MILLISECONDS);
-        
-        ksession.setGlobal("list", list);
-        
-        ksession.fireAllRules();
-        assertEquals(0, list.size());
-        
-        timeService.advanceTime(20, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals(0, list.size());
-        
-        timeService.advanceTime(15, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals(1, list.size());
-        
-        timeService.advanceTime(3, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals(1, list.size());
-        
-        timeService.advanceTime(2, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals(2, list.size());
-        
-        timeService.advanceTime(10, TimeUnit.SECONDS);
-        ksession.fireAllRules();
-        assertEquals(3, list.size());
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime(new Date().getTime(), TimeUnit.MILLISECONDS);
+
+            ksession.setGlobal("list", list);
+
+            ksession.fireAllRules();
+            assertEquals(0, list.size());
+
+            timeService.advanceTime(20, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals(0, list.size());
+
+            timeService.advanceTime(15, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+
+            timeService.advanceTime(3, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals(1, list.size());
+
+            timeService.advanceTime(2, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals(2, list.size());
+
+            timeService.advanceTime(10, TimeUnit.SECONDS);
+            ksession.fireAllRules();
+            assertEquals(3, list.size());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testIntervalTimerWithoutFire() throws Exception {
+    public void testIntervalTimerWithoutFire() {
         String str =
                 "package org.simple \n" +
                 "global java.util.List list \n" +
@@ -308,29 +326,32 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List list = new ArrayList();
 
-        List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
 
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
+            ksession.setGlobal( "list", list );
 
-        ksession.setGlobal( "list", list );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            timeService.advanceTime( 35, TimeUnit.SECONDS );
+            assertEquals( 1, list.size() );
 
-        timeService.advanceTime( 35, TimeUnit.SECONDS );
-        assertEquals( 1, list.size() );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            assertEquals( 2, list.size() );
 
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        assertEquals( 2, list.size() );
-
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        assertEquals( 3, list.size() );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            assertEquals( 3, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testExprIntervalTimerRaceCondition() throws Exception {
+    public void testExprIntervalTimerRaceCondition() {
         String str = "";
         str += "package org.simple \n";
         str += "global java.util.List list \n";
@@ -347,51 +368,54 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List list = new ArrayList();
 
-        List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
 
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
+            ksession.setGlobal( "list", list );
+            FactHandle fh = ksession.insert(10000l );
 
-        ksession.setGlobal( "list", list );
-        FactHandle fh = (FactHandle) ksession.insert( 10000l );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
 
 
-        timeService.advanceTime( 17, TimeUnit.SECONDS );
-        ksession.update( fh, 5000l );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            timeService.advanceTime( 17, TimeUnit.SECONDS );
+            ksession.update( fh, 5000l );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testUnknownProtocol() throws Exception {
+    public void testUnknownProtocol() {
         wrongTimerExpression("xyz:30");
     }
 
     @Test(timeout=10000)
-    public void testMissingColon() throws Exception {
+    public void testMissingColon() {
         wrongTimerExpression("int 30");
     }
 
     @Test(timeout=10000)
-    public void testMalformedExpression() throws Exception {
+    public void testMalformedExpression() {
         wrongTimerExpression("30s s30");
     }
 
     @Test(timeout=10000)
-    public void testMalformedIntExpression() throws Exception {
+    public void testMalformedIntExpression() {
         wrongTimerExpression("int 30s");
     }
 
     @Test(timeout=10000)
-    public void testMalformedCronExpression() throws Exception {
+    public void testMalformedCronExpression() {
         wrongTimerExpression("cron: 0/30 * * * * *");
     }
 
@@ -428,34 +452,37 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
-        Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        
-        ksession.setGlobal( "list", list );
-  
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-                
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-                 
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        
-        timeService.advanceTime( 30, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        
-        timeService.advanceTime( 30, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
+            Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 30, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 30, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -472,57 +499,51 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
         str += "end  \n";
 
 
-        Calendar calFalse = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-                return false;
-            }
-        };
-        
-        Calendar calTrue = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-                return true;
-            }
-        };
+        Calendar calFalse = timestamp -> false;
+        Calendar calTrue = timestamp -> true;
 
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( "pseudo" ) );
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
-        Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
-        
-        ksession.getCalendars().set( "cal1", calTrue );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        ksession.setGlobal( "list", list );
-        ksession.insert( "o1" );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-                
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.insert( "o2" );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        ksession.getCalendars().set( "cal1", calFalse );
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.insert( "o3" );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        ksession.getCalendars().set( "cal1", calTrue );
-        timeService.advanceTime( 30, TimeUnit.SECONDS );
-        ksession.insert( "o4" );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
+            Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
+
+            ksession.getCalendars().set( "cal1", calTrue );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+            ksession.setGlobal( "list", list );
+            ksession.insert( "o1" );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.insert( "o2" );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            ksession.getCalendars().set( "cal1", calFalse );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.insert( "o3" );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            ksession.getCalendars().set( "cal1", calTrue );
+            timeService.advanceTime( 30, TimeUnit.SECONDS );
+            ksession.insert( "o4" );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testUndefinedCalendar() throws Exception {
+    public void testUndefinedCalendar() {
         String str = "";
         str += "rule xxx \n";
         str += "  calendars \"cal1\"\n";
@@ -532,11 +553,14 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase);
-
         try {
-            ksession.fireAllRules();
-            fail("should throw UndefinedCalendarExcption");
-        } catch (UndefinedCalendarExcption e) { }
+            try {
+                ksession.fireAllRules();
+                fail("should throw UndefinedCalendarExcption");
+            } catch (UndefinedCalendarExcption e) { }
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -557,51 +581,46 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            Calendar calFalse = timestamp -> false;
 
-        Calendar calFalse = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-                return false;
-            }
-        };
-        
-        Calendar calTrue = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-                return true;
-            }
-        };
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
-        Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
-        
-        ksession.getCalendars().set( "cal1", calTrue );
-        ksession.getCalendars().set( "cal2", calTrue );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        ksession.setGlobal( "list", list );
-        ksession.insert( "o1" );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
+            Calendar calTrue = timestamp -> true;
 
-        ksession.getCalendars().set( "cal2", calFalse );
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.insert( "o2" );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-                
-        ksession.getCalendars().set( "cal1", calFalse );
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.insert( "o3" );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        
-        ksession.getCalendars().set( "cal1", calTrue );
-        ksession.getCalendars().set( "cal2", calTrue );
-        timeService.advanceTime( 30, TimeUnit.SECONDS );
-        ksession.insert( "o4" );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
+            Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
+
+            ksession.getCalendars().set( "cal1", calTrue );
+            ksession.getCalendars().set( "cal2", calTrue );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+            ksession.setGlobal( "list", list );
+            ksession.insert( "o1" );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            ksession.getCalendars().set( "cal2", calFalse );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.insert( "o2" );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            ksession.getCalendars().set( "cal1", calFalse );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.insert( "o3" );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            ksession.getCalendars().set( "cal1", calTrue );
+            ksession.getCalendars().set( "cal2", calTrue );
+            timeService.advanceTime( 30, TimeUnit.SECONDS );
+            ksession.insert( "o4" );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -622,72 +641,67 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
-        Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        
-        final Date date1 = new Date( date.getTime() +  (15 * 1000) );
-        final Date date2 = new Date( date1.getTime() + (60 * 1000) );
-        final Date date3 = new Date( date2.getTime() + (60 * 1000) );
-        final Date date4 = new Date( date3.getTime() + (60 * 1000) );
-        
-        Calendar cal1 = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
+            Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+
+            final Date date1 = new Date( date.getTime() +  (15 * 1000) );
+            final Date date2 = new Date( date1.getTime() + (60 * 1000) );
+            final Date date3 = new Date( date2.getTime() + (60 * 1000) );
+            final Date date4 = new Date( date3.getTime() + (60 * 1000) );
+
+            Calendar cal1 = timestamp -> {
                 if ( timestamp == date1.getTime() ) {
                     return true;
-                } else if ( timestamp == date4.getTime() ) {
-                    return false;
-                } else {
-                    return true;
-                }
-            }
-        };
-        
-        Calendar cal2 = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-               if ( timestamp == date2.getTime() ) {
+                } else return timestamp != date4.getTime();
+            };
+
+            Calendar cal2 = timestamp -> {
+                if ( timestamp == date2.getTime() ) {
                     return false;
                 }  else if ( timestamp == date3.getTime() ) {
                     return true;
                 } else {
                     return true;
                 }
-            }
-        };
-        
-        ksession.getCalendars().set( "cal1", cal1 );
-        ksession.getCalendars().set( "cal2", cal2 );
-        
-        ksession.setGlobal( "list", list );
-                         
-        ksession.fireAllRules();
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-                      
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-             
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            };
 
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
-        
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 4, list.size() );
+            ksession.getCalendars().set( "cal1", cal1 );
+            ksession.getCalendars().set( "cal2", cal2 );
+
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 4, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -708,72 +722,67 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
-        Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        
-        final Date date1 = new Date( date.getTime() +  (15 * 1000) );
-        final Date date2 = new Date( date1.getTime() + (60 * 1000) );
-        final Date date3 = new Date( date2.getTime() + (60 * 1000) );
-        final Date date4 = new Date( date3.getTime() + (60 * 1000) );
-        
-        Calendar cal1 = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss.SSSZ" );
+            Date date = df.parse( "2009-01-01T00:00:00.000-0000" );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+
+            final Date date1 = new Date( date.getTime() +  (15 * 1000) );
+            final Date date2 = new Date( date1.getTime() + (60 * 1000) );
+            final Date date3 = new Date( date2.getTime() + (60 * 1000) );
+            final Date date4 = new Date( date3.getTime() + (60 * 1000) );
+
+            Calendar cal1 = timestamp -> {
                 if ( timestamp == date1.getTime() ) {
                     return true;
-                } else if ( timestamp == date4.getTime() ) {
-                    return false;
-                } else {
-                    return true;
-                }
-            }
-        };
-        
-        Calendar cal2 = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-               if ( timestamp == date2.getTime() ) {
+                } else return timestamp != date4.getTime();
+            };
+
+            Calendar cal2 = timestamp -> {
+                if ( timestamp == date2.getTime() ) {
                     return false;
                 }  else if ( timestamp == date3.getTime() ) {
                     return true;
                 } else {
                     return true;
                 }
-            }
-        };
-        
-        ksession.getCalendars().set( "cal1", cal1 );
-        ksession.getCalendars().set( "cal2", cal2 );
-        
-        ksession.setGlobal( "list", list );
-                         
-        ksession.fireAllRules();
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-                      
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-             
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            };
 
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
-        
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 4, list.size() );
+            ksession.getCalendars().set( "cal1", cal1 );
+            ksession.getCalendars().set( "cal2", cal2 );
+
+            ksession.setGlobal( "list", list );
+
+            ksession.fireAllRules();
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 4, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -794,45 +803,44 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
-        Date date = df.parse( "1-JAN-2010" );
-        
-        Calendar cal1 = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-                return true;
-            }
-        };
-        
-        long oneDay = 60 * 60 * 24;
-        ksession.getCalendars().set( "cal1", cal1 );
-        ksession.setGlobal( "list", list );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-        
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-                      
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );  // day 3
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-             
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
+            Date date = df.parse( "1-JAN-2010" );
 
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+            Calendar cal1 = timestamp -> true;
+
+            long oneDay = 60 * 60 * 24;
+            ksession.getCalendars().set( "cal1", cal1 );
+            ksession.setGlobal( "list", list );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );  // day 3
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -853,45 +861,44 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        List list = new ArrayList();
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
-        Date date = df.parse( "1-JAN-2010" );
-        
-        Calendar cal1 = new Calendar() {
-            public boolean isTimeIncluded(long timestamp) {
-                return true;
-            }
-        };
-        
-        long oneDay = 60 * 60 * 24;
-        ksession.getCalendars().set( "cal1", cal1 );
-        ksession.setGlobal( "list", list );
-        
-        timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-        
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-                      
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS ); // day 3
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-             
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+        try {
+            List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
+            Date date = df.parse( "1-JAN-2010" );
 
-        timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+            Calendar cal1 = timestamp -> true;
+
+            long oneDay = 60 * 60 * 24;
+            ksession.getCalendars().set( "cal1", cal1 );
+            ksession.setGlobal( "list", list );
+
+            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS ); // day 3
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+
+            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
     
     @Test(timeout=10000)
@@ -917,45 +924,44 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
             KieBase kbase = loadKnowledgeBaseFromString(str );
             KieSession ksession = createKnowledgeSession(kbase, conf);
-            
-            List list = new ArrayList();
-            PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-            DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
-            Date date = df.parse( "1-JAN-2010" );
-            
-            Calendar cal1 = new Calendar() {
-                public boolean isTimeIncluded(long timestamp) {
-                    return true;
-                }
-            };
-            
-            long oneDay = 60 * 60 * 24;
-            ksession.getCalendars().set( "cal1", cal1 );
-            ksession.setGlobal( "list", list );
-            
-            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-            ksession.fireAllRules();
-            assertEquals( 0, list.size() );
-            
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-            ksession.fireAllRules();
-            assertEquals( 0, list.size() );
-                          
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS ); // day 3
-            ksession.fireAllRules();
-            assertEquals( 1, list.size() );
-                 
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-            ksession.fireAllRules();
-            assertEquals( 2, list.size() );
-            
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
-            ksession.fireAllRules();
-            assertEquals( 3, list.size() );
-    
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-            ksession.fireAllRules();
-            assertEquals( 3, list.size() );
+            try {
+                List list = new ArrayList();
+                PseudoClockScheduler timeService = ksession.getSessionClock();
+                DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
+                Date date = df.parse( "1-JAN-2010" );
+
+                Calendar cal1 = timestamp -> true;
+
+                long oneDay = 60 * 60 * 24;
+                ksession.getCalendars().set( "cal1", cal1 );
+                ksession.setGlobal( "list", list );
+
+                timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+                ksession.fireAllRules();
+                assertEquals( 0, list.size() );
+
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+                assertEquals( 0, list.size() );
+
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS ); // day 3
+                ksession.fireAllRules();
+                assertEquals( 1, list.size() );
+
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+                assertEquals( 2, list.size() );
+
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
+                ksession.fireAllRules();
+                assertEquals( 3, list.size() );
+
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+                assertEquals( 3, list.size() );
+            } finally {
+                ksession.dispose();
+            }
         } finally {
             Locale.setDefault( defaultLoc );
         }
@@ -985,45 +991,44 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
             KieBase kbase = loadKnowledgeBaseFromString(str );
             KieSession ksession = createKnowledgeSession(kbase, conf);
+            try {
+                List list = new ArrayList();
+                PseudoClockScheduler timeService = ksession.getSessionClock();
+                DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
+                Date date = df.parse( "1-JAN-2010" );
 
-            List list = new ArrayList();
-            PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-            DateFormat df = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
-            Date date = df.parse( "1-JAN-2010" );
+                Calendar cal1 = timestamp -> true;
 
-            Calendar cal1 = new Calendar() {
-                public boolean isTimeIncluded(long timestamp) {
-                    return true;
-                }
-            };
+                long oneDay = 60 * 60 * 24;
+                ksession.getCalendars().set( "cal1", cal1 );
+                ksession.setGlobal( "list", list );
 
-            long oneDay = 60 * 60 * 24;
-            ksession.getCalendars().set( "cal1", cal1 );
-            ksession.setGlobal( "list", list );
+                timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
+                ksession.fireAllRules();
+                assertEquals( 0, list.size() );
 
-            timeService.advanceTime( date.getTime(), TimeUnit.MILLISECONDS );
-            ksession.fireAllRules();
-            assertEquals( 0, list.size() );
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+                assertEquals( 0, list.size() );
 
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-            ksession.fireAllRules();
-            assertEquals( 0, list.size() );
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS ); // day 3
+                ksession.fireAllRules();
+                assertEquals( 1, list.size() );
 
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS ); // day 3
-            ksession.fireAllRules();
-            assertEquals( 1, list.size() );
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+                assertEquals( 2, list.size() );
 
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-            ksession.fireAllRules();
-            assertEquals( 2, list.size() );
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
+                ksession.fireAllRules();
+                assertEquals( 3, list.size() );
 
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );   // day 5
-            ksession.fireAllRules();
-            assertEquals( 3, list.size() );
-
-            timeService.advanceTime( oneDay, TimeUnit.SECONDS );
-            ksession.fireAllRules();
-            assertEquals( 4, list.size() );
+                timeService.advanceTime( oneDay, TimeUnit.SECONDS );
+                ksession.fireAllRules();
+                assertEquals( 4, list.size() );
+            } finally {
+                ksession.dispose();
+            }
         } finally {
             Locale.setDefault( defaultLoc );
         }
@@ -1033,25 +1038,27 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
     public void testTimerWithNot() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_Timer_With_Not.drl");
         KieSession ksession = createKnowledgeSession(kbase);
-
-        ksession.fireAllRules();
-        Thread.sleep( 200 );
-        ksession.fireAllRules();
-        Thread.sleep( 200 );
-        ksession.fireAllRules();
-        // now check that rule "wrap A" fired once, creating one B
-        assertEquals( 2, ksession.getFactCount() );
+        try {
+            ksession.fireAllRules();
+            Thread.sleep( 200 );
+            ksession.fireAllRules();
+            Thread.sleep( 200 );
+            ksession.fireAllRules();
+            // now check that rule "wrap A" fired once, creating one B
+            assertEquals( 2, ksession.getFactCount() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
     public void testHaltWithTimer() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_Halt_With_Timer.drl");
         final KieSession ksession = createKnowledgeSession(kbase);
-
         new Thread(ksession::fireUntilHalt).start();
         try {
             Thread.sleep( 1000 );
-            FactHandle handle = (FactHandle) ksession.insert( "halt" );
+            FactHandle handle = ksession.insert("halt" );
             Thread.sleep( 2000 );
 
             // now check that rule "halt" fired once, creating one Integer
@@ -1064,30 +1071,29 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
     }
 
     @Test(timeout=10000)
-    public void testTimerRemoval() {
+    public void testTimerRemoval() throws InterruptedException {
+        String str = "package org.drools.compiler.test\n" +
+                "import " + TimeUnit.class.getName() + "\n" +
+                "global java.util.List list \n" +
+                "global " + CountDownLatch.class.getName() + " latch\n" +
+                "rule TimerRule \n" +
+                "   timer (int:100 50) \n" +
+                "when \n" +
+                "then \n" +
+                "        //forces it to pause until main thread is ready\n" +
+                "        latch.await(10, TimeUnit.MINUTES); \n" +
+                "        list.add(list.size()); \n" +
+                " end";
+
+        KieBase kbase = loadKnowledgeBaseFromString(str );
+        KieSession ksession = createKnowledgeSession(kbase);
         try {
-            String str = "package org.drools.compiler.test\n" +
-                    "import " + TimeUnit.class.getName() + "\n" +
-            		"global java.util.List list \n" +
-            		"global " + CountDownLatch.class.getName() + " latch\n" + 
-                    "rule TimerRule \n" + 
-                    "   timer (int:100 50) \n" +
-                    "when \n" + 
-                    "then \n" +
-                    "        //forces it to pause until main thread is ready\n" +
-                    "        latch.await(10, TimeUnit.MINUTES); \n" +
-                    "        list.add(list.size()); \n" +  
-                    " end";
-
-            KieBase kbase = loadKnowledgeBaseFromString(str );
-            KieSession ksession = createKnowledgeSession(kbase);
-
             CountDownLatch latch = new CountDownLatch(1);
             List list = Collections.synchronizedList( new ArrayList() );
             ksession.setGlobal( "list", list );
-            ksession.setGlobal( "latch", latch );            
-            
-            ksession.fireAllRules();           
+            ksession.setGlobal( "latch", latch );
+
+            ksession.fireAllRules();
             Thread.sleep(500); // this makes sure it actually enters a rule
             kbase.removeRule("org.drools.compiler.test", "TimerRule");
             ksession.fireAllRules();
@@ -1098,14 +1104,13 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
             Thread.sleep(500); // now wait to see if any more fire, they shouldn't
             ksession.fireAllRules();
             assertEquals( 0, list.size() );
+        } finally {
             ksession.dispose();
-        } catch (InterruptedException e) {
-            throw new RuntimeException( e );
         }
     }
 
     @Test(timeout=10000)
-    public void testIntervalTimerWithLongExpressions() throws Exception {
+    public void testIntervalTimerWithLongExpressions() {
         String str = "package org.simple;\n" +
                 "global java.util.List list;\n" +
                 "\n" +
@@ -1135,60 +1140,63 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List list = new ArrayList();
 
-        List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.setStartupTime( DateUtils.parseDate("3-JAN-2010").getTime() );
 
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.setStartupTime( DateUtils.parseDate("3-JAN-2010").getTime() );
+            ksession.setGlobal( "list", list );
 
-        ksession.setGlobal( "list", list );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            timeService.advanceTime( 15, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
 
-        timeService.advanceTime( 15, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
+            timeService.advanceTime( 3, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
 
-        timeService.advanceTime( 3, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
+            timeService.advanceTime( 2, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
 
-        timeService.advanceTime( 2, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-
-        timeService.advanceTime( 10, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+            timeService.advanceTime( 10, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
 
     @Test(timeout=10000)
-    public void testIntervalTimerWithStringExpressions() throws Exception {
+    public void testIntervalTimerWithStringExpressions() {
         checkIntervalTimerWithStringExpressions(false, "3-JAN-2010");
     }
 
     @Test(timeout=10000)
-    public void testIntervalTimerWithAllExpressions() throws Exception {
+    public void testIntervalTimerWithAllExpressions() {
         checkIntervalTimerWithStringExpressions(true, "3-JAN-2010");
     }
 
     @Test(timeout=10000)
-    public void testIntervalTimerWithStringExpressionsAfterStart() throws Exception {
+    public void testIntervalTimerWithStringExpressionsAfterStart() {
         checkIntervalTimerWithStringExpressions(false, "3-FEB-2010");
     }
 
     @Test(timeout=10000)
-    public void testIntervalTimerWithAllExpressionsAfterStart() throws Exception {
+    public void testIntervalTimerWithAllExpressionsAfterStart() {
         checkIntervalTimerWithStringExpressions(true, "3-FEB-2010");
     }
 
-    private void checkIntervalTimerWithStringExpressions(boolean useExprForStart, String startTime) throws Exception {
+    private void checkIntervalTimerWithStringExpressions(boolean useExprForStart, String startTime) {
         String str = "package org.simple;\n" +
                 "global java.util.List list;\n" +
                 "\n" +
@@ -1218,64 +1226,67 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str );
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List list = new ArrayList();
 
-        List list = new ArrayList();
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.setStartupTime( DateUtils.parseDate(startTime).getTime() );
 
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.setStartupTime( DateUtils.parseDate(startTime).getTime() );
+            ksession.setGlobal( "list", list );
 
-        ksession.setGlobal( "list", list );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
+            timeService.advanceTime( 40, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
 
-        timeService.advanceTime( 40, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
 
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
+            // simulate a pause in the use of the engine by advancing the system clock
+            timeService.setStartupTime(DateUtils.parseDate("3-MAR-2010").getTime());
+            list.clear();
 
-        // simulate a pause in the use of the engine by advancing the system clock
-        timeService.setStartupTime(DateUtils.parseDate("3-MAR-2010").getTime());
-        list.clear();
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() ); // fires once to recover from missing activation
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() ); // fires once to recover from missing activation
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            timeService.advanceTime( 20, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
 
-        timeService.advanceTime( 20, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
+            timeService.advanceTime( 40, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
 
-        timeService.advanceTime( 40, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
-
-        timeService.advanceTime( 60, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 4, list.size() );
+            timeService.advanceTime( 60, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 4, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testIntervalTimerExpressionWithOr() throws Exception {
+    public void testIntervalTimerExpressionWithOr() {
         String text = "package org.kie.test\n"
                       + "global java.util.List list\n"
                       + "import " + FactA.class.getCanonicalName() + "\n"
@@ -1296,60 +1307,63 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(text);
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
-        
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );        
-        ksession.insert ( new Foo(null, null) );
-        ksession.insert ( new Pet(null) );
-        
-        FactA fact1 = new FactA();
-        fact1.setField1( "f1" );
-        fact1.setField2( 250 );
-        
-        FactA fact3 = new FactA();
-        fact3.setField1( "f2" );
-        fact3.setField2( 1000 );
-        
-        ksession.insert( fact1 );
-        ksession.insert( fact3 );
-        
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+        try {
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
 
-        timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        assertEquals( fact1, list.get( 0 ) );
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
+            ksession.insert ( new Foo(null, null) );
+            ksession.insert ( new Pet(null) );
 
-        timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        assertEquals( fact1, list.get( 1 ) );
+            FactA fact1 = new FactA();
+            fact1.setField1( "f1" );
+            fact1.setField2( 250 );
 
-        timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() ); // did not change, repeat-limit kicked in
+            FactA fact3 = new FactA();
+            fact3.setField1( "f2" );
+            fact3.setField2( 1000 );
 
-        timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
-        assertEquals( fact3, list.get( 2 ) );
+            ksession.insert( fact1 );
+            ksession.insert( fact3 );
 
-        timeService.advanceTime( 1000, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 4, list.size() );
-        assertEquals( fact3, list.get( 3 ) );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        timeService.advanceTime( 1000, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 4, list.size() ); // did not change, repeat-limit kicked in
+            timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+            assertEquals( fact1, list.get( 0 ) );
+
+            timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+            assertEquals( fact1, list.get( 1 ) );
+
+            timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() ); // did not change, repeat-limit kicked in
+
+            timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+            assertEquals( fact3, list.get( 2 ) );
+
+            timeService.advanceTime( 1000, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 4, list.size() );
+            assertEquals( fact3, list.get( 3 ) );
+
+            timeService.advanceTime( 1000, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 4, list.size() ); // did not change, repeat-limit kicked in
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
-    public void testExprTimeRescheduled() throws Exception {
+    public void testExprTimeRescheduled() {
         String text = "package org.kie.test\n"
                       + "global java.util.List list\n"
                       + "import " + FactA.class.getCanonicalName() + "\n"
@@ -1365,69 +1379,70 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(text);
         KieSession ksession = createKnowledgeSession(kbase, conf);
-        
-        PseudoClockScheduler timeService = ( PseudoClockScheduler ) ksession.<SessionClock>getSessionClock();
-        timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
-        
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
-        
-        FactA fact1 = new FactA();
-        fact1.setField1( "f1" );
-        fact1.setField2( 500 );
-        fact1.setField4( 1000 );
-        FactHandle fh = (FactHandle) ksession.insert (fact1 );        
-                
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+        try {
+            PseudoClockScheduler timeService = ksession.getSessionClock();
+            timeService.advanceTime( new Date().getTime(), TimeUnit.MILLISECONDS );
 
-        timeService.advanceTime( 1100, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        assertEquals( fact1, list.get( 0 ) );
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        timeService.advanceTime( 1100, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        assertEquals( fact1, list.get( 1 ) );
+            FactA fact1 = new FactA();
+            fact1.setField1( "f1" );
+            fact1.setField2( 500 );
+            fact1.setField4( 1000 );
+            FactHandle fh = ksession.insert (fact1 );
 
-        timeService.advanceTime( 400, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 3, list.size() );
-        assertEquals( fact1, list.get( 2 ) );
-        list.clear();
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
 
-        // the activation state of the rule is not changed so the timer isn't reset
-        // since the timer alredy fired it will only use only the period that now will be set to 2000
-        fact1.setField2( 300 );
-        fact1.setField4( 2000 );
-        ksession.update(  fh, fact1 );
-        ksession.fireAllRules();
+            timeService.advanceTime( 1100, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+            assertEquals( fact1, list.get( 0 ) );
 
-        // 100 has passed of the 1000, from the previous schedule
-        // so that should be deducted from the 2000 period above, meaning
-        //  we only need to increment another 1950
-        timeService.advanceTime( 1950, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        assertEquals( fact1, list.get( 0 ) );
-        list.clear();
+            timeService.advanceTime( 1100, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+            assertEquals( fact1, list.get( 1 ) );
 
-        timeService.advanceTime( 1000, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            timeService.advanceTime( 400, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 3, list.size() );
+            assertEquals( fact1, list.get( 2 ) );
+            list.clear();
 
-        timeService.advanceTime( 700, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
+            // the activation state of the rule is not changed so the timer isn't reset
+            // since the timer alredy fired it will only use only the period that now will be set to 2000
+            fact1.setField2( 300 );
+            fact1.setField4( 2000 );
+            ksession.update(  fh, fact1 );
+            ksession.fireAllRules();
 
-        timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        
-    }    
-    
-    
+            // 100 has passed of the 1000, from the previous schedule
+            // so that should be deducted from the 2000 period above, meaning
+            //  we only need to increment another 1950
+            timeService.advanceTime( 1950, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+            assertEquals( fact1, list.get( 0 ) );
+            list.clear();
+
+            timeService.advanceTime( 1000, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( 700, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+
+            timeService.advanceTime( 300, TimeUnit.MILLISECONDS );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
+    }
+
     @Test(timeout=10000) @Ignore
     public void testHaltAfterSomeTimeThenRestart() throws Exception {
         String drl = "package org.kie.test;" +
@@ -1468,28 +1483,28 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(drl);
         final KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
+            new Thread(() -> ksession.fireUntilHalt()).start();
+            Thread.sleep( 250 );
 
-        new Thread( new Runnable(){
-            public void run(){ ksession.fireUntilHalt(); }
-        } ).start();
-        Thread.sleep( 250 );
+            assertEquals( asList( 0, 0, 0 ), list );
 
-        assertEquals( asList( 0, 0, 0 ), list );
+            ksession.insert( "halt" );
+            ksession.insert( "trigger" );
+            Thread.sleep( 300 );
+            assertEquals( asList( 0, 0, 0 ), list );
 
-        ksession.insert( "halt" );
-        ksession.insert( "trigger" );
-        Thread.sleep( 300 );
-        assertEquals( asList( 0, 0, 0 ), list );
+            new Thread(() -> ksession.fireUntilHalt()).start();
+            Thread.sleep( 200 );
 
-        new Thread( new Runnable(){
-            public void run(){ ksession.fireUntilHalt(); }
-        } ).start();
-        Thread.sleep( 200 );
-
-        assertEquals( asList( 0, 0, 0, 5, 0, -5, 0, 0 ), list );
+            assertEquals( asList( 0, 0, 0, 5, 0, -5, 0, 0 ), list );
+        } finally {
+            ksession.halt();
+            ksession.dispose();
+        }
     }
 
 
@@ -1549,11 +1564,12 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
             }
         } finally {
             ksession.halt();
+            ksession.dispose();
         }
     }
 
     @Test
-    public void testExpiredPropagations() throws InterruptedException {
+    public void testExpiredPropagations() {
         // DROOLS-244
         String drl = "package org.drools.test;\n" +
                      "\n" +
@@ -1598,54 +1614,53 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( "pseudo" ) );
         KieSession ksession = kbase.newKieSession( conf, null );
-        ArrayList list = new ArrayList( );
-        ksession.setGlobal( "list", list );
+        try {
+            ArrayList list = new ArrayList( );
+            ksession.setGlobal( "list", list );
 
-        SessionPseudoClock clock = ( SessionPseudoClock ) ksession.getSessionClock();
+            SessionPseudoClock clock = ksession.getSessionClock();
 
-        clock.advanceTime( 1100, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 1100, TimeUnit.MILLISECONDS );
 
-        StockTick tick = new StockTick( 0, "AAA", 1.0, 0 );
-        StockTick tock = new StockTick( 1, "BBB", 1.0, 2500 );
-        StockTick tack = new StockTick( 1, "CCC", 1.0, 2700 );
+            StockTick tick = new StockTick( 0, "AAA", 1.0, 0 );
+            StockTick tock = new StockTick( 1, "BBB", 1.0, 2500 );
+            StockTick tack = new StockTick( 1, "CCC", 1.0, 2700 );
 
-        EntryPoint epa = ksession.getEntryPoint("AAA");
-        EntryPoint epb = ksession.getEntryPoint("BBB");
+            EntryPoint epa = ksession.getEntryPoint("AAA");
+            EntryPoint epb = ksession.getEntryPoint("BBB");
 
-        epa.insert( tick );
-        epb.insert( tock );
-        ksession.insert( tack );
+            epa.insert( tick );
+            epb.insert( tock );
+            ksession.insert( tack );
 
-        FactHandle handle = ksession.insert("go1");
-        ksession.fireAllRules();
-        System.out.println( "***** " + list + " *****");
-        assertEquals( asList( 0L, 1L, 1L ), list );
-        list.clear();
-        ksession.retract( handle );
+            FactHandle handle = ksession.insert("go1");
+            ksession.fireAllRules();
+            assertEquals( asList( 0L, 1L, 1L ), list );
+            list.clear();
+            ksession.delete( handle );
 
-        clock.advanceTime( 2550, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 2550, TimeUnit.MILLISECONDS );
 
-        handle = ksession.insert( "go2" );
-        ksession.fireAllRules();
-        System.out.println( "***** " + list + " *****");
-        assertEquals( asList( 0L, 0L, 1L ), list );
-        list.clear();
-        ksession.retract( handle );
+            handle = ksession.insert( "go2" );
+            ksession.fireAllRules();
+            assertEquals( asList( 0L, 0L, 1L ), list );
+            list.clear();
+            ksession.delete( handle );
 
-        clock.advanceTime( 500, TimeUnit.MILLISECONDS );
+            clock.advanceTime( 500, TimeUnit.MILLISECONDS );
 
-        handle = ksession.insert( "go3" );
-        ksession.fireAllRules();
-        System.out.println( "***** " + list + " *****");
-        assertEquals( asList( 0L, 0L, 0L ), list );
-        list.clear();
-        ksession.retract( handle );
-
-        ksession.dispose();
+            handle = ksession.insert( "go3" );
+            ksession.fireAllRules();
+            assertEquals( asList( 0L, 0L, 0L ), list );
+            list.clear();
+            ksession.delete( handle );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testCronFire() throws InterruptedException {
+    public void testCronFire() {
         // BZ-1059372
         String drl = "package test.drools\n" +
                      "rule TestRule " +
@@ -1658,14 +1673,17 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(drl);
         KieSession ksession = kbase.newKieSession();
+        try {
+            int repetitions = 10000;
+            for (int j = 0; j < repetitions; j++ ) {
+                ksession.insert( j );
+            }
 
-        int repetitions = 10000;
-        for (int j = 0; j < repetitions; j++ ) {
-            ksession.insert( j );
+            ksession.insert( "go" );
+            ksession.fireAllRules();
+        } finally {
+            ksession.dispose();
         }
-
-        ksession.insert( "go" );
-        ksession.fireAllRules();
     }
 
     @Test(timeout = 10000) @Ignore("the listener callback holds some locks so blocking in it is not safe")
@@ -1687,97 +1705,98 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str);
         KieSession ksession = createKnowledgeSession(kbase, conf);
-
-        final CyclicBarrier barrier = new CyclicBarrier(2);
-        final AtomicBoolean aBool = new AtomicBoolean(true);
-        AgendaEventListener agendaEventListener = new DefaultAgendaEventListener() {
-            public void afterMatchFired(org.kie.api.event.rule.AfterMatchFiredEvent event) {
-                try {
-                    if (aBool.get()) {
-                        barrier.await();
-                        aBool.set(false);
+        try {
+            final CyclicBarrier barrier = new CyclicBarrier(2);
+            final AtomicBoolean aBool = new AtomicBoolean(true);
+            AgendaEventListener agendaEventListener = new DefaultAgendaEventListener() {
+                public void afterMatchFired(org.kie.api.event.rule.AfterMatchFiredEvent event) {
+                    try {
+                        if (aBool.get()) {
+                            barrier.await();
+                            aBool.set(false);
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
                     }
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
                 }
-            }
-        };
-        ksession.addEventListener(agendaEventListener);
+            };
+            ksession.addEventListener(agendaEventListener);
 
-        List list = new ArrayList();
-        ksession.setGlobal("list", list);
+            List list = new ArrayList();
+            ksession.setGlobal("list", list);
 
-        // Using the Pseudo Clock.
-        SessionClock clock = ksession.getSessionClock();
-        SessionPseudoClock pseudoClock = (SessionPseudoClock) clock;
+            // Using the Pseudo Clock.
+            SessionClock clock = ksession.getSessionClock();
+            SessionPseudoClock pseudoClock = (SessionPseudoClock) clock;
 
-        // Insert the event.
-        String eventOne = "one";
-        ksession.insert(eventOne);
+            // Insert the event.
+            String eventOne = "one";
+            ksession.insert(eventOne);
 
-        // Advance the time .... so the timer will fire.
-        pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
+            // Advance the time .... so the timer will fire.
+            pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
 
-        // Rule doesn't fire in PHREAK. This is because you need to call 'fireAllRules' after you've inserted the fact, otherwise the timer
-        // job is not created.
+            // Rule doesn't fire in PHREAK. This is because you need to call 'fireAllRules' after you've inserted the fact, otherwise the timer
+            // job is not created.
 
-        ksession.fireAllRules();
+            ksession.fireAllRules();
 
-        // Rule still doesn't fire, because the DefaultTimerJob is created now, and now we need to advance the timer again.
+            // Rule still doesn't fire, because the DefaultTimerJob is created now, and now we need to advance the timer again.
 
-        pseudoClock.advanceTime(30000, TimeUnit.MILLISECONDS);
-        barrier.await();
-        barrier.reset();
-        aBool.set(true);
+            pseudoClock.advanceTime(30000, TimeUnit.MILLISECONDS);
+            barrier.await();
+            barrier.reset();
+            aBool.set(true);
 
-        pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
-        barrier.await();
-        barrier.reset();
-        aBool.set(true);
+            pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
+            barrier.await();
+            barrier.reset();
+            aBool.set(true);
 
-        String eventTwo = "two";
-        ksession.insert(eventTwo);
-        ksession.fireAllRules();
+            String eventTwo = "two";
+            ksession.insert(eventTwo);
+            ksession.fireAllRules();
 
-        // 60
-        pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
-        barrier.await();
-        barrier.reset();
-        aBool.set(true);
+            // 60
+            pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
+            barrier.await();
+            barrier.reset();
+            aBool.set(true);
 
-        // 70
-        pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
-        barrier.await();
-        barrier.reset();
-        aBool.set(true);
+            // 70
+            pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
+            barrier.await();
+            barrier.reset();
+            aBool.set(true);
 
-        //From here, the second rule should fire.
-        //phaser.register();
-        pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
-        barrier.await();
-        barrier.reset();
-        aBool.set(true);
+            //From here, the second rule should fire.
+            //phaser.register();
+            pseudoClock.advanceTime(10000, TimeUnit.MILLISECONDS);
+            barrier.await();
+            barrier.reset();
+            aBool.set(true);
 
-        // Now 2 rules have fired, and those will now fire every 10 seconds.
-        pseudoClock.advanceTime(20000, TimeUnit.MILLISECONDS);
-        barrier.await();
-        barrier.reset();
+            // Now 2 rules have fired, and those will now fire every 10 seconds.
+            pseudoClock.advanceTime(20000, TimeUnit.MILLISECONDS);
+            barrier.await();
+            barrier.reset();
 
-        pseudoClock.advanceTime(20000, TimeUnit.MILLISECONDS);
-        aBool.set(true);
-        barrier.await();
-        barrier.reset();
+            pseudoClock.advanceTime(20000, TimeUnit.MILLISECONDS);
+            aBool.set(true);
+            barrier.await();
+            barrier.reset();
 
-        pseudoClock.advanceTime(20000, TimeUnit.MILLISECONDS);
-        aBool.set(true);
-        barrier.await();
-        barrier.reset();
-
-        ksession.destroy();
+            pseudoClock.advanceTime(20000, TimeUnit.MILLISECONDS);
+            aBool.set(true);
+            barrier.await();
+            barrier.reset();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
-    public void testSharedTimers() throws Exception {
+    public void testSharedTimers() {
         // DROOLS-451
         String str = "package org.simple \n" +
                      "global java.util.List list \n" +
@@ -1804,19 +1823,22 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString(str);
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal("list", list);
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
+            SessionClock clock = ksession.getSessionClock();
+            SessionPseudoClock pseudoClock = (SessionPseudoClock) clock;
 
-        SessionClock clock = ksession.getSessionClock();
-        SessionPseudoClock pseudoClock = (SessionPseudoClock) clock;
-
-        ksession.insert(1);
-        ksession.fireAllRules();
-        pseudoClock.advanceTime( 35, TimeUnit.SECONDS );
-        ksession.fireAllRules();
-        assertEquals( 2, list.size() );
-        assertTrue( list.containsAll( asList( "1", "2" ) ) );
+            ksession.insert(1);
+            ksession.fireAllRules();
+            pseudoClock.advanceTime( 35, TimeUnit.SECONDS );
+            ksession.fireAllRules();
+            assertEquals( 2, list.size() );
+            assertTrue( list.containsAll( asList( "1", "2" ) ) );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -1840,15 +1862,18 @@ public class TimerAndCalendarTest extends CommonTestMethodBase {
         conf.setOption(TimedRuleExecutionOption.YES);
         KieBase kbase = loadKnowledgeBaseFromString(str);
         KieSession ksession = createKnowledgeSession(kbase, conf);
+        try {
+            List list = new ArrayList();
+            ksession.setGlobal( "list", list );
 
-        List list = new ArrayList();
-        ksession.setGlobal( "list", list );
-
-        ksession.fireAllRules();
-        assertEquals( 0, list.size() );
-        Thread.sleep( 900 );
-        assertEquals( 0, list.size() );
-        Thread.sleep( 500 );
-        assertEquals( 1, list.size() );
+            ksession.fireAllRules();
+            assertEquals( 0, list.size() );
+            Thread.sleep( 900 );
+            assertEquals( 0, list.size() );
+            Thread.sleep( 500 );
+            assertEquals( 1, list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TreeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TreeTest.java
@@ -30,17 +30,20 @@ public class TreeTest extends CommonTestMethodBase {
     public void testUnbalancedTrees() throws Exception {
         final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_UnbalancedTrees.drl"));
         final KieSession wm = createKnowledgeSession(kbase);
+        try {
+            wm.insert(new Cheese("a", 10));
+            wm.insert(new Cheese("b", 10));
+            wm.insert(new Cheese("c", 10));
+            wm.insert(new Cheese("d", 10));
+            final Cheese e = new Cheese("e", 10);
 
-        wm.insert(new Cheese("a", 10));
-        wm.insert(new Cheese("b", 10));
-        wm.insert(new Cheese("c", 10));
-        wm.insert(new Cheese("d", 10));
-        final Cheese e = new Cheese("e", 10);
+            wm.insert(e);
+            wm.fireAllRules();
 
-        wm.insert(e);
-        wm.fireAllRules();
-
-        assertEquals("Rule should have fired twice, seting the price to 30", 30, e.getPrice());
+            assertEquals("Rule should have fired twice, seting the price to 30", 30, e.getPrice());
+        } finally {
+            wm.dispose();
+        }
     }
 
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TruthMaintenanceTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/TruthMaintenanceTest.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.mock;
 
 public class TruthMaintenanceTest extends CommonTestMethodBase {
 
-    @Test() //timeout=10000)
+    @Test
     public void testLogicalInsertionsDynamicRule() throws Exception {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( ResourceFactory.newClassPathResource("test_LogicalInsertionsDynamicRule.drl",
@@ -88,162 +88,165 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         InternalKnowledgeBase kbase = (InternalKnowledgeBase) getKnowledgeBase();
         kbase.addPackages( kpkgs );
         KieSession ksession = createKnowledgeSession(kbase);
+        try {
+            final Cheese c1 = new Cheese( "a",
+                                          1 );
+            final Cheese c2 = new Cheese( "b",
+                                          2 );
+            final Cheese c3 = new Cheese( "c",
+                                          3 );
+            List list;
 
-        final Cheese c1 = new Cheese( "a",
-                                      1 );
-        final Cheese c2 = new Cheese( "b",
-                                      2 );
-        final Cheese c3 = new Cheese( "c",
-                                      3 );
-        List list;
+            ksession.insert( c1 );
+            FactHandle h = ksession.insert( c2 );
+            ksession.insert( c3 );
+            ksession.fireAllRules();
 
-        ksession.insert( c1 );
-        FactHandle h = ksession.insert( c2 );
-        ksession.insert( c3 );
-        ksession.fireAllRules();
+            ksession = getSerialisedStatefulKnowledgeSession( ksession,
+                                                              true );
 
-        ksession = getSerialisedStatefulKnowledgeSession( ksession,
-                                                          true );
+            // Check logical Insertions where made for c2 and c3        
+            list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
+            assertEquals( 2,
+                          list.size() );
+            assertFalse( list.contains( new Person( c1.getType() ) ) );
+            assertTrue( list.contains( new Person( c2.getType() ) ) );
+            assertTrue( list.contains( new Person( c3.getType() ) ) );
 
-        // Check logical Insertions where made for c2 and c3        
-        list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
-        assertEquals( 2,
-                      list.size() );
-        assertFalse( list.contains( new Person( c1.getType() ) ) );
-        assertTrue( list.contains( new Person( c2.getType() ) ) );
-        assertTrue( list.contains( new Person( c3.getType() ) ) );
-
-        // this rule will make a logical assertion for c1 too
-        kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newClassPathResource( "test_LogicalInsertionsDynamicRule2.drl",
-                                                            getClass() ),
-                      ResourceType.DRL );
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        Collection<KiePackage> kpkgs2 = kbuilder.getKnowledgePackages();
-        kbase.addPackages( kpkgs2 );
-        kbase = SerializationHelper.serializeObject(kbase);
-
-        ksession.fireAllRules();
-
-        ksession = getSerialisedStatefulKnowledgeSession( ksession,
-                                                          true );
-
-        kbase = (InternalKnowledgeBase) ksession.getKieBase();
-
-        // check all now have just one logical assertion each
-        list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
-        assertEquals( 3,
-                      list.size() );
-        assertTrue( list.contains( new Person( c1.getType() ) ) );
-        assertTrue( list.contains( new Person( c2.getType() ) ) );
-        assertTrue( list.contains( new Person( c3.getType() ) ) );
-
-        ksession = getSerialisedStatefulKnowledgeSession( ksession,
-                                                          true );
-
-        // check the packages are correctly populated
-        assertEquals( 3, kbase.getKiePackages().size() );
-        KiePackage test = null, test2 = null;
-        // different JVMs return the package list in different order
-        for( KiePackage kpkg : kbase.getKiePackages() ) {
-            if( kpkg.getName().equals( "org.drools.compiler.test" )) {
-                test = kpkg;
-            } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
-                test2 = kpkg;
+            // this rule will make a logical assertion for c1 too
+            kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+            kbuilder.add( ResourceFactory.newClassPathResource( "test_LogicalInsertionsDynamicRule2.drl",
+                                                                getClass() ),
+                          ResourceType.DRL );
+            if ( kbuilder.hasErrors() ) {
+                fail( kbuilder.getErrors().toString() );
             }
-        }
+            Collection<KiePackage> kpkgs2 = kbuilder.getKnowledgePackages();
+            kbase.addPackages( kpkgs2 );
+            kbase = SerializationHelper.serializeObject(kbase);
 
-        assertNotNull( test );
-        assertNotNull( test2 );
-        assertEquals( "rule1",
-                      test.getRules().iterator().next().getName() );
-        assertEquals( "rule2",
-                      test2.getRules().iterator().next().getName() );
+            ksession.fireAllRules();
 
-        // now remove the first rule
-        kbase.removeRule( test.getName(),
+            ksession = getSerialisedStatefulKnowledgeSession( ksession,
+                                                              true );
+
+            kbase = (InternalKnowledgeBase) ksession.getKieBase();
+
+            // check all now have just one logical assertion each
+            list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
+            assertEquals( 3,
+                          list.size() );
+            assertTrue( list.contains( new Person( c1.getType() ) ) );
+            assertTrue( list.contains( new Person( c2.getType() ) ) );
+            assertTrue( list.contains( new Person( c3.getType() ) ) );
+
+            ksession = getSerialisedStatefulKnowledgeSession( ksession,
+                                                              true );
+
+            // check the packages are correctly populated
+            assertEquals( 3, kbase.getKiePackages().size() );
+            KiePackage test = null, test2 = null;
+            // different JVMs return the package list in different order
+            for( KiePackage kpkg : kbase.getKiePackages() ) {
+                if( kpkg.getName().equals( "org.drools.compiler.test" )) {
+                    test = kpkg;
+                } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
+                    test2 = kpkg;
+                }
+            }
+
+            assertNotNull( test );
+            assertNotNull( test2 );
+            assertEquals( "rule1",
                           test.getRules().iterator().next().getName() );
-        // different JVMs return the package list in different order
-        for( KiePackage kpkg : kbase.getKiePackages() ) {
-            if( kpkg.getName().equals( "org.drools.compiler.test" )) {
-                test = kpkg;
-            } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
-                test2 = kpkg;
-            }
-        }
-        assertNotNull( test );
-        assertNotNull( test2 );
-
-        // Check the rule was correctly remove
-        assertEquals( 0,
-                      test.getRules().size() );
-        assertEquals( 1,
-                      test2.getRules().size() );
-        assertEquals( "rule2",
-                      test2.getRules().iterator().next().getName() );
-
-        list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
-        assertEquals( "removal of the rule should result in retraction of c3's logical assertion",
-                      2,
-                      list.size() );
-        assertTrue( "c1's logical assertion should not be deleted",
-                    list.contains( new Person( c1.getType() ) ) );
-        assertTrue( "c2's logical assertion should  not be deleted",
-                    list.contains( new Person( c2.getType() ) ) );
-        assertFalse( "c3's logical assertion should be  deleted",
-                     list.contains( new Person( c3.getType() ) ) );
-
-        c2.setPrice( 3 );
-        h = getFactHandle( h, ksession );
-        ksession.update( h,
-                         c2 );
-        ksession.fireAllRules();
-        ksession = getSerialisedStatefulKnowledgeSession( ksession,
-                                                          true );
-        list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
-        assertEquals( "c2 now has a higher price, its logical assertion should  be cancelled",
-                      1,
-                      list.size() );
-        assertFalse( "The logical assertion cor c2 should have been deleted",
-                     list.contains( new Person( c2.getType() ) ) );
-        assertTrue( "The logical assertion  for c1 should exist",
-                    list.contains( new Person( c1.getType() ) ) );
-
-        // different JVMs return the package list in different order
-        for( KiePackage kpkg : kbase.getKiePackages() ) {
-            if( kpkg.getName().equals( "org.drools.compiler.test" )) {
-                test = kpkg;
-            } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
-                test2 = kpkg;
-            }
-        }
-        assertNotNull( test );
-        assertNotNull( test2 );
-
-        kbase.removeRule( test2.getName(),
+            assertEquals( "rule2",
                           test2.getRules().iterator().next().getName() );
-        kbase = SerializationHelper.serializeObject(kbase);
 
-        // different JVMs return the package list in different order
-        for( KiePackage kpkg : kbase.getKiePackages() ) {
-            if( kpkg.getName().equals( "org.drools.compiler.test" )) {
-                test = kpkg;
-            } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
-                test2 = kpkg;
+            // now remove the first rule
+            kbase.removeRule( test.getName(),
+                              test.getRules().iterator().next().getName() );
+            // different JVMs return the package list in different order
+            for( KiePackage kpkg : kbase.getKiePackages() ) {
+                if( kpkg.getName().equals( "org.drools.compiler.test" )) {
+                    test = kpkg;
+                } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
+                    test2 = kpkg;
+                }
             }
-        }
-        assertNotNull( test );
-        assertNotNull( test2 );
+            assertNotNull( test );
+            assertNotNull( test2 );
 
-        assertEquals( 0,
-                      test.getRules().size() );
-        assertEquals( 0,
-                      test2.getRules().size() );
-        list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
-        assertEquals( 0,
-                      list.size() );
+            // Check the rule was correctly remove
+            assertEquals( 0,
+                          test.getRules().size() );
+            assertEquals( 1,
+                          test2.getRules().size() );
+            assertEquals( "rule2",
+                          test2.getRules().iterator().next().getName() );
+
+            list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
+            assertEquals( "removal of the rule should result in retraction of c3's logical assertion",
+                          2,
+                          list.size() );
+            assertTrue( "c1's logical assertion should not be deleted",
+                        list.contains( new Person( c1.getType() ) ) );
+            assertTrue( "c2's logical assertion should  not be deleted",
+                        list.contains( new Person( c2.getType() ) ) );
+            assertFalse( "c3's logical assertion should be  deleted",
+                         list.contains( new Person( c3.getType() ) ) );
+
+            c2.setPrice( 3 );
+            h = getFactHandle( h, ksession );
+            ksession.update( h,
+                             c2 );
+            ksession.fireAllRules();
+            ksession = getSerialisedStatefulKnowledgeSession( ksession,
+                                                              true );
+            list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
+            assertEquals( "c2 now has a higher price, its logical assertion should  be cancelled",
+                          1,
+                          list.size() );
+            assertFalse( "The logical assertion cor c2 should have been deleted",
+                         list.contains( new Person( c2.getType() ) ) );
+            assertTrue( "The logical assertion  for c1 should exist",
+                        list.contains( new Person( c1.getType() ) ) );
+
+            // different JVMs return the package list in different order
+            for( KiePackage kpkg : kbase.getKiePackages() ) {
+                if( kpkg.getName().equals( "org.drools.compiler.test" )) {
+                    test = kpkg;
+                } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
+                    test2 = kpkg;
+                }
+            }
+            assertNotNull( test );
+            assertNotNull( test2 );
+
+            kbase.removeRule( test2.getName(),
+                              test2.getRules().iterator().next().getName() );
+            kbase = SerializationHelper.serializeObject(kbase);
+
+            // different JVMs return the package list in different order
+            for( KiePackage kpkg : kbase.getKiePackages() ) {
+                if( kpkg.getName().equals( "org.drools.compiler.test" )) {
+                    test = kpkg;
+                } else if( kpkg.getName().equals( "org.drools.compiler.test2" )) {
+                    test2 = kpkg;
+                }
+            }
+            assertNotNull( test );
+            assertNotNull( test2 );
+
+            assertEquals( 0,
+                          test.getRules().size() );
+            assertEquals( 0,
+                          test2.getRules().size() );
+            list = new ArrayList( ksession.getObjects( new ClassObjectFilter( Person.class ) ) );
+            assertEquals( 0,
+                          list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -258,46 +261,49 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase.addPackages( kpkgs );
         kbase = SerializationHelper.serializeObject(kbase);
         KieSession session = createKnowledgeSession(kbase);
+        try {
+            final List list = new ArrayList();
+            session.setGlobal( "list",
+                               list );
 
-        final List list = new ArrayList();
-        session.setGlobal( "list",
-                           list );
+            final Cheese brie = new Cheese( "brie",
+                                            12 );
+            FactHandle brieHandle = session.insert( brie );
 
-        final Cheese brie = new Cheese( "brie",
-                                        12 );
-        FactHandle brieHandle = session.insert( brie );
+            final Cheese provolone = new Cheese( "provolone",
+                                                 12 );
+            FactHandle provoloneHandle = session.insert( provolone );
 
-        final Cheese provolone = new Cheese( "provolone",
-                                             12 );
-        FactHandle provoloneHandle = session.insert( provolone );
+            session.fireAllRules();
 
-        session.fireAllRules();
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
 
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
+            System.out.println( list );
+            assertEquals( 3,
+                          list.size() );
 
-        System.out.println( list );
-        assertEquals( 3,
-                      list.size() );
+            assertEquals( 3,
+                          session.getObjects().size() );
 
-        assertEquals( 3,
-                      session.getObjects().size() );
+            brieHandle = getFactHandle( brieHandle, session );
+            session.delete( brieHandle );
 
-        brieHandle = getFactHandle( brieHandle, session );
-        session.retract( brieHandle );
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
 
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
+            assertEquals( 2,
+                          session.getObjects().size() );
 
-        assertEquals( 2,
-                      session.getObjects().size() );
+            provoloneHandle = getFactHandle( provoloneHandle, session );
+            session.delete( provoloneHandle );
+            session.fireAllRules();
 
-        provoloneHandle = getFactHandle( provoloneHandle, session );
-        session.retract( provoloneHandle );
-        session.fireAllRules();
-
-        assertEquals(0,
-                     session.getObjects().size());
+            assertEquals(0,
+                         session.getObjects().size());
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -312,70 +318,72 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase.addPackages( kpkgs );
         kbase = SerializationHelper.serializeObject(kbase);
         KieSession session = createKnowledgeSession(kbase);
+        try {
+            final Cheese cheese1 = new Cheese( "c",
+                                               1 );
+            final Cheese cheese2 = new Cheese( cheese1.getType(),
+                                               1 );
 
-        final Cheese cheese1 = new Cheese( "c",
-                                           1 );
-        final Cheese cheese2 = new Cheese( cheese1.getType(),
-                                           1 );
+            FactHandle h1 = session.insert( cheese1 );
+            session.fireAllRules();
 
-        FactHandle h1 = session.insert( cheese1 );
-        session.fireAllRules();
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
 
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
+            Collection< ? > list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
+            assertEquals( 1,
+                          list.size() );
+            // probably dangerous, as contains works with equals, not identity
+            assertEquals( cheese1.getType(),
+                          list.iterator().next() );
 
-        Collection< ? > list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
-        assertEquals( 1,
-                      list.size() );
-        // probably dangerous, as contains works with equals, not identity
-        assertEquals( cheese1.getType(),
-                      list.iterator().next() );
+            FactHandle h2 = session.insert( cheese2 );
+            session.fireAllRules();
 
-        FactHandle h2 = session.insert( cheese2 );
-        session.fireAllRules();
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
 
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
+            list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
+            assertEquals( 1,
+                          list.size() );
+            assertEquals( cheese1.getType(),
+                          list.iterator().next() );
 
-        list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
-        assertEquals( 1,
-                      list.size() );
-        assertEquals( cheese1.getType(),
-                      list.iterator().next() );
+            assertEquals( 3,
+                          session.getObjects().size() );
 
-        assertEquals( 3,
-                      session.getObjects().size() );
+            h1 = getFactHandle( h1, session );
+            session.delete( h1 );
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
+            session.fireAllRules();
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
+            list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
+            assertEquals( "cheese-type " + cheese1.getType() + " was deleted, but should not. Backed by cheese2 => type.",
+                          1,
+                          list.size() );
+            assertEquals( "cheese-type " + cheese1.getType() + " was deleted, but should not. Backed by cheese2 => type.",
+                          cheese1.getType(),
+                          list.iterator().next() );
 
-        h1 = getFactHandle( h1, session );
-        session.retract( h1 );
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
-        session.fireAllRules();
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
-        list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
-        assertEquals( "cheese-type " + cheese1.getType() + " was deleted, but should not. Backed by cheese2 => type.",
-                      1,
-                      list.size() );
-        assertEquals( "cheese-type " + cheese1.getType() + " was deleted, but should not. Backed by cheese2 => type.",
-                      cheese1.getType(),
-                      list.iterator().next() );
-
-        h2 = getFactHandle( h2, session );
-        session.retract( h2 );
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
-        session.fireAllRules();
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
-        list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
-        assertEquals( "cheese-type " + cheese1.getType() + " was not deleted, but should have. Neither  cheese1 => type nor cheese2 => type is true.",
-                      0,
-                      list.size() );
+            h2 = getFactHandle( h2, session );
+            session.delete( h2 );
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
+            session.fireAllRules();
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
+            list = session.getObjects( new ClassObjectFilter( cheese1.getType().getClass() ) );
+            assertEquals( "cheese-type " + cheese1.getType() + " was not deleted, but should have. Neither  cheese1 => type nor cheese2 => type is true.",
+                          0,
+                          list.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
-    @Test //(timeout=10000)
-    //@Ignore
+    @Test
     public void testLogicalInsertionsSelfreferencing() throws Exception {
         final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( ResourceFactory.newClassPathResource( "test_LogicalInsertionsSelfreferencing.drl",
@@ -387,38 +395,41 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase.addPackages( kpkgs );
         kbase = SerializationHelper.serializeObject(kbase);
         final KieSession session = createKnowledgeSession(kbase);
+        try {
+            final Person b = new Person( "b" );
+            final Person a = new Person( "a" );
 
-        final Person b = new Person( "b" );
-        final Person a = new Person( "a" );
+            session.setGlobal( "b",
+                               b );
 
-        session.setGlobal( "b",
-                           b );
+            FactHandle h1 = session.insert( a );
+            session.fireAllRules();
+            Collection< ? > list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
+            assertEquals( 2,
+                          list.size() );
+            assertTrue( list.contains( a ) );
+            assertTrue( list.contains( b ) );
 
-        FactHandle h1 = session.insert( a );
-        session.fireAllRules();
-        Collection< ? > list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
-        assertEquals( 2,
-                      list.size() );
-        assertTrue( list.contains( a ) );
-        assertTrue( list.contains( b ) );
+            session.delete( h1 );
+            session.fireAllRules();
+            list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
+            assertEquals( "b was deleted, but it should not have. Is backed by b => b being true.",
+                          1,
+                          list.size() );
+            assertEquals( "b was deleted, but it should not have. Is backed by b => b being true.",
+                          b,
+                          list.iterator().next() );
 
-        session.retract( h1 );
-        session.fireAllRules();
-        list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
-        assertEquals( "b was deleted, but it should not have. Is backed by b => b being true.",
-                      1,
-                      list.size() );
-        assertEquals( "b was deleted, but it should not have. Is backed by b => b being true.",
-                      b,
-                      list.iterator().next() );
-
-        h1 = session.getFactHandle( b );
-        assertSame( ((InternalFactHandle)h1).getEqualityKey().getLogicalFactHandle(), h1);
-        ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem().delete( h1 );
-        session.fireAllRules();
-        list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
-        assertEquals( 0,
-                      list.size() );
+            h1 = session.getFactHandle( b );
+            assertSame( ((InternalFactHandle)h1).getEqualityKey().getLogicalFactHandle(), h1);
+            ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem().delete( h1 );
+            session.fireAllRules();
+            list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
+            assertEquals( 0,
+                          list.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -433,41 +444,47 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase.addPackages( kpkgs );
         kbase = SerializationHelper.serializeObject(kbase);
         final KieSession session = createKnowledgeSession(kbase);
+        try {
+            final List l = new ArrayList();
+            final Person a = new Person( "a" );
+            session.setGlobal( "a",
+                               a );
+            session.setGlobal( "l",
+                               l );
 
-        final List l = new ArrayList();
-        final Person a = new Person( "a" );
-        session.setGlobal( "a",
-                           a );
-        session.setGlobal( "l",
-                           l );
-
-        session.fireAllRules();
-        Collection< ? > list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
-        assertEquals( "a still asserted.",
-                      0,
-                      list.size() );
-        assertEquals( "Rule has not fired (looped) expected number of times",
-                      10,
-                      l.size() );
+            session.fireAllRules();
+            Collection< ? > list = session.getObjects( new ClassObjectFilter( a.getClass() ) );
+            assertEquals( "a still asserted.",
+                          0,
+                          list.size() );
+            assertEquals( "Rule has not fired (looped) expected number of times",
+                          10,
+                          l.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
-    @Test //(timeout=10000)
+    @Test
     public void testLogicalInsertionsNoLoop() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertionsNoLoop.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final List l = new ArrayList();
+            final Person a = new Person( "a" );
+            ksession.setGlobal( "a", a );
+            ksession.setGlobal( "l", l );
 
-        final List l = new ArrayList();
-        final Person a = new Person( "a" );
-        ksession.setGlobal( "a", a );
-        ksession.setGlobal( "l", l );
-
-        ksession.fireAllRules();
-        assertEquals("a still in WM",
-                     0,
-                     ksession.getObjects(new ClassObjectFilter(a.getClass())).size());
-        assertEquals( "Rule should not loop",
-                      1,
-                      l.size() );
+            ksession.fireAllRules();
+            assertEquals("a still in WM",
+                         0,
+                         ksession.getObjects(new ClassObjectFilter(a.getClass())).size());
+            assertEquals( "Rule should not loop",
+                          1,
+                          l.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -475,86 +492,92 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
     public void testLogicalInsertionsWithModify() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertionsWithUpdate.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final Person p = new Person( "person" );
+            p.setAge( 2 );
+            FactHandle h = ksession.insert( p );
+            assertEquals(1,
+                         ksession.getObjects().size());
 
-        final Person p = new Person( "person" );
-        p.setAge( 2 );
-        FactHandle h = ksession.insert( p );
-        assertEquals(1,
-                     ksession.getObjects().size());
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, false);
+            assertEquals( 2,
+                          ksession.getObjects().size() );
 
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, false);
-        assertEquals( 2,
-                      ksession.getObjects().size() );
+            Collection l = ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) );
+            assertEquals( 1,
+                          l.size() );
+            assertEquals( 2,
+                          ((CheeseEqual) l.iterator().next()).getPrice() );
 
-        Collection l = ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) );
-        assertEquals( 1,
-                      l.size() );
-        assertEquals( 2,
-                      ((CheeseEqual) l.iterator().next()).getPrice() );
+            h = getFactHandle( h, ksession );
+            ksession.delete( h );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, false);
+            assertEquals( 0,
+                          ksession.getObjects().size() );
 
-        h = getFactHandle( h, ksession );
-        ksession.retract( h );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, false);
-        assertEquals( 0,
-                      ksession.getObjects().size() );
+            TruthMaintenanceSystem tms =  ((NamedEntryPoint)ksession.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
 
-        TruthMaintenanceSystem tms =  ((NamedEntryPoint)ksession.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
-
-        final java.lang.reflect.Field field = tms.getClass().getDeclaredField( "equalityKeyMap" );
-        field.setAccessible( true );
-        final ObjectHashMap m = (ObjectHashMap) field.get( tms );
-        field.setAccessible( false );
-        assertEquals( "assertMap should be empty",
-                      0,
-                      m.size() );
+            final java.lang.reflect.Field field = tms.getClass().getDeclaredField( "equalityKeyMap" );
+            field.setAccessible( true );
+            final ObjectHashMap m = (ObjectHashMap) field.get( tms );
+            field.setAccessible( false );
+            assertEquals( "assertMap should be empty",
+                          0,
+                          m.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
     public void testLogicalInsertions2() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertions2.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final List events = new ArrayList();
 
-        final List events = new ArrayList();
+            ksession.setGlobal( "events", events );
 
-        ksession.setGlobal( "events", events );
+            final Sensor sensor = new Sensor( 80,
+                                              80 );
+            FactHandle handle = ksession.insert( sensor );
 
-        final Sensor sensor = new Sensor( 80,
-                                          80 );
-        FactHandle handle = ksession.insert( sensor );
+            // everything should be normal
 
-        // everything should be normal
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, false );
+            ksession.fireAllRules();
 
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, false );
-        ksession.fireAllRules();
+            Collection list = ksession.getObjects();
 
-        Collection list = ksession.getObjects();
+            assertEquals( "Only sensor is there",
+                          1,
+                          list.size() );
+            assertEquals( "Only one event",
+                          1,
+                          events.size() );
 
-        assertEquals( "Only sensor is there",
-                      1,
-                      list.size() );
-        assertEquals( "Only one event",
-                      1,
-                      events.size() );
+            // problems should be detected
+            sensor.setPressure( 200 );
+            sensor.setTemperature( 200 );
 
-        // problems should be detected
-        sensor.setPressure( 200 );
-        sensor.setTemperature( 200 );
+            handle = getFactHandle( handle, ksession );
+            ksession.update( handle, sensor );
 
-        handle = getFactHandle( handle, ksession );
-        ksession.update( handle, sensor );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true );
 
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true );
+            ksession.fireAllRules();
+            list = ksession.getObjects();
 
-        ksession.fireAllRules();
-        list = ksession.getObjects();
+            assertEquals( "Only sensor is there",
+                          1,
+                          list.size() );
 
-        assertEquals( "Only sensor is there",
-                      1,
-                      list.size() );
-
-        TruthMaintenanceSystem tms =  ((NamedEntryPoint)ksession.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
-        assertTrue(tms.getEqualityKeyMap().isEmpty());
+            TruthMaintenanceSystem tms =  ((NamedEntryPoint)ksession.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
+            assertTrue(tms.getEqualityKeyMap().isEmpty());
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -562,81 +585,87 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
     public void testLogicalInsertionsNot() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertionsNot.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final Person a = new Person( "a" );
+            final Cheese cheese = new Cheese( "brie",
+                                              1 );
+            ksession.setGlobal( "cheese",
+                                cheese );
 
-        final Person a = new Person( "a" );
-        final Cheese cheese = new Cheese( "brie",
-                                          1 );
-        ksession.setGlobal( "cheese",
-                                 cheese );
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            Collection list = ksession.getObjects();
+            assertEquals( "i was not asserted by not a => i.",
+                          1,
+                          list.size() );
+            assertEquals( "i was not asserted by not a => i.",
+                          cheese,
+                          list.iterator().next() );
 
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        Collection list = ksession.getObjects();
-        assertEquals( "i was not asserted by not a => i.",
-                      1,
-                      list.size() );
-        assertEquals( "i was not asserted by not a => i.",
-                      cheese,
-                      list.iterator().next() );
+            FactHandle h = ksession.insert( a );
 
-        FactHandle h = ksession.insert( a );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            // no need to fire rules, assertion alone removes justification for i,
+            // so it should be deleted.
+            // workingMemory.fireAllRules();
+            ksession.fireAllRules();
+            list = ksession.getObjects();
 
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        // no need to fire rules, assertion alone removes justification for i,
-        // so it should be deleted.
-        // workingMemory.fireAllRules();
-        ksession.fireAllRules();
-        list = ksession.getObjects();
+            assertEquals( "a was not asserted or i not deleted.",
+                          1,
+                          list.size() );
+            assertEquals( "a was asserted.",
+                          a,
+                          list.iterator().next() );
+            assertFalse( "i was not rectracted.",
+                         list.contains( cheese ) );
 
-        assertEquals( "a was not asserted or i not deleted.",
-                      1,
-                      list.size() );
-        assertEquals( "a was asserted.",
-                      a,
-                      list.iterator().next() );
-        assertFalse( "i was not rectracted.",
-                     list.contains( cheese ) );
+            // no rules should fire, but nevertheless...
+            // workingMemory.fireAllRules();
+            assertEquals("agenda should be empty.",
+                         0,
+                         ((InternalAgenda)((StatefulKnowledgeSessionImpl) ksession).getAgenda()).agendaSize());
 
-        // no rules should fire, but nevertheless...
-        // workingMemory.fireAllRules();
-        assertEquals("agenda should be empty.",
-                     0,
-                     ((InternalAgenda)((StatefulKnowledgeSessionImpl) ksession).getAgenda()).agendaSize());
-
-        h = getFactHandle( h, ksession );
-        ksession.retract( h );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        list = ksession.getObjects();
-        assertEquals( "i was not asserted by not a => i.",
-                      1,
-                      list.size() );
-        assertEquals( "i was not asserted by not a => i.",
-                      cheese,
-                      list.iterator().next() );
+            h = getFactHandle( h, ksession );
+            ksession.delete( h );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            list = ksession.getObjects();
+            assertEquals( "i was not asserted by not a => i.",
+                          1,
+                          list.size() );
+            assertEquals( "i was not asserted by not a => i.",
+                          cheese,
+                          list.iterator().next() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
     public void testLogicalInsertionsNotPingPong() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertionsNotPingPong.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final List list = new ArrayList();
 
-        final List list = new ArrayList();
+            final Person person = new Person( "person" );
+            final Cheese cheese = new Cheese( "cheese",
+                                              0 );
+            ksession.setGlobal( "cheese", cheese );
+            ksession.setGlobal( "person", person );
+            ksession.setGlobal( "list", list );
 
-        final Person person = new Person( "person" );
-        final Cheese cheese = new Cheese( "cheese",
-                                          0 );
-        ksession.setGlobal( "cheese", cheese );
-        ksession.setGlobal( "person", person );
-        ksession.setGlobal( "list", list );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
-
-        // not sure about desired state of working memory.
-        assertEquals( "Rules have not fired (looped) expected number of times",
-                      10,
-                      list.size() );
+            // not sure about desired state of working memory.
+            assertEquals( "Rules have not fired (looped) expected number of times",
+                          10,
+                          list.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -646,49 +675,52 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         // calling update on a justified FH, states it
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertionsUpdateEqual.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final Person p = new Person( "person" );
+            p.setAge( 2 );
+            FactHandle h = ksession.insert( p );
+            assertEquals(1,
+                         ksession.getObjects().size());
 
-        final Person p = new Person( "person" );
-        p.setAge( 2 );
-        FactHandle h = ksession.insert( p );
-        assertEquals(1,
-                     ksession.getObjects().size());
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            assertEquals( 2,
+                          ksession.getObjects().size() );
+            Collection l = ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) );
+            assertEquals( 1,
+                          l.size() );
+            assertEquals( 3,
+                          ((CheeseEqual) l.iterator().next()).getPrice() );
 
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        assertEquals( 2,
-                      ksession.getObjects().size() );
-        Collection l = ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) );
-        assertEquals( 1,
-                      l.size() );
-        assertEquals( 3,
-                      ((CheeseEqual) l.iterator().next()).getPrice() );
-
-        h = getFactHandle( h, ksession );
-        ksession.retract( h );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            h = getFactHandle( h, ksession );
+            ksession.delete( h );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
 
-        Collection list = ksession.getObjects();
-        // CheeseEqual was updated, making it stated, so it wouldn't have been logically deleted
-        assertEquals( 1,
-                      list.size() );
-        assertEquals( new CheeseEqual("person", 3), list.iterator().next());
-        FactHandle fh = ksession.getFactHandle( list.iterator().next() );
-        ksession.retract( fh );
+            Collection list = ksession.getObjects();
+            // CheeseEqual was updated, making it stated, so it wouldn't have been logically deleted
+            assertEquals( 1,
+                          list.size() );
+            assertEquals( new CheeseEqual("person", 3), list.iterator().next());
+            FactHandle fh = ksession.getFactHandle( list.iterator().next() );
+            ksession.delete( fh );
 
-        list = ksession.getObjects();
-        assertEquals( 0,
-                      list.size() );
+            list = ksession.getObjects();
+            assertEquals( 0,
+                          list.size() );
 
-        TruthMaintenanceSystem tms =  ((NamedEntryPoint)ksession.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
+            TruthMaintenanceSystem tms =  ((NamedEntryPoint)ksession.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
 
-        final java.lang.reflect.Field field = tms.getClass().getDeclaredField( "equalityKeyMap" );
-        field.setAccessible( true );
-        final ObjectHashMap m = (ObjectHashMap) field.get( tms );
-        field.setAccessible( false );
-        assertEquals( "assertMap should be empty",
-                      0,
-                      m.size() );
+            final java.lang.reflect.Field field = tms.getClass().getDeclaredField( "equalityKeyMap" );
+            field.setAccessible( true );
+            final ObjectHashMap m = (ObjectHashMap) field.get( tms );
+            field.setAccessible( false );
+            assertEquals( "assertMap should be empty",
+                          0,
+                          m.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -696,153 +728,159 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
     public void testLogicalInsertionsWithExists() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_LogicalInsertionWithExists.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final Person p1 = new Person( "p1",
+                                          "stilton",
+                                          20 );
+            p1.setStatus( "europe" );
+            FactHandle c1FactHandle = ksession.insert( p1 );
+            final Person p2 = new Person( "p2",
+                                          "stilton",
+                                          30 );
+            p2.setStatus( "europe" );
+            FactHandle c2FactHandle = ksession.insert( p2 );
+            final Person p3 = new Person( "p3",
+                                          "stilton",
+                                          40 );
+            p3.setStatus( "europe" );
+            FactHandle c3FactHandle = ksession.insert( p3 );
+            ksession.fireAllRules();
 
-        final Person p1 = new Person( "p1",
-                                      "stilton",
-                                      20 );
-        p1.setStatus( "europe" );
-        FactHandle c1FactHandle = ksession.insert( p1 );
-        final Person p2 = new Person( "p2",
-                                      "stilton",
-                                      30 );
-        p2.setStatus( "europe" );
-        FactHandle c2FactHandle = ksession.insert( p2 );
-        final Person p3 = new Person( "p3",
-                                      "stilton",
-                                      40 );
-        p3.setStatus( "europe" );
-        FactHandle c3FactHandle = ksession.insert( p3 );
-        ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            // all 3 in europe, so, 2 cheese
+            Collection cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 2,
+                          cheeseList.size() );
 
-        // all 3 in europe, so, 2 cheese
-        Collection cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 2,
-                      cheeseList.size() );
+            // europe=[ 1, 2 ], america=[ 3 ]
+            p3.setStatus( "america" );
+            c3FactHandle = getFactHandle( c3FactHandle, ksession );
+            ksession.update( c3FactHandle,
+                             p3 );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 1,
+                          cheeseList.size() );
 
-        // europe=[ 1, 2 ], america=[ 3 ]
-        p3.setStatus( "america" );
-        c3FactHandle = getFactHandle( c3FactHandle, ksession );
-        ksession.update( c3FactHandle,
-                              p3 );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 1,
-                      cheeseList.size() );
+            // europe=[ 1 ], america=[ 2, 3 ]
+            p2.setStatus( "america" );
+            c2FactHandle = getFactHandle( c2FactHandle, ksession );
+            ksession.update( c2FactHandle,
+                             p2 );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 1,
+                          cheeseList.size() );
 
-        // europe=[ 1 ], america=[ 2, 3 ]
-        p2.setStatus( "america" );
-        c2FactHandle = getFactHandle( c2FactHandle, ksession );
-        ksession.update( c2FactHandle,
-                              p2 );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 1,
-                      cheeseList.size() );
+            // europe=[ ], america=[ 1, 2, 3 ]
+            p1.setStatus( "america" );
+            c1FactHandle = getFactHandle( c1FactHandle, ksession );
+            ksession.update( c1FactHandle,
+                             p1 );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 2,
+                          cheeseList.size() );
 
-        // europe=[ ], america=[ 1, 2, 3 ]
-        p1.setStatus( "america" );
-        c1FactHandle = getFactHandle( c1FactHandle, ksession );
-        ksession.update( c1FactHandle,
-                              p1 );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 2,
-                      cheeseList.size() );
+            // europe=[ 2 ], america=[ 1, 3 ]
+            p2.setStatus( "europe" );
+            c2FactHandle = getFactHandle( c2FactHandle, ksession );
+            ksession.update( c2FactHandle,
+                             p2 );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 1,
+                          cheeseList.size() );
 
-        // europe=[ 2 ], america=[ 1, 3 ]
-        p2.setStatus( "europe" );
-        c2FactHandle = getFactHandle( c2FactHandle, ksession );
-        ksession.update( c2FactHandle,
-                              p2 );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 1,
-                      cheeseList.size() );
+            // europe=[ 1, 2 ], america=[ 3 ]
+            p1.setStatus( "europe" );
+            c1FactHandle = getFactHandle( c1FactHandle, ksession );
+            ksession.update( c1FactHandle,
+                             p1 );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 1,
+                          cheeseList.size() );
 
-        // europe=[ 1, 2 ], america=[ 3 ]
-        p1.setStatus( "europe" );
-        c1FactHandle = getFactHandle( c1FactHandle, ksession );
-        ksession.update( c1FactHandle,
-                              p1 );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 1,
-                      cheeseList.size() );
-
-        // europe=[ 1, 2, 3 ], america=[ ]
-        p3.setStatus( "europe" );
-        c3FactHandle = getFactHandle( c3FactHandle, ksession );
-        ksession.update( c3FactHandle,
-                              p3 );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
-        assertEquals( 2,
-                      cheeseList.size() );
+            // europe=[ 1, 2, 3 ], america=[ ]
+            p3.setStatus( "europe" );
+            c3FactHandle = getFactHandle( c3FactHandle, ksession );
+            ksession.update( c3FactHandle,
+                             p3 );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            cheeseList = ksession.getObjects(new ClassObjectFilter(Cheese.class));
+            assertEquals( 2,
+                          cheeseList.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test //(timeout=10000)
     public void testLogicalInsertions3() throws Exception {
         KieBase kbase = loadKnowledgeBase("test_logicalInsertions3.drl");
         KieSession ksession = kbase.newKieSession();
+        try {
+            final List list = new ArrayList();
+            ksession.setGlobal( "events", list );
 
-        final List list = new ArrayList();
-        ksession.setGlobal( "events", list );
+            // asserting the sensor object
+            final Sensor sensor = new Sensor( 150, 100 );
+            FactHandle sensorHandle = ksession.insert( sensor );
 
-        // asserting the sensor object
-        final Sensor sensor = new Sensor( 150, 100 );
-        FactHandle sensorHandle = ksession.insert( sensor );
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true );
 
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true );
+            // alarm must sound
+            assertEquals( 2,
+                          list.size() );
+            assertEquals(2,
+                         ksession.getObjects().size());
 
-        // alarm must sound
-        assertEquals( 2,
-                      list.size() );
-        assertEquals(2,
-                     ksession.getObjects().size());
+            // modifying sensor
+            sensor.setTemperature( 125 );
+            sensorHandle = getFactHandle( sensorHandle, ksession );
+            ksession.update( sensorHandle,
+                             sensor );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
 
-        // modifying sensor
-        sensor.setTemperature( 125 );
-        sensorHandle = getFactHandle( sensorHandle, ksession );
-        ksession.update( sensorHandle,
-                              sensor );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            // alarm must continue to sound
+            assertEquals( 3,
+                          list.size() );
+            assertEquals( 2,
+                          ksession.getObjects().size() );
 
-        // alarm must continue to sound
-        assertEquals( 3,
-                      list.size() );
-        assertEquals( 2,
-                      ksession.getObjects().size() );
+            // modifying sensor
+            sensor.setTemperature( 80 );
+            sensorHandle = getFactHandle( sensorHandle, ksession );
+            ksession.update( sensorHandle,
+                             sensor );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
+            ksession.fireAllRules();
 
-        // modifying sensor
-        sensor.setTemperature( 80 );
-        sensorHandle = getFactHandle( sensorHandle, ksession );
-        ksession.update( sensorHandle,
-                              sensor );
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession, true);
-        ksession.fireAllRules();
-
-        // no alarms anymore
-        assertEquals( 3,
-                      list.size() );
-        assertEquals( 1,
-                      ksession.getObjects().size() );
+            // no alarms anymore
+            assertEquals( 3,
+                          list.size() );
+            assertEquals( 1,
+                          ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -851,48 +889,51 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         KieBase kbase = loadKnowledgeBase( "test_LogicalInsertionsAccumulatorPattern.drl" );
         kbase = SerializationHelper.serializeObject(kbase);
         KieSession ksession = kbase.newKieSession();
+        try {
+            ksession.setGlobal( "ga",
+                                "a" );
+            ksession.setGlobal( "gb",
+                                "b" );
+            ksession.setGlobal( "gs",
+                                new Short( (short) 3 ) );
 
-        ksession.setGlobal( "ga",
-                            "a" );
-        ksession.setGlobal( "gb",
-                            "b" );
-        ksession.setGlobal( "gs",
-                            new Short( (short) 3 ) );
+            ksession.fireAllRules();
 
-        ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession,
+                                                                                 true);
 
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession,
-                true);
+            FactHandle h = ksession.insert( new Integer( 6 ) );
+            assertEquals( 1,
+                          ksession.getObjects().size() );
 
-        FactHandle h = ksession.insert( new Integer( 6 ) );
-        assertEquals( 1,
-                      ksession.getObjects().size() );
+            ksession.fireAllRules();
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession,
+                                                                                 true);
+            assertEquals( "There should be 2 CheeseEqual in Working Memory, 1 justified, 1 stated",
+                          2,
+                          ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) ).size() );
+            assertEquals( 6,
+                          ksession.getObjects().size() );
 
-        ksession.fireAllRules();
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession,
-                true);
-        assertEquals( "There should be 2 CheeseEqual in Working Memory, 1 justified, 1 stated",
-                      2,
-                      ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) ).size() );
-        assertEquals( 6,
-                      ksession.getObjects().size() );
+            h = getFactHandle( h, ksession );
+            ksession.delete( h );
+            ksession.fireAllRules();
 
-        h = getFactHandle( h, ksession );
-        ksession.retract( h );
-        ksession.fireAllRules();
+            for ( Object o : ksession.getObjects() ) {
+                System.out.println( o );
+            }
 
-        for ( Object o : ksession.getObjects() ) {
-            System.out.println( o );
+            ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession,
+                                                                                 true);
+            assertEquals( 0,
+                          ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) ).size() );
+            assertEquals( 0,
+                          ksession.getObjects( new ClassObjectFilter( Short.class ) ).size() );
+            assertEquals( 0,
+                          ksession.getObjects().size() );
+        } finally {
+            ksession.dispose();
         }
-
-        ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession(ksession,
-                true);
-        assertEquals( 0,
-                      ksession.getObjects( new ClassObjectFilter( CheeseEqual.class ) ).size() );
-        assertEquals( 0,
-                      ksession.getObjects( new ClassObjectFilter( Short.class ) ).size() );
-        assertEquals( 0,
-                      ksession.getObjects().size() );
     }
 
     @Test(timeout=10000)
@@ -909,42 +950,45 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase.addPackages( pkgs );
         kbase = SerializationHelper.serializeObject(kbase);
         KieSession session = createKnowledgeSession(kbase);
+        try {
+            Sensor sensor1 = new Sensor( 100,
+                                         0 );
+            FactHandle sensor1Handle = session.insert( sensor1 );
+            Sensor sensor2 = new Sensor( 200,
+                                         0 );
+            FactHandle sensor2Handle = session.insert( sensor2 );
+            Sensor sensor3 = new Sensor( 200,
+                                         0 );
+            FactHandle sensor3Handle = session.insert( sensor3 );
 
-        Sensor sensor1 = new Sensor( 100,
-                                     0 );
-        FactHandle sensor1Handle = session.insert( sensor1 );
-        Sensor sensor2 = new Sensor( 200,
-                                     0 );
-        FactHandle sensor2Handle = session.insert( sensor2 );
-        Sensor sensor3 = new Sensor( 200,
-                                     0 );
-        FactHandle sensor3Handle = session.insert( sensor3 );
+            session.fireAllRules();
 
-        session.fireAllRules();
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
 
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
+            List temperatureList = new ArrayList( session.getObjects( new ClassObjectFilter( Integer.class ) ) );
+            assertTrue( temperatureList.contains( Integer.valueOf( 100 ) ) );
+            assertTrue( temperatureList.contains( Integer.valueOf( 200 ) ) );
+            assertEquals( 2,
+                          temperatureList.size() );
 
-        List temperatureList = new ArrayList( session.getObjects( new ClassObjectFilter( Integer.class ) ) );
-        assertTrue( temperatureList.contains( Integer.valueOf( 100 ) ) );
-        assertTrue( temperatureList.contains( Integer.valueOf( 200 ) ) );
-        assertEquals( 2,
-                      temperatureList.size() );
+            sensor1.setTemperature( 150 );
+            sensor1Handle =  getFactHandle( sensor1Handle, session );
+            session.update( sensor1Handle, sensor1 );
 
-        sensor1.setTemperature( 150 );
-        sensor1Handle =  getFactHandle( sensor1Handle, session );
-        session.update( sensor1Handle, sensor1 );
+            session = getSerialisedStatefulKnowledgeSession( session,
+                                                             true );
+            session.fireAllRules();
 
-        session = getSerialisedStatefulKnowledgeSession( session,
-                                                         true );
-        session.fireAllRules();
-
-        temperatureList = new ArrayList( session.getObjects( new ClassObjectFilter( Integer.class ) ) );
-        assertFalse( temperatureList.contains( Integer.valueOf( 100 ) ) );
-        assertTrue( temperatureList.contains( Integer.valueOf( 150 ) ) );
-        assertTrue( temperatureList.contains( Integer.valueOf( 200 ) ) );
-        assertEquals( 2,
-                      temperatureList.size() );
+            temperatureList = new ArrayList( session.getObjects( new ClassObjectFilter( Integer.class ) ) );
+            assertFalse( temperatureList.contains( Integer.valueOf( 100 ) ) );
+            assertTrue( temperatureList.contains( Integer.valueOf( 150 ) ) );
+            assertTrue( temperatureList.contains( Integer.valueOf( 200 ) ) );
+            assertEquals( 2,
+                          temperatureList.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -960,25 +1004,29 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase = SerializationHelper.serializeObject(kbase);
 
         final KieSession session = createKnowledgeSession(kbase);
-        RuleRuntimeEventListener wmel = mock( RuleRuntimeEventListener.class );
-        session.addEventListener( wmel );
+        try {
+            RuleRuntimeEventListener wmel = mock( RuleRuntimeEventListener.class );
+            session.addEventListener( wmel );
 
-        Person bob = new Person( "bob" );
-        bob.setStatus( "hungry" );
-        Person mark = new Person( "mark" );
-        mark.setStatus( "thirsty" );
+            Person bob = new Person( "bob" );
+            bob.setStatus( "hungry" );
+            Person mark = new Person( "mark" );
+            mark.setStatus( "thirsty" );
 
-        session.insert( bob );
-        session.insert( mark );
+            session.insert( bob );
+            session.insert( mark );
 
-        int count = session.fireAllRules();
+            int count = session.fireAllRules();
 
-        assertEquals( 2, count );
+            assertEquals( 2, count );
 
-        assertEquals(2, session.getObjects().size());
+            assertEquals(2, session.getObjects().size());
 
-        TruthMaintenanceSystem tms =  ((NamedEntryPoint)session.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
-        assertTrue(tms.getEqualityKeyMap().isEmpty());
+            TruthMaintenanceSystem tms =  ((NamedEntryPoint)session.getEntryPoint(EntryPointId.DEFAULT.getEntryPointId()) ).getTruthMaintenanceSystem();
+            assertTrue(tms.getEqualityKeyMap().isEmpty());
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1027,15 +1075,16 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
         kbase.addPackages(kbuilder.getKnowledgePackages());
         KieSession kSession = createKnowledgeSession(kbase);
+        try {
+            List list = new ArrayList();
+            kSession.setGlobal("list",list);
 
-        List list = new ArrayList();
-        kSession.setGlobal("list",list);
 
-
-        kSession.fireAllRules();
-        assertEquals(0,list.size());
-
-        //System.err.println(reportWMObjects(kSession));
+            kSession.fireAllRules();
+            assertEquals(0,list.size());
+        } finally {
+            kSession.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1057,39 +1106,39 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
 
         KieBase kbase = loadKnowledgeBaseFromString( str );
         KieSession kSession = createKnowledgeSession(kbase);
+        try {
+            Father abraham = new Father("abraham");
+            Father bart = new Father("bart");
+            Collection<? extends Object> youngestFathers;
 
-        Father abraham = new Father("abraham");
-        Father bart = new Father("bart");
-        Collection<? extends Object> youngestFathers;
+            bart.setFather(abraham);
+            FactHandle abrahamHandle = kSession.insert(abraham);
+            FactHandle bartHandle = kSession.insert(bart);
+            kSession.fireAllRules();
 
-        bart.setFather(abraham);
-        FactHandle abrahamHandle = kSession.insert(abraham);
-        FactHandle bartHandle = kSession.insert(bart);
-        kSession.fireAllRules();
+            youngestFathers = kSession.getObjects( new ClassObjectFilter(YoungestFather.class) );
+            assertEquals( 1, youngestFathers.size() );
+            assertEquals( bart, ((YoungestFather) youngestFathers.iterator().next()).getMan() );
 
-        youngestFathers = kSession.getObjects( new ClassObjectFilter(YoungestFather.class) );
-        assertEquals( 1, youngestFathers.size() );
-        assertEquals( bart, ((YoungestFather) youngestFathers.iterator().next()).getMan() );
+            Father homer = new Father("homer");
+            FactHandle homerHandle = kSession.insert(homer);
 
-        Father homer = new Father("homer");
-        FactHandle homerHandle = kSession.insert(homer);
+            homer.setFather(abraham);
+            // If we do kSession.update(homerHandle, homer) here instead of after bart.setFather(homer) it works
+            // But in some use cases we cannot do this because fact fields are actually called
+            // while the facts are in an invalid temporary state
+            bart.setFather(homer);
+            // Late update call for homer, after bart has been changed too, but before fireAllRules
+            kSession.update(homerHandle, homer);
+            kSession.update(bartHandle, bart);
+            kSession.fireAllRules();
 
-        homer.setFather(abraham);
-        // If we do kSession.update(homerHandle, homer) here instead of after bart.setFather(homer) it works
-        // But in some use cases we cannot do this because fact fields are actually called
-        // while the facts are in an invalid temporary state
-        bart.setFather(homer);
-        // Late update call for homer, after bart has been changed too, but before fireAllRules
-        kSession.update(homerHandle, homer);
-        kSession.update(bartHandle, bart);
-        kSession.fireAllRules();
-
-        youngestFathers = kSession.getObjects( new ClassObjectFilter(YoungestFather.class) );
-        assertEquals(1, youngestFathers.size());
-        assertEquals(bart, ((YoungestFather) youngestFathers.iterator().next()).getMan());
-
-
-        //System.err.println(reportWMObjects(kSession));
+            youngestFathers = kSession.getObjects( new ClassObjectFilter(YoungestFather.class) );
+            assertEquals(1, youngestFathers.size());
+            assertEquals(bart, ((YoungestFather) youngestFathers.iterator().next()).getMan());
+        } finally {
+            kSession.dispose();
+        }
     }
 
     public class IntervalRequirement
@@ -1165,95 +1214,96 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         // load up the knowledge base
         KieBase kbase = loadKnowledgeBase( "test_RepetitiveUpdatesOnSameFacts.drl" );
         KieSession ksession = kbase.newKieSession();
+        try {
+            ksession.setGlobal("totallyCovered", totallyCovered);
+            ksession.setGlobal("partiallyCovered", partiallyCovered);
+            ksession.setGlobal("notCovered", notCovered);
 
-        ksession.setGlobal("totallyCovered", totallyCovered);
-        ksession.setGlobal("partiallyCovered", partiallyCovered);
-        ksession.setGlobal("notCovered", notCovered);
+            KieRuntimeLogger logger = KnowledgeRuntimeLoggerFactory.newFileLogger(ksession, "target/test");
 
-        KieRuntimeLogger logger = KnowledgeRuntimeLoggerFactory.newFileLogger(ksession, "target/test");
+            // Using 4 IntervalRequirement objects that never change during the execution of the test
+            // Staffing required at interval 100
+            IntervalRequirement ir100 = new IntervalRequirement(100, 2);
+            ksession.insert(ir100);
+            // Staffing required at interval 101
+            IntervalRequirement ir101 = new IntervalRequirement(101, 2);
+            ksession.insert(ir101);
+            // Staffing required at interval 102
+            IntervalRequirement ir102 = new IntervalRequirement(102, 2);
+            ksession.insert(ir102);
+            // Staffing required at interval 103
+            IntervalRequirement ir103 = new IntervalRequirement(103, 2);
+            ksession.insert(ir103);
 
-        // Using 4 IntervalRequirement objects that never change during the execution of the test
-        // Staffing required at interval 100
-        IntervalRequirement ir100 = new IntervalRequirement(100, 2);
-        ksession.insert(ir100);
-        // Staffing required at interval 101
-        IntervalRequirement ir101 = new IntervalRequirement(101, 2);
-        ksession.insert(ir101);
-        // Staffing required at interval 102
-        IntervalRequirement ir102 = new IntervalRequirement(102, 2);
-        ksession.insert(ir102);
-        // Staffing required at interval 103
-        IntervalRequirement ir103 = new IntervalRequirement(103, 2);
-        ksession.insert(ir103);
+            // Using a single ShiftAssignment object that will get updated multiple times during the execution of the test
+            ShiftAssignment sa = new ShiftAssignment();
+            sa.setShiftStartTime(100);
 
-        // Using a single ShiftAssignment object that will get updated multiple times during the execution of the test
-        ShiftAssignment sa = new ShiftAssignment();
-        sa.setShiftStartTime(100);
+            FactHandle saHandle = null;
 
-        FactHandle saHandle = null;
+            // Intersects 1 interval
+            totallyCovered.clear();
+            partiallyCovered.clear();
+            notCovered.clear();
+            sa.setShiftEndTime(101);
+            System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
+            saHandle = ksession.insert(sa);
+            ksession.fireAllRules();
+            assertEquals("notCovered with " + sa, 3, notCovered.size());
+            assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
+            assertEquals("partiallyCovered with " + sa, 1, partiallyCovered.size());
 
-        // Intersects 1 interval
-        totallyCovered.clear();
-        partiallyCovered.clear();
-        notCovered.clear();
-        sa.setShiftEndTime(101);
-        System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
-        saHandle = ksession.insert(sa);
-        ksession.fireAllRules();
-        assertEquals("notCovered with " + sa, 3, notCovered.size());
-        assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
-        assertEquals("partiallyCovered with " + sa, 1, partiallyCovered.size());
+            // Intersects 3 intervals
+            totallyCovered.clear();
+            partiallyCovered.clear();
+            notCovered.clear();
+            sa.setShiftEndTime(103);
+            System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
+            ksession.update(saHandle, sa);
+            ksession.fireAllRules();
+            assertEquals("notCovered with " + sa, 0, notCovered.size()); // this was fired in the previous scenario
+            assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
+            assertEquals("partiallyCovered with " + sa, 3, partiallyCovered.size());
 
-        // Intersects 3 intervals
-        totallyCovered.clear();
-        partiallyCovered.clear();
-        notCovered.clear();
-        sa.setShiftEndTime(103);
-        System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
-        ksession.update(saHandle, sa);
-        ksession.fireAllRules();
-        assertEquals("notCovered with " + sa, 0, notCovered.size()); // this was fired in the previous scenario
-        assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
-        assertEquals("partiallyCovered with " + sa, 3, partiallyCovered.size());
+            // Intersects 2 intervals
+            totallyCovered.clear();
+            partiallyCovered.clear();
+            notCovered.clear();
+            sa.setShiftEndTime(102);
+            System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
+            ksession.update(saHandle, sa);
+            ksession.fireAllRules();
+            assertEquals("notCovered with " + sa, 1, notCovered.size()); // new uncovered scenario
+            assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
+            assertEquals("partiallyCovered with " + sa, 2, partiallyCovered.size());
 
-        // Intersects 2 intervals
-        totallyCovered.clear();
-        partiallyCovered.clear();
-        notCovered.clear();
-        sa.setShiftEndTime(102);
-        System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
-        ksession.update(saHandle, sa);
-        ksession.fireAllRules();
-        assertEquals("notCovered with " + sa, 1, notCovered.size()); // new uncovered scenario
-        assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
-        assertEquals("partiallyCovered with " + sa, 2, partiallyCovered.size());
+            // Intersects 4 intervals
+            totallyCovered.clear();
+            partiallyCovered.clear();
+            notCovered.clear();
+            sa.setShiftEndTime(104);
+            System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
+            ksession.update(saHandle, sa);
+            ksession.fireAllRules();
+            assertEquals("notCovered with " + sa, 0, notCovered.size());
+            assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
+            assertEquals("partiallyCovered with " + sa, 4, partiallyCovered.size());
 
-        // Intersects 4 intervals
-        totallyCovered.clear();
-        partiallyCovered.clear();
-        notCovered.clear();
-        sa.setShiftEndTime(104);
-        System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
-        ksession.update(saHandle, sa);
-        ksession.fireAllRules();
-        assertEquals("notCovered with " + sa, 0, notCovered.size());
-        assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
-        assertEquals("partiallyCovered with " + sa, 4, partiallyCovered.size());
-
-        // Intersects 1 interval
-        totallyCovered.clear();
-        partiallyCovered.clear();
-        notCovered.clear();
-        sa.setShiftEndTime(101);
-        System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
-        ksession.update(saHandle, sa);
-        ksession.fireAllRules();
-        assertEquals("notCovered with " + sa, 3, notCovered.size());
-        assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
-        assertEquals("partiallyCovered with " + sa, 1, partiallyCovered.size());
-
-        ksession.dispose();
-        logger.close();
+            // Intersects 1 interval
+            totallyCovered.clear();
+            partiallyCovered.clear();
+            notCovered.clear();
+            sa.setShiftEndTime(101);
+            System.out.println("ShiftAssignment set from " + sa.getShiftStartTime() + " to " + sa.getShiftEndTime());
+            ksession.update(saHandle, sa);
+            ksession.fireAllRules();
+            assertEquals("notCovered with " + sa, 3, notCovered.size());
+            assertEquals("totallyCovered with " + sa, 0, totallyCovered.size());
+            assertEquals("partiallyCovered with " + sa, 1, partiallyCovered.size());
+            logger.close();
+        } finally {
+            ksession.dispose();
+        }
     }
 
     public InternalFactHandle getFactHandle(FactHandle factHandle,
@@ -1337,18 +1387,18 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kbase.addPackages( kBuilder.getKnowledgePackages() );
 
         KieSession session = kbase.newKieSession();
+        try {
+            session.fireAllRules();
 
-        session.fireAllRules();
+            FactHandle handle = session.insert( new HashBlack( 1 ) );
+            session.insert( "go" );
+            session.fireAllRules();
 
-        FactHandle handle = session.insert( new HashBlack( 1 ) );
-        session.insert( "go" );
-        session.fireAllRules();
-
-        assertNotNull( ((DefaultFactHandle) handle).getEqualityKey() );
-        session.dispose();
+            assertNotNull( ((DefaultFactHandle) handle).getEqualityKey() );
+        } finally {
+            session.dispose();
+        }
     }
-
-
 
     @Test(timeout=10000)
     public void testRestateJustified() {
@@ -1376,22 +1426,23 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
 
 
         KieSession session = loadKnowledgeBaseFromString( droolsSource ).newKieSession();
+        try {
+            session.fireAllRules();
+            FactHandle handle = session.insert( "go" );
+            session.fireAllRules();
 
-        session.fireAllRules();
-        FactHandle handle = session.insert( "go" );
-        session.fireAllRules();
+            FactHandle handle2 = session.insert( "go2" );
+            session.fireAllRules();
 
-        FactHandle handle2 = session.insert( "go2" );
-        session.fireAllRules();
+            session.delete( handle );
+            session.delete( handle2 );
+            session.fireAllRules();
 
-        session.delete( handle );
-        session.delete( handle2 );
-        session.fireAllRules();
-
-        assertEquals( 1, session.getObjects().size() );
-        session.dispose();
+            assertEquals( 1, session.getObjects().size() );
+        } finally {
+            session.dispose();
+        }
     }
-
 
     @Test(timeout=10000)
     public void testPrimeJustificationWithEqualityMode() {
@@ -1429,14 +1480,17 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
             kieConf.setOption( EqualityBehaviorOption.EQUALITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            FactHandle handle1 = session.insert( 10 );
+            FactHandle handle2 = session.insert( 20 );
 
-        FactHandle handle1 = session.insert( 10 );
-        FactHandle handle2 = session.insert( 20 );
+            assertEquals( 4, session.fireAllRules() );
 
-        assertEquals( 4, session.fireAllRules() );
-
-        session.delete( handle1 );
-        assertEquals( 0, session.fireAllRules() );
+            session.delete( handle1 );
+            assertEquals( 0, session.fireAllRules() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1472,16 +1526,17 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.EQUALITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            session.fireAllRules();
 
-        session.fireAllRules();
-
-        for ( FactHandle fh : session.getFactHandles() ) {
-            InternalFactHandle ifh = (InternalFactHandle) fh;
-            assertEquals( EqualityKey.JUSTIFIED, ifh.getEqualityKey().getStatus() );
+            for ( FactHandle fh : session.getFactHandles() ) {
+                InternalFactHandle ifh = (InternalFactHandle) fh;
+                assertEquals( EqualityKey.JUSTIFIED, ifh.getEqualityKey().getStatus() );
+            }
+        } finally {
+            session.dispose();
         }
-
     }
-
 
     @Test(timeout=10000)
          public void testLogicalWithDeleteException() {
@@ -1503,17 +1558,20 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
+            session.insert( "go1" );
+            session.fireAllRules();
 
-        session.insert( "go1" );
-        session.fireAllRules();
+            TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
+            InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
 
-        TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
-        InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
-
-        assertSame( jfh1, session.getFactHandle( "f1" ) );
+            assertSame( jfh1, session.getFactHandle( "f1" ) );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1536,37 +1594,40 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
+            InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
+            InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
 
-        InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
-        InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
+            session.insert( "go1" );
+            session.fireAllRules();
 
-        session.insert( "go1" );
-        session.fireAllRules();
+            // TMS is now enabled
+            assertNotNull(fh1.getEqualityKey() );
+            assertNotNull(fh2.getEqualityKey() );
 
-        // TMS is now enabled
-        assertNotNull(fh1.getEqualityKey() );
-        assertNotNull(fh2.getEqualityKey() );
+            // EqualtyKey shows both are stated
+            assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
+            assertEquals(EqualityKey.STATED, fh2.getEqualityKey().getStatus() );
 
-        // EqualtyKey shows both are stated
-        assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
-        assertEquals(EqualityKey.STATED, fh2.getEqualityKey().getStatus() );
+            // Only fh1 has a logical
+            assertEquals( 1, fh1.getEqualityKey().getBeliefSet().size() );
+            assertNull( fh2.getEqualityKey().getBeliefSet() );
 
-        // Only fh1 has a logical
-        assertEquals( 1, fh1.getEqualityKey().getBeliefSet().size() );
-        assertNull( fh2.getEqualityKey().getBeliefSet() );
+            // Get the logical Handle too
+            TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
+            InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
+            EqualityKey key = jfh1.getEqualityKey();
+            assertSame( fh1.getEqualityKey(), key );
+            assertNotSame( fh1, jfh1 );
 
-        // Get the logical Handle too
-        TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
-        InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
-        EqualityKey key = jfh1.getEqualityKey();
-        assertSame( fh1.getEqualityKey(), key );
-        assertNotSame( fh1, jfh1 );
-
-        assertEquals(2, key.size());
-        assertSame(jfh1, key.getLogicalFactHandle());
+            assertEquals(2, key.size());
+            assertSame(jfh1, key.getLogicalFactHandle());
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1598,22 +1659,25 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
+            InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
+            InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
 
-        InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
-        InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
+            session.insert( "go1" );
+            session.fireAllRules();
 
-        session.insert( "go1" );
-        session.fireAllRules();
+            session.insert( "go2" );
+            session.fireAllRules();
 
-        session.insert( "go2" );
-        session.fireAllRules();
-
-        // Make sure f1 only occurs once
-        assertEquals( 1, list.size() );
-        assertEquals( "f1", list.get( 0 ) );
+            // Make sure f1 only occurs once
+            assertEquals( 1, list.size() );
+            assertEquals( "f1", list.get( 0 ) );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1645,37 +1709,40 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
+            session.insert( "go1" );
+            session.fireAllRules();
 
-        session.insert( "go1" );
-        session.fireAllRules();
+            TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
+            InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
+            assertEquals(EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus() );
 
-        TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
-        InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
-        assertEquals(EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus() );
+            InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
+            InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
 
-        InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
-        InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
+            session.insert("go2");
+            session.fireAllRules();
 
-        session.insert("go2");
-        session.fireAllRules();
+            assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
+            assertSame( fh1.getEqualityKey(), jfh1.getEqualityKey() );
+            assertNotSame( fh1, jfh1 );
 
-        assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
-        assertSame( fh1.getEqualityKey(), jfh1.getEqualityKey() );
-        assertNotSame( fh1, jfh1 );
+            EqualityKey key = jfh1.getEqualityKey();
+            assertSame( fh1.getEqualityKey(), key );
+            assertNotSame( fh1, jfh1 );
 
-        EqualityKey key = jfh1.getEqualityKey();
-        assertSame( fh1.getEqualityKey(), key );
-        assertNotSame( fh1, jfh1 );
+            assertEquals(2, key.size());
+            assertSame( jfh1,  key.getLogicalFactHandle() );
 
-        assertEquals(2, key.size());
-        assertSame( jfh1,  key.getLogicalFactHandle() );
-
-        // Make sure f1 only occurs once
-        assertEquals( 1, list.size() );
-        assertEquals( "f1", list.get( 0 ) );
+            // Make sure f1 only occurs once
+            assertEquals( 1, list.size() );
+            assertEquals( "f1", list.get( 0 ) );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1707,34 +1774,36 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
-
-        InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
-        InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
+            InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
+            InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
 
 
-        FactHandle g1 = session.insert( "go1" );
-        session.fireAllRules();
+            FactHandle g1 = session.insert( "go1" );
+            session.fireAllRules();
 
-        // This removes the stated position, but it should still be logical now and exist
-        session.delete( fh1, FactHandle.State.STATED );
-        session.insert( "go2" );
-        session.fireAllRules();
+            // This removes the stated position, but it should still be logical now and exist
+            session.delete( fh1, FactHandle.State.STATED );
+            session.insert( "go2" );
+            session.fireAllRules();
 
-        // fh1 is invalid and no longer in the WM. However it's now reverted to it's Justified version and will still be there
-        assertFalse(fh1.isValid());
+            // fh1 is invalid and no longer in the WM. However it's now reverted to it's Justified version and will still be there
+            assertFalse(fh1.isValid());
 
-        // Make sure f1 is still there, but logical only now
-        assertEquals(1, list.size());
-        assertEquals("f1", list.get(0));
-        InternalFactHandle jfh1 = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem().get( "f1" ).getLogicalFactHandle();
-        assertEquals( EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus());
+            // Make sure f1 is still there, but logical only now
+            assertEquals(1, list.size());
+            assertEquals("f1", list.get(0));
+            InternalFactHandle jfh1 = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem().get( "f1" ).getLogicalFactHandle();
+            assertEquals( EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus());
 
-        assertSame(jfh1, session.getFactHandle("f1") );
+            assertSame(jfh1, session.getFactHandle("f1") );
+        } finally {
+            session.dispose();
+        }
     }
-
 
     @Test(timeout=10000)
     public void testLogicalThenUpdateAsStatedShadowSingleOccurance() {
@@ -1765,30 +1834,33 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
+            session.insert( "go1" );
+            session.fireAllRules();
 
-        session.insert( "go1" );
-        session.fireAllRules();
+            TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
+            InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
+            assertEquals(EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus() );
 
-        TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
-        InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
-        assertEquals(EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus() );
+            InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
+            InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
 
-        InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
-        InternalFactHandle fh2 = (InternalFactHandle) session.insert( "f2" );
+            session.insert("go2");
+            session.fireAllRules();
 
-        session.insert("go2");
-        session.fireAllRules();
+            assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
+            assertSame( fh1.getEqualityKey(), jfh1.getEqualityKey() );
+            assertNotSame( fh1, jfh1 );
 
-        assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
-        assertSame( fh1.getEqualityKey(), jfh1.getEqualityKey() );
-        assertNotSame( fh1, jfh1 );
-
-        // Make sure f1 only occurs once
-        assertEquals( 1, list.size() );
-        assertEquals( "f1", list.get( 0 ) );
+            // Make sure f1 only occurs once
+            assertEquals( 1, list.size() );
+            assertEquals( "f1", list.get( 0 ) );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1820,48 +1892,51 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
+        try {
+            List list = new ArrayList();
+            session.setGlobal("list", list);
 
-        List list = new ArrayList();
-        session.setGlobal("list", list);
+            session.insert( "go1" );
+            session.fireAllRules();
 
-        session.insert( "go1" );
-        session.fireAllRules();
+            TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
+            InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
+            assertEquals(EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus() );
 
-        TruthMaintenanceSystem tms = ((StatefulKnowledgeSessionImpl)session).getTruthMaintenanceSystem();
-        InternalFactHandle jfh1 = tms.get( "f1" ).getLogicalFactHandle();
-        assertEquals(EqualityKey.JUSTIFIED, jfh1.getEqualityKey().getStatus() );
+            InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
 
-        InternalFactHandle fh1 = (InternalFactHandle) session.insert( "f1" );
+            session.insert("go2");
+            session.fireAllRules();
 
-        session.insert("go2");
-        session.fireAllRules();
+            assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
+            assertEquals( 1, fh1.getEqualityKey().getBeliefSet().size() );
+            assertSame( fh1.getEqualityKey(), jfh1.getEqualityKey() );
+            assertNotSame( fh1, jfh1 );
 
-        assertEquals( EqualityKey.STATED, fh1.getEqualityKey().getStatus());
-        assertEquals( 1, fh1.getEqualityKey().getBeliefSet().size() );
-        assertSame( fh1.getEqualityKey(), jfh1.getEqualityKey() );
-        assertNotSame( fh1, jfh1 );
+            // Make sure f1 only occurs once
+            assertEquals( 1, list.size() );
+            assertEquals( "f1", list.get( 0 ) );
 
-        // Make sure f1 only occurs once
-        assertEquals( 1, list.size() );
-        assertEquals( "f1", list.get( 0 ) );
+            list.clear();
+            tms.delete( jfh1 );
+            session.insert("go3");
+            session.fireAllRules();
 
-        list.clear();
-        tms.delete( jfh1 );
-        session.insert("go3");
-        session.fireAllRules();
+            assertNull(fh1.getEqualityKey().getBeliefSet());
 
-        assertNull(fh1.getEqualityKey().getBeliefSet());
+            // Make sure f1 only occurs once
+            assertEquals( 1, list.size() );
+            assertEquals( "f1", list.get( 0 ) );
 
-        // Make sure f1 only occurs once
-        assertEquals( 1, list.size() );
-        assertEquals( "f1", list.get( 0 ) );
+            list.clear();
+            session.delete( fh1 );
+            session.insert("go4");
+            session.fireAllRules();
 
-        list.clear();
-        session.delete( fh1 );
-        session.insert("go4");
-        session.fireAllRules();
-
-        assertEquals( 0, list.size() );
+            assertEquals( 0, list.size() );
+        } finally {
+            session.dispose();
+        }
     }
 
     @Test(timeout=10000)
@@ -1913,16 +1988,16 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         kieConf.setOption( EqualityBehaviorOption.IDENTITY );
         KieBase kbase = loadKnowledgeBaseFromString( kieConf, droolsSource );
         KieSession session = kbase.newKieSession();
-
-        List list = new ArrayList();
-
         try {
-            session.fireAllRules();
-            fail("Currently we cannot handle updates for a belief set that is mixed stated and justified" );
-        } catch ( ConsequenceException e) {
-            assertEquals(IllegalStateException.class, e.getCause().getClass() );
+            try {
+                session.fireAllRules();
+                fail("Currently we cannot handle updates for a belief set that is mixed stated and justified" );
+            } catch ( ConsequenceException e) {
+                assertEquals(IllegalStateException.class, e.getCause().getClass() );
+            }
+        } finally {
+            session.dispose();
         }
-
     }
 
     @Test
@@ -1937,17 +2012,20 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            ksession.fireAllRules();
+            Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 1, fhs.size() );
 
-        ksession.fireAllRules();
-        Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 1, fhs.size() );
+            for (FactHandle fh : fhs) {
+                ksession.delete( fh );
+            }
 
-        for (FactHandle fh : fhs) {
-            ksession.delete( fh );
+            fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 0, fhs.size() );
+        } finally {
+            ksession.dispose();
         }
-
-        fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 0, fhs.size() );
     }
 
     @Test
@@ -1962,24 +2040,27 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            ksession.fireAllRules();
+            Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 1, fhs.size() );
 
-        ksession.fireAllRules();
-        Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 1, fhs.size() );
+            for (FactHandle fh : fhs) {
+                ksession.delete( fh, FactHandle.State.STATED );
+            }
 
-        for (FactHandle fh : fhs) {
-            ksession.delete( fh, FactHandle.State.STATED );
+            fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 1, fhs.size() );
+
+            for (FactHandle fh : fhs) {
+                ksession.delete( fh, FactHandle.State.LOGICAL );
+            }
+
+            fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 0, fhs.size() );
+        } finally {
+            ksession.dispose();
         }
-
-        fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 1, fhs.size() );
-
-        for (FactHandle fh : fhs) {
-            ksession.delete( fh, FactHandle.State.LOGICAL );
-        }
-
-        fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 0, fhs.size() );
     }
 
     @Test
@@ -2001,16 +2082,19 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+            assertEquals( "test", list.get(0) );
 
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        assertEquals( "test", list.get(0) );
-
-        Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 0, fhs.size() );
+            Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 0, fhs.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 
     @Test
@@ -2032,16 +2116,19 @@ public class TruthMaintenanceTest extends CommonTestMethodBase {
         KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
                                              .build()
                                              .newKieSession();
+        try {
+            List<String> list = new ArrayList<String>();
+            ksession.setGlobal( "list", list );
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal( "list", list );
+            ksession.fireAllRules();
+            assertEquals( 1, list.size() );
+            assertEquals( "test", list.get(0) );
 
-        ksession.fireAllRules();
-        assertEquals( 1, list.size() );
-        assertEquals( "test", list.get(0) );
-
-        Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
-        assertEquals( 1, fhs.size() );
+            Collection<FactHandle> fhs = ksession.getFactHandles( new ClassObjectFilter( String.class ) );
+            assertEquals( 1, fhs.size() );
+        } finally {
+            ksession.dispose();
+        }
     }
 }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/AbstractConcurrentInsertionsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/AbstractConcurrentInsertionsTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractConcurrentInsertionsTest {
 
         final KieBase kieBase = new KieHelper().addContent(drl, ResourceType.DRL).build();
 
-        final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount, r -> {
             final Thread t = new Thread(r);
             t.setDaemon(true);
             return t;

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -1894,13 +1894,16 @@ public class IncrementalCompilationTest extends CommonTestMethodBase {
         // DROOLS-923
         int parallelThreads = 10;
         ExecutorService executor = Executors.newFixedThreadPool( parallelThreads );
-
-        CompletionService<Boolean> ecs = new ExecutorCompletionService<Boolean>(executor);
-        for (Callable<Boolean> s : Deployer.getDeployer( parallelThreads )) {
-            ecs.submit(s);
-        }
-        for (int i = 0; i < parallelThreads; ++i) {
-            assertTrue( ecs.take().get() );
+        try {
+            CompletionService<Boolean> ecs = new ExecutorCompletionService<Boolean>(executor);
+            for (Callable<Boolean> s : Deployer.getDeployer( parallelThreads )) {
+                ecs.submit(s);
+            }
+            for (int i = 0; i < parallelThreads; ++i) {
+                assertTrue( ecs.take().get() );
+            }
+        } finally {
+            executor.shutdownNow();
         }
     }
 

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieModuleRepoTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieModuleRepoTest.java
@@ -170,12 +170,11 @@ public class KieModuleRepoTest {
                         storeOperationBarrier, threadsFinishedBarrier));
 
         final ExecutorService executor = Executors.newFixedThreadPool(2);
-        firstThread.setName("normal");
-        executor.submit(firstThread);
-        secondThread.setName("newFeature");
-        executor.submit(secondThread);
-
         try {
+            firstThread.setName("normal");
+            executor.submit(firstThread);
+            secondThread.setName("newFeature");
+            executor.submit(secondThread);
             waitFor(threadsFinishedBarrier);
         } finally {
             executor.shutdownNow();
@@ -241,11 +240,11 @@ public class KieModuleRepoTest {
         };
 
         final ExecutorService executor = Executors.newFixedThreadPool(2);
-        // 2. remove and redploy
-        executor.submit(removeRunnable);
-        executor.submit(redeployRunnable);
 
         try {
+            // 2. remove and redploy
+            executor.submit(removeRunnable);
+            executor.submit(redeployRunnable);
             waitFor(threadsFinishedBarrier);
         } finally {
             executor.shutdownNow();
@@ -456,16 +455,16 @@ public class KieModuleRepoTest {
         };
 
         final ExecutorService executor = Executors.newFixedThreadPool(2);
-        // 2. remove and redploy
-        final Thread deployThread = new Thread(deployRunnable);
-        deployThread.setName("one");
-        executor.submit(deployThread);
-
-        final Thread secondDeployThread = new Thread(deployRunnable);
-        secondDeployThread.setName("two");
-        executor.submit(secondDeployThread);
-
         try {
+            // 2. remove and redploy
+            final Thread deployThread = new Thread(deployRunnable);
+            deployThread.setName("one");
+            executor.submit(deployThread);
+
+            final Thread secondDeployThread = new Thread(deployRunnable);
+            secondDeployThread.setName("two");
+            executor.submit(secondDeployThread);
+
             waitFor(threadsFinishedBarrier);
         } finally {
             executor.shutdownNow();

--- a/drools-core/src/test/java/org/drools/core/common/ClassLoaderTest.java
+++ b/drools-core/src/test/java/org/drools/core/common/ClassLoaderTest.java
@@ -38,34 +38,38 @@ public class ClassLoaderTest {
         ((ProjectClassLoader) projectClassLoader).setInternalClassLoader((ProjectClassLoader.InternalTypesClassLoader) internalTypesClassLoader);
 
         final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
-        final List<Future> futures = new ArrayList<>();
+        try {
+            final List<Future> futures = new ArrayList<>();
 
-        for (int i = 0; i < THREAD_COUNT; i++) {
-            if (i % 2 == 0) {
-                futures.add(executorService.submit(() -> {
-                    try {
-                        Class.forName("nonexistant", true, projectClassLoader);
-                    } catch (ClassNotFoundException e) {
-                        //
-                    }
-                }));
-            } else {
-                futures.add(executorService.submit(() -> {
-                    try {
-                        Class.forName("nonexistant", true, internalTypesClassLoader);
-                    } catch (ClassNotFoundException e) {
-                        //
-                    }
-                }));
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                if (i % 2 == 0) {
+                    futures.add(executorService.submit(() -> {
+                        try {
+                            Class.forName("nonexistant", true, projectClassLoader);
+                        } catch (ClassNotFoundException e) {
+                            //
+                        }
+                    }));
+                } else {
+                    futures.add(executorService.submit(() -> {
+                        try {
+                            Class.forName("nonexistant", true, internalTypesClassLoader);
+                        } catch (ClassNotFoundException e) {
+                            //
+                        }
+                    }));
+                }
             }
-        }
 
-        for (int i = 1; i <= THREAD_COUNT; i++) {
-            try {
-                futures.get(i - 1).get();
-            } catch (final InterruptedException | ExecutionException e) {
-                // Nothing
+            for (int i = 1; i <= THREAD_COUNT; i++) {
+                try {
+                    futures.get(i - 1).get();
+                } catch (final InterruptedException | ExecutionException e) {
+                    // Nothing
+                }
             }
+        } finally {
+            executorService.shutdownNow();
         }
     }
 


### PR DESCRIPTION
When running compiler tests, we have many thread pool leaks. These are caused by not shutting down ExecutorServices or not disposing KieSessions properly. These changes clear the leaks. Session dispose is not added everywhere, it is added just where necessary to clean the leaks. More complex fix for this will be done later. 

- Added executorService.shutdownNow() call in a try-finally block where necessary
- Added kieSession.dispose() call in a try-finally block where necessary
- Small code cleanup around the affected areas. 
