### PR TITLE
DROOLS-2643: Extraneous parentheses generated by Guided Rule editor

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -666,7 +666,7 @@ public class RuleModelDRLPersistenceImpl
 
         public void visitFromCompositeFactPattern(final FromCompositeFactPattern pattern) {
             visitFromCompositeFactPattern(pattern,
-                                          false);
+                                          generatorContextFactory.getMaximumDepth() > 1);
         }
 
         public void visitFromCompositeFactPattern(final FromCompositeFactPattern pattern,
@@ -680,8 +680,11 @@ public class RuleModelDRLPersistenceImpl
             if (pattern.getFactPattern() != null) {
                 final LHSGeneratorContext gctx = generatorContextFactory.newChildGeneratorContext(rootContext,
                                                                                                   pattern.getFactPattern());
+
+                final boolean _isSubPattern = gctx.getDepth() > 1;
+
                 // DROOLS-1308 - wraps from pattern in parenthesis
-                if (!isSubPattern) {
+                if (!_isSubPattern) {
                     buf.append("(");
                 }
                 generateFactPattern(pattern.getFactPattern(),
@@ -689,7 +692,7 @@ public class RuleModelDRLPersistenceImpl
 
                 buf.append(" from ");
                 renderExpression(pattern.getExpression());
-                if (!isSubPattern) {
+                if (!_isSubPattern) {
                     buf.append(")");
                 }
                 buf.append("\n");
@@ -698,7 +701,7 @@ public class RuleModelDRLPersistenceImpl
 
         public void visitFromCollectCompositeFactPattern(final FromCollectCompositeFactPattern pattern) {
             visitFromCollectCompositeFactPattern(pattern,
-                                                 false);
+                                                 generatorContextFactory.getMaximumDepth() > 1);
         }
 
         public void visitFromCollectCompositeFactPattern(final FromCollectCompositeFactPattern pattern,
@@ -715,9 +718,9 @@ public class RuleModelDRLPersistenceImpl
                 generateFactPattern(pattern.getFactPattern(),
                                     gctx);
 
-                buf.append(" from collect ( ");
+                final boolean _isSubPattern = gctx.getDepth() > 1;
 
-                buf.append("\n");
+                buf.append(" from collect ( ");
 
                 if (pattern.getRightPattern() != null) {
                     if (pattern.getRightPattern() instanceof FactPattern) {
@@ -725,16 +728,16 @@ public class RuleModelDRLPersistenceImpl
                                             generatorContextFactory.newGeneratorContext());
                     } else if (pattern.getRightPattern() instanceof FromAccumulateCompositeFactPattern) {
                         visitFromAccumulateCompositeFactPattern((FromAccumulateCompositeFactPattern) pattern.getRightPattern(),
-                                                                isSubPattern);
+                                                                _isSubPattern);
                     } else if (pattern.getRightPattern() instanceof FromCollectCompositeFactPattern) {
                         visitFromCollectCompositeFactPattern((FromCollectCompositeFactPattern) pattern.getRightPattern(),
-                                                             isSubPattern);
+                                                             _isSubPattern);
                     } else if (pattern.getRightPattern() instanceof FromEntryPointFactPattern) {
                         visitFromEntryPointFactPattern((FromEntryPointFactPattern) pattern.getRightPattern(),
-                                                       isSubPattern);
+                                                       _isSubPattern);
                     } else if (pattern.getRightPattern() instanceof FromCompositeFactPattern) {
                         visitFromCompositeFactPattern((FromCompositeFactPattern) pattern.getRightPattern(),
-                                                      isSubPattern);
+                                                      _isSubPattern);
                     } else if (pattern.getRightPattern() instanceof FreeFormLine) {
                         visitFreeFormLine((FreeFormLine) pattern.getRightPattern());
                     } else {
@@ -752,7 +755,7 @@ public class RuleModelDRLPersistenceImpl
 
         public void visitFromAccumulateCompositeFactPattern(final FromAccumulateCompositeFactPattern pattern) {
             visitFromAccumulateCompositeFactPattern(pattern,
-                                                    false);
+                                                    generatorContextFactory.getMaximumDepth() > 1);
         }
 
         public void visitFromAccumulateCompositeFactPattern(final FromAccumulateCompositeFactPattern pattern,
@@ -769,6 +772,8 @@ public class RuleModelDRLPersistenceImpl
                 generateFactPattern(pattern.getFactPattern(),
                                     gctx);
 
+                final boolean _isSubPattern = gctx.getDepth() > 1;
+
                 buf.append(" from accumulate ( ");
                 if (pattern.getSourcePattern() != null) {
                     if (pattern.getSourcePattern() instanceof FactPattern) {
@@ -777,16 +782,16 @@ public class RuleModelDRLPersistenceImpl
                                             soucrceGctx);
                     } else if (pattern.getSourcePattern() instanceof FromAccumulateCompositeFactPattern) {
                         visitFromAccumulateCompositeFactPattern((FromAccumulateCompositeFactPattern) pattern.getSourcePattern(),
-                                                                isSubPattern);
+                                                                _isSubPattern);
                     } else if (pattern.getSourcePattern() instanceof FromCollectCompositeFactPattern) {
                         visitFromCollectCompositeFactPattern((FromCollectCompositeFactPattern) pattern.getSourcePattern(),
-                                                             isSubPattern);
+                                                             _isSubPattern);
                     } else if (pattern.getSourcePattern() instanceof FromEntryPointFactPattern) {
                         visitFromEntryPointFactPattern((FromEntryPointFactPattern) pattern.getSourcePattern(),
-                                                       isSubPattern);
+                                                       _isSubPattern);
                     } else if (pattern.getSourcePattern() instanceof FromCompositeFactPattern) {
                         visitFromCompositeFactPattern((FromCompositeFactPattern) pattern.getSourcePattern(),
-                                                      isSubPattern);
+                                                      _isSubPattern);
                     } else {
                         throw new IllegalArgumentException("Unsupported pattern " + pattern.getSourcePattern() + " for FROM ACCUMULATE");
                     }
@@ -833,7 +838,7 @@ public class RuleModelDRLPersistenceImpl
 
         public void visitFromEntryPointFactPattern(final FromEntryPointFactPattern pattern) {
             visitFromEntryPointFactPattern(pattern,
-                                           false);
+                                           generatorContextFactory.getMaximumDepth() > 1);
         }
 
         public void visitFromEntryPointFactPattern(final FromEntryPointFactPattern pattern,

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/LHSGeneratorContextFactory.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/LHSGeneratorContextFactory.java
@@ -30,37 +30,37 @@ public class LHSGeneratorContextFactory {
 
     public LHSGeneratorContext newGeneratorContext() {
         final LHSGeneratorContext gc = new LHSGeneratorContext();
-        contexts.add( gc );
+        contexts.add(gc);
         return gc;
     }
 
-    public LHSGeneratorContext newChildGeneratorContext( final LHSGeneratorContext parent,
-                                                         final IPattern pattern ) {
-        final LHSGeneratorContext gc = new LHSGeneratorContext( parent,
-                                                                pattern,
-                                                                getMaximumDepth() + 1,
-                                                                0 );
-        contexts.add( gc );
+    public LHSGeneratorContext newChildGeneratorContext(final LHSGeneratorContext parent,
+                                                        final IPattern pattern) {
+        final LHSGeneratorContext gc = new LHSGeneratorContext(parent,
+                                                               pattern,
+                                                               getMaximumDepth() + 1,
+                                                               0);
+        contexts.add(gc);
         return gc;
     }
 
-    public LHSGeneratorContext newChildGeneratorContext( final LHSGeneratorContext parent,
-                                                         final FieldConstraint fieldConstraint ) {
-        final LHSGeneratorContext gc = new LHSGeneratorContext( parent,
-                                                                fieldConstraint,
-                                                                getMaximumDepth() + 1,
-                                                                0 );
-        contexts.add( gc );
+    public LHSGeneratorContext newChildGeneratorContext(final LHSGeneratorContext parent,
+                                                        final FieldConstraint fieldConstraint) {
+        final LHSGeneratorContext gc = new LHSGeneratorContext(parent,
+                                                               fieldConstraint,
+                                                               getMaximumDepth() + 1,
+                                                               0);
+        contexts.add(gc);
         return gc;
     }
 
-    public LHSGeneratorContext newPeerGeneratorContext( final LHSGeneratorContext peer,
-                                                        final FieldConstraint fieldConstraint ) {
-        final LHSGeneratorContext gc = new LHSGeneratorContext( peer.getParent(),
-                                                                fieldConstraint,
-                                                                peer.getDepth(),
-                                                                peer.getOffset() + 1 );
-        contexts.add( gc );
+    public LHSGeneratorContext newPeerGeneratorContext(final LHSGeneratorContext peer,
+                                                       final FieldConstraint fieldConstraint) {
+        final LHSGeneratorContext gc = new LHSGeneratorContext(peer.getParent(),
+                                                               fieldConstraint,
+                                                               peer.getDepth(),
+                                                               peer.getOffset() + 1);
+        contexts.add(gc);
         return gc;
     }
 
@@ -68,24 +68,23 @@ public class LHSGeneratorContextFactory {
         return contexts;
     }
 
-    private int getMaximumDepth() {
+    public int getMaximumDepth() {
         int depth = 0;
-        for ( LHSGeneratorContext gctx : contexts ) {
-            depth = Math.max( depth,
-                              gctx.getDepth() );
+        for (LHSGeneratorContext gctx : contexts) {
+            depth = Math.max(depth,
+                             gctx.getDepth());
         }
         return depth;
     }
 
-    public List<LHSGeneratorContext> getPeers( final LHSGeneratorContext peer ) {
+    public List<LHSGeneratorContext> getPeers(final LHSGeneratorContext peer) {
         final List<LHSGeneratorContext> peers = new ArrayList<LHSGeneratorContext>();
-        for ( LHSGeneratorContext c : contexts ) {
-            if ( c.getDepth() == peer.getDepth() ) {
-                peers.add( c );
+        for (LHSGeneratorContext c : contexts) {
+            if (c.getDepth() == peer.getDepth()) {
+                peers.add(c);
             }
         }
-        peers.remove( peer );
+        peers.remove(peer);
         return peers;
     }
-
 }

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -214,8 +214,8 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
         assertDSLEscaping(newDrl);
 
         Assertions.assertThat(newDrl)
-                  .contains(">java.lang.Number( ) from accumulate ( $p : Person( ),\n")
-                  .contains(">\t\t\tcount($p))");
+                .contains(">java.lang.Number( ) from accumulate ( $p : Person( ),\n")
+                .contains(">\t\t\tcount($p))");
     }
 
     private void assertDSLEscaping(final String drl) {
@@ -3343,6 +3343,89 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
 
         checkMarshalling(expected,
                          m);
+    }
+
+    @Test
+    public void testFromAccumulateFromCollectionWithFunction() {
+        final RuleModel model = new RuleModel();
+        model.name = "r1";
+
+        final SingleFieldConstraint orderLineQuantity = new SingleFieldConstraint("quantity");
+        orderLineQuantity.setFactType(DataType.TYPE_NUMERIC_INTEGER);
+        orderLineQuantity.setFieldBinding("$q");
+        orderLineQuantity.setOperator(">");
+        orderLineQuantity.setValue("0");
+
+        final FactPattern orderLine = new FactPattern("OrderLine");
+        orderLine.addConstraint(orderLineQuantity);
+
+        final ExpressionFormLine accumulateSourceExpression = new ExpressionFormLine();
+        accumulateSourceExpression.appendPart(new ExpressionText("$o.lines"));
+
+        final FromCompositeFactPattern accumulateSource = new FromCompositeFactPattern();
+        accumulateSource.setFactPattern(orderLine);
+        accumulateSource.setExpression(accumulateSourceExpression);
+
+        final FromAccumulateCompositeFactPattern accumulate = new FromAccumulateCompositeFactPattern();
+        accumulate.setSourcePattern(accumulateSource);
+        accumulate.setFactPattern(new FactPattern("java.util.Number"));
+        accumulate.setFunction("sum($q)");
+
+        model.addLhsItem(accumulate);
+
+        final String expected = "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "java.util.Number( ) from accumulate ( OrderLine( $q : quantity > 0 ) from $o.lines, \n"
+                + "sum($q))\n"
+                + "then\n"
+                + "end";
+
+        checkMarshalling(expected, model);
+    }
+
+    @Test
+    public void testFromAccumulateFromCollectionWithInitActionResult() {
+        final RuleModel model = new RuleModel();
+        model.name = "r1";
+
+        final SingleFieldConstraint orderLineQuantity = new SingleFieldConstraint("quantity");
+        orderLineQuantity.setFactType(DataType.TYPE_NUMERIC_INTEGER);
+        orderLineQuantity.setFieldBinding("$q");
+        orderLineQuantity.setOperator(">");
+        orderLineQuantity.setValue("0");
+
+        final FactPattern orderLine = new FactPattern("OrderLine");
+        orderLine.addConstraint(orderLineQuantity);
+
+        final ExpressionFormLine accumulateSourceExpression = new ExpressionFormLine();
+        accumulateSourceExpression.appendPart(new ExpressionText("$o.lines"));
+
+        final FromCompositeFactPattern accumulateSource = new FromCompositeFactPattern();
+        accumulateSource.setFactPattern(orderLine);
+        accumulateSource.setExpression(accumulateSourceExpression);
+
+        final FromAccumulateCompositeFactPattern accumulate = new FromAccumulateCompositeFactPattern();
+        accumulate.setSourcePattern(accumulateSource);
+        accumulate.setFactPattern(new FactPattern("java.util.Number"));
+        accumulate.setInitCode("init");
+        accumulate.setActionCode("action");
+        accumulate.setResultCode("result");
+
+        model.addLhsItem(accumulate);
+
+        final String expected = "rule \"r1\"\n"
+                + "dialect \"mvel\"\n"
+                + "when\n"
+                + "java.util.Number( ) from accumulate ( OrderLine( $q : quantity > 0 ) from $o.lines, \n"
+                + "init( init ),\n"
+                + "action( action ),\n"
+                + "result( result )\n"
+                + ")\n"
+                + "then\n"
+                + "end";
+
+        checkMarshalling(expected, model);
     }
 
     @Test

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -3399,7 +3399,7 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
                 "dialect \"mvel\"\n" +
                 "when\n" +
                 "$d : Data( )\n" +
-                "(Person( ) from $d)\n" +
+                "Person( ) from $d\n" +
                 "\n" +
                 "then\n" +
                 "end\n";

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -7596,8 +7596,8 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
                 "dialect \"java\"\n" +
                 "when\n" +
                 "  $father: Father()\n" +
-                "  ($kid: Kid() from $father.kids)\n" +
-                "  ($toy: Toy(name == null) from $kid.toys)\n" +
+                "  $kid: Kid() from $father.kids\n" +
+                "  $toy: Toy(name == null) from $kid.toys\n" +
                 "then\n" +
                 "  System.out.println(\"blabla\");\n" +
                 "end";
@@ -8119,7 +8119,7 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
                 "when\n" +
                 "  var : NotImported( )\n" +
                 "  OtherType( field != var.field )\n" +
-                "  (MyType( ) from var.collectionField)\n" +
+                "  MyType( ) from var.collectionField\n" +
                 "then\n" +
                 "end";
 


### PR DESCRIPTION
@jomarko This is an alternative (non-hacked) fix for https://issues.jboss.org/browse/DROOLS-2643

This uses the "depth" of patterns to determine whether they are "sub patterns".