### PR TITLE
[DROOLS-2752] - Fix StringIndexOutOfBounds exception for scorecards

### DIFF
--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/ExternalBeanDefinition.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/ExternalBeanDefinition.java
@@ -1,14 +1,25 @@
 package org.kie.pmml.pmml_4_2.model;
 
+import org.kie.pmml.pmml_4_2.PMMLError;
+
 public class ExternalBeanDefinition {
 
     private String beanPackageName;
     private String beanName;
+    public static final String DEFAULT_BEAN_PKG = "org.kie.pmml.externalbean";
 
-    public ExternalBeanDefinition(String beanInfo) {
+    public ExternalBeanDefinition(String beanInfo) throws IllegalArgumentException {
+        if (beanInfo == null || beanInfo.isEmpty()) {
+            throw new IllegalArgumentException("External type name missing");
+        }
         int lastPos = beanInfo.lastIndexOf(".");
-        this.beanPackageName = beanInfo.substring(0, lastPos);
-        this.beanName = beanInfo.substring(lastPos + 1);
+        if (lastPos >= 0) {
+            this.beanPackageName = beanInfo.substring(0, lastPos);
+            this.beanName = beanInfo.substring(lastPos + 1);
+        } else {
+            this.beanPackageName = DEFAULT_BEAN_PKG;
+            this.beanName = beanInfo;
+        }
     }
 
     public ExternalBeanDefinition(String beanPackageName, String beanName) {

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/ExternalBeanRef.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/ExternalBeanRef.java
@@ -11,10 +11,14 @@ public class ExternalBeanRef {
         OUTPUT;
     }
 
-    public ExternalBeanRef(String modelFieldName, String beanInfo, ModelUsage usage) {
+    public ExternalBeanRef(String modelFieldName, String beanInfo, ModelUsage usage) throws IllegalArgumentException {
         this.modelFieldName = modelFieldName;
         this.usage = usage;
-        this.beanDefinition = new ExternalBeanDefinition(beanInfo);
+        try {
+            this.beanDefinition = new ExternalBeanDefinition(beanInfo);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unable to construct ExternalBeanRef. ", e);
+        }
     }
 
     public String getBeanPackageName() {

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/model/ExternalBeanRefTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/model/ExternalBeanRefTest.java
@@ -2,19 +2,51 @@ package org.kie.pmml.pmml_4_2.model;
 
 import static org.junit.Assert.*;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.kie.pmml.pmml_4_2.model.ExternalBeanRef.ModelUsage;
 
 public class ExternalBeanRefTest {
 
     private static final String pkgName = "org.drools.scorecard.example";
     private static final String clsName = "Attribute";
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    
 
     @Test
-    public void test() {
-        ExternalBeanRef ref = new ExternalBeanRef("attribute", "org.drools.scorecard.example.Attribute", ModelUsage.MINING);
-        assertNotNull(ref);
-        assertEquals(pkgName, ref.getBeanPackageName());
-        assertEquals(clsName, ref.getBeanName());
+    public void testValidExternalRef() {
+        ExternalBeanRef ref;
+        try {
+            ref = new ExternalBeanRef("attribute", "org.drools.scorecard.example.Attribute", ModelUsage.MINING);
+            assertNotNull(ref);
+            assertEquals(pkgName, ref.getBeanPackageName());
+            assertEquals(clsName, ref.getBeanName());
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testExternalRefMissingPackage() {
+        ExternalBeanRef ref;
+        try {
+            ref = new ExternalBeanRef("attribute", "Attribute", ModelUsage.MINING);
+            assertNotNull(ref);
+            assertEquals(ExternalBeanDefinition.DEFAULT_BEAN_PKG, ref.getBeanPackageName());
+            assertEquals(clsName, ref.getBeanName());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testExternalRefEmptyName() throws Exception {
+        ExternalBeanRef ref;
+        thrown.expect(java.lang.IllegalArgumentException.class);
+        thrown.expectMessage("Unable to construct ExternalBeanRef.");
+        ref = new ExternalBeanRef("attribute", "", ModelUsage.MINING);
+        fail("Expected an Exception due to empty bean information string");
     }
 }


### PR DESCRIPTION
Fix for issue that caused a StringIndexOutOfBounds exception when using external types, without a package name.