### PR TITLE
Use <target> instead of deprecated <tasks> in antrun plugin config

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -286,7 +286,7 @@
               <execution>
                 <phase>generate-sources</phase>
                 <configuration>
-                  <tasks>
+                  <target>
                     <condition property="antlr.debugParser" value="-Xconversiontimeout 32000 -debug" else="">
                       <isset property="debugParser"/>
                     </condition>
@@ -356,7 +356,7 @@
                         <include name="Java__.g"/>
                       </fileset>
                     </delete>
-                  </tasks>
+                  </target>
                 </configuration>
                 <goals>
                   <goal>run</goal>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -243,9 +243,9 @@
             <id>create-custom-maven-repo-dir</id>
             <phase>generate-test-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <mkdir dir="${project.build.directory}/testing-maven-repo"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Fixes the warning
"[WARNING] Parameter tasks is deprecated, use target instead"
which appears during the build.

See maven-antrun-plugin [docs](http://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks)