### PR TITLE
[RHPAM-1184] URLDecoder: Illegal hex characters in escape (%) patternwhen a rule has a name with "%" 

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompiler.java
@@ -19,6 +19,8 @@ package org.drools.compiler.commons.jci.compilers;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Locale;
@@ -87,6 +89,7 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
 
     final class CompilationUnit implements ICompilationUnit {
 
+        final private String fsFileName;
         final private String clazzName;
         final private String fileName;
         final private char[] typeName;
@@ -95,10 +98,12 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
 
         CompilationUnit( final ResourceReader pReader, final String pSourceFile ) {
             reader = pReader;
+
+            fsFileName = pSourceFile;
+
+            clazzName = ClassUtils.convertResourceToClassName( decode(getPathName( pSourceFile )) );
             
-            clazzName = ClassUtils.convertResourceToClassName( getPathName( pSourceFile ) );
-            
-            fileName = pSourceFile;
+            fileName = decode(pSourceFile);
             int dot = clazzName.lastIndexOf('.');
             if (dot > 0) {
                 typeName = clazzName.substring(dot + 1).toCharArray();
@@ -113,12 +118,20 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
             }
         }
 
+        private String decode( final String path ) {
+            try {
+                return URLDecoder.decode( path, "UTF-8" );
+            } catch ( UnsupportedEncodingException e ) {
+                return path;
+            }
+        }
+
         public char[] getFileName() {
             return fileName.toCharArray();
         }
 
         public char[] getContents() {
-            final byte[] content = reader.getBytes(fileName);
+            final byte[] content = reader.getBytes(fsFileName);
 
             if (content == null) {
                 return null;

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
@@ -104,7 +104,7 @@ public class MemoryFileSystem
         if ( lastSlashPos >= 0 ) {
             Folder folder = getFolder( path.substring( 0,
                                                        lastSlashPos ) );
-            String name = decode( path.substring( lastSlashPos + 1 ) );
+            String name = path.substring( lastSlashPos + 1 );
             return new MemoryFile( this,
                                    name,
                                    folder );
@@ -575,11 +575,4 @@ public class MemoryFileSystem
         return clone;
     }
 
-    private String decode( final String path ) {
-        try {
-            return URLDecoder.decode( path, "UTF-8" );
-        } catch ( UnsupportedEncodingException e ) {
-            return path;
-        }
-    }
 }

--- a/drools-compiler/src/test/java/org/drools/compiler/commons/jci/compilers/JavaCompilerI18NTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/commons/jci/compilers/JavaCompilerI18NTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.commons.jci.compilers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.compiler.compiler.io.memory.MemoryFile;
+import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.junit.Test;
+
+public class JavaCompilerI18NTest {
+
+    @Test
+    public void testi18NFile () throws Exception {
+        String fileStr = "com/myspace/test/" + URLEncoder.encode("あ", "UTF-8") + ".java";
+        List<String> classes = new ArrayList<>();
+        classes.add(fileStr);
+
+        MemoryFileSystem fs = new MemoryFileSystem();
+        MemoryFile file = (MemoryFile) fs.getFile(fileStr);
+
+        String fileContents = "package com.myspace.test; public class あ { }";
+        fs.setFileContents(file, fileContents.getBytes());
+
+
+        EclipseJavaCompilerSettings settings = new EclipseJavaCompilerSettings();
+        settings.setSourceVersion( "1.5" );
+        settings.setTargetVersion( "1.5" );
+        EclipseJavaCompiler compiler = new EclipseJavaCompiler( settings, "" );
+        CompilationResult res = compiler.compile( classes.toArray( new String[classes.size()] ), fs, fs );
+        assertEquals(res.getErrors().length, 0);
+	}
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/compiler/io/memory/MemoryFileSystemTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/compiler/io/memory/MemoryFileSystemTest.java
@@ -42,6 +42,6 @@ public class MemoryFileSystemTest {
     public void testGetJapaneseFileName() throws Exception {
         final File file = memoryFileSystem.getFile( "path/path/%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.java" );
 
-        assertEquals( "あいうえお.java", file.getName() );
+        assertEquals( "%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.java", file.getName() );
     }
 }


### PR DESCRIPTION

moving decoding the file name to the EJC compilation unit adapter so memory file system
is not inconsistent anymore regarding the names