### PR TITLE
RHPAM-1509 [7.11.x] Mining model modelChain mode does not compile

### DIFF
--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
@@ -614,7 +614,7 @@ public class PMML4Compiler {
                     if (outfield.getRawDataField() != null && outfield.getRawDataField().getDataType() != null) {
                         e = outfield.getRawDataField();
                     } else if (target != null) {
-                        e = target.getRawDataField();
+                        e = copyDataField(target.getRawDataField());
                     }
                     if (e != null) {
                         e.setName(fldName);
@@ -626,6 +626,20 @@ public class PMML4Compiler {
                 }
             }
         });
+    }
+
+    private DataField copyDataField(DataField df) {
+        if (df == null) {
+            return null;
+        }
+        DataField copy = new DataField();
+        copy.setDataType(df.getDataType());
+        copy.setDisplayName(df.getDisplayName());
+        copy.setIsCyclic(df.getIsCyclic());
+        copy.setOptype(df.getOptype());
+        copy.setName(df.getName());
+
+        return copy;
     }
 
     protected PMMLResource buildResourceFromSegment(PMML pmml_origin, MiningSegment segment, ClassLoader classLoader, KieModuleModel module) {

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Helper.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Helper.java
@@ -929,6 +929,9 @@ public class PMML4Helper {
 
 
     public String compactUpperCase(String s) {
+        if (s == null) {
+            throw new IllegalArgumentException("Cannot call PMML4Helper::compactUpperCase with a null string.");
+        }
         java.util.StringTokenizer tok = new java.util.StringTokenizer(s);
         StringBuilder sb = new StringBuilder();
 

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/mining/MiningSegmentation.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/model/mining/MiningSegmentation.java
@@ -167,7 +167,7 @@ public class MiningSegmentation {
 		StringBuilder builder = new StringBuilder();
 		loadTemplates(this.multipleModelMethod);
 		Map<String, Object> templateVars = new HashMap<>();
-		String pkgName = this.getOwner().getModelPackageName();//"org.kie.pmml.pmml_4_2."+this.getSegmentationId();
+		String pkgName = this.getOwner().getModelPackageName();
 		CompiledTemplate ct = null;
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		switch (this.multipleModelMethod) {
@@ -180,15 +180,9 @@ public class MiningSegmentation {
 			case MEDIAN:
 				break;
 			case MODEL_CHAIN:
-				List<MiningSegmentTransfer> segmentTransfers = new ArrayList<>();
-				MiningSegmentTransfer mst = new MiningSegmentTransfer(this.getSegmentationId(), "1","2");
-				mst.addResultToRequestMapping("calculatedScore","calculatedScore");
-				segmentTransfers.add(mst);
-				templateVars.put("segmentTransfers", segmentTransfers);
 				templateVars.put("miningModel", this.getOwner());
 				templateVars.put("childSegments", this.getMiningSegments());
 				templateVars.put("packageName", pkgName);
-				templateVars.put("resultMappings", segmentTransfers);
 				templateVars.put("ruleUnitClassName", this.getOwner().getRuleUnitClassName());
 				ct = templates.getNamedTemplate(this.multipleModelMethod.name());
 				TemplateRuntime.execute(ct,null,new MapVariableResolverFactory(templateVars),baos);

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/modelChain.mvel
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/modelChain.mvel
@@ -30,6 +30,11 @@ import org.kie.api.pmml.PMML4Result;
 
 @code{ int salienceValue; }
 
+declare @{miningModel.targetField}
+   value: Double
+   weight: Double
+end
+
 
 rule "Start Mining - @{miningModel.modelId}"
 salience 1000
@@ -66,6 +71,24 @@ then
    }
 end
 
+rule "Insert Segment Executions"
+salience 1000
+when
+   model: @{miningModel.miningPojoClassName}( ) from miningModelPojo
+then
+   SegmentExecution segEx = null;
+   @foreach{ childSegment: childSegments }
+   segEx = new SegmentExecution( model.getCorrelationId(),
+                                 "@{childSegment.owner.segmentationId}",
+                                 "@{childSegment.segmentId}",
+                                 @{childSegment.segmentIndex},
+                                 "@{childSegment.segmentRuleUnit}");
+   segEx.setState(SegmentExecutionState.UNKNOWN);
+   childModelSegments.insert(segEx);
+   @end{}
+end
+
+
 
 @foreach{ childSegment: childSegments }
 @code{ salienceValue = 100 - childSegment.segmentIndex; }
@@ -74,7 +97,7 @@ end
 rule "Clean up previous request - @{childSegment.segmentId}"
 salience 9000
 when
-   segEx: SegmentExecution( $cid: correlationId, $segId: segmentId == @{childSegment.segmentId},
+   segEx: SegmentExecution( $cid: correlationId, $segId: segmentId == "@{childSegment.segmentId}",
                             state == SegmentExecutionState.COMPLETE, requestData != null ) from childModelSegments
    data: PMMLRequestData( this == segEx.requestData ) from request
 then
@@ -85,14 +108,13 @@ rule "Add previous segment results - Segment @{childSegment.segmentId}"
 salience 1000
 no-loop
 when
-   segEx: SegmentExecution( $cid: correlationId, $segmId: segmentationId, $segId: segmentId == @{childSegment.segmentId},
+   segEx: SegmentExecution( $cid: correlationId, $segmId: segmentationId, $segId: segmentId == "@{childSegment.segmentId}",
                             $segIndex: segmentIndex,
                             state == SegmentExecutionState.WAITING, requestData != null ) from childModelSegments
    rqst: PMMLRequestData() from segEx.requestData
    prior: SegmentExecution( correlationId == $cid, segmentationId == $segmId, segmentIndex < $segIndex, 
                             state == SegmentExecutionState.COMPLETE ) from childModelSegments
 then
-   System.out.println("doing the mapping!!");
    PMMLRequestData data = segEx.getRequestData();
    PMML4Result result = prior.getResult();
    @foreach{ field: childSegment.model.miningFields }
@@ -101,7 +123,6 @@ then
    @end{}
    @end{}
    update(segEx);
-   System.out.println(rqst.getMappedRequestParams());
 end
 
 rule "Execute Segment @{childSegment.owner.segmentationId}-@{childSegment.segmentId}"
@@ -114,7 +135,6 @@ when
    not SegmentExecution( correlationId == $corrId, segmentationId == $segmId, 
       (state == SegmentExecutionState.WAITING && segmentIndex < $segIndex) ) from childModelSegments
 then
-   System.out.println("Executing segment @{childSegment.segmentId}");
    PMML4Result rslt = new PMML4Result();
    rslt.setCorrelationId($seg.getCorrelationId());
    rslt.setSegmentationId($seg.getSegmentationId());
@@ -134,6 +154,8 @@ rule "Check Segment Can Fire - Segment @{childSegment.segmentId}"
 salience @{salienceValue}
 when
    model: @{miningModel.miningPojoClassName}( @{childSegment.predicateText} ) from miningModelPojo
+   segEx: SegmentExecution( segmentId == "@{childSegment.segmentId}", state == SegmentExecutionState.UNKNOWN ) from childModelSegments
+   not ( SegmentExecution( state == SegmentExecutionState.WAITING || state == SegmentExecutionState.EXECUTING ) )
 then
 
    PMMLRequestData rqstData = new PMMLRequestData(model.getCorrelationId(),"@{childSegment.model.modelId}");
@@ -141,13 +163,10 @@ then
    @if{ field.inDictionary==true }rqstData.addRequestParam( "@{field.name}",model.getV@{field.compactUpperCaseName}() );@end{}
    @end{}
    rqstData.setSource(model.getClass().getName());
-   SegmentExecution segEx = new SegmentExecution( model.getCorrelationId(),
-                                                  "@{childSegment.owner.segmentationId}",
-                                                  "@{childSegment.segmentId}",
-                                                   @{childSegment.segmentIndex},
-                                                  "@{childSegment.segmentRuleUnit}");
-   segEx.setRequestData(rqstData);
-   childModelSegments.insert(segEx);
+   modify(segEx) {
+      setRequestData(rqstData),
+      setState(SegmentExecutionState.WAITING)
+   };
 end
 
 

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelChainRegressionTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelChainRegressionTest.java
@@ -16,11 +16,12 @@
 
 package org.kie.pmml.pmml_4_2.predictive.models.mining;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,11 +32,7 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.pmml.pmml_4_2.PMML4ExecutionHelper;
 import org.kie.pmml.pmml_4_2.PMMLRequestDataBuilder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 @RunWith(Parameterized.class)
-@Ignore("RHPAM-1509")
 public class MiningModelChainRegressionTest {
 
     private static final String PMML_SOURCE = "org/kie/pmml/pmml_4_2/test_mining_model_modelchain_regression.pmml";

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_mining_model_modelchain.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_mining_model_modelchain.pmml
@@ -40,7 +40,7 @@
          <MiningField name="residenceState" />
          <MiningField name="validLicense" />
          <MiningField name="overallScore" />
-         <MiningField name="qualificationLevel"/>
+         <MiningField name="qualificationLevel" usageType="target"/>
       </MiningSchema>
       <Segmentation multipleModelMethod="modelChain">
          <Segment id="1">

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_mining_model_modelchain_regression.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_mining_model_modelchain_regression.pmml
@@ -2,11 +2,12 @@
    xmlns="http://www.dmg.org/PMML-4_2">
    <Header/>
  
-   <DataDictionary numberOfFields="4">
+   <DataDictionary numberOfFields="5">
     <DataField dataType="double" name="input1" optype="continuous" />
     <DataField dataType="double" name="input2" optype="continuous" />
     <DataField dataType="double" name="input3" optype="continuous"/>
     <DataField dataType="double" name="result" optype="continuous"/>
+    <DataField dataType="double" name="resultRegression" optype="continuous" />
   </DataDictionary>
   
   <MiningModel modelName="SampleMiningModel" functionName="regression">
@@ -20,7 +21,7 @@
     <Segmentation multipleModelMethod="modelChain">
       <Segment id="innerFunction1PartA">
         <SimplePredicate field="input1" operator="lessThan" value="10" />
-        <RegressionModel functionName="regression">
+        <RegressionModel functionName="regression" modelName="innerRegression1A">
           <MiningSchema>
             <MiningField name="input1" usageType="active" />
             <MiningField name="input2" usageType="active" />
@@ -39,7 +40,7 @@
       </Segment>
       <Segment id="innerFunction1PartB">
         <SimplePredicate field="input1" operator="greaterOrEqual" value="10" />
-        <RegressionModel functionName="regression">
+        <RegressionModel functionName="regression" modelName="innerRegression1B">
           <MiningSchema>
             <MiningField name="input1" usageType="active" />
             <MiningField name="input2" usageType="active" />
@@ -58,7 +59,7 @@
       </Segment>
       <Segment id="innerFunction2">
         <True />
-        <RegressionModel functionName="regression">
+        <RegressionModel functionName="regression" modelName="innerRegression2">
           <MiningSchema>
             <MiningField name="input1" usageType="active" />
             <MiningField name="input2" usageType="active" />
@@ -77,7 +78,7 @@
       </Segment>
       <Segment id="outerFunction">
         <True />
-        <RegressionModel functionName="regression">
+        <RegressionModel functionName="regression" modelName="outerRegression">
           <MiningSchema>
             <MiningField name="resultRegressionInner1" usageType="active" />
             <MiningField name="resultRegressionInner2" usageType="active" />


### PR DESCRIPTION
* Fixed an error, in the PMML4Compiler, that was caused when instead of creating a copy of a DataField object the object was being updated
* Fixed problems in the test data...
  - Models need to have a modelName attribute
  - A target element, in a MiningSchema, must have a corresponding DataField defined