### PR TITLE
DO NOT MERGE: DROOLS-2924  Factor out Unit behavior to allow pluggable backends

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -55,6 +55,7 @@ public class AgendaGroupQueueImpl
 
     private InternalWorkingMemory workingMemory;
     private boolean               autoDeactivate = true;
+    private boolean               keepWhenEmpty = false;
     private Map<Long, String>     nodeInstances  = new ConcurrentHashMap<Long, String>();
 
     private volatile              boolean hasRuleFlowLister;
@@ -311,6 +312,13 @@ public class AgendaGroupQueueImpl
 
     public boolean isSequential() {
         return sequential;
+    }
+
+    public void setKeepWhenEmpty(boolean keep) {
+        keepWhenEmpty = keep;
+    }
+    public boolean keepWhenEmpty() {
+        return keepWhenEmpty;
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/impl/GuardedRuleUnitSession.java
+++ b/drools-core/src/main/java/org/drools/core/impl/GuardedRuleUnitSession.java
@@ -1,0 +1,36 @@
+package org.drools.core.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.core.spi.Activation;
+import org.kie.api.runtime.rule.RuleUnit;
+
+public class GuardedRuleUnitSession extends RuleUnitSession {
+
+    private Set<Activation> activations = new HashSet<>();
+
+    public GuardedRuleUnitSession(
+            RuleUnit unit,
+            StatefulKnowledgeSessionImpl session,
+            EntryPoint entryPoint) {
+        super(unit, session, entryPoint);
+    }
+
+    public void addActivation(Activation activation) {
+        activations.add(activation);
+    }
+
+    public void removeActivation(Activation activation) {
+        activations.remove(activation);
+    }
+
+    public boolean isActive() {
+        return !activations.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "GS:" + unit();
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/impl/InternalUnitExecutorDelegate.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalUnitExecutorDelegate.java
@@ -1,0 +1,154 @@
+package org.drools.core.impl;
+
+import java.util.Collection;
+
+import org.drools.core.datasources.InternalDataSource;
+import org.drools.core.spi.Activation;
+import org.kie.api.KieBase;
+import org.kie.api.logger.KieRuntimeLogger;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.ObjectFilter;
+import org.kie.api.runtime.rule.DataSource;
+import org.kie.api.runtime.rule.RuleUnit;
+import org.kie.api.runtime.rule.RuleUnitExecutor;
+
+public class InternalUnitExecutorDelegate implements InternalRuleUnitExecutor {
+
+    private final UnitExecutor unitExecutor;
+
+    @Override
+    public int run(Class<? extends RuleUnit> ruleUnitClass) {
+        return unitExecutor.run(ruleUnitClass);
+    }
+
+    @Override
+    public int run(RuleUnit ruleUnit) {
+        return unitExecutor.run(ruleUnit);
+    }
+
+    @Override
+    public RuleUnitExecutor bind(KieBase kiebase) {
+        return unitExecutor.bind(kiebase);
+    }
+
+    @Override
+    public KieSession getKieSession() {
+        return unitExecutor.getKieSession();
+    }
+
+    @Override
+    public void runUntilHalt(Class<? extends RuleUnit> ruleUnitClass) {
+        unitExecutor.runUntilHalt(ruleUnitClass);
+    }
+
+    @Override
+    public void runUntilHalt(RuleUnit ruleUnit) {
+        unitExecutor.runUntilHalt(ruleUnit);
+    }
+
+    @Override
+    public void halt() {
+        unitExecutor.halt();
+    }
+
+    @Override
+    public <T> DataSource<T> newDataSource(String name, T... items) {
+        return unitExecutor.newDataSource(name, items);
+    }
+
+    @Override
+    public RuleUnitExecutor bindVariable(String name, Object value) {
+        return unitExecutor.bindVariable(name, value);
+    }
+
+    @Override
+    public void dispose() {
+        unitExecutor.dispose();
+    }
+
+    public InternalUnitExecutorDelegate(UnitExecutor unitExecutor) {
+        this.unitExecutor = unitExecutor;
+    }
+
+    @Override
+    public void onSuspend() {
+
+    }
+
+    @Override
+    public void onResume() {
+
+    }
+
+    @Override
+    public void switchToRuleUnit(Class<? extends RuleUnit> ruleUnitClass, Activation activation) {
+        switchToRuleUnit( unitExecutor.ruleUnitFactory.getOrCreateRuleUnit( this, ruleUnitClass ), activation );
+    }
+
+    @Override
+    public void switchToRuleUnit(RuleUnit ruleUnit, Activation activation) {
+        unitExecutor.scheduler.schedule(
+                unitExecutor.sessionFactory.create(ruleUnit), activation);
+    }
+
+    @Override
+    public void guardRuleUnit(Class<? extends RuleUnit> ruleUnitClass, Activation activation) {
+        guardRuleUnit( unitExecutor.ruleUnitFactory.getOrCreateRuleUnit( this, ruleUnitClass ), activation );
+    }
+
+    @Override
+    public void guardRuleUnit(RuleUnit ruleUnit, Activation activation) {
+        //System.out.println("REGISTERING GUARD: "+ruleUnit);
+        unitExecutor.scheduler.registerGuard(
+                unitExecutor.sessionFactory.createGuard(
+                        unitExecutor.ruleUnitFactory.registerUnit(this, ruleUnit)),
+                activation);
+    }
+
+
+    @Override
+    public void cancelActivation(Activation activation) {
+        unitExecutor.scheduler.unregisterGuard(activation);
+    }
+
+    @Override
+    public RuleUnit getCurrentRuleUnit() {
+        UnitSession current = unitExecutor.scheduler.current();
+        return current == null? null: current.unit();
+    }
+
+    @Override
+    public KieRuntimeLogger addConsoleLogger() {
+        return null;
+    }
+
+    @Override
+    public KieRuntimeLogger addFileLogger(String fileName) {
+        return null;
+    }
+
+    @Override
+    public KieRuntimeLogger addFileLogger(String fileName, int maxEventsInMemory) {
+        return null;
+    }
+
+    @Override
+    public KieRuntimeLogger addThreadedFileLogger(String fileName, int interval) {
+        return null;
+    }
+
+    @Override
+    public Collection<?> getSessionObjects() {
+        return null;
+    }
+
+    @Override
+    public Collection<?> getSessionObjects(ObjectFilter filter) {
+        return null;
+    }
+
+    @Override
+    public void bindDataSource(InternalDataSource dataSource) {
+        unitExecutor.bindDataSource(dataSource);
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/impl/RuleUnitSession.java
+++ b/drools-core/src/main/java/org/drools/core/impl/RuleUnitSession.java
@@ -1,0 +1,197 @@
+package org.drools.core.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.drools.core.common.AgendaGroupQueueImpl;
+import org.drools.core.common.InternalAgenda;
+import org.drools.core.common.InternalAgendaGroup;
+import org.drools.core.ruleunit.RuleUnitDescr;
+import org.drools.core.spi.Activation;
+import org.drools.core.spi.AgendaGroup;
+import org.kie.api.runtime.Globals;
+import org.kie.api.runtime.rule.RuleUnit;
+
+public class RuleUnitSession implements UnitSession {
+
+
+    private boolean yielded = false;
+
+    @Override
+    public RuleUnit unit() {
+        return ruleUnit;
+    }
+
+    @Override
+    public void halt() {
+        unbindRuleUnit();
+    }
+
+    @Override
+    public void fireUntilHalt() {
+        bindRuleUnit();
+        try {
+            session.fireUntilHalt();
+        } finally {
+            unbindRuleUnit();
+        }
+    }
+
+    private final StatefulKnowledgeSessionImpl session;
+    private final Agenda agenda;
+    private final EntryPoint entryPoint;
+    private RuleUnit ruleUnit;
+    private RuleUnitDescr ruleUnitDescr;
+    private final Set<GuardedRuleUnitSession> guards = new HashSet<>();
+
+    private AtomicBoolean suspended = new AtomicBoolean(false);
+
+    public RuleUnitSession(
+            RuleUnit unit,
+            StatefulKnowledgeSessionImpl session,
+            EntryPoint entryPoint) {
+        this.ruleUnit = unit;
+        this.session = session;
+        this.agenda = new Agenda(session);
+        this.entryPoint = entryPoint;
+    }
+
+    @Override
+    public int fireAllRules() {
+        bindRuleUnit();
+        try {
+            return session.fireAllRules();
+        } finally {
+            unbindRuleUnit();
+        }
+    }
+
+    public void bindRuleUnit() {
+        suspended.set(false);
+        ruleUnit.onStart();
+
+        entryPoint.bind(ruleUnit);
+
+        this.ruleUnitDescr = session.kBase.getRuleUnitRegistry().getRuleUnitDescr(ruleUnit);
+        getGlobalResolver().setDelegate(new RuleUnitGlobals(ruleUnitDescr, ruleUnit));
+        ruleUnitDescr.bindDataSources(session, ruleUnit);
+
+        agenda.focus(ruleUnit);
+    }
+
+    private void unbindRuleUnit() {
+        if (yielded) {
+            yielded = false;
+            return;
+        }
+        ruleUnitDescr.unbindDataSources(session, ruleUnit);
+        (getGlobalResolver()).setDelegate(null);
+        ruleUnit.onEnd();
+        suspended.set(true);
+    }
+
+    @Override
+    public void yield(RuleUnit unit) {
+        yielded = true;
+        ruleUnit.onYield(unit);
+        session.getPropagationList().flush();
+        agenda.unfocus(ruleUnit);
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public void registerGuard(GuardedRuleUnitSession session, Activation activation) {
+        guards.add(session);
+        session.addActivation(activation);
+    }
+
+    @Override
+    public void unregisterGuard(Activation activation) {
+        guards.forEach(g -> g.removeActivation(activation));
+    }
+
+    @Override
+    public Collection<GuardedRuleUnitSession> getGuards() {
+        return Collections.unmodifiableCollection(guards);
+    }
+
+    private Globals getGlobalResolver() {
+        return (Globals) session.getGlobalResolver();
+    }
+
+    private static class RuleUnitGlobals implements Globals {
+
+        private final RuleUnitDescr ruDescr;
+        private final RuleUnit ruleUnit;
+
+        private RuleUnitGlobals(RuleUnitDescr ruDescr, RuleUnit ruleUnit) {
+            this.ruDescr = ruDescr;
+            this.ruleUnit = ruleUnit;
+        }
+
+        @Override
+        public Object get(String identifier) {
+            return ruDescr.getValue(ruleUnit, identifier);
+        }
+
+        @Override
+        public void set(String identifier, Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setDelegate(Globals delegate) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<String> getGlobalKeys() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "S:" + unit().getClass().getSimpleName();
+    }
+
+    private static class Agenda {
+        private static final String EMPTY_AGENDA = "$$$EMPTY_AGENDA$$";
+        final StatefulKnowledgeSessionImpl session;
+
+        Agenda(StatefulKnowledgeSessionImpl session) {
+            this.session = session;
+        }
+
+        void focus(RuleUnit unit) {
+            InternalAgenda agenda = session.getAgenda();
+            InternalAgendaGroup unitGroup = (InternalAgendaGroup) agenda.getAgendaGroup(unit.getClass().getName());
+            unitGroup.setAutoDeactivate(false);
+            unitGroup.setFocus();
+        }
+        void unfocus(RuleUnit unit) {
+            InternalAgenda agenda = session.getAgenda();
+            AgendaGroup agendaGroup = agenda.getAgendaGroup(unit.getClass().getName());
+            agenda.getStackList().remove(agendaGroup);
+
+            AgendaGroupQueueImpl unitGroup =
+                    (AgendaGroupQueueImpl) session.getAgenda().getAgendaGroup(EMPTY_AGENDA);
+            unitGroup.setAutoDeactivate(false);
+            unitGroup.setKeepWhenEmpty(true);
+            unitGroup.setFocus();
+
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -771,14 +771,14 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     public String getEntryPointId() {
         return EntryPointId.DEFAULT.getEntryPointId();
     }
-    
+
     /**
-     * (This shall NOT be exposed on public API)  
+     * (This shall NOT be exposed on public API)
      */
     public QueryResultsImpl getQueryResultsFromRHS(String queryName, Object... arguments) {
     	return internalGetQueryResult(true, queryName, arguments);
     }
-    
+
     public QueryResultsImpl getQueryResults(String queryName, Object... arguments) {
     	return internalGetQueryResult(false, queryName, arguments);
     }
@@ -945,7 +945,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
             done(tnodes);
         }
-        
+
         @Override
         public boolean isCalledFromRHS() {
         	return calledFromRHS;

--- a/drools-core/src/main/java/org/drools/core/impl/UnitExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/impl/UnitExecutor.java
@@ -1,0 +1,128 @@
+package org.drools.core.impl;
+
+import org.drools.core.datasources.CursoredDataSource;
+import org.drools.core.datasources.InternalDataSource;
+import org.drools.core.ruleunit.RuleUnitFactory;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.DataSource;
+import org.kie.api.runtime.rule.RuleUnit;
+import org.kie.api.runtime.rule.RuleUnitExecutor;
+
+public final class UnitExecutor implements RuleUnitExecutor {
+
+    public final UnitScheduler scheduler;
+    public final RuleUnitFactory ruleUnitFactory;
+    public final UnitSession.Factory sessionFactory;
+    private StatefulKnowledgeSessionImpl session;
+
+    public UnitExecutor() {
+        this.session = new StatefulKnowledgeSessionImpl();
+        this.sessionFactory = UnitSession.Factory.of(
+                this, this.session);
+        this.scheduler = new UnitScheduler();
+        this.ruleUnitFactory = new RuleUnitFactory();
+    }
+
+    public UnitExecutor(KieSession session) {
+        this.session = (StatefulKnowledgeSessionImpl) session;
+        this.sessionFactory = UnitSession.Factory.of(
+                this, this.session);
+        this.scheduler = new UnitScheduler();
+        this.ruleUnitFactory = new RuleUnitFactory();
+    }
+
+    @Override
+    public int run(Class<? extends RuleUnit> ruleUnitClass) {
+        RuleUnit unit = ruleUnitFactory.getOrCreateRuleUnit(
+                new InternalUnitExecutorDelegate(this), ruleUnitClass);
+        UnitSession session = sessionFactory.create(unit);
+        return runSession(session);
+    }
+
+    @Override
+    public int run(RuleUnit ruleUnit) {
+        RuleUnit unit = ruleUnitFactory.injectUnitVariables(
+                new InternalUnitExecutorDelegate(this), ruleUnit);
+        UnitSession session = sessionFactory.create(unit);
+        return runSession(session);
+    }
+
+    private int runSession(UnitSession session) {
+        int fired = 0;
+        scheduler.schedule(session);
+        session = scheduler.next();
+        while (session != null) {
+            fired += session.fireAllRules();
+            session = scheduler.next();
+        }
+        return fired;
+    }
+
+    @Override
+    public RuleUnitExecutor bind(KieBase kiebase) {
+        InternalKnowledgeBase kb = (InternalKnowledgeBase) kiebase;
+        if (!kb.hasUnits()) {
+            throw new IllegalStateException(
+                    "Cannot create a RuleUnitExecutor against a KieBase without units");
+        }
+        sessionFactory.bind(kb);
+        return this;
+    }
+
+    @Override
+    public KieSession getKieSession() {
+        return session;
+    }
+
+    @Override
+    public void runUntilHalt(Class<? extends RuleUnit> ruleUnitClass) {
+        runUntilHalt(ruleUnitFactory.getOrCreateRuleUnit(
+                new InternalUnitExecutorDelegate(this), ruleUnitClass));
+    }
+
+    @Override
+    public void runUntilHalt(RuleUnit ruleUnit) {
+        UnitSession session = sessionFactory.create(ruleUnit);
+        scheduler.schedule(session);
+        scheduler.next();
+        session.fireUntilHalt();
+    }
+
+    @Override
+    public void halt() {
+        scheduler.halt();
+    }
+
+    @Override
+    public <T> DataSource<T> newDataSource(String name, T... items) {
+        DataSource<T> dataSource = new CursoredDataSource(session);
+        for (T item : items) {
+            dataSource.insert(item);
+        }
+        ruleUnitFactory.bindVariable(name, dataSource);
+        return dataSource;
+    }
+
+    @Override
+    public RuleUnitExecutor bindVariable(String name, Object value) {
+        ruleUnitFactory.bindVariable(name, value);
+        if (value instanceof InternalDataSource) {
+            bindDataSource((InternalDataSource) value);
+        }
+        return this;
+    }
+
+    public void bindDataSource(InternalDataSource dataSource) {
+        dataSource.setWorkingMemory(session);
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+
+    public static UnitExecutor create() {
+        return new UnitExecutor();
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/impl/UnitScheduler.java
+++ b/drools-core/src/main/java/org/drools/core/impl/UnitScheduler.java
@@ -1,0 +1,84 @@
+package org.drools.core.impl;
+
+import java.util.LinkedList;
+
+import org.drools.core.spi.Activation;
+
+public class UnitScheduler {
+
+    private final LinkedList<UnitSession> units = new LinkedList<>();
+    private UnitSession stackPointer;
+
+    public UnitScheduler() {
+
+    }
+
+    public void schedule(UnitSession session) {
+        stackPointer = null;
+        units.push(session);
+    }
+
+    public void schedule(UnitSession session, Activation activation) {
+        if (isActivatedUnit(stackPointer, activation)) {
+            current().yield(session.unit());
+            schedule(stackPointer);
+            schedule(session);
+        } else {
+            scheduleRelative(session, activation);
+        }
+    }
+
+    public void scheduleRelative(UnitSession session, Activation activation) {
+        int idx = findActivatedUnit(activation);
+        units.add(idx, session);
+    }
+
+    public int findActivatedUnit(Activation activation) {
+        for (int i = 0; i < units.size(); i++) {
+            if (isActivatedUnit(units.get(i), activation)) {
+                return i;
+            }
+        }
+        throw new ArrayIndexOutOfBoundsException("Cannot find Unit for activation " + activation);
+    }
+
+    private boolean isActivatedUnit(UnitSession unitSession, Activation activation) {
+        return unitSession != null &&
+                unitSession.unit().getClass().getName().equals(
+                        activation.getRule().getRuleUnitClassName());
+    }
+
+    public UnitSession current() {
+        return stackPointer;
+    }
+
+    public UnitSession next() {
+        if (stackPointer != null) {
+            stackPointer.getGuards().stream()
+                    .filter(GuardedRuleUnitSession::isActive)
+                    .forEach(units::add);
+        }
+        stackPointer = units.poll();
+        return stackPointer;
+    }
+
+    public void halt() {
+        current().halt();
+    }
+
+    public void registerGuard(GuardedRuleUnitSession session, Activation activation) {
+        stackPointer.registerGuard(session, activation);
+        session.addActivation(activation);
+    }
+
+    public void unregisterGuard(Activation activation) {
+        if (stackPointer != null) {
+            stackPointer.unregisterGuard(activation);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "UnitScheduler(" + stackPointer + "::" + units + ")";
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/impl/UnitSession.java
+++ b/drools-core/src/main/java/org/drools/core/impl/UnitSession.java
@@ -1,0 +1,120 @@
+package org.drools.core.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.core.SessionConfigurationImpl;
+import org.drools.core.event.AgendaEventSupport;
+import org.drools.core.event.RuleEventListenerSupport;
+import org.drools.core.event.RuleRuntimeEventSupport;
+import org.drools.core.spi.Activation;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.api.runtime.rule.RuleUnit;
+
+import static org.drools.core.ruleunit.RuleUnitUtil.RULE_UNIT_ENTRY_POINT;
+
+public interface UnitSession {
+
+    RuleUnit unit();
+
+    void halt();
+
+    void fireUntilHalt();
+
+    int fireAllRules();
+
+    void yield(RuleUnit unit);
+
+    void dispose();
+
+    boolean isActive();
+
+    void registerGuard(GuardedRuleUnitSession session, Activation activation);
+
+    void unregisterGuard(Activation activation);
+
+    Collection<GuardedRuleUnitSession> getGuards();
+
+    class EntryPoint {
+
+        private final StatefulKnowledgeSessionImpl session;
+        private final Map<Class<?>, FactHandle> registry = new HashMap<>();
+
+        public EntryPoint(StatefulKnowledgeSessionImpl session) {
+            this.session = session;
+        }
+
+        public void bind(RuleUnit unit) {
+            registry.computeIfAbsent(unit.getClass(),
+                                     c -> session.getEntryPoint(RULE_UNIT_ENTRY_POINT).insert(unit));
+        }
+    }
+
+    class Registry {
+
+        private final Map<RuleUnit.Identity, UnitSession> registry = new HashMap<>();
+
+        <T extends UnitSession> T register(T session) {
+            if (registry.containsKey(session.unit().getUnitIdentity())) {
+                return (T) registry.get(session.unit().getUnitIdentity());
+            } else {
+                registry.put(session.unit().getUnitIdentity(), session);
+                return session;
+            }
+        }
+
+        public UnitSession get(RuleUnit unit) {
+            return registry.get(unit.getUnitIdentity());
+        }
+    }
+
+    class Factory {
+
+        private final StatefulKnowledgeSessionImpl session;
+        private final EntryPoint entryPoint;
+        private final Registry registry;
+        private InternalKnowledgeBase kiebase;
+
+        public Factory(UnitExecutor executor, StatefulKnowledgeSessionImpl session) {
+            this.session = session;
+            this.kiebase = (InternalKnowledgeBase) session.getKieBase();
+            this.entryPoint = new EntryPoint(session);
+            this.registry = new Registry();
+
+            this.session.init(
+                    new SessionConfigurationImpl(),
+                    EnvironmentFactory.newEnvironment());
+
+            this.session.ruleUnitExecutor = new InternalUnitExecutorDelegate(executor);
+            this.session.agendaEventSupport = new AgendaEventSupport();
+            this.session.ruleRuntimeEventSupport = new RuleRuntimeEventSupport();
+            this.session.ruleEventListenerSupport = new RuleEventListenerSupport();
+        }
+
+        public static Factory of(UnitExecutor executor, StatefulKnowledgeSessionImpl session) {
+            return new Factory(executor, session);
+        }
+
+        public RuleUnitSession create(RuleUnit unit) {
+            return registry.register(new RuleUnitSession(
+                    unit,
+                    session,
+                    entryPoint));
+        }
+
+        public GuardedRuleUnitSession createGuard(RuleUnit unit) {
+            return registry.register(new GuardedRuleUnitSession(
+                    unit,
+                    session,
+                    entryPoint));
+        }
+
+        public void bind(InternalKnowledgeBase kiebase) {
+            this.kiebase = kiebase;
+            this.session.handleFactory = kiebase.newFactHandleFactory();
+            this.session.bindRuleBase(kiebase, null, false);
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -18,6 +18,7 @@ package org.drools.core.phreak;
 import java.util.Comparator;
 
 import org.drools.core.base.SalienceInteger;
+import org.drools.core.common.AgendaGroupQueueImpl;
 import org.drools.core.common.AgendaItem;
 import org.drools.core.common.DefaultAgenda;
 import org.drools.core.common.EventFactHandle;
@@ -249,6 +250,9 @@ public class RuleExecutor {
 
         // The eager list must be evaluated first, as dynamic salience rules will impact the results of peekNextRule
         agenda.evaluateEagerList();
+
+        AgendaGroupQueueImpl nextFocus = (AgendaGroupQueueImpl) agenda.getNextFocus();
+        if (nextFocus.keepWhenEmpty()) return true; // fixme only when it is not current group
 
         RuleAgendaItem nextRule = agenda.peekNextRule();
         return nextRule != null && (!ruleAgendaItem.getAgendaGroup().equals( nextRule.getAgendaGroup() ) || !isHigherSalience(nextRule));


### PR DESCRIPTION
This is still partially incomplete, but it should pass all unit-related tests -- a change is required in `kie-api` to enable it though, otherwise it uses the current impl: I will open a separate PR. 

Currently I just want feedback / code review for the code. The meat is in

- UnitExecutor
- UnitSession (and subtypes -- currently RuleUnitSession and GuardedRuleUnitSession) 
- UnitScheduler

**UnitExecutor** exposes the public API. Forwards units to the scheduler, and, for `run()`, it pulls from the scheduler one UnitSession at a time, and invokes its `fireAllRules()`, until no more UnitSessions are available. Notice that the *InternalRuleUnitExecutor* interface is implemented as a wrapper around UnitExecutor (`InternalUnitExecutorDelegate`) because they do not need to share state. I think that eventually we might even get rid of this interface altogether.

**UnitSession** wraps a (stateful) session and transparently manages binding and unbinding of the Unit. To the Executor, the session is invisible. There are two types, RuleUnitSession and GuardedRuleUnitSession; the latter only differs from the former, because it holds a set of `Activation` records. Each `RuleUnitSession` also contains a collection `GuarderRuleUnitSessions` that it refers to.  

**UnitScheduler** inserts rule units and guarded rule units to an internal stack-like structure. For each RuleUnitSession, it also checks if it contains any GuardedRuleUnitSessions (notice this is recursive, because a GuardedRuleUnitSession is a subclass of RuleUnitSession); if it does, and these are `active` (they have >0 Activation records) then it schedules the Guarded session(s) as well.

I would like to review a bit how the guarding mechanism is implemented, because I think there could be a way to streamline it a little bit.

(once complete: please do squash before merge)
