### PR TITLE
[7.7.x] [DROOLS-2591] fix reloading of updated SNAPSHOT KJars

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
@@ -40,7 +40,11 @@ public class ReleaseIdImpl extends org.appformer.maven.support.AFReleaseIdImpl i
     }
 
     public static ReleaseIdImpl adapt(org.appformer.maven.support.AFReleaseId r ) {
-        return new ReleaseIdImpl(r.getGroupId(), r.getArtifactId(), r.getVersion(), ( (org.appformer.maven.support.AFReleaseIdImpl) r ).getType() );
+        final ReleaseIdImpl newReleaseIdImpl = new ReleaseIdImpl(r.getGroupId(), r.getArtifactId(), r.getVersion(), ((org.appformer.maven.support.AFReleaseIdImpl) r).getType());
+        if (r.isSnapshot()) {
+            newReleaseIdImpl.setSnapshotVersion(r.getVersion());
+        }
+        return newReleaseIdImpl;
     }
 
     public static Collection<ReleaseId> adaptAll( Collection<org.appformer.maven.support.AFReleaseId> rs ) {

--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -188,9 +188,6 @@ public class KieRepositoryScannerImpl implements InternalKieScanner {
     private InternalKieModule buildArtifact(Artifact artifact, ArtifactResolver resolver) {
         DependencyDescriptor dependencyDescriptor = new DependencyDescriptor(artifact);
         ReleaseId releaseId = adapt( dependencyDescriptor.getReleaseId() );
-        if (releaseId.isSnapshot()) {
-            ((ReleaseIdImpl)releaseId).setSnapshotVersion(artifact.getVersion());
-        }
         InternalKieModule kieModule = createKieModule(releaseId, artifact.getFile());
         if (kieModule != null) {
             addDependencies(kieModule, resolver, resolver.getArtifactDependecies(dependencyDescriptor.toString()));

--- a/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerNexusTest.java
+++ b/kie-ci/src/test/java/org/kie/scanner/KieRepositoryScannerNexusTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieModule;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
@@ -111,6 +112,9 @@ public class KieRepositoryScannerNexusTest extends AbstractKieCiTest {
         // create a ksesion and check it works as expected
         KieSession ksession = kieContainer.newKieSession("KSession1");
         checkKSession(ksession, "rule1", "rule2");
+        
+        // Store the module originally being loaded from Nexus to re-insert it, after generating a new version
+        KieModule firstModuleLoadedFromNexus = ks.getRepository().removeKieModule( releaseId );
 
         // create a new kjar
         InternalKieModule kJar2 = createKieJar(ks, releaseId, getPomWithDistributionManagement(releaseId), true, "rule2", "rule3");
@@ -120,6 +124,9 @@ public class KieRepositoryScannerNexusTest extends AbstractKieCiTest {
 
         // remove kjar from KieRepo
         ks.getRepository().removeKieModule( releaseId );
+        
+        // Insert the module once again - should be an older snapshot than the second one and therefore be replaced when getting the second one
+        ks.getRepository().addKieModule(firstModuleLoadedFromNexus);
 
         // create new KieContainer
         KieContainer kieContainer2 = ks.newKieContainer(releaseId);


### PR DESCRIPTION
Cherrypick of https://github.com/kiegroup/drools/pull/1926
Seems to be the missing backport for RHPAM-282
@mariofusco @baldimir Please take a look.