### PR TITLE
[DROOLS-2923] Improve DMN execution performance

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -52,6 +52,7 @@ import org.kie.dmn.core.impl.DMNPackageImpl;
 import org.kie.dmn.feel.util.Either;
 import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.Import;
+import org.kie.dmn.feel.util.EvalHelper;
 import org.kie.internal.builder.ResultSeverity;
 import org.kie.internal.utils.ChainedProperties;
 import org.slf4j.Logger;
@@ -73,6 +74,7 @@ public class DMNAssemblerService implements KieAssemblerService {
 
     @Override
     public void addResources(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+        EvalHelper.clearGenericAccessorCache();
         KnowledgeBuilderImpl kbuilderImpl = (KnowledgeBuilderImpl) kbuilder;
         DMNCompilerImpl dmnCompiler = (DMNCompilerImpl) kbuilderImpl.getCachedOrCreate(DMN_COMPILER_CACHE_KEY, () -> getCompiler(kbuilderImpl));
         DMNMarshaller dmnMarshaller = dmnCompiler.getMarshaller();

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -28,11 +28,11 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalQueries;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiPredicate;
@@ -49,18 +49,10 @@ public class EvalHelper {
     public static final Logger LOG = LoggerFactory.getLogger( EvalHelper.class );
     private static final Pattern SPACES_PATTERN = Pattern.compile( "[\\s\u00A0]+" );
 
-    private static final Map<String, Method> accessorCache = new HashMap<>();
-    private static final Map<String, String> normalizationCache = new HashMap<>();
+    private static final Map<String, Method> accessorCache = new ConcurrentHashMap<>();
 
     public static String normalizeVariableName(String name) {
-		if (normalizationCache.containsKey(name)){
-			return normalizationCache.get(name);
-		}
-        String normalized = SPACES_PATTERN.matcher( name.trim() ).replaceAll( " " );
-
-        normalizationCache.put(name, normalized);
-
-        return normalized;
+        return SPACES_PATTERN.matcher( name.trim() ).replaceAll( " " );
     }
 
     public static BigDecimal getBigDecimalOrNull(Object value) {
@@ -328,21 +320,14 @@ public class EvalHelper {
         String accessorQualifiedName = new StringBuilder(clazz.getCanonicalName())
 			.append(".").append(field).toString();
 
-        if (accessorCache.containsKey(accessorQualifiedName)) {
-			return accessorCache.get(accessorQualifiedName);
-        }
-
-        Method method = Stream.of( clazz.getMethods() )
-                .filter( m -> Optional.ofNullable( m.getAnnotation( FEELProperty.class ) )
-                        .map( ann -> ann.value().equals( field ) )
-                        .orElse( false )
-                )
-                .findFirst()
-                .orElse( getAccessor( clazz, field ) );
-
-        accessorCache.put(accessorQualifiedName, method);
-
-        return method;
+        return accessorCache.computeIfAbsent(accessorQualifiedName, key ->
+        	Stream.of( clazz.getMethods() )
+            .filter( m -> Optional.ofNullable( m.getAnnotation( FEELProperty.class ) )
+                    .map( ann -> ann.value().equals( field ) )
+                    .orElse( false )
+            )
+            .findFirst()
+            .orElse( getAccessor( clazz, field ) ));
     }
 
     /**

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -330,6 +330,10 @@ public class EvalHelper {
             .orElse( getAccessor( clazz, field ) ));
     }
 
+    public static void clearGenericAccessorCache() {
+        accessorCache.clear();
+    }
+
     /**
      * JavaBean -spec compliant accessor.
      * @param clazz


### PR DESCRIPTION
The DMN feel evaluation runs the same Java reflection calls for previously seen Objects, which is not performant. A cache of known accessors is added to avoid useless computation. The cache is a simple HashMap and thus does not have an eviction policy. This has an impact on memory but it is assumed that the amount of different Classes mapped to DMN rules is neglible for a single application and is naturally bounded.

Additionally, a cache is added to the normalization of variable names that was also detected as a performance bottleneck, same logic applies there.

On a simple perfomance test against a similar boolean rule using DRL the results are:
Before: DMN is x5 times slower than DRL
After: DMN is x2 times slower than DRL