### PR TITLE
[RHBRMS-3099] NullPointerException in BaseClassFieldReader.writeExternal() when a global method is used in LHS and serialize package

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/MyUtil.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/MyUtil.java
@@ -1,0 +1,8 @@
+package org.drools.compiler;
+
+public class MyUtil {
+
+    public String transform(Object o) {
+        return o.toString() + "-san";
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTest.java
@@ -33,7 +33,6 @@ import org.drools.core.common.DroolsObjectInputStream;
 import org.drools.core.common.DroolsObjectOutputStream;
 import org.junit.Test;
 import org.kie.api.KieBase;
-import org.kie.api.definition.KiePackage;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.KnowledgeBase;
@@ -213,14 +212,15 @@ public class SerializedPackageMergeTest {
 
         KnowledgeBuilder builder2 = KnowledgeBuilderFactory.newKnowledgeBuilder();
         builder2.add(ResourceFactory.newByteArrayResource(pkgBin), ResourceType.PKG);
-        KieBase kbase = builder2.newKnowledgeBase();
 
+        KieBase kbase = builder2.newKnowledgeBase();
         KieSession ksession = kbase.newKieSession();
         ksession.insert(new org.drools.compiler.Person("aaa"));
         ksession.insert(new org.drools.compiler.Cheese("aaa"));
         ksession.fireAllRules();
         ksession.dispose();
     }
+
 
     @Test
     public void testBuildAndSerializePackagesWithGlobalMethodInLHS() throws Exception {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializedPackageMergeTest.java
@@ -32,6 +32,8 @@ import org.drools.compiler.Message;
 import org.drools.core.common.DroolsObjectInputStream;
 import org.drools.core.common.DroolsObjectOutputStream;
 import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.definition.KiePackage;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.KnowledgeBase;
@@ -183,4 +185,78 @@ public class SerializedPackageMergeTest {
 
         ksession.dispose();
     }
+
+    @Test
+    public void testBuildAndSerializePackagesWithGetterInLHS() throws Exception {
+        // DROOLS-2495
+        String drl =   "package com.sample\n" +
+                        "import org.drools.compiler.Person\n" +
+                        "import org.drools.compiler.Cheese\n" +
+                        "rule R1\n" +
+                        "when\n" +
+                        "  $p : Person()\n" +
+                        "  $c : Cheese(type == $p.getName())\n" +
+                        "then\n" +
+                        "end\n";
+
+        KnowledgeBuilder builder1 = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        builder1.add(ResourceFactory.newByteArrayResource(drl.getBytes()), ResourceType.DRL);
+        Collection<KnowledgePackage> knowledgePackages = builder1.getKnowledgePackages();
+
+        byte[] pkgBin = null;
+        try (ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+                DroolsObjectOutputStream out = new DroolsObjectOutputStream(byteOutStream);) {
+            out.writeObject(knowledgePackages);
+            out.flush();
+            pkgBin = byteOutStream.toByteArray();
+        }
+
+        KnowledgeBuilder builder2 = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        builder2.add(ResourceFactory.newByteArrayResource(pkgBin), ResourceType.PKG);
+        KieBase kbase = builder2.newKnowledgeBase();
+
+        KieSession ksession = kbase.newKieSession();
+        ksession.insert(new org.drools.compiler.Person("aaa"));
+        ksession.insert(new org.drools.compiler.Cheese("aaa"));
+        ksession.fireAllRules();
+        ksession.dispose();
+    }
+
+    @Test
+    public void testBuildAndSerializePackagesWithGlobalMethodInLHS() throws Exception {
+        // DROOLS-2517
+        String drl =   "package com.sample\n" +
+                "import org.drools.compiler.Person\n" +
+                "global org.drools.compiler.MyUtil myUtil\n" +
+                "rule R1\n" +
+                "when\n" +
+                "  Person(myUtil.transform(name) == \"John-san\")\n" + // call global's method
+                "then\n" +
+                "end\n";
+
+        KnowledgeBuilder builder1 = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        builder1.add(ResourceFactory.newByteArrayResource(drl.getBytes()), ResourceType.DRL);
+        Collection<KnowledgePackage> knowledgePackages = builder1.getKnowledgePackages();
+
+        byte[] pkgBin = null;
+        try (ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+                DroolsObjectOutputStream out = new DroolsObjectOutputStream(byteOutStream);) {
+            out.writeObject(knowledgePackages);
+            out.flush();
+            pkgBin = byteOutStream.toByteArray();
+        }
+
+        KnowledgeBuilder builder2 = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        builder2.add(ResourceFactory.newByteArrayResource(pkgBin), ResourceType.PKG);
+        KieBase kbase = builder2.newKnowledgeBase();
+
+        KieSession ksession = kbase.newKieSession();
+        ksession.setGlobal("myUtil", new org.drools.compiler.MyUtil());
+        ksession.insert(new org.drools.compiler.Person("John"));
+        int fired = ksession.fireAllRules();
+        assertEquals(1, fired);
+
+        ksession.dispose();
+    }
+
 }

--- a/drools-core/src/main/java/org/drools/core/base/AccessorKey.java
+++ b/drools-core/src/main/java/org/drools/core/base/AccessorKey.java
@@ -44,7 +44,7 @@ public class AccessorKey
         final int PRIME = 31;
         int result = 1;
         result = PRIME * result + className.hashCode();
-        result = PRIME * result + ( (fieldName == null) ? 0 : fieldName.hashCode() );
+        result = PRIME * result + ( (this.fieldName == null) ? 0 : this.fieldName.hashCode() );
         result = PRIME * result + type.name().hashCode();
         this.hashCode = result;
     }

--- a/drools-core/src/main/java/org/drools/core/base/BaseClassFieldReader.java
+++ b/drools-core/src/main/java/org/drools/core/base/BaseClassFieldReader.java
@@ -193,7 +193,11 @@ abstract public class BaseClassFieldReader
     public void writeExternal(ObjectOutput out) throws IOException {
         out.writeInt( index );
         out.writeObject( valueType );
-        out.writeUTF( fieldType.getName() );
+        if (fieldType == null) {
+            out.writeUTF( "" );
+        } else {
+            out.writeUTF( fieldType.getName() );
+        }
     }
 
     public void readExternal(ObjectInput in) throws IOException,
@@ -202,12 +206,14 @@ abstract public class BaseClassFieldReader
         valueType = (ValueType) in.readObject();
         String clsName = in.readUTF();
 
-        try {
-            fieldType = in instanceof DroolsObjectInput ?
-                        ClassUtils.getClassFromName( clsName, false, ( (DroolsObjectInput) in ).getClassLoader() ) :
-                        ClassUtils.getClassFromName( clsName );
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException( e );
+        if (!clsName.isEmpty()) {
+            try {
+                fieldType = in instanceof DroolsObjectInput ?
+                            ClassUtils.getClassFromName( clsName, false, ( (DroolsObjectInput) in ).getClassLoader() ) :
+                            ClassUtils.getClassFromName( clsName );
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException( e );
+            }
         }
     }
 }


### PR DESCRIPTION
both commits are required in order to backport properly RHBRMS-3099