### PR TITLE
RHPAM-1500 PMML compilation problem with weightedAverage mining operator

### DIFF
--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/mining/MiningSegmentWeight.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/mining/MiningSegmentWeight.java
@@ -63,12 +63,16 @@ public class MiningSegmentWeight {
 		return segmentValue;
 	}
 
+	public Double getSegmentValueAsDouble() {
+		return segmentValue != null ? segmentValue.doubleValue() : null;
+	}
+
 	public void setSegmentValue(Number segmentValue) {
 		this.segmentValue = segmentValue;
 	}
 	
 	public Number getWeightedSegmentValue() {
-		return this.segmentValue.doubleValue() * this.weight;
+		return segmentValue != null ? segmentValue.doubleValue() * weight : null;
 	}
 
 	@Override

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/weightedAvg.mvel
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/weightedAvg.mvel
@@ -32,7 +32,7 @@ import org.kie.api.runtime.rule.FactHandle;
 @code{ int salienceValue; }
 @code{ String nextSegmentId; }
 
-declare WeightedAvg_@{miningModel.targetField}
+declare @{miningModel.targetField}
    value: Number
    weight: Double
 end
@@ -74,7 +74,7 @@ end
 rule "Set result value for segment"
 when
    $segExec: SegmentExecution( $segmId: segmentationId, $segId: segmentId, state == SegmentExecutionState.COMPLETE, $res: result != null ) from childModelSegments
-   $result: PMML4Result( this == $res, resultVariables != null ) from results
+   $result: PMML4Result( segmentationId != null, segmentId != null, this == $res, resultVariables != null ) from results
    $msw: MiningSegmentWeight( segmentationId == $segmId, segmentId == $segId, $targ: targetName != null )
 then
    Number n = $result.getResultValue($targ,"value",Number.class).orElse(null);
@@ -83,22 +83,42 @@ then
    }
 end
 
-
 rule "Calculate weighted average"
 salience -100
 when
    forall( SegmentExecution( state == SegmentExecutionState.COMPLETE || == SegmentExecutionState.ERROR ) )
-   accumulate( MiningSegmentWeight( $wt: weight, $val: weightedSegmentValue ); $sweight: sum($wt), $svalue: sum($val) )
-   $reslt: PMML4Result( segmentId == null, resultVariables == null || "WeightedAvg_@{miningModel.targetField}" not memberOf resultVariables.keySet() ) from results
+   accumulate( MiningSegmentWeight( $wt: weight != null, segmentValue != null ); $sweight: sum($wt) )
+   accumulate( MiningSegmentWeight( $w: weight != null, segmentValue != null, $val: segmentValueAsDouble ); $svalue: sum( $w / $sweight * $val ) )
+   $reslt: PMML4Result( segmentId == null, resultVariables == null ) from results
 then
-   WeightedAvg_@{miningModel.targetField} target = new WeightedAvg_@{miningModel.targetField}();
+   @{miningModel.targetField} target = new @{miningModel.targetField}();
    target.setValue($svalue);
    target.setWeight($sweight);
    FactHandle fh = ((org.drools.core.datasources.InternalDataSource)results).getFactHandleForObject($reslt);
    $reslt.setResultCode("OK");
-   $reslt.addResultVariable("WeightedAvg_@{miningModel.targetField}",target);
+   $reslt.addResultVariable("@{miningModel.targetField}",target);
    results.update(fh,$reslt);
 end
+
+rule "Calculate weighted average updating @{miningModel.targetField}"
+salience -100
+when
+   forall( SegmentExecution( state == SegmentExecutionState.COMPLETE || == SegmentExecutionState.ERROR ) )
+   accumulate( MiningSegmentWeight( $wt: weight != null, segmentValue != null ); $sweight: sum($wt) )
+   accumulate( MiningSegmentWeight( $w: weight != null, segmentValue != null, $val: segmentValueAsDouble ); $svalue: sum( $w / $sweight * $val ) )
+   $reslt: PMML4Result( segmentId == null, $res: resultVariables ) from results
+   not @{packageName}.@{miningModel.targetField}() from $res["@{miningModel.targetField}"]
+then
+   @{miningModel.targetField} target = new @{miningModel.targetField}();
+   target.setValue($svalue);
+   target.setWeight($sweight);
+   FactHandle fh = ((org.drools.core.datasources.InternalDataSource)results).getFactHandleForObject($reslt);
+   $reslt.setResultCode("OK");
+   $reslt.addResultVariable("@{miningModel.targetField}",target);
+   results.update(fh,$reslt);
+end
+
+
 
 
 rule "Insert Segment Weights"
@@ -107,6 +127,23 @@ when
 then
    @foreach{ childSegment: childSegments }
    insert( new MiningSegmentWeight( "@{childSegment.owner.segmentationId}", "@{childSegment.segmentId}", "@{childSegment.targetForWeighting}", @{childSegment.weight} ) );
+   @end{}
+end
+
+rule "Insert Segment Executions"
+salience 1000
+when
+   model: @{miningModel.miningPojoClassName}( ) from miningModelPojo
+then
+   SegmentExecution segEx = null;
+   @foreach{ childSegment: childSegments }
+   segEx = new SegmentExecution( model.getCorrelationId(),
+                                 "@{childSegment.owner.segmentationId}",
+                                 "@{childSegment.segmentId}",
+                                 @{childSegment.segmentIndex},
+                                 "@{childSegment.segmentRuleUnit}");
+   segEx.setState(SegmentExecutionState.UNKNOWN);
+   childModelSegments.insert(segEx);
    @end{}
 end
 
@@ -144,18 +181,16 @@ rule "Check Segment Can Fire - Segment @{childSegment.segmentId}"
 salience @{salienceValue}
 when
    model: @{miningModel.miningPojoClassName}( @{childSegment.predicateText} ) from miningModelPojo
+   segEx: SegmentExecution( segmentId == "@{childSegment.segmentId}", state == SegmentExecutionState.UNKNOWN ) from childModelSegments
 then
    PMMLRequestData rqstData = new PMMLRequestData(model.getCorrelationId(),"@{childSegment.model.modelId}");
    @foreach{ field: childSegment.model.miningFields }
    rqstData.addRequestParam( "@{field.name}",model.getV@{field.compactUpperCaseName}() );
    @end{}
-   SegmentExecution segEx = new SegmentExecution( model.getCorrelationId(),
-                                                  "@{childSegment.owner.segmentationId}",
-                                                  "@{childSegment.segmentId}",
-                                                   @{childSegment.segmentIndex},
-                                                  "@{childSegment.segmentRuleUnit}");
-   segEx.setRequestData(rqstData);
-   childModelSegments.insert(segEx);
+   modify( segEx ) {
+      setRequestData(rqstData),
+      setState(SegmentExecutionState.WAITING)
+   };
 end
 
 

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/MiningmodelTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/MiningmodelTest.java
@@ -307,9 +307,9 @@ public class MiningmodelTest extends DroolsAbstractPMMLTest {
                 .build();
         PMML4Result resultHolder = helper.submitRequest(request);
 
-        Double sepal_length = resultHolder.getResultValue("WeightedAvg_Sepal_length", "value",Double.class).orElse(null);
+        Double sepal_length = resultHolder.getResultValue("Sepal_length", "value",Double.class).orElse(null);
         assertEquals(7.1833385,sepal_length,1e-6);
-        Double weight = resultHolder.getResultValue("WeightedAvg_Sepal_length", "weight", Double.class).orElse(null);
+        Double weight = resultHolder.getResultValue("Sepal_length", "weight", Double.class).orElse(null);
         assertEquals(1.00, weight, 1e-2);
     }
 

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelWeightedAverageTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelWeightedAverageTest.java
@@ -16,11 +16,13 @@
 
 package org.kie.pmml.pmml_4_2.predictive.models.mining;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,11 +32,7 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.pmml.pmml_4_2.PMML4ExecutionHelper;
 import org.kie.pmml.pmml_4_2.PMMLRequestDataBuilder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 @RunWith(Parameterized.class)
-@Ignore("RHPAM-1500")
 public class MiningModelWeightedAverageTest {
 
     private static final String PMML_SOURCE = "org/kie/pmml/pmml_4_2/test_mining_model_weighted_avg_regression.pmml";
@@ -79,6 +77,7 @@ public class MiningModelWeightedAverageTest {
         input2.ifPresent(x -> rdb.addParameter(INPUT2_FIELD_NAME, x, Double.class));
         input3.ifPresent(x -> rdb.addParameter(INPUT3_FIELD_NAME, x, Double.class));
         PMMLRequestData request = rdb.build();
+
         helper.submitRequest(request);
         helper.getResultData().iterator().forEachRemaining(rd -> {
             assertEquals(request.getCorrelationId(), rd.getCorrelationId());


### PR DESCRIPTION
* Removed @Ignore from MiningModelWeightedAverageTest
* Added a method to get the Double value from the MiningSegmentWeight
* Fixed errors in the weightedAvg.mvel including
  - making sure that the correct PMML4Result is used for setting a MiningSegmentWeight
  - making sure that the correct PMML4Result gets the weighted average for its target field
  - making sure that the all possible SegmentExecutions are inserted prior to starting any SegmentExecution
  - updating the "Check Segment Can Fire" rules to update the proper SegmentExecution, instead of inserting a new one
* Fixed tests in MiningmodelTest that were broken by the above fixes