### PR TITLE
[AF-1555]: Upgrade to WF14

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -68,7 +68,7 @@ public class ClasspathKieProject extends AbstractKieProject {
     private Map<String, InternalKieModule>  kJarFromKBaseName = new HashMap<String, InternalKieModule>();
 
     private final KieRepository kieRepository;
-    
+
     private final ClassLoader parentCL;
 
     private ClassLoader classLoader;


### PR DESCRIPTION
## Description

Upgrate to Wildfly 14

@mariofusco : Wildfly14 changed jboss vfs implementation . `url.openConnection().getContent()` for _kmodule.xml_ now returns a `ZipFile.ZipFileInflatedStream` instead of a `VirtualFile`, so I'm doing that check to get the physical path. It worked, I didn't see any error but I want to be sure that I'm not missing anything.  Would you mind to review it please?

## Related to:
* https://github.com/jboss-integration/jboss-integration-platform-bom/pull/427
* https://github.com/errai/errai/pull/363
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/843
* https://github.com/kiegroup/appformer/pull/483
* https://github.com/kiegroup/kie-wb-common/pull/2147
* https://github.com/kiegroup/jbpm/pull/1336
* https://github.com/kiegroup/jbpm-wb/pull/1206
* https://github.com/kiegroup/drools/pull/2086
* https://github.com/kiegroup/droolsjbpm-integration/pull/1583
* https://github.com/kiegroup/kie-wb-distributions/pull/821 
* https://github.com/kiegroup/kie-docs/pull/1108
* https://github.com/kiegroup/optaplanner/pull/437
* https://github.com/kiegroup/optaplanner-wb/pull/304