### PR TITLE
DROOLS-2592 PMML - Fix race conditions caused by corner cases of used "after" and "before" operators

### DIFF
--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/inputFromEP.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/inputFromEP.drlt
@@ -53,7 +53,7 @@ dialect "java"
 salience 2
 when
    $new: PMML4Data( name == "@{rawName}", $value: value ) from pmmlData
-   $old: PMML4Data( name == $new.name, value != $value, this before $new ) from pmmlData
+   $old: PMML4Data( this != $new, name == $new.name, value != $value, this before[0] $new ) from pmmlData
 then
    retract($old);
 end

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/updateIOField.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/dataDefinition/updateIOField.drlt
@@ -38,7 +38,7 @@ salience 2000
 
 when
    $new: PMML4Data( $cid: correlationId != null, capitalizedName == "@{name}", $ctx : context == @if{context != null} @{format("string",context)} @else{} null @end{} ) from pmmlData
-   $old: PMML4Data( correlationId == $cid, name == $new.name, context == $ctx, this before $new ) from pmmlData
+   $old: PMML4Data( this != $new, correlationId == $cid, name == $new.name, context == $ctx, this before[0] $new ) from pmmlData
 then
     retract( $old );
 end

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/pmml_header.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/global/pmml_header.drlt
@@ -74,7 +74,7 @@ rule "Override Value"
 salience 2
 when
    $new: PMML4Data( $value: value ) from pmmlData
-   $old: PMML4Data( name == $new.name, value != $value, this before $new ) from pmmlData
+   $old: PMML4Data( this != $new, name == $new.name, value != $value, this before[0] $new ) from pmmlData
 then
    retract($old);
 end

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/scorecard/scorecardOutputRankCode.drlt
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/models/scorecard/scorecardOutputRankCode.drlt
@@ -71,7 +71,7 @@ salience -10
 when
    $reslt: PMML4Result( "@{target}" memberOf resultVariables.keySet() ) from results
    $old: @{target}( ) from $reslt.resultVariables["@{target}"]
-   $new: @{target}( this after $old)
+   $new: @{target}( this != $old, this after[0] $old)
 then
    $reslt.updateResultVariable("@{target}",$new);
    update($reslt);


### PR DESCRIPTION
- Running ScorecardReasonCodeTest, it happened sometimes, that the old and new fact instances handling ReasonCode result value had the same timestamp, therefore simple "after" used in the PMML rules wasn't enough
- I found out that there is also "before" operator used at three places, so I applied similar fix also there. 

@lanceleverich @jiripetrlik @mariofusco could you please check, if the rules are correct? These fixes should stabilize all remaining unstable PMML tests. 