### PR TITLE
[RHPAM-2] NullPointerException during transaction rollback when using CMT

### DIFF
--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
@@ -262,8 +262,18 @@ public class JtaTransactionManager
             		this.ut.rollback();
         		}
         	} else {
-        		getUt().setRollbackOnly();
-        	}
+                // use transaction sync registry if available. this works if there is tx associated
+                if (this.tsr != null) {
+                    try {
+                        ((TransactionSynchronizationRegistry) this.tsr).setRollbackOnly();
+                    } catch ( IllegalStateException e) { 
+                        getUt().setRollbackOnly();
+                    }
+                } else {
+                    // if no transaction sync registry available fallback to user transaction
+                    getUt().setRollbackOnly();
+                }
+            }
         } catch ( Exception e ) {
             logger.warn( "Unable to rollback transaction", e);
             throw new RuntimeException( "Unable to rollback transaction",


### PR DESCRIPTION
if it is not the transaction owner we try to rely on the transaction registry
and set the current tx associated as a rollback