### PR TITLE
fix DecisionTableProviderImpl ignoring CSV type for drt templates

### DIFF
--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/DecisionTableProviderImpl.java
@@ -53,7 +53,20 @@ public class DecisionTableProviderImpl
         ExternalSpreadsheetCompiler converter = new ExternalSpreadsheetCompiler();
         for ( RuleTemplateConfiguration template : configuration.getRuleTemplateConfigurations() ) {
             try {
-                drls.add(converter.compile(resource.getInputStream(), template.getTemplate().getInputStream(), template.getRow(), template.getCol()));
+                InputType inputType;
+                switch ( configuration.getInputType() ) {
+                case XLS :
+                case XLSX :
+                	inputType= InputType.XLS;
+                	break;
+                case CSV : 
+                	inputType= InputType.CSV;
+                	break;
+                default:
+                	throw new IllegalArgumentException("unsuported input type : "+configuration.getInputType());
+                }
+                
+				drls.add(converter.compile(resource.getInputStream(), template.getTemplate().getInputStream(), inputType,template.getRow(), template.getCol()));
             } catch (IOException e) {
                 logger.error( "Cannot open " + template.getTemplate(), e );
             }


### PR DESCRIPTION
So the issue is that the ruleTemplate declared in kmodule.xml is aware that it's csv, but the information is not used by the ExternalSpreadsheetCompiler and default to XLS and it fails.
