### PR TITLE
DROOLS-2884 Guided Score Card build fails

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/base/Helper.java
+++ b/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/base/Helper.java
@@ -79,6 +79,53 @@ public class Helper {
         return GuidedScoreCardXMLPersistence.getInstance().marshal( model );
     }
 
+    /**
+     * This method creates a scorecard that does not have the fully qualified
+     * class names for the Applicant and ApplicantAttribute fact types.
+     * Note: The generated classes must be in the same package as the scorecard.
+     *
+     * @return
+     */
+    public static ScoreCardModel createGuidedScoreCardShortFactName() {
+        final ScoreCardModel model = new ScoreCardModel();
+        model.setName("test_short");
+
+        model.setPackageName("org.drools.workbench.models.guided.scorecard.backend.test2");
+        model.setReasonCodesAlgorithm( "none" );
+        model.setBaselineScore( 0.0 );
+        model.setInitialScore( 0.0 );
+
+        model.setFactName( "Applicant" );
+        model.setFieldName( "calculatedScore" );
+        model.setUseReasonCodes( false );
+        model.setReasonCodeField( "" );
+
+        final Characteristic c = new Characteristic();
+        c.setName( "c1" );
+        c.setFact( "ApplicantAttribute" );
+        c.setDataType( "int" );
+        c.setField( "attribute" );
+        c.setBaselineScore( 0.0 );
+        c.setReasonCode( "" );
+
+        final Attribute a = new Attribute();
+        a.setOperator( "=" );
+        a.setValue( "10" );
+        a.setPartialScore( 0.1 );
+        a.setReasonCode( "" );
+
+        c.getAttributes().add( a );
+        model.getCharacteristics().add( c );
+
+        return model;
+    }
+
+    /**
+     * Creates a scorecard that has the fully qualified class names
+     * for the Applicant and ApplicantAttribute fact types.
+     *
+     * @return
+     */
     public static ScoreCardModel createGuidedScoreCard() {
         final ScoreCardModel model = new ScoreCardModel();
         model.setName( "test" );
@@ -113,8 +160,8 @@ public class Helper {
         return model;
     }
 
-    public static String createGuidedScoreCardXML() {
-        final ScoreCardModel model = createGuidedScoreCard();
+    public static String createGuidedScoreCardXML(boolean useShortFactName) {
+        final ScoreCardModel model = useShortFactName ? createGuidedScoreCardShortFactName() : createGuidedScoreCard();
         return GuidedScoreCardXMLPersistence.getInstance().marshal( model );
     }
 

--- a/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/test1/GuidedScoreCardIntegrationJavaClassesOnClassPathTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/test1/GuidedScoreCardIntegrationJavaClassesOnClassPathTest.java
@@ -53,7 +53,7 @@ public class GuidedScoreCardIntegrationJavaClassesOnClassPathTest {
 
     @Test
     public void testCompletedScoreCardCompilation() throws Exception {
-        String xml1 = Helper.createGuidedScoreCardXML();
+        String xml1 = Helper.createGuidedScoreCardXML(false);
 
         KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem();
@@ -75,7 +75,7 @@ public class GuidedScoreCardIntegrationJavaClassesOnClassPathTest {
     @Test
     public void testIncrementalCompilation() throws Exception {
         String xml1_1 = Helper.createEmptyGuidedScoreCardXML();
-        String xml1_2 = Helper.createGuidedScoreCardXML();
+        String xml1_2 = Helper.createGuidedScoreCardXML(false);
 
         KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem();

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/AbstractModel.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/AbstractModel.java
@@ -116,6 +116,9 @@ public abstract class AbstractModel<T> implements PMML4Model {
                     ExternalBeanRef ref;
                     try {
                         ref = new ExternalBeanRef(field.getName(), ext.getValue(), ModelUsage.MINING);
+                        if (ExternalBeanDefinition.DEFAULT_BEAN_PKG.equals(ref.getBeanPackageName()) && this.getOwner().getRootPackage() != null) {
+                            ref.setBeanPackageName(this.getOwner().getRootPackage());
+                        }
                         externalMiningFields.add(ref);
                     } catch (IllegalArgumentException e) {
                         throw new IllegalArgumentException("Error while initializing the MiningField map. ",e);

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/inputBinding.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/inputBinding.drlt
@@ -18,15 +18,6 @@
 @declare{'inputBinding'}
 
 
- rule "Bind @{fieldName} Input from Fact @{factType}"
- @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
- dialect "mvel"
- when
-    @{factType}( $val : @{fieldName} )
- then
-    drools.getEntryPoint("in_@{compactUpperCase(fieldName)}").insert( $val );
- end
-
 @end{}
 
 

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/outputBinding.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/outputBinding.drlt
@@ -17,17 +17,6 @@
 
 @declare{'outputBinding'}
 
-
- rule "Bind @{fieldName} Output into Fact @{factType}"
- @includeNamed{ 'rule_meta.drlt'; attributes=attributes }
- dialect "mvel"
- when
-    @{compactUpperCase(fieldName)}( $val : value)
-    $x : @{factType}( @{fieldName} != $val )
- then
-    modify ( $x ) { set@{compactUpperCase(fieldName)}( $val ); }
- end
-
 @end{}
 
 


### PR DESCRIPTION
* Fixed issue that prevented build/compile when the guided scorecard referenced a type without a fully qualified name
* Updated tests to include testing for external types referenced without fully qualified names