### PR TITLE
DROOLS-2558 Improve error message for Msg.EXPRESSION_IS_RANGE ...

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InNode.java
@@ -87,7 +87,7 @@ public class InNode
                 return ((Range) expr).includes( value );
             } catch ( Exception e ) {
                 ctx.notifyEvt( astEvent(Severity.ERROR, Msg.createMessage(Msg.EXPRESSION_IS_RANGE_BUT_VALUE_IS_NOT_COMPARABLE, value.toString(), expr.toString() ), e ) );
-                throw e;
+                return null;
             }
         } else if ( value != null ) {
             return value.equals( expr );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/RangeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/RangeNode.java
@@ -16,19 +16,17 @@
 
 package org.kie.dmn.feel.lang.ast;
 
+import java.time.Period;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
-import org.kie.dmn.feel.lang.CompiledExpression;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.runtime.Range;
-import org.kie.dmn.feel.runtime.UnaryTest;
 import org.kie.dmn.feel.runtime.impl.RangeImpl;
-import org.kie.dmn.feel.util.EvalHelper;
 import org.kie.dmn.feel.util.Msg;
-
-import java.time.Period;
+import org.kie.dmn.feel.util.TypeUtil;
 
 public class RangeNode
         extends BaseNode {
@@ -123,9 +121,11 @@ public class RangeNode
 
     public static class ComparablePeriod implements Comparable<Period> {
         private final int left;
+        private final String toStringRep;
 
         public ComparablePeriod(Period value) {
             this.left = value.getYears() * 12 + value.getMonths();
+            this.toStringRep = TypeUtil.formatPeriod(value, true);
         }
 
         @Override
@@ -148,6 +148,12 @@ public class RangeNode
         public int hashCode() {
             return left;
         }
+
+        @Override
+        public String toString() {
+            return toStringRep;
+        }
+
     }
 
     @Override

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELOperatorsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELOperatorsTest.java
@@ -18,6 +18,7 @@ package org.kie.dmn.feel.runtime;
 
 import java.util.Arrays;
 import java.util.Collection;
+
 import org.junit.runners.Parameterized;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 
@@ -59,6 +60,9 @@ public class FEELOperatorsTest extends BaseFEELTest {
                 { "10 in ]5..10[", Boolean.FALSE , null},
                 { "10 in (5..10]", Boolean.TRUE , null},
                 { "\"b\" in (\"a\"..\"z\"]", Boolean.TRUE , null},
+                {" duration(\"P1Y2M\") in [ duration(\"P1Y2M\") .. duration(\"P1Y3M\")] ", Boolean.TRUE, null},
+                {" duration(\"P1Y4M\") in [ duration(\"P1Y2M\") .. duration(\"P1Y3M\")] ", Boolean.FALSE, null},
+                {" duration(\"PT24H\") in [ duration(\"P1Y2M\") .. duration(\"P1Y3M\")] ", null, FEELEvent.Severity.ERROR},
 
                 // instance of
                 {"10 instance of number", Boolean.TRUE , null},


### PR DESCRIPTION
... _BUT_VALUE_IS_NOT_COMPARABLE

Improve error message for:
Msg.EXPRESSION_IS_RANGE_BUT_VALUE_IS_NOT_COMPARABLE

Before

```
Value 'PT24H' is not comparable with range '[
org.kie.dmn.feel.lang.ast.RangeNode$ComparablePeriod@e ..
org.kie.dmn.feel.lang.ast.RangeNode$ComparablePeriod@f ]'
```

After:

```
Value 'PT24H' is not comparable with range '[ duration( "P1Y2M" ) ..
duration( "P1Y3M" ) ]'
```

Please notice throw e; was introduced with

https://github.com/kiegroup/drools/pull/1300/files#diff-08e75d1c223499cdf91a46ba16639841L86

but before this commit, there was no test coverage of the `throw e;`
branch in the codebase in fact was wrong, it should as originally report
the message but return null. Now the test cases introduced with this
commit do cover for that branch.

/cc @etirelli @kurobako @baldimir @winklerm 