### PR TITLE
[DROOLS-2625] Support function with external bind in the Exec Model accumulate

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
@@ -20,6 +20,7 @@ import org.drools.modelcompiler.builder.generator.RuleContext;
 import org.drools.modelcompiler.builder.generator.TypedExpression;
 import org.drools.modelcompiler.builder.generator.drlxparse.DrlxParseSuccess;
 
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.BIND_AS_CALL;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.INDEXED_BY_CALL;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.WATCH_CALL;
@@ -80,6 +81,7 @@ public class FlowExpressionBuilder extends AbstractExpressionBuilder {
         final Expression constraintExpression = getConstraintExpression(drlxParseResult);
         MethodCallExpr bindAsDSL = new MethodCallExpr(bindDSL, BIND_AS_CALL);
         bindAsDSL.addArgument(context.getVarExpr(drlxParseResult.getPatternBinding()));
+        drlxParseResult.getUsedDeclarationsOnLeft().forEach(d -> bindAsDSL.addArgument(toVar(d)));
         bindAsDSL.addArgument(constraintExpression);
         return buildReactOn( drlxParseResult, bindAsDSL );
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
@@ -81,7 +81,7 @@ public class FlowExpressionBuilder extends AbstractExpressionBuilder {
         final Expression constraintExpression = getConstraintExpression(drlxParseResult);
         MethodCallExpr bindAsDSL = new MethodCallExpr(bindDSL, BIND_AS_CALL);
         bindAsDSL.addArgument(context.getVarExpr(drlxParseResult.getPatternBinding()));
-        drlxParseResult.getUsedDeclarationsOnLeft().forEach(d -> bindAsDSL.addArgument(toVar(d)));
+        drlxParseResult.getUsedDeclarationsOnLeft().forEach(d -> bindAsDSL.addArgument(context.getVar(d)));
         bindAsDSL.addArgument(constraintExpression);
         return buildReactOn( drlxParseResult, bindAsDSL );
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
@@ -87,7 +87,7 @@ public class PatternExpressionBuilder extends AbstractExpressionBuilder {
             bindDSL.addArgument(context.getVarExpr(drlxParseResult.getExprBinding()));
         }
         final Expression constraintExpression = getConstraintExpression(drlxParseResult);
-        drlxParseResult.getUsedDeclarationsOnLeft().forEach(d -> bindDSL.addArgument(toVar(d)));
+        drlxParseResult.getUsedDeclarationsOnLeft().forEach(d -> bindDSL.addArgument(context.getVar(d)));
         bindDSL.addArgument(constraintExpression);
         final Optional<MethodCallExpr> methodCallExpr = buildReactOn(drlxParseResult);
         methodCallExpr.ifPresent(bindDSL::addArgument);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
@@ -24,6 +24,7 @@ import org.drools.modelcompiler.builder.generator.drlxparse.DrlxParseSuccess;
 
 import static java.util.Optional.of;
 
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toVar;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.ALPHA_INDEXED_BY_CALL;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.BETA_INDEXED_BY_CALL;
 
@@ -86,6 +87,7 @@ public class PatternExpressionBuilder extends AbstractExpressionBuilder {
             bindDSL.addArgument(context.getVarExpr(drlxParseResult.getExprBinding()));
         }
         final Expression constraintExpression = getConstraintExpression(drlxParseResult);
+        drlxParseResult.getUsedDeclarationsOnLeft().forEach(d -> bindDSL.addArgument(toVar(d)));
         bindDSL.addArgument(constraintExpression);
         final Optional<MethodCallExpr> methodCallExpr = buildReactOn(drlxParseResult);
         methodCallExpr.ifPresent(bindDSL::addArgument);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -234,9 +234,10 @@ public abstract class AccumulateVisitor {
                 // Then the accumulate function will have that binding expression as a source
                 final String bindExpressionVariable = context.getExprId(accumulateFunctionResultType, typedExpression.toString());
                 Expression withThis = DrlxParseUtil.prepend(DrlxParseUtil._THIS_EXPR, typedExpression.getExpression());
-                DrlxParseSuccess result = new DrlxParseSuccess(accumulateFunctionResultType, "", rootNodeName, withThis, accumulateFunctionResultType)
-                        .setLeft(typedExpression)
-                        .setExprBinding(bindExpressionVariable);
+
+                final DrlxParseResult drlxParseResult = new ConstraintParser(context, context.getPackageModel()).drlxParse(Object.class, rootNodeName, "$c.convert($length)");
+                final DrlxParseSuccess result = (DrlxParseSuccess) drlxParseResult;
+                result.setExprBinding(bindExpressionVariable);
                 final MethodCallExpr binding = expressionBuilder.buildBinding(result);
                 newBinding = Optional.of(new AccumulateVisitorPatternDSL.NewBinding(Optional.of(result.getPatternBinding()), binding));
                 context.addDeclarationReplacing(new DeclarationSpec(bindExpressionVariable, methodCallExprType));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -235,7 +235,7 @@ public abstract class AccumulateVisitor {
                 final String bindExpressionVariable = context.getExprId(accumulateFunctionResultType, typedExpression.toString());
                 Expression withThis = DrlxParseUtil.prepend(DrlxParseUtil._THIS_EXPR, typedExpression.getExpression());
 
-                final DrlxParseResult drlxParseResult = new ConstraintParser(context, context.getPackageModel()).drlxParse(Object.class, rootNodeName, "$c.convert($length)");
+                final DrlxParseResult drlxParseResult = new ConstraintParser(context, context.getPackageModel()).drlxParse(Object.class, rootNodeName, accumulateFunctionParameterStr);
                 final DrlxParseSuccess result = (DrlxParseSuccess) drlxParseResult;
                 result.setExprBinding(bindExpressionVariable);
                 final MethodCallExpr binding = expressionBuilder.buildBinding(result);

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -926,4 +926,37 @@ public class AccumulateTest extends BaseModelTest {
 
         assertEquals(1, ksession.fireAllRules());
     }
+
+    @Test
+    public void testAccumulateWithFunctionWithExternalBinding() {
+        final String drl =
+                "import " + Converter.class.getCanonicalName() + ";\n" +
+                        "global java.util.List list;\n" +
+                        "rule R when\n" +
+                        "   String( $length : length )\n" +
+                        "   accumulate ( $c : Converter(), $result : sum( $c.convert($length) ) )\n" +
+                        "then\n" +
+                        "    list.add($result);\n" +
+                        "end";
+
+        KieSession ksession = getKieSession(drl);
+
+        final List<Number> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+
+        ksession.insert(1);
+        ksession.insert("hello");
+        ksession.insert(new Converter());
+        ksession.fireAllRules();
+
+        assertEquals(1, list.size());
+        assertEquals(5, list.get(0).intValue());
+    }
+
+    public static class Converter {
+
+        public static int convert(final int i) {
+            return i;
+        }
+    }
 }


### PR DESCRIPTION
New test: testAccumulateWithFunctionWithExternalBinding

This also fixes compilation for 

org.drools.compiler.integrationtests.AccumulateTest
testAccumulateWithOr
testMvelAccumulateWithOr

Which are still red for other reasons