### PR TITLE
DROOLS-2972 Don't use Collections.emptyList() as a class provided to PMML template

### DIFF
--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderPMMLTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderPMMLTest.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import static org.junit.Assert.*;
 import static org.kie.internal.builder.ScoreCardConfiguration.SCORECARD_INPUT_TYPE;
 
-@Ignore
 public class ScorecardProviderPMMLTest {
 
     private static String drl;

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardProviderTest.java
@@ -58,7 +58,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
-@Ignore
 public class ScorecardProviderTest {
 
     private static String drl;

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardReasonCodeTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardReasonCodeTest.java
@@ -58,7 +58,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Ignore
 public class ScorecardReasonCodeTest {
 
     @Test

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardsKModuleTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScorecardsKModuleTest.java
@@ -32,7 +32,6 @@ import org.kie.pmml.pmml_4_2.PMMLRequestDataBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Ignore
 public class ScorecardsKModuleTest {
 
     @Before

--- a/drools-scorecards/src/test/java/org/drools/scorecards/ScoringStrategiesTest.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/ScoringStrategiesTest.java
@@ -48,7 +48,6 @@ import java.io.InputStream;
 import static org.junit.Assert.*;
 import static org.drools.scorecards.ScorecardCompiler.DrlType.INTERNAL_DECLARED_TYPES;
 
-@Ignore
 public class ScoringStrategiesTest {
 
     @Before

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
@@ -546,20 +546,6 @@ public class PMML4Compiler {
         return javaClasses;
     }
 
-    public List<PMMLResource> precompile(String fileName, ClassLoader classLoader, KieBaseModel rootKieBaseModel) {
-        InputStream is = getInputStreamByFileName(fileName);
-        List<PMMLResource> resources = null;
-        if (is != null) {
-            try {
-                resources = precompile(is, classLoader, rootKieBaseModel);
-            } catch (Exception e) {
-                PMMLError err = new PMMLError("Unable to retrieve pre-compiled resources for PMML: " + e.getMessage());
-                this.results.add(err);
-            }
-        }
-        return (resources != null) ? resources : new ArrayList<>();
-    }
-
     public List<PMMLResource> precompile(InputStream stream, ClassLoader classLoader, KieBaseModel rootKieBaseModel) {
         List<PMMLResource> resources = new ArrayList<>();
         KieServices services = KieServices.Factory.get();

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/AbstractModel.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/AbstractModel.java
@@ -251,7 +251,11 @@ public abstract class AbstractModel<T> implements PMML4Model {
                     .distinct()
                     .collect(Collectors.toList());
         }
-        return list != null ? list : new ArrayList<>();
+        // DO NOT USE Collections.emptyList() here!!! emptyList() returns an EmptyList instance
+        // which is an internal class from Collections class, therefore not accessible
+        // by reflection - when mvel parses a RuleUnit template and there is
+        // a size call, it tries to invoke the method using reflection
+        return list != null ? list : new ArrayList<>(0);
     }
 
     public List<ExternalBeanRef> getExternalMiningFields() {

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/PMMLDataField.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/PMMLDataField.java
@@ -15,48 +15,44 @@
  */
 package org.kie.pmml.pmml_4_2.model;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.dmg.pmml.pmml_4_2.descr.DATATYPE;
 import org.dmg.pmml.pmml_4_2.descr.DataField;
-import org.dmg.pmml.pmml_4_2.descr.Interval;
 import org.dmg.pmml.pmml_4_2.descr.MiningField;
 import org.dmg.pmml.pmml_4_2.descr.OutputField;
 import org.kie.pmml.pmml_4_2.PMML4Helper;
 
 public class PMMLDataField {
+
     private String type;
     private String name;
     private DataField dataDictionaryField;
     private static PMML4Helper helper = new PMML4Helper();
-    
+
     public PMMLDataField(String name, DATATYPE type) {
-    	this.name = name;
-    	this.type = helper.mapDatatype(type, true);
+        this.name = name;
+        this.type = helper.mapDatatype(type, true);
     }
-    
+
     public PMMLDataField(MiningField miningField, DataField field) {
-    	this.name = miningField.getName();
-    	if (field != null) {
-    		this.type = helper.mapDatatype(field.getDataType(), true);
-    	}
-    	this.dataDictionaryField = field;
+        this.name = miningField.getName();
+        if (field != null) {
+            this.type = helper.mapDatatype(field.getDataType(), true);
+        }
+        this.dataDictionaryField = field;
     }
-    
+
     public PMMLDataField(OutputField outputField, DataField field) {
-    	this.name = outputField.getName();
-    	if (outputField.getDataType() != null) {
-    		this.type = helper.mapDatatype(outputField.getDataType(), true);
-    	} else if (field != null) {
-    		this.type = helper.mapDatatype(field.getDataType(), true);
-    	}
-    	this.dataDictionaryField = field;
+        this.name = outputField.getName();
+        if (outputField.getDataType() != null) {
+            this.type = helper.mapDatatype(outputField.getDataType(), true);
+        } else if (field != null) {
+            this.type = helper.mapDatatype(field.getDataType(), true);
+        }
+        this.dataDictionaryField = field;
     }
 
     public PMMLDataField(DataField field) {
-        this.type = helper.mapDatatype(field.getDataType(),true);
+        this.type = helper.mapDatatype(field.getDataType(), true);
         this.name = helper.compactAsJavaId(field.getName());
         this.dataDictionaryField = field;
     }
@@ -80,19 +76,12 @@ public class PMMLDataField {
     public String getCompactUpperCaseName() {
         return helper.compactUpperCase(name);
     }
-    
-    public List<Interval> getIntervals() {
-    	if (dataDictionaryField != null) {
-    		return dataDictionaryField.getIntervals();
-    	}
-    	return new ArrayList<>();
-    }
 
     public DataField getRawDataField() {
-		return dataDictionaryField;
-	}
+        return dataDictionaryField;
+    }
 
-	@Override
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <module>drools-templates</module>
     <module>drools-decisiontables</module>
     <module>drools-examples</module>
-    <module>drools-scorecards</module>
     <module>kie-ci</module>
     <module>kie-ci-osgi</module>
     <module>drools-model</module>
     <module>kie-dmn</module>
     <module>kie-pmml</module>
+    <module>drools-scorecards</module>
     <module>drools-examples-api</module>
     <module>drools-examples-cdi</module>
     <module>drools-workbench-models</module>


### PR DESCRIPTION
- This fixes the failing Scorecard tests

Collections.emptyList() returns an EmptyList instance, which is then checked with reflection during RuleUnit generation process - mvel tries to call size() on the EmptyList through reflection, which fails, because EmptyList is an internal private class of Collections class (so it is not accessible with reflection). 

@jiripetrlik @lanceleverich please be aware that the randomness of the failures indicates that there might be another bug in the RuleUnit generation process, because it implies that EmptyList class was not generated all the time for the RuleUnit. Mentioning this because it could be a good area to extend test coverage, so we find out what is going on in case of the randomness. 