### PR TITLE
[DROOLS-2619] Fix test names to follow surefire and failsafe patterns

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MessageImplTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/MessageImplTest.java
@@ -15,7 +15,6 @@
 
 package org.drools.compiler.integrationtests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -29,7 +28,7 @@ import static org.junit.Assert.*;
 /**
  * Tests for MessageImpl
  */
-public class MessageImplTests {
+public class MessageImplTest {
 
     @Test
     //See DROOLS-193 (KnowledgeBuilderResult does not always contain a Resource)

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Query2Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Query2Test.java
@@ -29,7 +29,7 @@ import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.fail;
 
-public class QueryTest2 extends CommonTestMethodBase {
+public class Query2Test extends CommonTestMethodBase {
     
     @Test
     public void testEvalRewrite() throws Exception {

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Query3Test.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/Query3Test.java
@@ -16,24 +16,21 @@
 package org.drools.compiler.integrationtests;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.junit.Before;
 import org.junit.Test;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.api.KieBase;
 import org.kie.api.io.ResourceType;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.QueryResults;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
 
-public class QueryTest3 {
+import static org.junit.Assert.*;
+
+public class Query3Test {
 
     private InternalKnowledgeBase knowledgeBase;
 
@@ -44,9 +41,9 @@ public class QueryTest3 {
     public void setUp() throws Exception {
         String text = "";
         text += "package org.drools.integrationtests\n";
-        text += "import " + QueryTest3.Bar.class.getCanonicalName() + "\n";
-        text += "import " + QueryTest3.Foo.class.getCanonicalName() + "\n";
-        text += "import " + QueryTest3.Foo2.class.getCanonicalName() + "\n";
+        text += "import " + Query3Test.Bar.class.getCanonicalName() + "\n";
+        text += "import " + Query3Test.Foo.class.getCanonicalName() + "\n";
+        text += "import " + Query3Test.Foo2.class.getCanonicalName() + "\n";
         text += "query \"testDifferent\"\n";
         text += "    foo : Foo();\n";
         text += "    bar : Bar(id == foo.id)\n";

--- a/drools-compiler/src/test/java/org/drools/compiler/oopath/OOPathReactiveTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/oopath/OOPathReactiveTest.java
@@ -23,9 +23,7 @@ import org.assertj.core.api.Assertions;
 import org.drools.compiler.integrationtests.SerializationHelper;
 import org.drools.compiler.oopath.model.Adult;
 import org.drools.compiler.oopath.model.Child;
-import org.drools.compiler.oopath.model.Company;
 import org.drools.compiler.oopath.model.Disease;
-import org.drools.compiler.oopath.model.Employee;
 import org.drools.compiler.oopath.model.Group;
 import org.drools.compiler.oopath.model.Man;
 import org.drools.compiler.oopath.model.School;
@@ -55,7 +53,7 @@ import static org.drools.compiler.oopath.model.BodyMeasurement.CHEST;
 import static org.drools.compiler.oopath.model.BodyMeasurement.RIGHT_FOREARM;
 import static org.junit.Assert.*;
 
-public class OOPathReactiveTests {
+public class OOPathReactiveTest {
 
     @Test
     public void testReactiveOnLia() {
@@ -539,44 +537,6 @@ public class OOPathReactiveTests {
         ksession.fireAllRules();
 
         Assertions.assertThat(list).containsExactlyInAnyOrder("gun");
-    }
-
-    @Test
-    public void testReactiveArray() {
-        // RHBRMS-2768
-        final String drl =
-                "import org.drools.compiler.oopath.model.*;\n" +
-                        "global java.util.List list\n" +
-                        "\n" +
-                        "rule R when\n" +
-                        "  Company( $employee: /employees )\n" +
-                        "then\n" +
-                        "  list.add( $employee.getName() );\n" +
-                        "end\n";
-
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
-
-        final List<String> list = new ArrayList<>();
-        ksession.setGlobal( "list", list );
-
-        final Company robotics = new Company("Robotics");
-        final Employee mark = new Employee("Mark", 35);
-        final Employee thomas = new Employee("Thomas", 40);
-        robotics.setEmployees(new Employee[] {mark, thomas});
-
-        ksession.insert(robotics);
-        ksession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Mark", "Thomas");
-
-        list.clear();
-        final Employee arnold = new Employee("Arnold", 50);
-        robotics.setEmployees(new Employee[] {mark, thomas, arnold});
-        ksession.fireAllRules();
-
-        Assertions.assertThat(list).containsExactlyInAnyOrder("Mark", "Thomas", "Arnold");
     }
 
     @Test

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/SingleFieldConstraintEBLeftSideTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/SingleFieldConstraintEBLeftSideTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class SingleFieldConstraintEBLeftSideTests {
+public class SingleFieldConstraintEBLeftSideTest {
 
     @Test
     public void testHashCode() {

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/workitems/PortableParameterDefinitionTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/workitems/PortableParameterDefinitionTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for PortableParameterDefinitions
  */
-public class PortableParameterDefinitionTests {
+public class PortableParameterDefinitionTest {
 
     @Test
     public void testClassNames() {

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelIncrementalCompilationTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelIncrementalCompilationTest.java
@@ -17,7 +17,6 @@ package org.drools.workbench.models.guided.template.backend;
 
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -31,7 +30,7 @@ import static org.junit.Assert.*;
 /**
  * Tests for incremental compilation of templates
  */
-public class RuleTemplateModelIncrementalCompilationTests {
+public class RuleTemplateModelIncrementalCompilationTest {
 
     @Test
     public void testRuleTemplateInvalidFullBuild() throws Exception {


### PR DESCRIPTION
@mariofusco I discovered that there are some tests that were not run in Jenkins as they did not follow the correct pattern for names (see https://issues.jboss.org/browse/DROOLS-2619). After my fix, it seems that one of the tests failed. Could you please take a look at the fail? Thanks.
