### PR TITLE
[DROOLS-3088] FEEL Compiler: refactor to AST-based tree walk

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
@@ -21,6 +21,8 @@ import org.kie.dmn.core.impl.DMNModelImpl;
 import org.kie.dmn.core.util.Msg;
 import org.kie.dmn.core.util.MsgUtil;
 import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.codegen.feel11.ASTCompilerVisitor;
+import org.kie.dmn.feel.codegen.feel11.ASTUnaryTestTransform;
 import org.kie.dmn.feel.codegen.feel11.CompiledFEELSupport;
 import org.kie.dmn.feel.codegen.feel11.CompilerBytecodeLoader;
 import org.kie.dmn.feel.codegen.feel11.DirectCompilerResult;
@@ -29,10 +31,12 @@ import org.kie.dmn.feel.lang.CompiledExpression;
 import org.kie.dmn.feel.lang.CompilerContext;
 import org.kie.dmn.feel.lang.FEELProfile;
 import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.ast.BaseNode;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.lang.impl.FEELImpl;
 import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
 import org.kie.dmn.feel.parser.feel11.FEELParser;
 import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
 import org.kie.dmn.feel.runtime.FEELFunction;
@@ -266,8 +270,9 @@ public class DMNFEELHelper {
         if (errorListener.isError()) {
             result = CompiledFEELSupport.compiledErrorUnaryTest(errorListener.event().getMessage());
         } else {
-            DirectCompilerVisitor v = new DirectCompilerVisitor(variableTypes, true);
-            result = v.visit(tree);
+            BaseNode ast = tree.accept(new ASTBuilderVisitor(variableTypes));
+            BaseNode rewritten = ast.accept(new ASTUnaryTestTransform()).node();
+            result = rewritten.accept(new ASTCompilerVisitor());
         }
         return new CompilerBytecodeLoader().getSourceForUnaryTest(packageName, className, input, result);
     }

--- a/kie-dmn/kie-dmn-feel/src/main/antlr4/org/kie/dmn/feel/parser/feel11/FEEL_1_1.g4
+++ b/kie-dmn/kie-dmn-feel/src/main/antlr4/org/kie/dmn/feel/parser/feel11/FEEL_1_1.g4
@@ -377,9 +377,9 @@ nameRef
        )  nameRefOtherToken*
     ;
 
-nameRefOtherToken // added some special cases here: we should rework a bit the lexing part, though --ev
-    : { helper.followUp( _input.LT(1), _localctx==null ) }? //~('('|')'|'['|']'|'{'|'}'|'>'|'<'|'='|'!'|'/'|'*'|'in'|',')
-        ~(LPAREN|RPAREN|LBRACK|RBRACK|LBRACE|RBRACE|LT|GT|EQUAL|DIV|MUL|IN|COMMA)
+nameRefOtherToken
+    : { helper.followUp( _input.LT(1), _localctx==null ) }?
+        ~(LPAREN|RPAREN|LBRACK|RBRACK|LBRACE|RBRACE|LT|GT|EQUAL|BANG|DIV|MUL|IN|COMMA)
     ;
 
 /********************************
@@ -710,10 +710,14 @@ ADD : '+';
 SUB : '-';
 MUL : '*';
 DIV : '/';
+BANG
+    : '!'
+    ;
 
 NOT
     : 'not'
     ;
+
 
 Identifier
 	:	JavaLetter JavaLetterOrDigit*

--- a/kie-dmn/kie-dmn-feel/src/main/antlr4/org/kie/dmn/feel/parser/feel11/FEEL_1_1.g4
+++ b/kie-dmn/kie-dmn-feel/src/main/antlr4/org/kie/dmn/feel/parser/feel11/FEEL_1_1.g4
@@ -56,23 +56,23 @@ textualExpression
 
 // #41
 parameters
-    : '(' ')'                       #parametersEmpty
-    | '(' namedParameters ')'       #parametersNamed
-    | '(' positionalParameters ')'  #parametersPositional
+    : LPAREN RPAREN                       #parametersEmpty
+    | LPAREN namedParameters RPAREN       #parametersNamed
+    | LPAREN positionalParameters RPAREN  #parametersPositional
     ;
 
 // #42 #43
 namedParameters
-    : namedParameter (',' namedParameter)*
+    : namedParameter (COMMA namedParameter)*
     ;
 
 namedParameter
-    : name=nameDefinition ':' value=expression
+    : name=nameDefinition COLON value=expression
     ;
 
 // #44
 positionalParameters
-    : expression ( ',' expression )*
+    : expression ( COMMA expression )*
     ;
 
 // #46
@@ -83,21 +83,21 @@ forExpression
 @after {
     helper.popScope();
 }
-    : for_key iterationContexts return_key {helper.enableDynamicResolution();} expression {helper.disableDynamicResolution();}
+    : FOR iterationContexts RETURN {helper.enableDynamicResolution();} expression {helper.disableDynamicResolution();}
     ;
 
 iterationContexts
-    : iterationContext ( ',' iterationContext )*
+    : iterationContext ( COMMA iterationContext )*
     ;
 
 iterationContext
-    : {helper.isFeatDMN12EnhancedForLoopEnabled()}? nameDefinition in_key expression '..' expression
-    | nameDefinition in_key expression
+    : {helper.isFeatDMN12EnhancedForLoopEnabled()}? nameDefinition IN expression '..' expression
+    | nameDefinition IN expression
     ;
     
 // #47
 ifExpression
-    : if_key c=expression then_key t=expression else_key e=expression
+    : IF c=expression THEN t=expression ELSE e=expression
     ;
 
 // #48
@@ -108,19 +108,19 @@ quantifiedExpression
 @after {
     helper.popScope();
 }
-    : some_key iterationContexts satisfies_key {helper.enableDynamicResolution();} expression {helper.disableDynamicResolution();}    #quantExprSome
-    | every_key iterationContexts satisfies_key {helper.enableDynamicResolution();} expression {helper.disableDynamicResolution();}   #quantExprEvery
+    : SOME iterationContexts SATISFIES {helper.enableDynamicResolution();} expression {helper.disableDynamicResolution();}    #quantExprSome
+    | EVERY iterationContexts SATISFIES {helper.enableDynamicResolution();} expression {helper.disableDynamicResolution();}   #quantExprEvery
     ;
 
 // #54
 type
-    : ( function_key | qualifiedName )
+    : ( FUNCTION | qualifiedName )
     ;
 
 // #56
 list
-    : '[' ']'
-    | '[' expressionList ']'
+    : LBRACK RBRACK
+    | LBRACK expressionList RBRACK
     ;
 
 // #57
@@ -131,11 +131,11 @@ functionDefinition
 @after {
     helper.popScope();
 }
-    : function_key '(' formalParameters? ')' external=external_key? {helper.enableDynamicResolution();} body=expression {helper.disableDynamicResolution();}
+    : FUNCTION LPAREN formalParameters? RPAREN external=EXTERNAL? {helper.enableDynamicResolution();} body=expression {helper.disableDynamicResolution();}
     ;
 
 formalParameters
-    : formalParameter ( ',' formalParameter )*
+    : formalParameter ( COMMA formalParameter )*
     ;
 
 // #58
@@ -151,18 +151,18 @@ context
 @after {
     helper.popScope();
 }
-    : '{' '}'
-    | '{' contextEntries '}'
+    : LBRACE RBRACE
+    | LBRACE contextEntries RBRACE
     ;
 
 contextEntries
-    : contextEntry ( ',' contextEntry )*
+    : contextEntry ( COMMA contextEntry )*
     ;
 
 // #60
 contextEntry
     : key { helper.pushName( $key.ctx ); }
-      ':' expression { helper.popName(); helper.defineVariable( $key.ctx ); }
+      COLON expression { helper.popName(); helper.defineVariable( $key.ctx ); }
     ;
 
 // #61
@@ -187,66 +187,72 @@ nameDefinitionTokens
 
 
 additionalNameSymbol
-    : ( '.' | '/' | '-' | '\'' | '+' | '*' )
+    : //( '.' | '/' | '-' | '\'' | '+' | '*' )
+    DOT | DIV | SUB | ADD | MUL | QUOTE
     ;
 
 conditionalOrExpression
 	:	conditionalAndExpression                                                 #condOrAnd
- 	|	left=conditionalOrExpression op=or_key right=conditionalAndExpression    #condOr
+ 	|	left=conditionalOrExpression op=OR right=conditionalAndExpression    #condOr
 	;
 
 conditionalAndExpression
 	:	comparisonExpression                                                   #condAndComp
-	|	left=conditionalAndExpression op=and_key right=comparisonExpression      #condAnd
+	|	left=conditionalAndExpression op=AND right=comparisonExpression      #condAnd
 	;
 
 comparisonExpression
 	:	relationalExpression                                                                   #compExpressionRel
-	|   left=comparisonExpression op=('<'|'>'|'<='|'>='|'='|'!=') right=relationalExpression   #compExpression
+	|   left=comparisonExpression op=(LT |
+                                      GT |
+                                      LE |
+                                      GE |
+                                      EQUAL |
+                                      NOTEQUAL) right=relationalExpression   #compExpression
 	;
 
 relationalExpression
 	:	additiveExpression                                                                           #relExpressionAdd
-	|	val=relationalExpression between_key start=additiveExpression and_key end=additiveExpression   #relExpressionBetween
-	|   val=relationalExpression in_key '(' positiveUnaryTests ')'                                     #relExpressionTestList
-    |   val=relationalExpression in_key expression                                                   #relExpressionValue        // includes simpleUnaryTest
-    |   val=relationalExpression instance_key of_key type                                            #relExpressionInstanceOf
+	|	val=relationalExpression BETWEEN start=additiveExpression AND end=additiveExpression   #relExpressionBetween
+	|   val=relationalExpression IN LPAREN positiveUnaryTests RPAREN                                     #relExpressionTestList
+    |   val=relationalExpression IN expression                                                   #relExpressionValue        // includes simpleUnaryTest
+    |   val=relationalExpression INSTANCE OF type                                            #relExpressionInstanceOf
 	;
 
 expressionList
-    :   expression  (',' expression)*
+    :   expression  (COMMA expression)*
     ;
 
 additiveExpression
 	:	multiplicativeExpression                            #addExpressionMult
-	|	additiveExpression op='+' multiplicativeExpression  #addExpression
-	|	additiveExpression op='-' multiplicativeExpression  #addExpression
+	|	additiveExpression op=ADD multiplicativeExpression  #addExpression
+	|	additiveExpression op=SUB multiplicativeExpression  #addExpression
 	;
 
 multiplicativeExpression
 	:	powerExpression                                              #multExpressionPow
-	|	multiplicativeExpression op=( '*' | '/' ) powerExpression    #multExpression
+	|	multiplicativeExpression op=( MUL | DIV ) powerExpression    #multExpression
 	;
 
 powerExpression
     :   filterPathExpression                           #powExpressionUnary
-    |   powerExpression op='**' filterPathExpression   #powExpression
+    |   powerExpression op=POW filterPathExpression   #powExpression
     ;
 
 filterPathExpression
     :   unaryExpression
-    |   filterPathExpression '[' {helper.enableDynamicResolution();} filter=expression {helper.disableDynamicResolution();} ']'
-    |   filterPathExpression '.' {helper.enableDynamicResolution();} qualifiedName {helper.disableDynamicResolution();}
+    |   filterPathExpression LBRACK {helper.enableDynamicResolution();} filter=expression {helper.disableDynamicResolution();} RBRACK
+    |   filterPathExpression DOT {helper.enableDynamicResolution();} qualifiedName {helper.disableDynamicResolution();}
     ;
 
 unaryExpression
-	:	'-' unaryExpression                      #signedUnaryExpressionMinus
+	:	SUB unaryExpression                      #signedUnaryExpressionMinus
 	|   unaryExpressionNotPlusMinus              #nonSignedUnaryExpression
-    |	'+' unaryExpressionNotPlusMinus          #signedUnaryExpressionPlus
+    |	ADD unaryExpressionNotPlusMinus          #signedUnaryExpressionPlus
 	;
 
 unaryExpressionNotPlusMinus
-	: primary ('.' {helper.recoverScope();helper.enableDynamicResolution();} qualifiedName parameters? {helper.disableDynamicResolution();helper.dismissScope();} )?   #uenpmPrimary
+	: primary (DOT {helper.recoverScope();helper.enableDynamicResolution();} qualifiedName parameters? {helper.disableDynamicResolution();helper.dismissScope();} )?   #uenpmPrimary
 	;
 
 primary
@@ -257,7 +263,7 @@ primary
     | interval                    #primaryInterval
     | list                        #primaryList
     | context                     #primaryContext
-    | '(' expression ')'          #primaryParens
+    | LPAREN expression RPAREN          #primaryParens
     | simplePositiveUnaryTest     #primaryUnaryTest
     | qualifiedName parameters?   #primaryName
     ;
@@ -266,14 +272,14 @@ primary
 literal
     :	IntegerLiteral          #numberLiteral
     |	FloatingPointLiteral    #numberLiteral
-    |	booleanLiteral          #boolLiteral
+    |	BooleanLiteral          #boolLiteral
     |	StringLiteral           #stringLiteral
-    |	null_key                #nullLiteral
+    |	NULL                #nullLiteral
     ;
 
-booleanLiteral
-    :   true_key
-    |   false_key
+BooleanLiteral
+    :   TRUE
+    |   FALSE
     ;
 
 /**************************
@@ -282,27 +288,27 @@ booleanLiteral
 
 // #7
 simplePositiveUnaryTest
-    : op='<'  {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
-    | op='>'  {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
-    | op='<=' {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
-    | op='>=' {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
-    | op='='  {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
-    | op='!=' {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
+    : op=LT  {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
+    | op=GT  {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
+    | op=LE {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
+    | op=GE {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
+    | op=EQUAL  {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
+    | op=NOTEQUAL {helper.enableDynamicResolution();}  endpoint {helper.disableDynamicResolution();}   #positiveUnaryTestIneq
     | interval           #positiveUnaryTestInterval
     ;
 
 
 // #13
 simplePositiveUnaryTests
-    : simplePositiveUnaryTest ( ',' simplePositiveUnaryTest )*
+    : simplePositiveUnaryTest ( COMMA simplePositiveUnaryTest )*
     ;
 
 
 // #14
 simpleUnaryTests
     : simplePositiveUnaryTests                     #positiveSimplePositiveUnaryTests
-    | not_key '(' simplePositiveUnaryTests ')'     #negatedSimplePositiveUnaryTests
-    | '-'                                          #positiveUnaryTestDash
+    | NOT LPAREN simplePositiveUnaryTests RPAREN     #negatedSimplePositiveUnaryTests
+    | SUB                                          #positiveUnaryTestDash
     ;
 
 // #15
@@ -312,7 +318,7 @@ positiveUnaryTest
 
 // #16
 positiveUnaryTests
-    : positiveUnaryTest ( ',' positiveUnaryTest )* 
+    : positiveUnaryTest ( COMMA positiveUnaryTest )*
     ;
 
 
@@ -323,9 +329,9 @@ unaryTestsRoot
 // #17 (root for decision tables)
 unaryTests
     :
-    not_key '(' positiveUnaryTests ')' #unaryTests_negated
+    NOT LPAREN positiveUnaryTests RPAREN #unaryTests_negated
     | positiveUnaryTests               #unaryTests_positive
-    | '-'                              #unaryTests_empty
+    | SUB                              #unaryTests_empty
     ;
 
 // #18
@@ -335,15 +341,15 @@ endpoint
 
 // #8-#12
 interval
-    : low='(' start=endpoint '..' end=endpoint up=')'
-    | low='(' start=endpoint '..' end=endpoint up='['
-    | low='(' start=endpoint '..' end=endpoint up=']'
-    | low=']' start=endpoint '..' end=endpoint up=')'
-    | low=']' start=endpoint '..' end=endpoint up='['
-    | low=']' start=endpoint '..' end=endpoint up=']'
-    | low='[' start=endpoint '..' end=endpoint up=')'
-    | low='[' start=endpoint '..' end=endpoint up='['
-    | low='[' start=endpoint '..' end=endpoint up=']'
+    : low=LPAREN start=endpoint ELIPSIS end=endpoint up=RPAREN
+    | low=LPAREN start=endpoint ELIPSIS end=endpoint up=LBRACK
+    | low=LPAREN start=endpoint ELIPSIS end=endpoint up=RBRACK
+    | low=RBRACK start=endpoint ELIPSIS end=endpoint up=RPAREN
+    | low=RBRACK start=endpoint ELIPSIS end=endpoint up=LBRACK
+    | low=RBRACK start=endpoint ELIPSIS end=endpoint up=RBRACK
+    | low=LBRACK start=endpoint ELIPSIS end=endpoint up=RPAREN
+    | low=LBRACK start=endpoint ELIPSIS end=endpoint up=LBRACK
+    | low=LBRACK start=endpoint ELIPSIS end=endpoint up=RBRACK
     ;
 
 // #20
@@ -358,7 +364,7 @@ qualifiedName
         helper.dismissScope();
 }
     : n1=nameRef { name = getOriginalText( $n1.ctx ); qn.add( name ); helper.validateVariable( $n1.ctx, qn, name ); }
-        ( '.'
+        ( DOT
             {helper.recoverScope( name ); count++;}
             n2=nameRef
             {name=getOriginalText( $n2.ctx );  qn.add( name ); helper.validateVariable( $n1.ctx, qn, name ); }
@@ -372,113 +378,115 @@ nameRef
     ;
 
 nameRefOtherToken // added some special cases here: we should rework a bit the lexing part, though --ev
-    : { helper.followUp( _input.LT(1), _localctx==null ) }? ~('('|')'|'['|']'|'{'|'}'|'>'|'<'|'='|'!'|'/'|'*'|'in'|',')
+    : { helper.followUp( _input.LT(1), _localctx==null ) }? //~('('|')'|'['|']'|'{'|'}'|'>'|'<'|'='|'!'|'/'|'*'|'in'|',')
+        ~(LPAREN|RPAREN|LBRACK|RBRACK|LBRACE|RBRACE|LT|GT|EQUAL|DIV|MUL|IN|COMMA)
     ;
 
 /********************************
  *      KEYWORDS
  ********************************/
 reusableKeywords
-    : for_key
-    | return_key
-    | if_key
-    | then_key
-    | else_key
-    | some_key
-    | every_key
-    | satisfies_key
-    | instance_key
-    | of_key
-    | function_key
-    | external_key
-    | or_key
-    | and_key
-    | between_key
-    | not_key
-    | null_key
-    | true_key
-    | false_key
+    : FOR
+    | RETURN
+    | IF
+    | THEN
+    | ELSE
+    | SOME
+    | EVERY
+    | SATISFIES
+    | INSTANCE
+    | OF
+    | FUNCTION
+    | EXTERNAL
+    | OR
+    | AND
+    | BETWEEN
+    | NOT
+    | NULL
+    | TRUE
+    | FALSE
     ;
 
-for_key
+FOR
     : 'for'
     ;
 
-return_key
+RETURN
     : 'return'
     ;
 
 // can't be reused
-in_key
+IN
     : 'in'
     ;
 
-if_key
+IF
     : 'if'
     ;
 
-then_key
+THEN
     : 'then'
     ;
 
-else_key
+ELSE
     : 'else'
     ;
 
-some_key
+SOME
     : 'some'
     ;
 
-every_key
+EVERY
     : 'every'
     ;
 
-satisfies_key
+SATISFIES
     : 'satisfies'
     ;
 
-instance_key
+INSTANCE
     : 'instance'
     ;
 
-of_key
+OF
     : 'of'
     ;
 
-function_key
+FUNCTION
     : 'function'
     ;
 
-external_key
+EXTERNAL
     : 'external'
     ;
 
-or_key
+OR
     : 'or'
     ;
 
-and_key
+AND
     : 'and'
     ;
 
-between_key
+BETWEEN
     : 'between'
     ;
 
-not_key
-    : NOT
-    ;
-
-null_key
+NULL
     : 'null'
     ;
 
-true_key
+TRUE
     : 'true'
     ;
 
-false_key
+FALSE
     : 'false'
+    ;
+
+QUOTE
+    :
+    '\''
     ;
 
 /********************************

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.util.ArrayDeque;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
@@ -1,0 +1,574 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.drools.javaparser.ast.body.FieldDeclaration;
+import org.drools.javaparser.ast.expr.BinaryExpr;
+import org.drools.javaparser.ast.expr.BooleanLiteralExpr;
+import org.drools.javaparser.ast.expr.ConditionalExpr;
+import org.drools.javaparser.ast.expr.EnclosedExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.LambdaExpr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.NullLiteralExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.kie.dmn.feel.lang.CompositeType;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.ast.ASTNode;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.ast.BetweenNode;
+import org.kie.dmn.feel.lang.ast.BooleanNode;
+import org.kie.dmn.feel.lang.ast.ContextEntryNode;
+import org.kie.dmn.feel.lang.ast.ContextNode;
+import org.kie.dmn.feel.lang.ast.DashNode;
+import org.kie.dmn.feel.lang.ast.FilterExpressionNode;
+import org.kie.dmn.feel.lang.ast.ForExpressionNode;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
+import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
+import org.kie.dmn.feel.lang.ast.IfExpressionNode;
+import org.kie.dmn.feel.lang.ast.InNode;
+import org.kie.dmn.feel.lang.ast.InfixOpNode;
+import org.kie.dmn.feel.lang.ast.InstanceOfNode;
+import org.kie.dmn.feel.lang.ast.IterationContextNode;
+import org.kie.dmn.feel.lang.ast.ListNode;
+import org.kie.dmn.feel.lang.ast.NameDefNode;
+import org.kie.dmn.feel.lang.ast.NameRefNode;
+import org.kie.dmn.feel.lang.ast.NamedParameterNode;
+import org.kie.dmn.feel.lang.ast.NullNode;
+import org.kie.dmn.feel.lang.ast.NumberNode;
+import org.kie.dmn.feel.lang.ast.PathExpressionNode;
+import org.kie.dmn.feel.lang.ast.QualifiedNameNode;
+import org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode;
+import org.kie.dmn.feel.lang.ast.RangeNode;
+import org.kie.dmn.feel.lang.ast.SignedUnaryNode;
+import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.ast.TypeNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestListNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestNode;
+import org.kie.dmn.feel.lang.ast.Visitor;
+import org.kie.dmn.feel.lang.impl.MapBackedType;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.util.EvalHelper;
+
+import static org.kie.dmn.feel.codegen.feel11.DirectCompilerResult.mergeFDs;
+
+public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
+
+    private static class ScopeHelper {
+
+        Deque<Map<String, Type>> stack;
+
+        public ScopeHelper() {
+            this.stack = new ArrayDeque<>();
+            this.stack.push(new HashMap<>());
+        }
+
+        public void addTypes(Map<String, Type> inputTypes) {
+            stack.peek().putAll(inputTypes);
+        }
+
+        public void addType(String name, Type type) {
+            stack.peek().put(name,
+                             type);
+        }
+
+        public void pushScope() {
+            stack.push(new HashMap<>());
+        }
+
+        public void popScope() {
+            stack.pop();
+        }
+
+        public Optional<Type> resolveType(String name) {
+            return stack.stream()
+                    .map(scope -> Optional.ofNullable(scope.get(name)))
+                    .flatMap(o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty())
+                    .findFirst();
+        }
+    }
+
+    ScopeHelper scopeHelper = new ScopeHelper();
+
+    @Override
+    public DirectCompilerResult visit(ASTNode n) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public DirectCompilerResult visit(DashNode n) {
+        return DirectCompilerResult.of(Expressions.dash(), BuiltInType.UNARY_TEST);
+    }
+
+    @Override
+    public DirectCompilerResult visit(BooleanNode n) {
+        return DirectCompilerResult.of(new BooleanLiteralExpr(n.getValue()), BuiltInType.BOOLEAN);
+    }
+
+    @Override
+    public DirectCompilerResult visit(NumberNode n) {
+        String originalText = n.getText();
+        String constantName = Constants.numericName(originalText);
+        FieldDeclaration constant = Constants.numeric(constantName, originalText);
+        return DirectCompilerResult.of(
+                new NameExpr(constantName),
+                BuiltInType.NUMBER,
+                constant);
+    }
+
+    @Override
+    public DirectCompilerResult visit(StringNode n) {
+        return DirectCompilerResult.of(
+                Expressions.stringLiteral(n.getText()), // setString escapes the contents Java-style
+                BuiltInType.STRING);
+    }
+
+    @Override
+    public DirectCompilerResult visit(UnaryTestListNode n) {
+        MethodCallExpr expr = Expressions.list();
+        HashSet<FieldDeclaration> fds = new HashSet<>();
+        for (BaseNode e : n.getElements()) {
+            DirectCompilerResult r = e.accept(this);
+            fds.addAll(r.getFieldDeclarations());
+            expr.addArgument(r.getExpression());
+        }
+
+        if (n.isNegated()) {
+            Expressions.NamedLambda negated =
+                    Expressions.namedUnaryLambda(
+                            Expressions.notExists(expr), n.getText());
+
+            fds.add(negated.field());
+            return DirectCompilerResult.of(
+                    Expressions.list(negated.name()),
+                    BuiltInType.LIST, fds);
+        } else {
+            return DirectCompilerResult.of(
+                    expr, BuiltInType.LIST, fds);
+        }
+    }
+
+    @Override
+    public DirectCompilerResult visit(NullNode n) {
+        return DirectCompilerResult.of(new NullLiteralExpr(), BuiltInType.UNKNOWN);
+    }
+
+    @Override
+    public DirectCompilerResult visit(NameDefNode n) {
+        StringLiteralExpr expr = Expressions.stringLiteral(EvalHelper.normalizeVariableName(n.getText()));
+        return DirectCompilerResult.of(expr, BuiltInType.STRING);
+    }
+
+    @Override
+    public DirectCompilerResult visit(NameRefNode n) {
+        String nameRef = EvalHelper.normalizeVariableName(n.getText());
+        Type type = scopeHelper.resolveType(nameRef).orElse(BuiltInType.UNKNOWN);
+        return DirectCompilerResult.of(FeelCtx.getValue(nameRef), type);
+    }
+
+    @Override
+    public DirectCompilerResult visit(QualifiedNameNode n) {
+        List<NameRefNode> parts = n.getParts();
+        DirectCompilerResult nameRef0 = parts.get(0).accept(this);
+        Type typeCursor = nameRef0.resultType;
+        Expression currentContext = nameRef0.getExpression();
+        for (int i = 1; i < parts.size(); i++) {
+            NameRefNode acc = parts.get(i);
+            String key = acc.getText();
+            if (typeCursor instanceof CompositeType) {
+                CompositeType currentContextType = (CompositeType) typeCursor;
+                currentContext = Contexts.getKey(currentContext, currentContextType, key);
+                typeCursor = currentContextType.getFields().get(key);
+            } else {
+                //  degraded mode, or accessing fields of DATE etc.
+                currentContext = Expressions.path(currentContext, new StringLiteralExpr(key));
+                typeCursor = BuiltInType.UNKNOWN;
+            }
+        }
+        // If it was a NameRef expression, the number coercion is directly performed by the EvaluationContext for the simple variable.
+        // Otherwise in case of QualifiedName expression, for a structured type like this case, it need to be coerced on the last accessor:
+        return DirectCompilerResult.of(
+                Expressions.coerceNumber(currentContext),
+                typeCursor);
+    }
+
+    @Override
+    public DirectCompilerResult visit(InfixOpNode n) {
+        DirectCompilerResult left = n.getLeft().accept(this);
+        DirectCompilerResult right = n.getRight().accept(this);
+        MethodCallExpr expr = Expressions.binary(
+                n.getOperator(),
+                left.getExpression(),
+                right.getExpression());
+        return DirectCompilerResult.of(expr, BuiltInType.UNKNOWN).withFD(left).withFD(right);
+    }
+
+    @Override
+    public DirectCompilerResult visit(InstanceOfNode n) {
+        DirectCompilerResult expr = n.getExpression().accept(this);
+        DirectCompilerResult type = n.getType().accept(this);
+        return DirectCompilerResult.of(
+                Expressions.isInstanceOf(expr.getExpression(), type.getExpression()),
+                BuiltInType.BOOLEAN,
+                mergeFDs(expr, type));
+    }
+
+    @Override
+    public DirectCompilerResult visit(TypeNode n) {
+        return DirectCompilerResult.of(
+                Expressions.determineTypeFromName(n.getText()),
+                BuiltInType.UNKNOWN);
+    }
+
+    @Override
+    public DirectCompilerResult visit(IfExpressionNode n) {
+        DirectCompilerResult condition = n.getCondition().accept(this);
+        DirectCompilerResult thenExpr = n.getThenExpression().accept(this);
+        DirectCompilerResult elseExpr = n.getElseExpression().accept(this);
+
+        return DirectCompilerResult.of(
+                new ConditionalExpr(
+                        new BinaryExpr(
+                                Expressions.nativeInstanceOf(
+                                        Constants.BooleanT, condition.getExpression()),
+                                Expressions.reflectiveCastTo(
+                                        Constants.BooleanT, condition.getExpression()),
+                                BinaryExpr.Operator.AND),
+                        new EnclosedExpr(thenExpr.getExpression()),
+                        new EnclosedExpr(elseExpr.getExpression())),
+                thenExpr.resultType // should find common type between then/else
+        ).withFD(condition).withFD(thenExpr).withFD(elseExpr);
+    }
+
+    @Override
+    public DirectCompilerResult visit(ForExpressionNode n) {
+        DirectCompilerResult expr = n.getExpression().accept(this);
+        HashSet<FieldDeclaration> fds = new HashSet<>();
+
+        Expressions.NamedLambda namedLambda =
+                Expressions.namedLambda(
+                        expr.getExpression(),
+                        n.getExpression().getText());
+
+        fds.add(namedLambda.field());
+        fds.addAll(expr.getFieldDeclarations());
+
+        List<Expression> expressions = n.getIterationContexts()
+                .stream()
+                .map(iter -> iter.accept(this))
+                .peek(r -> fds.addAll(r.getFieldDeclarations()))
+                .map(DirectCompilerResult::getExpression)
+                .collect(Collectors.toList());
+
+        // .satisfies(expr)
+        return DirectCompilerResult.of(
+                Expressions.ffor(expressions, namedLambda.name()),
+                expr.resultType,
+                fds);
+    }
+
+    @Override
+    public DirectCompilerResult visit(BetweenNode n) {
+        DirectCompilerResult value = n.getValue().accept(this);
+        DirectCompilerResult start = n.getStart().accept(this);
+        DirectCompilerResult end = n.getEnd().accept(this);
+
+        return DirectCompilerResult.of(
+                Expressions.between(
+                        value.getExpression(),
+                        start.getExpression(),
+                        end.getExpression()),
+                BuiltInType.BOOLEAN)
+                .withFD(value)
+                .withFD(start)
+                .withFD(end);
+    }
+
+    @Override
+    public DirectCompilerResult visit(ContextNode n) {
+        if (n.getEntries().isEmpty()) {
+            return DirectCompilerResult.of(
+                    FeelCtx.emptyContext(), BuiltInType.CONTEXT);
+        }
+
+        // openContext(feelCtx)
+        MapBackedType resultType = new MapBackedType();
+        DirectCompilerResult openContext =
+                DirectCompilerResult.of(FeelCtx.openContext(), resultType);
+
+        //   .setEntry( k,v )
+        //   .setEntry( k,v )
+        //   ...
+        DirectCompilerResult entries = n.getEntries()
+                .stream()
+                .map(e -> {
+                    DirectCompilerResult r = e.accept(this);
+                    scopeHelper.addType(e.getName().getText(), r.resultType);
+                    return r;
+                })
+                .reduce(openContext,
+                        (l, r) -> DirectCompilerResult.of(
+                                r.getExpression().asMethodCallExpr().setScope(l.getExpression()),
+                                r.resultType,
+                                DirectCompilerResult.mergeFDs(l, r)));
+
+        // .closeContext()
+        return DirectCompilerResult.of(
+                FeelCtx.closeContext(entries),
+                resultType,
+                entries.getFieldDeclarations());
+    }
+
+    @Override
+    public DirectCompilerResult visit(ContextEntryNode n) {
+        DirectCompilerResult key = n.getName().accept(this);
+        DirectCompilerResult value = n.getValue().accept(this);
+        if (key.resultType != BuiltInType.STRING) {
+            throw new IllegalArgumentException(
+                    "a Context Entry Key must be a valid FEEL String type");
+        }
+        String keyText = key.getExpression().asStringLiteralExpr().getValue();
+
+        // .setEntry(key, value)
+        MethodCallExpr setEntryContextCall =
+                FeelCtx.setEntry(keyText, value.getExpression());
+
+        return DirectCompilerResult.of(
+                setEntryContextCall,
+                value.resultType,
+                value.getFieldDeclarations());
+    }
+
+    @Override
+    public DirectCompilerResult visit(FilterExpressionNode n) {
+        DirectCompilerResult expr = n.getExpression().accept(this);
+        DirectCompilerResult filter = n.getFilter().accept(this);
+
+        Expressions.NamedLambda lambda = Expressions.namedLambda(filter.getExpression(), n.getFilter().getText());
+        DirectCompilerResult r = DirectCompilerResult.of(
+                Expressions.filter(expr.getExpression(), lambda.name()),
+                // here we could still try to infer the result type, but presently use ANY
+                BuiltInType.UNKNOWN).withFD(expr).withFD(filter);
+        r.addFieldDesclaration(lambda.field());
+        return r;
+    }
+
+    @Override
+    public DirectCompilerResult visit(FunctionDefNode n) {
+        MethodCallExpr list = Expressions.list();
+        n.getFormalParameters()
+                .stream()
+                .map(fp -> fp.accept(this))
+                .map(DirectCompilerResult::getExpression)
+                .forEach(list::addArgument);
+
+        if (n.isExternal()) {
+            List<String> paramNames =
+                    n.getFormalParameters().stream()
+                            .map(BaseNode::getText)
+                            .collect(Collectors.toList());
+
+            return Functions.declaration(
+                    n, list,
+                    Functions.external(paramNames, n.getBody()));
+        } else {
+            DirectCompilerResult body = n.getBody().accept(this);
+            return Functions.declaration(n, list,
+                                         body.getExpression()).withFD(body);
+        }
+    }
+
+    @Override
+    public DirectCompilerResult visit(FunctionInvocationNode n) {
+        DirectCompilerResult functionName = n.getName().accept(this);
+        DirectCompilerResult params = n.getParams().accept(this);
+        return DirectCompilerResult.of(
+                Expressions.invoke(functionName.getExpression(), params.getExpression()),
+                functionName.resultType)
+                .withFD(functionName)
+                .withFD(params);
+    }
+
+    @Override
+    public DirectCompilerResult visit(NamedParameterNode n) {
+        DirectCompilerResult name = n.getName().accept(this);
+        DirectCompilerResult expr = n.getExpression().accept(this);
+        return DirectCompilerResult.of(
+                Expressions.namedParameter(name.getExpression(), expr.getExpression()),
+                BuiltInType.UNKNOWN).withFD(name).withFD(expr);
+    }
+
+    @Override
+    public DirectCompilerResult visit(InNode n) {
+        DirectCompilerResult value = n.getValue().accept(this);
+        DirectCompilerResult exprs = n.getExprs().accept(this);
+
+        if (exprs.resultType == BuiltInType.LIST) {
+            return DirectCompilerResult.of(
+                    Expressions.exists(exprs.getExpression(), value.getExpression()),
+                    BuiltInType.BOOLEAN).withFD(value).withFD(exprs);
+        } else if (exprs.resultType == BuiltInType.RANGE) {
+            return DirectCompilerResult.of(
+                    Expressions.includes(exprs.getExpression(), value.getExpression()),
+                    BuiltInType.BOOLEAN).withFD(value).withFD(exprs);
+        } else {
+            // this should be turned into a tree rewrite
+            return DirectCompilerResult.of(
+                    Expressions.exists(exprs.getExpression(), value.getExpression()),
+                    BuiltInType.BOOLEAN).withFD(value).withFD(exprs);
+        }
+    }
+
+    @Override
+    public DirectCompilerResult visit(IterationContextNode n) {
+        DirectCompilerResult iterName = n.getName().accept(this);
+        DirectCompilerResult iterExpr = n.getExpression().accept(this);
+
+        Expressions.NamedLambda nameLambda =
+                Expressions.namedLambda(
+                        iterName.getExpression(),
+                        n.getName().getText());
+        Expressions.NamedLambda exprLambda =
+                Expressions.namedLambda(
+                        iterExpr.getExpression(),
+                        n.getExpression().getText());
+
+        MethodCallExpr with =
+                new MethodCallExpr(null, "with")
+                        .addArgument(nameLambda.name())
+                        .addArgument(exprLambda.name());
+
+        DirectCompilerResult r =
+                DirectCompilerResult.of(with, BuiltInType.UNKNOWN);
+        r.addFieldDesclaration(nameLambda.field());
+        r.addFieldDesclaration(exprLambda.field());
+        r.withFD(iterName);
+        r.withFD(iterExpr);
+
+        BaseNode rangeEndExpr = n.getRangeEndExpr();
+        if (rangeEndExpr != null) {
+            DirectCompilerResult rangeEnd = rangeEndExpr.accept(this);
+            Expressions.NamedLambda rangeLambda =
+                    Expressions.namedLambda(
+                            rangeEnd.getExpression(),
+                            rangeEndExpr.getText());
+            with.addArgument(rangeLambda.name());
+            r.addFieldDesclaration(rangeLambda.field());
+            r.withFD(rangeEnd);
+        }
+
+        return r;
+    }
+
+    @Override
+    public DirectCompilerResult visit(ListNode n) {
+        MethodCallExpr list = Expressions.list();
+        DirectCompilerResult result = DirectCompilerResult.of(list, BuiltInType.LIST);
+
+        for (BaseNode e : n.getElements()) {
+            DirectCompilerResult r = e.accept(this);
+            result.withFD(r.getFieldDeclarations());
+            list.addArgument(r.getExpression());
+        }
+
+        return result;
+    }
+
+    @Override
+    public DirectCompilerResult visit(PathExpressionNode n) {
+        DirectCompilerResult expr = n.getExpression().accept(this);
+        BaseNode nameNode = n.getName();
+        if (nameNode instanceof QualifiedNameNode) {
+            QualifiedNameNode qualifiedNameNode = (QualifiedNameNode) n.getName();
+            List<Expression> exprs =
+                    qualifiedNameNode.getParts().stream()
+                            .map(name -> new StringLiteralExpr(name.getText()))
+                            .collect(Collectors.toList());
+
+            return DirectCompilerResult.of(
+                    Expressions.path(expr.getExpression(), exprs),
+                    // here we could still try to infer the result type, but presently use ANY
+                    BuiltInType.UNKNOWN).withFD(expr);
+        } else {
+            return DirectCompilerResult.of(
+                    Expressions.path(expr.getExpression(), new StringLiteralExpr(nameNode.getText())),
+                    // here we could still try to infer the result type, but presently use ANY
+                    BuiltInType.UNKNOWN).withFD(expr);
+        }
+    }
+
+    @Override
+    public DirectCompilerResult visit(QuantifiedExpressionNode n) {
+        DirectCompilerResult expr = n.getExpression().accept(this);
+        HashSet<FieldDeclaration> fds = new HashSet<>();
+
+        Expressions.NamedLambda namedLambda =
+                Expressions.namedLambda(
+                        expr.getExpression(),
+                        n.getExpression().getText());
+
+        fds.add(namedLambda.field());
+        fds.addAll(expr.getFieldDeclarations());
+
+        List<Expression> expressions = n.getIterationContexts()
+                .stream()
+                .map(iter -> iter.accept(this))
+                .peek(r -> fds.addAll(r.getFieldDeclarations()))
+                .map(DirectCompilerResult::getExpression)
+                .collect(Collectors.toList());
+
+        // .satisfies(expr)
+        return DirectCompilerResult.of(
+                Expressions.quantifier(n.getQuantifier(), namedLambda.name(), expressions),
+                expr.resultType,
+                fds);
+    }
+
+    @Override
+    public DirectCompilerResult visit(RangeNode n) {
+        DirectCompilerResult start = n.getStart().accept(this);
+        DirectCompilerResult end = n.getEnd().accept(this);
+        return DirectCompilerResult.of(
+                Expressions.range(
+                        n.getLowerBound(),
+                        start.getExpression(),
+                        end.getExpression(),
+                        n.getUpperBound()),
+                BuiltInType.RANGE,
+                DirectCompilerResult.mergeFDs(start, end));
+    }
+
+    @Override
+    public DirectCompilerResult visit(SignedUnaryNode n) {
+        DirectCompilerResult result = n.getExpression().accept(this);
+        if (n.getSign() == SignedUnaryNode.Sign.NEGATIVE) {
+            return DirectCompilerResult.of(
+                    Expressions.negate(result.getExpression()),
+                    result.resultType,
+                    result.getFieldDeclarations());
+        } else {
+            return result;
+        }
+    }
+
+    @Override
+    public DirectCompilerResult visit(UnaryTestNode n) {
+        DirectCompilerResult value = n.getValue().accept(this);
+        Expression expr = Expressions.unary(n.getOperator(), value.getExpression());
+        Expressions.NamedLambda namedLambda = Expressions.namedUnaryLambda(expr, n.getText());
+        DirectCompilerResult r =
+                DirectCompilerResult.of(namedLambda.name(), BuiltInType.UNARY_TEST)
+                        .withFD(value);
+        r.addFieldDesclaration(namedLambda.field());
+        return r;
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
@@ -64,16 +64,11 @@ import static org.kie.dmn.feel.codegen.feel11.DirectCompilerResult.mergeFDs;
 public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
 
     private static class ScopeHelper {
-
         Deque<Map<String, Type>> stack;
 
         public ScopeHelper() {
             this.stack = new ArrayDeque<>();
             this.stack.push(new HashMap<>());
-        }
-
-        public void addTypes(Map<String, Type> inputTypes) {
-            stack.peek().putAll(inputTypes);
         }
 
         public void addType(String name, Type type) {
@@ -300,6 +295,8 @@ public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
                     FeelCtx.emptyContext(), BuiltInType.CONTEXT);
         }
 
+        scopeHelper.pushScope();
+
         // openContext(feelCtx)
         MapBackedType resultType = new MapBackedType();
         DirectCompilerResult openContext =
@@ -320,6 +317,8 @@ public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
                                 r.getExpression().asMethodCallExpr().setScope(l.getExpression()),
                                 r.resultType,
                                 DirectCompilerResult.mergeFDs(l, r)));
+
+        scopeHelper.popScope();
 
         // .closeContext()
         return DirectCompilerResult.of(

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
@@ -1,0 +1,184 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.kie.dmn.feel.lang.ast.ASTBuilderFactory;
+import org.kie.dmn.feel.lang.ast.ASTNode;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.ast.BooleanNode;
+import org.kie.dmn.feel.lang.ast.DashNode;
+import org.kie.dmn.feel.lang.ast.ListNode;
+import org.kie.dmn.feel.lang.ast.NameDefNode;
+import org.kie.dmn.feel.lang.ast.NameRefNode;
+import org.kie.dmn.feel.lang.ast.NullNode;
+import org.kie.dmn.feel.lang.ast.NumberNode;
+import org.kie.dmn.feel.lang.ast.QualifiedNameNode;
+import org.kie.dmn.feel.lang.ast.RangeNode;
+import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.ast.TypeNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestListNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestNode;
+
+public class ASTUnaryTestTransform extends DefaultedVisitor<ASTUnaryTestTransform.UnaryTestSubexpr> {
+
+    @Override
+    public UnaryTestSubexpr defaultVisit(ASTNode n) {
+        return propagateWildcard(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(UnaryTestListNode n) {
+        List<BaseNode> collect =
+                new ArrayList<>();
+        for (BaseNode e : n.getElements()) {
+            UnaryTestSubexpr accept = e.accept(this);
+            if (accept.isWildcard()) {
+                collect.add(asWildcard(accept.node));
+            } else if (!accept.isUnaryTest()) {
+                collect.add(asUnaryEq(accept.node));
+            } else {
+                collect.add(accept.node);
+            }
+        }
+        return new TopLevel(
+                ASTBuilderFactory.newUnaryTestListNode(n.getParserRuleContext(), collect, n.getState()));
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(ASTNode n) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(DashNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(BooleanNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(NumberNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(StringNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(NullNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(TypeNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(NameDefNode n) {
+        return new SimpleUnaryExpression(n);
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(NameRefNode n) {
+        if (n.getText().equals("?")) {
+            return new WildCardUnaryExpression(n);
+        } else {
+            return new SimpleUnaryExpression(n);
+        }
+    }
+
+    @Override
+    public UnaryTestSubexpr visit(QualifiedNameNode n) {
+        // wildcard is allowed only as the first part
+        UnaryTestSubexpr leading =
+                n.getParts().get(0).accept(this);
+        if (leading.isWildcard()) {
+            return new WildCardUnaryExpression(n);
+        } else {
+            return new SimpleUnaryExpression(n);
+        }
+    }
+
+    private BaseNode asWildcard(BaseNode node) {
+        return ASTBuilderFactory.newUnaryTestNode(
+                node.getParserRuleContext(), "test", node);
+    }
+
+    public BaseNode asUnaryEq(BaseNode node) {
+        if (node instanceof ListNode || node instanceof RangeNode) {
+            return ASTBuilderFactory.newUnaryTestNode(
+                    node.getParserRuleContext(), "in", node);
+        } else {
+            return ASTBuilderFactory.newUnaryTestNode(
+                    node.getParserRuleContext(), "=", node);
+        }
+    }
+
+    private UnaryTestSubexpr propagateWildcard(ASTNode n) {
+        return Arrays.stream(n.getChildrenNode()).map(e -> e.accept(this)).anyMatch(UnaryTestSubexpr::isWildcard) ?
+                new WildCardUnaryExpression((BaseNode) n) : new SimpleUnaryExpression((BaseNode) n);
+    }
+
+    public static abstract class UnaryTestSubexpr {
+
+        private final BaseNode node;
+
+        public UnaryTestSubexpr(BaseNode node) {
+            this.node = node;
+        }
+
+        public BaseNode node() {
+            return node;
+        }
+
+        public abstract boolean isWildcard();
+
+        public boolean isUnaryTest() {
+            return node instanceof UnaryTestNode || node instanceof DashNode;
+        }
+    }
+
+    static class TopLevel extends UnaryTestSubexpr {
+
+        public TopLevel(BaseNode node) {
+            super(node);
+        }
+
+        @Override
+        public boolean isWildcard() {
+            return false;
+        }
+    }
+
+    static class WildCardUnaryExpression extends UnaryTestSubexpr {
+
+        public WildCardUnaryExpression(BaseNode node) {
+            super(node);
+        }
+
+        @Override
+        public boolean isWildcard() {
+            return true;
+        }
+    }
+
+    static class SimpleUnaryExpression extends UnaryTestSubexpr {
+
+        public SimpleUnaryExpression(BaseNode node) {
+            super(node);
+        }
+
+        @Override
+        public boolean isWildcard() {
+            return false;
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.util.ArrayList;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTUnaryTestTransform.java
@@ -35,15 +35,30 @@ public class ASTUnaryTestTransform extends DefaultedVisitor<ASTUnaryTestTransfor
         for (BaseNode e : n.getElements()) {
             UnaryTestSubexpr accept = e.accept(this);
             if (accept.isWildcard()) {
-                collect.add(asWildcard(accept.node));
+                collect.add(rewriteToUnaryTestExpr(accept.node));
             } else if (!accept.isUnaryTest()) {
-                collect.add(asUnaryEq(accept.node));
+                collect.add(rewriteToUnaryEqInExpr(accept.node));
             } else {
                 collect.add(accept.node);
             }
         }
         return new TopLevel(
                 ASTBuilderFactory.newUnaryTestListNode(n.getParserRuleContext(), collect, n.getState()));
+    }
+
+    private BaseNode rewriteToUnaryTestExpr(BaseNode node) {
+        return ASTBuilderFactory.newUnaryTestNode(
+                node.getParserRuleContext(), "test", node);
+    }
+
+    public BaseNode rewriteToUnaryEqInExpr(BaseNode node) {
+        if (node instanceof ListNode || node instanceof RangeNode) {
+            return ASTBuilderFactory.newUnaryTestNode(
+                    node.getParserRuleContext(), "in", node);
+        } else {
+            return ASTBuilderFactory.newUnaryTestNode(
+                    node.getParserRuleContext(), "=", node);
+        }
     }
 
     @Override
@@ -104,21 +119,6 @@ public class ASTUnaryTestTransform extends DefaultedVisitor<ASTUnaryTestTransfor
             return new WildCardUnaryExpression(n);
         } else {
             return new SimpleUnaryExpression(n);
-        }
-    }
-
-    private BaseNode asWildcard(BaseNode node) {
-        return ASTBuilderFactory.newUnaryTestNode(
-                node.getParserRuleContext(), "test", node);
-    }
-
-    public BaseNode asUnaryEq(BaseNode node) {
-        if (node instanceof ListNode || node instanceof RangeNode) {
-            return ASTBuilderFactory.newUnaryTestNode(
-                    node.getParserRuleContext(), "in", node);
-        } else {
-            return ASTBuilderFactory.newUnaryTestNode(
-                    node.getParserRuleContext(), "=", node);
         }
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
@@ -17,6 +17,7 @@
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
@@ -175,7 +176,7 @@ public class CompiledFEELSemanticMappings {
     }
 
     public static Boolean coerceToBoolean(EvaluationContext ctx, Object value) {
-        if (value instanceof Boolean) return (Boolean) value;
+        if (value == null || value instanceof Boolean) return (Boolean) value;
 
         ctx.notifyEvt( () -> new ASTEventBase(
                 FEELEvent.Severity.ERROR,
@@ -317,8 +318,13 @@ public class CompiledFEELSemanticMappings {
 
     // to ground to null if right = 0
     public static Object div(Object left, BigDecimal right) {
-        return right.signum() == 0 ? null : InfixOpNode.div(left, right, null);
+        return right == null || right.signum() == 0 ? null : InfixOpNode.div(left, right, null);
     }
+
+    public static Object pow(Object left, Object right) {
+        return InfixOpNode.math( left, right, null, (l, r) -> l.pow(r.intValue(), MathContext.DECIMAL128 ) );
+    }
+
 
     /**
      * FEEL spec Table 42 and derivations

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import ch.obermuhlner.math.big.BigDecimalMath;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.ast.InfixOpNode;
@@ -53,7 +54,7 @@ public class CompiledFEELSemanticMappings {
         Comparable left = asComparable(lowEndPoint);
         Comparable right = asComparable(highEndPoint);
         if (left == null || right == null || !compatible(left, right)) {
-            ctx.notifyEvt( () -> new ASTEventBase(
+            ctx.notifyEvt(() -> new ASTEventBase(
                     FEELEvent.Severity.ERROR,
                     Msg.createMessage(
                             Msg.INCOMPATIBLE_TYPE_FOR_RANGE,
@@ -78,7 +79,7 @@ public class CompiledFEELSemanticMappings {
                 return ((Range) range).includes(param);
             } catch (ClassCastException e) {
                 // e.g. java.base/java.time.Duration cannot be cast to java.base/java.time.Period
-                ctx.notifyEvt( () -> new ASTEventBase(
+                ctx.notifyEvt(() -> new ASTEventBase(
                         FEELEvent.Severity.ERROR,
                         Msg.createMessage(
                                 Msg.INCOMPATIBLE_TYPE_FOR_RANGE,
@@ -88,8 +89,8 @@ public class CompiledFEELSemanticMappings {
             }
         } else if (range instanceof List) {
             return ((List) range).contains(param);
-        } else if (range == null){
-            ctx.notifyEvt( () -> new ASTEventBase(
+        } else if (range == null) {
+            ctx.notifyEvt(() -> new ASTEventBase(
                     FEELEvent.Severity.ERROR,
                     Msg.createMessage(
                             Msg.IS_NULL,
@@ -112,7 +113,7 @@ public class CompiledFEELSemanticMappings {
 
         if (!(tests instanceof List)) {
             if (tests == null) {
-                ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "value"), null) );
+                ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "value"), null));
                 return null;
             }
             return applyUnaryTest(ctx, tests, target);
@@ -120,7 +121,9 @@ public class CompiledFEELSemanticMappings {
 
         for (Object test : (List) tests) {
             Boolean r = applyUnaryTest(ctx, test, target);
-            if (Boolean.TRUE.equals(r)) return true;
+            if (Boolean.TRUE.equals(r)) {
+                return true;
+            }
         }
 
         return false;
@@ -131,7 +134,7 @@ public class CompiledFEELSemanticMappings {
             Boolean result = ((UnaryTest) test).apply(ctx, target);
             return result != null && result;
         } else if (test == null) {
-            return target == null? true : null;
+            return target == null ? true : null;
         } else {
             return Objects.equals(test, target);
         }
@@ -139,7 +142,7 @@ public class CompiledFEELSemanticMappings {
 
     /**
      * Implements a negated exists.
-     *
+     * <p>
      * Returns <strong>false</strong> when at least one of the elements of the list
      * <strong>matches</strong> the target.
      * The list may contain both objects (equals) and UnaryTests (apply)
@@ -151,7 +154,9 @@ public class CompiledFEELSemanticMappings {
 
         for (Object test : tests) {
             Boolean r = applyUnaryTest(ctx, test, target);
-            if (r == null || r) return false;
+            if (r == null || r) {
+                return false;
+            }
         }
 
         return true;
@@ -176,13 +181,15 @@ public class CompiledFEELSemanticMappings {
     }
 
     public static Boolean coerceToBoolean(EvaluationContext ctx, Object value) {
-        if (value == null || value instanceof Boolean) return (Boolean) value;
+        if (value == null || value instanceof Boolean) {
+            return (Boolean) value;
+        }
 
-        ctx.notifyEvt( () -> new ASTEventBase(
+        ctx.notifyEvt(() -> new ASTEventBase(
                 FEELEvent.Severity.ERROR,
                 Msg.createMessage(
                         Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE,
-                        value == null? "null" : value.getClass(),
+                        value == null ? "null" : value.getClass(),
                         "Boolean"),
                 null));
 
@@ -191,42 +198,42 @@ public class CompiledFEELSemanticMappings {
 
     public static <T> T coerceTo(Class<?> paramType, Object value) {
         Object actual;
-        if( paramType.isAssignableFrom( value.getClass() ) ) {
+        if (paramType.isAssignableFrom(value.getClass())) {
             actual = value;
         } else {
             // try to coerce
-            if( value instanceof Number ) {
-                if( paramType == byte.class || paramType == Byte.class ) {
-                    actual = ((Number)value).byteValue();
-                } else if( paramType == short.class || paramType == Short.class ) {
+            if (value instanceof Number) {
+                if (paramType == byte.class || paramType == Byte.class) {
+                    actual = ((Number) value).byteValue();
+                } else if (paramType == short.class || paramType == Short.class) {
                     actual = ((Number) value).shortValue();
-                } else if( paramType == int.class || paramType == Integer.class ) {
+                } else if (paramType == int.class || paramType == Integer.class) {
                     actual = ((Number) value).intValue();
-                } else if( paramType == long.class || paramType == Long.class ) {
+                } else if (paramType == long.class || paramType == Long.class) {
                     actual = ((Number) value).longValue();
-                } else if( paramType == float.class || paramType == Float.class ) {
+                } else if (paramType == float.class || paramType == Float.class) {
                     actual = ((Number) value).floatValue();
-                } else if( paramType == double.class || paramType == Double.class ) {
+                } else if (paramType == double.class || paramType == Double.class) {
                     actual = ((Number) value).doubleValue();
                 } else if (paramType == Object[].class) {
-                    actual = new Object[]{ value };
+                    actual = new Object[]{value};
                 } else {
-                    throw new IllegalArgumentException( "Unable to coerce parameter "+value+". Expected "+paramType+" but found "+value.getClass() );
+                    throw new IllegalArgumentException("Unable to coerce parameter " + value + ". Expected " + paramType + " but found " + value.getClass());
                 }
-            } else if ( value instanceof String
+            } else if (value instanceof String
                     && ((String) value).length() == 1
-                    && (paramType == char.class || paramType == Character.class) ) {
+                    && (paramType == char.class || paramType == Character.class)) {
                 actual = ((String) value).charAt(0);
-            } else if ( value instanceof Boolean && paramType == boolean.class ) {
+            } else if (value instanceof Boolean && paramType == boolean.class) {
                 // Because Boolean can be also null, boolean.class is not assignable from Boolean.class. So we must coerce this.
                 actual = value;
             } else {
-                throw new IllegalArgumentException( "Unable to coerce parameter "+value+". Expected "+paramType+" but found "+value.getClass() );
+                throw new IllegalArgumentException("Unable to coerce parameter " + value + ". Expected " + paramType + " but found " + value.getClass());
             }
         }
         return (T) actual;
     }
-    
+
     /**
      * Represent a [e1, e2, e3] construct.
      */
@@ -251,15 +258,15 @@ public class CompiledFEELSemanticMappings {
     public static Object and(Object left, Object right) {
         return InfixOpNode.and(left, right, null);
     }
-    
+
     public static Object and(boolean left, Object right) {
-        if ( left == true ) {
-            return EvalHelper.getBooleanOrNull( right );
+        if (left == true) {
+            return EvalHelper.getBooleanOrNull(right);
         } else {
             return false;
         }
     }
-    
+
     public static Object and(boolean left, boolean right) {
         return left && right;
     }
@@ -271,15 +278,15 @@ public class CompiledFEELSemanticMappings {
     public static Object or(Object left, Object right) {
         return InfixOpNode.or(left, right, null);
     }
-    
+
     public static Object or(Object left, boolean right) {
-        if ( right == true ) {
+        if (right == true) {
             return true;
         } else {
-            return EvalHelper.getBooleanOrNull( left );
+            return EvalHelper.getBooleanOrNull(left);
         }
     }
-    
+
     public static Object or(boolean left, boolean right) {
         return left || right;
     }
@@ -322,9 +329,8 @@ public class CompiledFEELSemanticMappings {
     }
 
     public static Object pow(Object left, Object right) {
-        return InfixOpNode.math( left, right, null, (l, r) -> l.pow(r.intValue(), MathContext.DECIMAL128 ) );
+        return InfixOpNode.math(left, right, null, (l, r) -> BigDecimalMath.pow(l, r, MathContext.DECIMAL128));
     }
-
 
     /**
      * FEEL spec Table 42 and derivations
@@ -376,17 +382,26 @@ public class CompiledFEELSemanticMappings {
 
     public static Boolean between(EvaluationContext ctx,
                                   Object value, Object start, Object end) {
-        if ( value == null ) { ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "value"), null) ); return null; }
-        if ( start == null ) { ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "start"), null) ); return null; }
-        if ( end == null )   { ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "end"), null) ); return null; }
+        if (value == null) {
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "value"), null));
+            return null;
+        }
+        if (start == null) {
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "start"), null));
+            return null;
+        }
+        if (end == null) {
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.IS_NULL, "end"), null));
+            return null;
+        }
 
         if (!value.getClass().isAssignableFrom(start.getClass())) {
-            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "value", "start"), null) );
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "value", "start"), null));
             return null;
         }
 
         if (!value.getClass().isAssignableFrom(end.getClass())) {
-            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "value", "end"), null) );
+            ctx.notifyEvt(() -> new ASTEventBase(FEELEvent.Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "value", "end"), null));
             return null;
         }
 
@@ -400,14 +415,14 @@ public class CompiledFEELSemanticMappings {
         return not(EvalHelper.isEqual(left, right, null));
     }
 
-    public static Object negateTest( Object param ) {
-        if( param instanceof Boolean) {
+    public static Object negateTest(Object param) {
+        if (param instanceof Boolean) {
             return param.equals(Boolean.FALSE);
-        } else if ( param instanceof UnaryTest ) {
+        } else if (param instanceof UnaryTest) {
             UnaryTest orig = (UnaryTest) param;
             UnaryTest t = negatedUnaryTest(orig);
             return t;
-        } else if ( param instanceof Range ) {
+        } else if (param instanceof Range) {
             UnaryTest t = (c, left) -> not(includes(c, param, left));
             return t;
         } else {
@@ -419,7 +434,9 @@ public class CompiledFEELSemanticMappings {
     private static UnaryTest negatedUnaryTest(UnaryTest orig) {
         return (c, left) -> {
             Boolean r = orig.apply(c, left);
-            if (r == null) return null;
+            if (r == null) {
+                return null;
+            }
             return r.equals(Boolean.FALSE);
         };
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Constants.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Constants.java
@@ -1,0 +1,81 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.math.BigDecimal;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.Modifier;
+import org.drools.javaparser.ast.body.FieldDeclaration;
+import org.drools.javaparser.ast.body.VariableDeclarator;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.FieldAccessExpr;
+import org.drools.javaparser.ast.expr.LambdaExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.ObjectCreationExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.javaparser.ast.type.Type;
+import org.kie.dmn.feel.lang.ast.RangeNode;
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+public class Constants {
+
+    public static final Expression DECIMAL_128 = JavaParser.parseExpression("java.math.MathContext.DECIMAL128");
+    public static final ClassOrInterfaceType BigDecimalT = new ClassOrInterfaceType(BigDecimal.class.getCanonicalName());
+    public static final ClassOrInterfaceType BooleanT = new ClassOrInterfaceType(Boolean.class.getCanonicalName());
+    private static final org.drools.javaparser.ast.type.Type ListT =
+            JavaParser.parseType(List.class.getCanonicalName());
+    public static final ClassOrInterfaceType UnaryTestT = JavaParser.parseClassOrInterfaceType(UnaryTest.class.getCanonicalName());
+    public static final String RangeBoundary =
+            Range.RangeBoundary.class.getCanonicalName();
+    public static final Expression BuiltInTypeT = JavaParser.parseExpression("org.kie.dmn.feel.lang.types.BuiltInType");
+    public static final ClassOrInterfaceType FunctionT = JavaParser.parseClassOrInterfaceType("java.util.function.Function<EvaluationContext, Object>");
+
+    public static FieldDeclaration of(Type type, String name, Expression initializer) {
+        return new FieldDeclaration(
+                EnumSet.of(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL),
+                new VariableDeclarator(type, name, initializer));
+    }
+
+    public static FieldDeclaration numeric(String name, String numericValue) {
+        ObjectCreationExpr initializer = new ObjectCreationExpr();
+        initializer.setType(BigDecimalT);
+        String originalText = numericValue;
+        try {
+            Long.parseLong(originalText);
+            initializer.addArgument(originalText.replaceFirst("^0+(?!$)", "")); // see EvalHelper.getBigDecimalOrNull
+        } catch (Throwable t) {
+            initializer.addArgument(new StringLiteralExpr(originalText));
+        }
+        initializer.addArgument(DECIMAL_128);
+        return of(BigDecimalT, name, initializer);
+    }
+
+    public static String numericName(String originalText) {
+        return "K_" + CodegenStringUtil.escapeIdentifier(originalText);
+    }
+
+    public static FieldDeclaration unaryTest(String name, LambdaExpr value) {
+        return of(UnaryTestT, name, value);
+    }
+
+    public static String unaryTestName(String originalText) {
+        return "UT_" + CodegenStringUtil.escapeIdentifier(originalText);
+    }
+
+    public static FieldDeclaration function(String name, LambdaExpr value) {
+        return of(FunctionT, name, value);
+    }
+
+    public static String functionName(String originalText) {
+        return "ZZFN_" + CodegenStringUtil.escapeIdentifier(originalText);
+    }
+
+    public static FieldAccessExpr rangeBoundary(RangeNode.IntervalBoundary boundary) {
+        return new FieldAccessExpr(
+                new NameExpr(RangeBoundary),
+                boundary == RangeNode.IntervalBoundary.OPEN ? "OPEN" : "CLOSED");
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Constants.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Constants.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.math.BigDecimal;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Contexts.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Contexts.java
@@ -1,0 +1,36 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.expr.EnclosedExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.type.Type;
+import org.kie.dmn.feel.lang.CompositeType;
+import org.kie.dmn.feel.lang.impl.JavaBackedType;
+import org.kie.dmn.feel.lang.impl.MapBackedType;
+import org.kie.dmn.feel.util.EvalHelper;
+
+public class Contexts {
+
+    public static final Type MapT = JavaParser.parseType(Map.class.getCanonicalName());
+
+    public static Expression getKey(Expression currentContext, CompositeType contextType, String key) {
+        if (contextType instanceof MapBackedType) {
+            EnclosedExpr enclosedExpr = Expressions.castTo(MapT, currentContext);
+            return new MethodCallExpr(enclosedExpr, "get")
+                    .addArgument(new StringLiteralExpr(key));
+        } else if (contextType instanceof JavaBackedType) {
+            JavaBackedType javaBackedType = (JavaBackedType) contextType;
+            Class<?> wrappedType = javaBackedType.getWrapped();
+            Method accessor = EvalHelper.getGenericAccessor(wrappedType, key);
+            Type type = JavaParser.parseType(wrappedType.getCanonicalName());
+            return new MethodCallExpr(Expressions.castTo(type, currentContext), accessor.getName());
+        } else {
+            throw new UnsupportedOperationException("A Composite type is either MapBacked or JavaBAcked");
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Contexts.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Contexts.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.lang.reflect.Method;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DefaultedVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DefaultedVisitor.java
@@ -1,0 +1,188 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import org.kie.dmn.feel.lang.ast.ASTNode;
+import org.kie.dmn.feel.lang.ast.BetweenNode;
+import org.kie.dmn.feel.lang.ast.BooleanNode;
+import org.kie.dmn.feel.lang.ast.ContextEntryNode;
+import org.kie.dmn.feel.lang.ast.ContextNode;
+import org.kie.dmn.feel.lang.ast.DashNode;
+import org.kie.dmn.feel.lang.ast.FilterExpressionNode;
+import org.kie.dmn.feel.lang.ast.ForExpressionNode;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
+import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
+import org.kie.dmn.feel.lang.ast.IfExpressionNode;
+import org.kie.dmn.feel.lang.ast.InNode;
+import org.kie.dmn.feel.lang.ast.InfixOpNode;
+import org.kie.dmn.feel.lang.ast.InstanceOfNode;
+import org.kie.dmn.feel.lang.ast.IterationContextNode;
+import org.kie.dmn.feel.lang.ast.ListNode;
+import org.kie.dmn.feel.lang.ast.NameDefNode;
+import org.kie.dmn.feel.lang.ast.NameRefNode;
+import org.kie.dmn.feel.lang.ast.NamedParameterNode;
+import org.kie.dmn.feel.lang.ast.NullNode;
+import org.kie.dmn.feel.lang.ast.NumberNode;
+import org.kie.dmn.feel.lang.ast.PathExpressionNode;
+import org.kie.dmn.feel.lang.ast.QualifiedNameNode;
+import org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode;
+import org.kie.dmn.feel.lang.ast.RangeNode;
+import org.kie.dmn.feel.lang.ast.SignedUnaryNode;
+import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.ast.TypeNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestListNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestNode;
+import org.kie.dmn.feel.lang.ast.Visitor;
+
+public abstract class DefaultedVisitor<T> implements Visitor<T> {
+
+    public abstract T defaultVisit(ASTNode n);
+
+    @Override
+    public T visit(ASTNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(DashNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(BooleanNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(NumberNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(StringNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(NullNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(TypeNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(NameDefNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(NameRefNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(QualifiedNameNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(InfixOpNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(InstanceOfNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(IfExpressionNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(ForExpressionNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(BetweenNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(ContextNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(ContextEntryNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(FilterExpressionNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(FunctionDefNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(FunctionInvocationNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(NamedParameterNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(InNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(IterationContextNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(ListNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(PathExpressionNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(QuantifiedExpressionNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(RangeNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(SignedUnaryNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(UnaryTestNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public T visit(UnaryTestListNode n) {
+        return defaultVisit(n);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DefaultedVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DefaultedVisitor.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import org.kie.dmn.feel.lang.ast.ASTNode;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerVisitor.java
@@ -91,6 +91,7 @@ import org.kie.dmn.feel.util.Msg;
 
 import static org.kie.dmn.feel.codegen.feel11.DirectCompilerResult.mergeFDs;
 
+@Deprecated
 public class DirectCompilerVisitor extends FEEL_1_1BaseVisitor<DirectCompilerResult> {
 
     private static final Expression QUANTIFIER_SOME = JavaParser.parseExpression("org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode.Quantifier.SOME");
@@ -197,7 +198,7 @@ public class DirectCompilerVisitor extends FEEL_1_1BaseVisitor<DirectCompilerRes
     }
 
     @Override
-    public DirectCompilerResult visitBooleanLiteral(FEEL_1_1Parser.BooleanLiteralContext ctx) {
+    public DirectCompilerResult visitBoolLiteral(FEEL_1_1Parser.BoolLiteralContext ctx) {
         Expression result = null;
         String literalText = ParserHelper.getOriginalText(ctx);
         // FEEL spec grammar rule 36. Boolean literal = "true" | "false" ;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.util.Collection;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
@@ -1,0 +1,392 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.NodeList;
+import org.drools.javaparser.ast.body.FieldDeclaration;
+import org.drools.javaparser.ast.body.Parameter;
+import org.drools.javaparser.ast.expr.CastExpr;
+import org.drools.javaparser.ast.expr.ClassExpr;
+import org.drools.javaparser.ast.expr.EnclosedExpr;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.LambdaExpr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.ObjectCreationExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.stmt.ExpressionStmt;
+import org.drools.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.javaparser.ast.type.Type;
+import org.drools.javaparser.ast.type.UnknownType;
+import org.kie.dmn.feel.lang.ast.InfixOpNode;
+import org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode;
+import org.kie.dmn.feel.lang.ast.RangeNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestNode;
+import org.kie.dmn.feel.lang.impl.NamedParameter;
+import org.kie.dmn.feel.util.EvalHelper;
+
+import static org.kie.dmn.feel.codegen.feel11.Constants.BigDecimalT;
+import static org.kie.dmn.feel.codegen.feel11.Constants.BuiltInTypeT;
+
+public class Expressions {
+
+    public static final ClassOrInterfaceType NamedParamterT = new ClassOrInterfaceType(null, NamedParameter.class.getCanonicalName());
+    private static final Expression DASH_UNARY_TEST = JavaParser.parseExpression(org.kie.dmn.feel.lang.ast.DashNode.DashUnaryTest.class.getCanonicalName() + ".INSTANCE");
+
+    public static class NamedLambda {
+
+        private final NameExpr name;
+
+        private final LambdaExpr expr;
+        private final FieldDeclaration field;
+
+        private NamedLambda(NameExpr name, LambdaExpr expr, FieldDeclaration field) {
+            this.name = name;
+            this.expr = expr;
+            this.field = field;
+        }
+
+        public NameExpr name() {
+            return name;
+        }
+
+        public LambdaExpr expr() {
+            return expr;
+        }
+
+        public FieldDeclaration field() {
+            return field;
+        }
+    }
+
+    private static final Expression QUANTIFIER_SOME = JavaParser.parseExpression("org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode.Quantifier.SOME");
+    private static final Expression QUANTIFIER_EVERY = JavaParser.parseExpression("org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode.Quantifier.EVERY");
+
+    public static final String LEFT = "left";
+    public static final NameExpr LEFT_EXPR = new NameExpr(LEFT);
+    public static final UnknownType UNKNOWN_TYPE = new UnknownType();
+    public static final NameExpr STDLIB = new NameExpr(CompiledFEELSupport.class.getSimpleName());
+
+    public static Expression dash() {
+        return DASH_UNARY_TEST;
+    }
+
+    public static Expression negate(Expression expression) {
+        EnclosedExpr e = castTo(BigDecimalT, expression);
+        return new MethodCallExpr(e, "negate");
+    }
+
+    public static MethodCallExpr binary(
+            InfixOpNode.InfixOperator operator,
+            Expression l,
+            Expression r) {
+        switch (operator) {
+            case ADD:
+                return arithmetic("add", l, r);
+            case SUB:
+                return arithmetic("sub", l, r);
+            case MULT:
+                return arithmetic("mult", l, r);
+            case DIV:
+                return arithmetic("div", l, r);
+            case POW:
+                return arithmetic("pow", l, r);
+
+            case LTE:
+                return comparison("lte", l, r);
+            case LT:
+                return comparison("lt", l, r);
+            case GT:
+                return comparison("gt", l, r);
+            case GTE:
+                return comparison("gte", l, r);
+            case EQ:
+                return equality("eq", l, r);
+            case NE:
+                return equality("ne", l, r);
+            case AND:
+                return booleans("and", l, r);
+            case OR:
+                return booleans("or", l, r);
+            default:
+                throw new UnsupportedOperationException(operator.toString());
+        }
+    }
+
+    private static MethodCallExpr arithmetic(String op, Expression left, Expression right) {
+        return new MethodCallExpr(null, op, new NodeList<>(left, right));
+    }
+
+    private static MethodCallExpr equality(String op, Expression left, Expression right) {
+        return new MethodCallExpr(null, op, new NodeList<>(left, right));
+    }
+
+    private static MethodCallExpr comparison(String op, Expression left, Expression right) {
+        return new MethodCallExpr(null, op, new NodeList<>(left, right));
+    }
+
+    private static MethodCallExpr booleans(String op, Expression left, Expression right) {
+        Expression l = coerceToBoolean(left);
+        Expression r = coerceToBoolean(right);
+
+        return new MethodCallExpr(null, op, new NodeList<>(l, r));
+    }
+
+    public static Expression unary(
+            UnaryTestNode.UnaryOperator operator,
+            Expression right) {
+        switch (operator) {
+            case LTE:
+                return unaryComparison("lte", right);
+            case LT:
+                return unaryComparison("lt", right);
+            case GT:
+                return unaryComparison("gt", right);
+            case GTE:
+                return unaryComparison("gte", right);
+            case EQ:
+                return new MethodCallExpr(null, "gracefulEq", new NodeList<>(FeelCtx.FEELCTX, right, LEFT_EXPR));
+            case NE:
+                return unaryComparison("ne", right);
+            case IN:
+                // only used in decision tables: refactor? how?
+                return new MethodCallExpr(null, "includes", new NodeList<>(FeelCtx.FEELCTX, right, LEFT_EXPR));
+            case NOT:
+                return new MethodCallExpr(null, "notExists", new NodeList<>(FeelCtx.FEELCTX, right, LEFT_EXPR));
+            case TEST:
+                return coerceToBoolean(right);
+            default:
+                throw new UnsupportedOperationException(operator.toString());
+        }
+    }
+
+    public static MethodCallExpr unaryComparison(String operator, Expression right) {
+        return new MethodCallExpr(null, operator, new NodeList<>(LEFT_EXPR, right));
+    }
+
+    public static MethodCallExpr lt(Expression left, Expression right) {
+        return new MethodCallExpr(null, "lt")
+                .addArgument(left)
+                .addArgument(right);
+    }
+
+    public static MethodCallExpr gt(Expression left, Expression right) {
+        return new MethodCallExpr(null, "gt")
+                .addArgument(left)
+                .addArgument(right);
+    }
+
+    public static MethodCallExpr between(Expression value, Expression start, Expression end) {
+        return new MethodCallExpr(null, "between")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(value)
+                .addArgument(start)
+                .addArgument(end);
+    }
+
+    public static EnclosedExpr castTo(Type type, Expression expr) {
+        return new EnclosedExpr(new CastExpr(type, new EnclosedExpr(expr)));
+    }
+
+    public static MethodCallExpr reflectiveCastTo(Type type, Expression expr) {
+        return new MethodCallExpr(new ClassExpr(type), "cast")
+                .addArgument(new EnclosedExpr(expr));
+    }
+
+    public static Expression quantifier(
+            QuantifiedExpressionNode.Quantifier quantifier,
+            Expression condition,
+            List<Expression> iterationContexts) {
+
+        // quant({SOME,EVERY}, FEELCTX)
+        MethodCallExpr quant =
+                new MethodCallExpr(Expressions.STDLIB, "quant")
+                        .addArgument(quantifier == QuantifiedExpressionNode.Quantifier.SOME ?
+                                             QUANTIFIER_SOME :
+                                             QUANTIFIER_EVERY)
+                        .addArgument(FeelCtx.FEELCTX);
+
+        // .with(expr)
+        // .with(expr)
+        Expression chainedCalls = iterationContexts.stream()
+                .reduce(quant, (l, r) -> r.asMethodCallExpr().setScope(l));
+
+        return new MethodCallExpr(chainedCalls, "satisfies")
+                .addArgument(condition);
+    }
+
+    public static MethodCallExpr ffor(
+            List<Expression> iterationContexts,
+            Expression returnExpr) {
+        MethodCallExpr ffor =
+                new MethodCallExpr(Expressions.STDLIB, "ffor")
+                        .addArgument(FeelCtx.FEELCTX);
+
+        // .with(expr)
+        // .with(expr)
+        Expression chainedCalls = iterationContexts.stream()
+                .reduce(ffor, (l, r) -> r.asMethodCallExpr().setScope(l));
+
+        return new MethodCallExpr(chainedCalls, "rreturn")
+                .addArgument(returnExpr);
+    }
+
+    public static MethodCallExpr list(Expression... exprs) {
+        return new MethodCallExpr(null, "list", NodeList.nodeList(exprs));
+    }
+
+    public static MethodCallExpr list(Collection<Expression> exprs) {
+        return new MethodCallExpr(null, "list", NodeList.nodeList(exprs));
+    }
+
+
+    public static MethodCallExpr range(RangeNode.IntervalBoundary lowBoundary,
+                                       Expression lowEndPoint,
+                                       Expression highEndPoint,
+                                       RangeNode.IntervalBoundary highBoundary) {
+
+        return new MethodCallExpr(null, "range")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(Constants.rangeBoundary(lowBoundary))
+                .addArgument(lowEndPoint)
+                .addArgument(highEndPoint)
+                .addArgument(Constants.rangeBoundary(highBoundary));
+    }
+
+    public static MethodCallExpr includes(Expression range, Expression target) {
+        return new MethodCallExpr(null, "includes")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(range)
+                .addArgument(target);
+    }
+
+    public static MethodCallExpr exists(Expression tests, Expression target) {
+        return new MethodCallExpr(null, "exists")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(tests)
+                .addArgument(target);
+    }
+
+    public static MethodCallExpr notExists(Expression expr) {
+        return new MethodCallExpr(null, "notExists")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(expr)
+                .addArgument(LEFT_EXPR);
+    }
+
+    public static NamedLambda namedLambda(Expression expr, String text) {
+        LambdaExpr lambda = Expressions.lambda(expr);
+        String name = Constants.functionName(text);
+        FieldDeclaration field = Constants.function(name, lambda);
+        return new NamedLambda(new NameExpr(name), lambda, field);
+    }
+
+    public static LambdaExpr lambda(Expression expr) {
+        return new LambdaExpr(
+                new NodeList<>(
+                        new Parameter(UNKNOWN_TYPE, FeelCtx.FEELCTX_N)),
+                new ExpressionStmt(expr),
+                true);
+    }
+
+    public static NamedLambda namedUnaryLambda(Expression expr, String text) {
+        LambdaExpr lambda = Expressions.unaryLambda(expr);
+        String name = Constants.unaryTestName(text);
+        FieldDeclaration field = Constants.unaryTest(name, lambda);
+        return new NamedLambda(new NameExpr(name), lambda, field);
+    }
+
+
+    public static LambdaExpr unaryLambda(Expression expr) {
+        return new LambdaExpr(
+                new NodeList<>(
+                        new Parameter(UNKNOWN_TYPE, FeelCtx.FEELCTX_N),
+                        new Parameter(UNKNOWN_TYPE, "left")),
+                new ExpressionStmt(expr),
+                true);
+    }
+
+    public static ObjectCreationExpr namedParameter(Expression name, Expression value) {
+        return new ObjectCreationExpr(null, NamedParamterT, new NodeList<>(name, value));
+    }
+
+    public static MethodCallExpr invoke(Expression functionName, Expression params) {
+        return new MethodCallExpr(STDLIB, "invoke")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(functionName)
+                .addArgument(params);
+    }
+
+    public static MethodCallExpr filter(Expression expr, Expression filter) {
+        return new MethodCallExpr(new MethodCallExpr(STDLIB, "filter")
+                                          .addArgument(FeelCtx.FEELCTX)
+                                          .addArgument(expr),
+                                  "with")
+                .addArgument(filter);
+    }
+
+    public static MethodCallExpr path(Expression expr, Expression filter) {
+        return new MethodCallExpr(new MethodCallExpr(STDLIB, "path")
+                                          .addArgument(FeelCtx.FEELCTX)
+                                          .addArgument(expr),
+                                  "with")
+                .addArgument(filter);
+    }
+
+    public static MethodCallExpr path(Expression expr, List<Expression> filters) {
+        MethodCallExpr methodCallExpr = new MethodCallExpr(new MethodCallExpr(STDLIB, "path")
+                                                                   .addArgument(FeelCtx.FEELCTX)
+                                                                   .addArgument(expr),
+                                                           "with");
+        filters.forEach(methodCallExpr::addArgument);
+        return methodCallExpr;
+    }
+
+    public static MethodCallExpr isInstanceOf(Expression expr, Expression type) {
+        return new MethodCallExpr(type, "isInstanceOf")
+                .addArgument(expr);
+    }
+
+    public static MethodCallExpr nativeInstanceOf(Type type, Expression condition) {
+        return new MethodCallExpr(
+                new ClassExpr(type),
+                "isInstance")
+                .addArgument(new EnclosedExpr(condition));
+    }
+
+    public static MethodCallExpr determineTypeFromName(String typeAsText) {
+        return new MethodCallExpr(BuiltInTypeT, "determineTypeFromName")
+                .addArgument(new StringLiteralExpr(typeAsText));
+    }
+
+    public static Expression contains(Expression expr, Expression value) {
+        return new MethodCallExpr(expr, "contains")
+                .addArgument(value);
+    }
+
+    public static StringLiteralExpr stringLiteral(String text) {
+        if (text.startsWith("\"") && text.endsWith("\"")) {
+            String actualStringContent = text.substring(1, text.length() - 1); // remove start/end " from the FEEL text expression.
+            String unescaped = EvalHelper.unescapeString(actualStringContent); // unescapes String, FEEL-style
+            return new StringLiteralExpr().setString(unescaped); // setString escapes the contents Java-style
+        } else {
+            return new StringLiteralExpr().setString(text);
+        }
+    }
+
+    public static Expression coerceToBoolean(Expression expression) {
+        return new MethodCallExpr(null, "coerceToBoolean")
+                .addArgument(FeelCtx.FEELCTX)
+                .addArgument(expression);
+    }
+
+    public static MethodCallExpr coerceNumber(Expression exprCursor) {
+        MethodCallExpr coerceNumberMethodCallExpr = new MethodCallExpr(new NameExpr(CompiledFEELSupport.class.getSimpleName()), "coerceNumber");
+        coerceNumberMethodCallExpr.addArgument(exprCursor);
+        return coerceNumberMethodCallExpr;
+    }
+}
+
+

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FeelCtx.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FeelCtx.java
@@ -1,0 +1,52 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.NodeList;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+
+public class FeelCtx {
+
+    public static final String FEELCTX_N = "feelExprCtx";
+    public static final NameExpr FEELCTX = new NameExpr(FEELCTX_N);
+    private static final String FEEL_SUPPORT = CompiledFEELSupport.class.getSimpleName();
+    private static final Expression EMPTY_MAP = JavaParser.parseExpression("java.util.Collections.emptyMap()");
+
+    public static Expression emptyContext() {
+        return EMPTY_MAP;
+    }
+
+    public static MethodCallExpr getValue(String nameRef) {
+        return new MethodCallExpr(FEELCTX, "getValue", new NodeList<>(new StringLiteralExpr(nameRef)));
+    }
+
+    public static MethodCallExpr current() {
+        return new MethodCallExpr(FeelCtx.FEELCTX, "current");
+    }
+
+    public static MethodCallExpr openContext() {
+        return new MethodCallExpr(
+                new NameExpr(FEEL_SUPPORT),
+                "openContext")
+                .addArgument(FEELCTX);
+    }
+
+
+    public static MethodCallExpr setEntry(String keyText, Expression expression) {
+        return new MethodCallExpr(
+                null,
+                "setEntry",
+                new NodeList<>(
+                        new StringLiteralExpr(keyText),
+                        expression));
+    }
+
+    public static MethodCallExpr closeContext(DirectCompilerResult contextEntriesMethodChain) {
+        return new MethodCallExpr(
+                contextEntriesMethodChain.getExpression(),
+                "closeContext");
+    }
+
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FeelCtx.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/FeelCtx.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import org.drools.javaparser.JavaParser;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.util.List;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
@@ -1,0 +1,81 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.drools.javaparser.JavaParser;
+import org.drools.javaparser.ast.expr.Expression;
+import org.drools.javaparser.ast.expr.LambdaExpr;
+import org.drools.javaparser.ast.expr.MethodCallExpr;
+import org.drools.javaparser.ast.expr.NameExpr;
+import org.drools.javaparser.ast.expr.ObjectCreationExpr;
+import org.drools.javaparser.ast.expr.StringLiteralExpr;
+import org.drools.javaparser.ast.type.ClassOrInterfaceType;
+import org.kie.dmn.feel.lang.FunctionDefs;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
+import org.kie.dmn.feel.lang.ast.ListNode;
+import org.kie.dmn.feel.lang.ast.NameDefNode;
+import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
+import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
+import org.kie.dmn.feel.util.Msg;
+
+public class Functions {
+    public static final ClassOrInterfaceType TYPE_CUSTOM_FEEL_FUNCTION =
+            JavaParser.parseClassOrInterfaceType(CompiledCustomFEELFunction.class.getSimpleName());
+    private static final Expression ANONYMOUS_STRING_LITERAL = new StringLiteralExpr("<anonymous>");
+    private static final Expression EMPTY_LIST = JavaParser.parseExpression("java.util.Collections.emptyList()");
+
+    public static Expression external(List<String> paramNames, BaseNode body) {
+        EvaluationContextImpl emptyEvalCtx =
+                new EvaluationContextImpl(Functions.class.getClassLoader(), new FEELEventListenersManager());
+
+
+        Map<String, Object> conf = (Map<String, Object>) body.evaluate(emptyEvalCtx);
+        Map<String, String> java = (Map<String, String>) conf.get( "java" );
+
+        if (java != null) {
+
+            String className = java.get("class");
+            String methodSignature = java.get("method signature");
+            if (className == null || methodSignature == null) {
+                throw new FEELCompilationError(Msg.createMessage(Msg.UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY, methodSignature));
+            }
+            Expression methodCallExpr = FunctionDefs.asMethodCall(className, methodSignature, paramNames);
+//            DirectCompilerResult parameters = visit(ctx.formalParameters());
+
+            return methodCallExpr;
+        } else {
+            throw new FEELCompilationError(Msg.createMessage(Msg.UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY, null));
+        }
+    }
+
+    public static ObjectCreationExpr internal(Expression parameters, Expression body) {
+        ObjectCreationExpr functionDefExpr = new ObjectCreationExpr();
+        functionDefExpr.setType(TYPE_CUSTOM_FEEL_FUNCTION);
+        functionDefExpr.addArgument(ANONYMOUS_STRING_LITERAL);
+        functionDefExpr.addArgument(parameters);
+        functionDefExpr.addArgument(body);
+        functionDefExpr.addArgument(new MethodCallExpr(new NameExpr("feelExprCtx"), "current"));
+        return functionDefExpr;
+    }
+
+    public static DirectCompilerResult declaration(FunctionDefNode n, MethodCallExpr list, Expression fnBody) {
+        LambdaExpr lambda = Expressions.lambda(fnBody);
+        String fnName = Constants.functionName(n.getBody().getText());
+        DirectCompilerResult r = DirectCompilerResult.of(
+                Functions.internal(list, new NameExpr(fnName)),
+                BuiltInType.FUNCTION);
+        r.addFieldDesclaration(Constants.function(fnName, lambda));
+        return r;
+    }
+
+
+
+
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
@@ -1,9 +1,7 @@
 package org.kie.dmn.feel.codegen.feel11;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.drools.javaparser.JavaParser;
 import org.drools.javaparser.ast.expr.Expression;
@@ -16,13 +14,9 @@ import org.drools.javaparser.ast.type.ClassOrInterfaceType;
 import org.kie.dmn.feel.lang.FunctionDefs;
 import org.kie.dmn.feel.lang.ast.BaseNode;
 import org.kie.dmn.feel.lang.ast.FunctionDefNode;
-import org.kie.dmn.feel.lang.ast.ListNode;
-import org.kie.dmn.feel.lang.ast.NameDefNode;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.lang.types.BuiltInType;
-import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
-import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
 import org.kie.dmn.feel.util.Msg;
 
 public class Functions {
@@ -44,12 +38,11 @@ public class Functions {
             String className = java.get("class");
             String methodSignature = java.get("method signature");
             if (className == null || methodSignature == null) {
-                throw new FEELCompilationError(Msg.createMessage(Msg.UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY, methodSignature));
+                throw new FEELCompilationError(
+                        Msg.createMessage(Msg.UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY, methodSignature));
             }
-            Expression methodCallExpr = FunctionDefs.asMethodCall(className, methodSignature, paramNames);
-//            DirectCompilerResult parameters = visit(ctx.formalParameters());
 
-            return methodCallExpr;
+            return FunctionDefs.asMethodCall(className, methodSignature, paramNames);
         } else {
             throw new FEELCompilationError(Msg.createMessage(Msg.UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY, null));
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTBuilderFactory.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTBuilderFactory.java
@@ -52,6 +52,10 @@ public class ASTBuilderFactory {
         return new BetweenNode( ctx, value, start, end );
     }
 
+    public static UnaryTestListNode newUnaryTestListNode(ParserRuleContext ctx, List<BaseNode> exprs, UnaryTestListNode.State state) {
+        return new UnaryTestListNode( ctx, exprs, state );
+    }
+
     public static ListNode newListNode(ParserRuleContext ctx, List<BaseNode> exprs) {
         return new ListNode( ctx, exprs );
     }
@@ -102,6 +106,10 @@ public class ASTBuilderFactory {
 
     public static NameRefNode newNameRefNode( ParserRuleContext ctx, Type type ) {
         return new NameRefNode( ctx, type );
+    }
+
+    public static NameRefNode newNameRefNode( ParserRuleContext ctx, String name, Type type ) {
+        return new NameRefNode( ctx, name, type );
     }
 
     public static QualifiedNameNode newQualifiedNameNode(ParserRuleContext ctx, ArrayList<NameRefNode> parts, Type type ) {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ASTNode.java
@@ -45,4 +45,7 @@ public interface ASTNode {
     Object evaluate(EvaluationContext ctx);
 
     ASTNode[] getChildrenNode();
+
+    <T> T accept(Visitor<T> v);
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BaseNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BaseNode.java
@@ -33,6 +33,7 @@ import org.kie.dmn.feel.util.Msg;
 public class BaseNode
         implements ASTNode {
     protected final ASTNode[] EMPTY_CHILDREN = new ASTNode[0];
+    private ParserRuleContext ctx;
     private int startChar;
     private int endChar;
     private int startLine;
@@ -46,6 +47,7 @@ public class BaseNode
     }
 
     public BaseNode( ParserRuleContext ctx ) {
+        this.ctx = ctx;
         this.setStartChar( ctx.getStart().getStartIndex() );
         this.setStartLine( ctx.getStart().getLine() );
         this.setStartColumn( ctx.getStart().getCharPositionInLine() );
@@ -53,6 +55,14 @@ public class BaseNode
         this.setEndLine( ctx.getStop().getLine() );
         this.setEndColumn( ctx.getStop().getCharPositionInLine() + ctx.getStop().getText().length() );
         this.setText( ParserHelper.getOriginalText( ctx ) );
+    }
+
+    public void setCtx(ParserRuleContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public ParserRuleContext getParserRuleContext() {
+        return ctx;
     }
 
     @Override
@@ -146,4 +156,8 @@ public class BaseNode
         return EMPTY_CHILDREN;
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BetweenNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BetweenNode.java
@@ -101,4 +101,9 @@ public class BetweenNode
         return new ASTNode[] { value, start, end };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BooleanNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/BooleanNode.java
@@ -44,4 +44,10 @@ public class BooleanNode
     public Type getResultType() {
         return BuiltInType.BOOLEAN;
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextEntryNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextEntryNode.java
@@ -73,4 +73,9 @@ public class ContextEntryNode
     public ASTNode[] getChildrenNode() {
         return new ASTNode[] { name, value };
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
@@ -91,5 +91,8 @@ public class ContextNode
         return entries.toArray( new ASTNode[entries.size()] );
     }
 
-
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/DashNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/DashNode.java
@@ -56,4 +56,9 @@ public class DashNode
     public Type getResultType() {
         return BuiltInType.BOOLEAN;
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FilterExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FilterExpressionNode.java
@@ -126,4 +126,8 @@ public class FilterExpressionNode
         return new ASTNode[] { expression, filter };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ForExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ForExpressionNode.java
@@ -240,4 +240,9 @@ public class ForExpressionNode
         return children;
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
@@ -205,4 +205,9 @@ public class FunctionDefNode
         return children;
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionInvocationNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/FunctionInvocationNode.java
@@ -131,4 +131,8 @@ public class FunctionInvocationNode
         return new ASTNode[] { name, params };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IfExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IfExpressionNode.java
@@ -86,4 +86,8 @@ public class IfExpressionNode
         return new ASTNode[] { condition, thenExpression, elseExpression };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InNode.java
@@ -108,4 +108,8 @@ public class InNode
         return new ASTNode[] { value, exprs };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
@@ -386,4 +386,8 @@ public class InfixOpNode
         return new ASTNode[] { left, right };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InstanceOfNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InstanceOfNode.java
@@ -66,4 +66,9 @@ public class InstanceOfNode
         return new ASTNode[] { expression };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IterationContextNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/IterationContextNode.java
@@ -51,6 +51,10 @@ public class IterationContextNode
         return expression;
     }
 
+    public BaseNode getRangeEndExpr() {
+        return rangeEndExpr;
+    }
+
     public void setExpression(BaseNode expression) {
         this.expression = expression;
     }
@@ -74,6 +78,11 @@ public class IterationContextNode
             return new ASTNode[] { name, expression, rangeEndExpr };
         }
         return new ASTNode[] { name, expression };
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
     }
 
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameDefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameDefNode.java
@@ -65,4 +65,10 @@ public class NameDefNode
     public String evaluate(EvaluationContext ctx) {
         return EvalHelper.normalizeVariableName( getText() );
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameRefNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NameRefNode.java
@@ -36,6 +36,12 @@ public class NameRefNode
         this.resultType = type;
     }
 
+    public NameRefNode(ParserRuleContext ctx, String text, Type type) {
+        super( ctx );
+        this.resultType = type;
+        this.setText(text);
+    }
+
     @Override
     public Object evaluate(EvaluationContext ctx) {
         String varName = EvalHelper.normalizeVariableName( getText() );
@@ -50,6 +56,9 @@ public class NameRefNode
     public Type getResultType() {
         return resultType;
     }
-    
-    
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NamedParameterNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NamedParameterNode.java
@@ -62,4 +62,10 @@ public class NamedParameterNode
     public ASTNode[] getChildrenNode() {
         return new ASTNode[] { name, expression };
     }
+
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NullNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NullNode.java
@@ -30,4 +30,9 @@ public class NullNode
     public Object evaluate(EvaluationContext ctx) {
         return null;
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NumberNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/NumberNode.java
@@ -51,4 +51,9 @@ public class NumberNode
     public Type getResultType() {
         return BuiltInType.NUMBER;
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/PathExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/PathExpressionNode.java
@@ -130,4 +130,9 @@ public class PathExpressionNode
         return new ASTNode[] { expression, name };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QualifiedNameNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QualifiedNameNode.java
@@ -89,4 +89,9 @@ public class QualifiedNameNode
         return parts.toArray( new ASTNode[parts.size()] );
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QuantifiedExpressionNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/QuantifiedExpressionNode.java
@@ -197,4 +197,9 @@ public class QuantifiedExpressionNode
         return children;
     }
 
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/RangeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/RangeNode.java
@@ -182,4 +182,8 @@ public class RangeNode
         return new ASTNode[] { start, end };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/SignedUnaryNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/SignedUnaryNode.java
@@ -82,4 +82,8 @@ public class SignedUnaryNode
         return new ASTNode[] { expression };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/StringNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/StringNode.java
@@ -38,4 +38,9 @@ public class StringNode
     public Type getResultType() {
         return BuiltInType.STRING;
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/TypeNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/TypeNode.java
@@ -32,4 +32,9 @@ public class TypeNode
     public Type evaluate(EvaluationContext ctx) {
         return BuiltInType.determineTypeFromName( getText() );
     }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestListNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestListNode.java
@@ -16,29 +16,48 @@
 
 package org.kie.dmn.feel.lang.ast;
 
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.kie.dmn.feel.lang.EvaluationContext;
-import org.kie.dmn.feel.lang.Type;
-import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
-import org.kie.dmn.feel.lang.types.BuiltInType;
-
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class ListNode
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+
+public class UnaryTestListNode
         extends BaseNode {
 
-    private List<BaseNode> elements;
-
-    public ListNode(ParserRuleContext ctx) {
-        super( ctx );
-        elements = new ArrayList<>();
+    public enum State {
+        Positive,
+        Negated
     }
 
-    public ListNode(ParserRuleContext ctx, List<BaseNode> elements) {
-        super( ctx );
+    private List<BaseNode> elements;
+    private State state;
+    private BaseNode notNode;
+
+    public UnaryTestListNode(ParserRuleContext ctx) {
+        this(ctx, new ArrayList<>(), State.Positive);
+    }
+
+    public UnaryTestListNode(ParserRuleContext ctx, List<BaseNode> elements, State state) {
+        super(ctx);
         this.elements = elements;
+        this.state = state;
+        if (isNegated()) {
+            notNode = ASTBuilderFactory.newUnaryTestNode(ctx, "not",
+                                                         ASTBuilderFactory.newListNode(ctx, elements));
+        }
+    }
+
+    public boolean isNegated() {
+        return state == State.Negated;
+    }
+
+    public State getState() {
+        return state;
     }
 
     public List<BaseNode> getElements() {
@@ -51,7 +70,11 @@ public class ListNode
 
     @Override
     public List evaluate(EvaluationContext ctx) {
-        return elements.stream().map( e -> e != null ? e.evaluate( ctx ) : null ).collect( Collectors.toList() );
+        if (notNode != null) {
+            return Collections.singletonList(notNode.evaluate(ctx));
+        } else {
+            return elements.stream().map(e -> e != null ? e.evaluate(ctx) : null).collect(Collectors.toList());
+        }
     }
 
     @Override
@@ -61,12 +84,11 @@ public class ListNode
 
     @Override
     public ASTNode[] getChildrenNode() {
-        return elements.toArray( new ASTNode[elements.size()] );
+        return elements.toArray(new ASTNode[elements.size()]);
     }
 
     @Override
     public <T> T accept(Visitor<T> v) {
         return v.visit(this);
     }
-
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestListNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestListNode.java
@@ -1,17 +1,19 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *
  */
 
 package org.kie.dmn.feel.lang.ast;

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/UnaryTestNode.java
@@ -240,4 +240,8 @@ public class UnaryTestNode
         return new ASTNode[] { value };
     }
 
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/Visitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/Visitor.java
@@ -1,0 +1,34 @@
+package org.kie.dmn.feel.lang.ast;
+
+public interface Visitor<T> {
+    T visit(ASTNode n);
+    T visit(DashNode n);
+    T visit(BooleanNode n);
+    T visit(NumberNode n);
+    T visit(StringNode n);
+    T visit(NullNode n);
+    T visit(TypeNode n);
+    T visit(NameDefNode n);
+    T visit(NameRefNode n);
+    T visit(QualifiedNameNode n);
+    T visit(InfixOpNode n);
+    T visit(InstanceOfNode n);
+    T visit(IfExpressionNode n);
+    T visit(ForExpressionNode n);
+    T visit(BetweenNode n);
+    T visit(ContextNode n);
+    T visit(ContextEntryNode n);
+    T visit(FilterExpressionNode n);
+    T visit(FunctionDefNode n);
+    T visit(FunctionInvocationNode n);
+    T visit(NamedParameterNode n);
+    T visit(InNode n);
+    T visit(IterationContextNode n);
+    T visit(ListNode n);
+    T visit(PathExpressionNode n);
+    T visit(QuantifiedExpressionNode n);
+    T visit(RangeNode n);
+    T visit(SignedUnaryNode n);
+    T visit(UnaryTestNode n);
+    T visit(UnaryTestListNode n);
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/Visitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/Visitor.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
 package org.kie.dmn.feel.lang.ast;
 
 public interface Visitor<T> {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ASTBuilderVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ASTBuilderVisitor.java
@@ -48,6 +48,7 @@ import org.kie.dmn.feel.lang.ast.QualifiedNameNode;
 import org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode;
 import org.kie.dmn.feel.lang.ast.RangeNode;
 import org.kie.dmn.feel.lang.ast.TypeNode;
+import org.kie.dmn.feel.lang.ast.UnaryTestListNode;
 import org.kie.dmn.feel.lang.ast.UnaryTestNode;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser.RelExpressionValueContext;
@@ -101,7 +102,7 @@ public class ASTBuilderVisitor
     }
 
     @Override
-    public BaseNode visitBooleanLiteral(FEEL_1_1Parser.BooleanLiteralContext ctx) {
+    public BaseNode visitBoolLiteral(FEEL_1_1Parser.BoolLiteralContext ctx) {
         return ASTBuilderFactory.newBooleanNode( ctx );
     }
 
@@ -477,19 +478,20 @@ public class ASTBuilderVisitor
 
     @Override
     public BaseNode visitUnaryTests_empty(FEEL_1_1Parser.UnaryTests_emptyContext ctx) {
-        return ASTBuilderFactory.newListNode(ctx, Collections.singletonList(ASTBuilderFactory.newDashNode(ctx)));
+        return ASTBuilderFactory.newUnaryTestListNode(ctx, Collections.singletonList(ASTBuilderFactory.newDashNode(ctx)), UnaryTestListNode.State.Positive);
     }
 
     @Override
     public BaseNode visitUnaryTests_positive(FEEL_1_1Parser.UnaryTests_positiveContext ctx) {
-        return visit( ctx.positiveUnaryTests() );
+        ListNode list = (ListNode) visit(ctx.positiveUnaryTests());
+        return ASTBuilderFactory.newUnaryTestListNode(ctx, list.getElements(), UnaryTestListNode.State.Positive);
     }
 
     @Override
     public BaseNode visitUnaryTests_negated(FEEL_1_1Parser.UnaryTests_negatedContext ctx) {
-        BaseNode name = ASTBuilderFactory.newNameRefNode( ctx.not_key(), BuiltInType.BOOLEAN ); // negating a unary tests: BOOLEAN-type anyway
+        BaseNode name = ASTBuilderFactory.newNameRefNode( ctx, "not", BuiltInType.BOOLEAN ); // negating a unary tests: BOOLEAN-type anyway
         ListNode value = (ListNode) visit( ctx.positiveUnaryTests() );
-        return ASTBuilderFactory.newListNode(ctx, Collections.singletonList(buildNotCall(ctx, name, value)))    ;
+        return ASTBuilderFactory.newUnaryTestListNode(ctx, value.getElements(), UnaryTestListNode.State.Negated);
     }
 
     private BaseNode buildNotCall(ParserRuleContext ctx, BaseNode name, ListNode params) {

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerTest.java
@@ -30,9 +30,11 @@ import org.junit.Test;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.FEELProperty;
 import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.ast.BaseNode;
 import org.kie.dmn.feel.lang.impl.JavaBackedType;
 import org.kie.dmn.feel.lang.impl.MapBackedType;
 import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
 import org.kie.dmn.feel.parser.feel11.FEELParser;
 import org.kie.dmn.feel.parser.feel11.FEELParserTest;
 import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
@@ -480,8 +482,9 @@ public class DirectCompilerTest {
 
         ParseTree tree = parser.compilation_unit();
 
-        DirectCompilerVisitor v = new DirectCompilerVisitor(inputTypes);
-        DirectCompilerResult directResult = v.visit(tree);
+        ASTBuilderVisitor v = new ASTBuilderVisitor(inputTypes);
+        BaseNode node = v.visit(tree);
+        DirectCompilerResult directResult = node.accept(new ASTCompilerVisitor());
         
         Expression expr = directResult.getExpression();
         CompiledFEELExpression cu = new CompilerBytecodeLoader().makeFromJPExpression(input, expr, directResult.getFieldDeclarations());


### PR DESCRIPTION
Current compiler backend is harder to maintain because it closely follows the parse tree that ANTLR generates. We could improve the tree that ANTLR generates, but luckily a lot of work already has been done to build an AST, and we can build a lot on top of that. Reusing the separate AST representation allows us

1) to better represent compilation stages 
2) to manage less cases, because the number of AST node is much smaller the number of parse tree node (the visitor is much smaller!)
3) with less cases to manage, it is also easier to separate compilation concerns and to further improve by adding more processing phases: e.g. a name resolution phase and a type-checking phase (and possibly different compiler backends)

In this PR:

- a minor refactoring of the grammar, where we only use named tokens in the lexer, and remove inline token definitions (`'my-token'`) in the grammar, so that lexing and parsing are better distinguished
- we add a new AST node (used also in the interpreter) to deal with the root of the UnaryTests grammar (used in Decision Tables). This node supports being flagged as Negated, to better distinguish the `not` case in Decision Tables (different from the `not()` function)  
- we better support the question mark `?` special name (here called a `Wildcard`) -- now it cannot be mistaken as a wildcard if it occurs within a qualified expression (`foo.?.bar` is not a wildcard, `?.foo.bar` is) 
- we add and implement a Visitor for the AST nodes
- we support compiling the AST visitor down to a `DirectCompilerResult`, i.e. the same type returned by current compiler -- (`ASTCompilerVisitor`)
- we support AST rewriting (`ASTUnaryTestTransform`) to reduce an AST for unary tests, to a "canonical" form that can be processed by the simple AST compiler (e.g.: [1, 2, 3] is rewritten to [=1, =2, =3])

All tests are currently passing including TCK's.

Further work will be done in a follow-up PR, but it's unrelated to the compiler backend itself, rather to the way components interact at higher-level ( compiler vs. interpreter vs. public APIs vs. internal APIs. see: https://issues.jboss.org/browse/DROOLS-3112 )

@tarilabs for review, cc @etirelli 
@baldimir can you take a look and run the benchmarks on this PR so that we are sure we are not regressing