### PR TITLE
Remove label from code

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/testframework/TestingEventListener.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/testframework/TestingEventListener.java
@@ -63,8 +63,6 @@ public class TestingEventListener implements AgendaEventListener {
                 if (ruleNames.size() ==0) return true;
                 String ruleName = match.getRule().getName();
 
-                http://www.wtf.com
-
                 //jdelong: please don't want to see records of cancelled activations
 
                 if (inclusive) {


### PR DESCRIPTION
This removed some comment/code fragment which happens to be valid Java syntax, but doesn't look like it really belongs here.

I guess more by accident, this actually is a label named `http` with a comment of `//www.wtf.com`.