### PR TITLE
DROOLS-2893 DMN v1.2 Serialization degraded mode without XSD

### DIFF
--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
@@ -43,13 +43,18 @@ import org.xmlunit.diff.ComparisonResult;
 import org.xmlunit.diff.ComparisonType;
 import org.xmlunit.diff.Diff;
 import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.validation.Languages;
+import org.xmlunit.validation.ValidationProblem;
+import org.xmlunit.validation.ValidationResult;
+import org.xmlunit.validation.Validator;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class UnmarshalMarshalTest {
 
-    private static final StreamSource DMN12_SCHEMA_SOURCE = null; // DROOLS-2893: new StreamSource(UnmarshalMarshalTest.class.getResource("/DMN12.xsd").getFile());
+    private static final StreamSource DMN12_SCHEMA_SOURCE = new StreamSource(UnmarshalMarshalTest.class.getResource("/DMN12.xsd").getFile());
     protected static final Logger logger = LoggerFactory.getLogger(UnmarshalMarshalTest.class);
     
     @Test
@@ -84,17 +89,16 @@ public class UnmarshalMarshalTest {
         FileInputStream fis = new FileInputStream( inputXMLFile );
                 
         Definitions unmarshal = marshaller.unmarshal( new InputStreamReader( fis ) );
-
-        // DROOLS-2893 DMN v1.2 Serialization degraded mode without XSD
-        //        Validator v = Validator.forLanguage(Languages.W3C_XML_SCHEMA_NS_URI);
-        //        v.setSchemaSource(schemaSource);
-        //        ValidationResult validateInputResult = v.validateInstance(new StreamSource( inputXMLFile ));
-        //        if (!validateInputResult.isValid()) {
-        //            for ( ValidationProblem p : validateInputResult.getProblems()) {
-        //                System.err.println(p);
-        //            }
-        //        }
-        //        assertTrue(validateInputResult.isValid());
+        
+        Validator v = Validator.forLanguage(Languages.W3C_XML_SCHEMA_NS_URI);
+        v.setSchemaSource(schemaSource);
+        ValidationResult validateInputResult = v.validateInstance(new StreamSource( inputXMLFile ));
+        if (!validateInputResult.isValid()) {
+            for ( ValidationProblem p : validateInputResult.getProblems()) {
+                System.err.println(p);
+            }
+        }
+        assertTrue(validateInputResult.isValid());
 
         final File subdirFile = new File(baseOutputDir, subdir);
         if (!subdirFile.mkdirs()) {
@@ -114,15 +118,14 @@ public class UnmarshalMarshalTest {
             marshaller.marshal(unmarshal, targetFos);
         }
         
-        // DROOLS-2893 DMN v1.2 Serialization degraded mode without XSD
-        //        // Should also validate output XML:
-        //        ValidationResult validateOutputResult = v.validateInstance(new StreamSource( outputXMLFile ));
-        //        if (!validateOutputResult.isValid()) {
-        //            for ( ValidationProblem p : validateOutputResult.getProblems()) {
-        //                System.err.println(p);
-        //            }
-        //        }
-        //        assertTrue(validateOutputResult.isValid());
+        // Should also validate output XML:
+        ValidationResult validateOutputResult = v.validateInstance(new StreamSource( outputXMLFile ));
+        if (!validateOutputResult.isValid()) {
+            for ( ValidationProblem p : validateOutputResult.getProblems()) {
+                System.err.println(p);
+            }
+        }
+        assertTrue(validateOutputResult.isValid());
         
         System.out.println("\n---\nDefault XMLUnit comparison:");
         Source control = Input.fromFile( inputXMLFile ).build();

--- a/kie-dmn/kie-dmn-backend/src/test/resources/DC.xsd
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/DC.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DC/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+
+	<xsd:element name="Color" type="dc:Color"/>
+	<xsd:element name="Point" type="dc:Point"/>
+	<xsd:element name="Bounds" type="dc:Bounds"/>
+	<xsd:element name="Dimension" type="dc:Dimension"/>
+
+	<xsd:complexType name="Color">
+		<xsd:annotation>
+			<xsd:documentation>Color is a data type that represents a color value in the RGB format.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="red" type="dc:rgb" use="required"/>
+		<xsd:attribute name="green" type="dc:rgb" use="required"/>
+		<xsd:attribute name="blue" type="dc:rgb" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="rgb">
+		<xsd:restriction base="xsd:int">
+			<xsd:minInclusive value="0"/>
+			<xsd:maxInclusive value="255"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="Point">
+		<xsd:annotation>
+			<xsd:documentation>A Point specifies an location in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Dimension">
+		<xsd:annotation>
+			<xsd:documentation>Dimension specifies two lengths (width and height) along the x and y axes in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Bounds">
+	   <xsd:annotation>
+			<xsd:documentation>Bounds specifies a rectangular area in some x-y coordinate system that is defined by a location (x and y) and a size (width and height).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="AlignmentKind">
+		<xsd:annotation>
+			<xsd:documentation>AlignmentKind enumerates the possible options for alignment for layout purposes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="start"/>
+			<xsd:enumeration value="end"/>
+			<xsd:enumeration value="center"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="KnownColor">
+		<xsd:annotation>
+			<xsd:documentation>KnownColor is an enumeration of 17 known colors.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="maroon">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="red">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF0000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="orange">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFA500</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="yellow">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="olive">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="purple">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fuchsia">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF00FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="white">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lime">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="green">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="navy">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="blue">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #0000FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="aqua">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="teal">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="black">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="silver">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #C0C0C0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="gray">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/DI.xsd
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/DI.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DI/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation>The Diagram Interchange (DI) package enables interchange of graphical information that language users have control over, such as position of nodes and line routing points. Language specifications specialize elements of DI to define diagram interchange elements for a language.</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="Style" type="di:Style">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DiagramElement" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. When contained in a diagram, diagram elements are laid out relative to the diagram's origin.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element ref="di:Style" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>an optional locally-owned style for this diagram element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="sharedStyle" type="xsd:IDREF">
+			<xsd:annotation>
+				<xsd:documentation>a reference to an optional shared style element for this diagram element.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Diagram" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">			
+				<xsd:attribute name="name" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the name of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="documentation" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the documentation of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="resolution" type="xsd:double">
+					<xsd:annotation>
+						<xsd:documentation>the resolution of the diagram expressed in user units per inch.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Shape" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>the optional bounds of the shape relative to the origin of its nesting plane.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Edge" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element name="waypoint" type="dc:Point" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>an optional list of points relative to the origin of the nesting diagram that specifies the connected line segments of the edge</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Style" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Style contains formatting properties that affect the appearance or style of diagram elements, including diagram themselves.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/DMN12.xsd
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/DMN12.xsd
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified"
+	xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+	targetNamespace="http://www.omg.org/spec/DMN/20180521/MODEL/">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+	            schemaLocation="DMNDI12.xsd">
+		<xsd:annotation>
+			<xsd:documentation>
+				Include the DMN Diagram Interchange (DI) schema
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:import>
+
+	<xsd:element name="DMNElement" type="tDMNElement" abstract="true"/>
+	<xsd:complexType name="tDMNElement">
+		<xsd:sequence>
+			<xsd:element name="description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="extensionElements" minOccurs="0" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="label" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:element name="namedElement" type="tNamedElement" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tNamedElement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tDMNElementReference">
+		<xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="definitions" type="tDefinitions" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="itemDefinition" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="drgElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="elementCollection" type="tElementCollection" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="businessContextElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dmndi:DMNDI" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/DMN/20180521/FEEL/"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/DMN/20180521/FEEL/"/>
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="exporter" type="xsd:string" use="optional"/>
+				<xsd:attribute name="exporterVersion" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="import" type="tImport" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tImport">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="elementCollection" type="tElementCollection" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tElementCollection">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="drgElement" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="drgElement" type="tDRGElement" abstract="true" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDRGElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decision" type="tDecision" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tDecision">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="question" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="allowedAnswers" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="informationRequirement" type="tInformationRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supportedObjective" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="impactedPerformanceIndicator" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionMaker" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwner" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingProcess" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingTask" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- decisionLogic -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessContextElement" type="tBusinessContextElement" abstract="true"/>
+	<xsd:complexType name="tBusinessContextElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="performanceIndicator" type="tPerformanceIndicator" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tPerformanceIndicator">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="impactingDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="organizationUnit" type="tOrganizationUnit" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tOrganizationUnit">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="decisionMade" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwned" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocable" type="tInvocable" abstract="true" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInvocable">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessKnowledgeModel" type="tBusinessKnowledgeModel" substitutionGroup="invocable"/>
+	<xsd:complexType name="tBusinessKnowledgeModel">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="encapsulatedLogic" type="tFunctionDefinition" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="inputData" type="tInputData" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInputData">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeSource" type="tKnowledgeSource" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tKnowledgeSource">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="owner" type="tDMNElementReference" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="informationRequirement" type="tInformationRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tInformationRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:choice minOccurs="1" maxOccurs="1">
+						<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+						<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					</xsd:choice>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tKnowledgeRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="requiredKnowledge" type="tDMNElementReference" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="authorityRequirement" type="tAuthorityRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tAuthorityRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:choice minOccurs="1" maxOccurs="1">
+					<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+					<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					<xsd:element name="requiredAuthority" type="tDMNElementReference"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="expression" type="tExpression" abstract="true"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element name="typeRef" type="xsd:string"/>
+						<xsd:element name="allowedValues" type="tUnaryTests" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:element name="itemComponent" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:choice>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="literalExpression" type="tLiteralExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tLiteralExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:element name="text" type="xsd:string"/>
+					<xsd:element name="importedValues" type="tImportedValues"/>
+				</xsd:choice>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocation" type="tInvocation" substitutionGroup="expression"/>
+	<xsd:complexType name="tInvocation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- calledFunction -->
+					<xsd:element ref="expression" minOccurs="0"/>
+					<xsd:element name="binding" type="tBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tBinding">
+		<xsd:sequence>
+			<xsd:element name="parameter" type="tInformationItem" minOccurs="1" maxOccurs="1"/>
+			<!-- bindingFormula -->
+			<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="informationItem" type="tInformationItem" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tInformationItem">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionTable" type="tDecisionTable" substitutionGroup="expression"/>
+	<xsd:complexType name="tDecisionTable">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="input" type="tInputClause" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="output" type="tOutputClause" maxOccurs="unbounded"/>
+					<xsd:element name="annotation" type="tRuleAnnotationClause"  minOccurs="0" maxOccurs="unbounded"/>
+					<!-- NB: when the hit policy is FIRST or RULE ORDER, the ordering of the rules is significant and MUST be preserved -->
+					<xsd:element name="rule" type="tDecisionRule" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"/>
+				<xsd:attribute name="aggregation" type="tBuiltinAggregator" use="optional"/>
+				<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"/>
+				<xsd:attribute name="outputLabel" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputExpression" type="tLiteralExpression"/>
+					<xsd:element name="inputValues" type="tUnaryTests" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tOutputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="outputValues" type="tUnaryTests" minOccurs="0"/>
+					<xsd:element name="defaultOutputEntry" type="tLiteralExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotationClause">
+		<xsd:attribute name="name" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:complexType name="tDecisionRule">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputEntry" type="tUnaryTests" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputEntry" type="tLiteralExpression" maxOccurs="unbounded"/>
+					<xsd:element name="annotationEntry" type="tRuleAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotation">
+		<xsd:sequence>
+			<xsd:element name="text" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:simpleType name="tHitPolicy">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNIQUE"/>
+			<xsd:enumeration value="FIRST"/>
+			<xsd:enumeration value="PRIORITY"/>
+			<xsd:enumeration value="ANY"/>
+			<xsd:enumeration value="COLLECT"/>
+			<xsd:enumeration value="RULE ORDER"/>
+			<xsd:enumeration value="OUTPUT ORDER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tBuiltinAggregator">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SUM"/>
+			<xsd:enumeration value="COUNT"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tDecisionTableOrientation">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rule-as-Row"/>
+			<xsd:enumeration value="Rule-as-Column"/>
+			<xsd:enumeration value="CrossTable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="tImportedValues">
+		<xsd:complexContent>
+			<xsd:extension base="tImport">
+				<xsd:sequence>
+					<xsd:element name="importedElement" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="artifact" type="tArtifact" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tArtifact">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="tDMNElementReference"/>
+					<xsd:element name="targetRef" type="tDMNElementReference"/>
+				</xsd:sequence>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="context" type="tContext" substitutionGroup="expression"/>
+	<xsd:complexType name="tContext">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element ref="contextEntry" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="contextEntry" type="tContextEntry" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tContextEntry">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0" maxOccurs="1"/>
+					<!-- value -->
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionDefinition" type="tFunctionDefinition" substitutionGroup="expression"/>
+	<xsd:complexType name="tFunctionDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="formalParameter" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- body -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="kind" type="tFunctionKind" default="FEEL"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tFunctionKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="FEEL"/>
+			<xsd:enumeration value="Java"/>
+			<xsd:enumeration value="PMML"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="relation" type="tRelation" substitutionGroup="expression"/>
+	<xsd:complexType name="tRelation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="column" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="row" type="tList" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="list" type="tList" substitutionGroup="expression"/>
+	<xsd:complexType name="tList">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- element -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tUnaryTests">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionService" type="tDecisionService" substitutionGroup="invocable"/>
+	<xsd:complexType name="tDecisionService">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="outputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="encapsulatedDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputData" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/DMNDI12.xsd
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/DMNDI12.xsd
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+            elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DI/"
+	            schemaLocation="DI.xsd"/>
+
+	<xsd:element name="DMNDI" type="dmndi:DMNDI"/>
+	<xsd:element name="DMNDiagram" type="dmndi:DMNDiagram"/>
+	<xsd:element name="DMNDiagramElement" type="di:DiagramElement">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="DMNShape" type="dmndi:DMNShape" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNEdge" type="dmndi:DMNEdge" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNStyle" type="dmndi:DMNStyle" substitutionGroup="di:Style"/>
+	<xsd:element name="DMNLabel" type="dmndi:DMNLabel"/>
+	<xsd:element name="DMNDecisionServiceDividerLine" type="dmndi:DMNDecisionServiceDividerLine"/>
+
+	<xsd:complexType name="DMNDI">
+		<xsd:sequence>
+			<xsd:element ref="dmndi:DMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="dmndi:DMNStyle" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDiagramElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDecisionServiceDividerLine" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="isListedInputData" type="xsd:boolean" use="optional"/>
+				<xsd:attribute name="isCollapsed" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+		<xsd:complexType name="DMNDecisionServiceDividerLine">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element name="FillColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="StrokeColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="FontColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="fontFamily" type="xsd:string"/>
+				<xsd:attribute name="fontSize" type="xsd:double"/>
+				<xsd:attribute name="fontItalic" type="xsd:boolean"/>
+				<xsd:attribute name="fontBold" type="xsd:boolean"/>
+				<xsd:attribute name="fontUnderline" type="xsd:boolean"/>
+				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean"/>
+				<xsd:attribute name="labelHorizontalAlignement" type="dc:AlignmentKind"/>
+				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
@@ -92,15 +92,13 @@ public class DMNValidatorImpl implements DMNValidator {
     static final Schema schemav1_2;
     static {
         try {
-            // DROOLS-2893 DMN v1.2 Serialization degraded mode without XSD
-            //            schemav1_2 = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-            //                                      .newSchema(new Source[]{new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DC.xsd")),
-            //                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DI.xsd")),
-            //                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DMNDI12.xsd")),
-            //                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DMN12.xsd"))
-            //                                      });
-            schemav1_2 = null;
-        } catch (Exception e) {
+            schemav1_2 = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                                      .newSchema(new Source[]{new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DC.xsd")),
+                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DI.xsd")),
+                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DMNDI12.xsd")),
+                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20180521/DMN12.xsd"))
+                                      });
+        } catch (SAXException e) {
             throw new RuntimeException("Unable to initialize correctly DMNValidator.", e);
         }
     }
@@ -481,9 +479,8 @@ public class DMNValidatorImpl implements DMNValidator {
     private List<DMNMessage> validateSchemaV1_2(Source s) {
         List<DMNMessage> problems = new ArrayList<>();
         try {
-            // DROOLS-2893 DMN v1.2 Serialization degraded mode without XSD
-            throw new UnsupportedOperationException("DROOLS-2893 currently DMN Schema Validation for v1.2 is not yet supported.");
-        } catch (Exception e) {
+            schemav1_2.newValidator().validate(s);
+        } catch (SAXException | IOException e) {
             problems.add(new DMNMessageImpl(DMNMessage.Severity.ERROR, MsgUtil.createMessage(Msg.FAILED_XML_VALIDATION, e.getMessage()), Msg.FAILED_XML_VALIDATION.getType(), null, e));
             logDebugMessages(problems);
         }

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DC.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DC.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DC/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+
+	<xsd:element name="Color" type="dc:Color"/>
+	<xsd:element name="Point" type="dc:Point"/>
+	<xsd:element name="Bounds" type="dc:Bounds"/>
+	<xsd:element name="Dimension" type="dc:Dimension"/>
+
+	<xsd:complexType name="Color">
+		<xsd:annotation>
+			<xsd:documentation>Color is a data type that represents a color value in the RGB format.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="red" type="dc:rgb" use="required"/>
+		<xsd:attribute name="green" type="dc:rgb" use="required"/>
+		<xsd:attribute name="blue" type="dc:rgb" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="rgb">
+		<xsd:restriction base="xsd:int">
+			<xsd:minInclusive value="0"/>
+			<xsd:maxInclusive value="255"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="Point">
+		<xsd:annotation>
+			<xsd:documentation>A Point specifies an location in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Dimension">
+		<xsd:annotation>
+			<xsd:documentation>Dimension specifies two lengths (width and height) along the x and y axes in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Bounds">
+	   <xsd:annotation>
+			<xsd:documentation>Bounds specifies a rectangular area in some x-y coordinate system that is defined by a location (x and y) and a size (width and height).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="AlignmentKind">
+		<xsd:annotation>
+			<xsd:documentation>AlignmentKind enumerates the possible options for alignment for layout purposes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="start"/>
+			<xsd:enumeration value="end"/>
+			<xsd:enumeration value="center"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="KnownColor">
+		<xsd:annotation>
+			<xsd:documentation>KnownColor is an enumeration of 17 known colors.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="maroon">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="red">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF0000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="orange">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFA500</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="yellow">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="olive">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="purple">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fuchsia">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF00FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="white">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lime">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="green">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="navy">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="blue">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #0000FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="aqua">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="teal">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="black">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="silver">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #C0C0C0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="gray">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DI.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DI.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DI/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation>The Diagram Interchange (DI) package enables interchange of graphical information that language users have control over, such as position of nodes and line routing points. Language specifications specialize elements of DI to define diagram interchange elements for a language.</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="Style" type="di:Style">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DiagramElement" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. When contained in a diagram, diagram elements are laid out relative to the diagram's origin.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element ref="di:Style" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>an optional locally-owned style for this diagram element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="sharedStyle" type="xsd:IDREF">
+			<xsd:annotation>
+				<xsd:documentation>a reference to an optional shared style element for this diagram element.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Diagram" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">			
+				<xsd:attribute name="name" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the name of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="documentation" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the documentation of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="resolution" type="xsd:double">
+					<xsd:annotation>
+						<xsd:documentation>the resolution of the diagram expressed in user units per inch.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Shape" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>the optional bounds of the shape relative to the origin of its nesting plane.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Edge" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element name="waypoint" type="dc:Point" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>an optional list of points relative to the origin of the nesting diagram that specifies the connected line segments of the edge</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Style" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Style contains formatting properties that affect the appearance or style of diagram elements, including diagram themselves.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DMN12.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DMN12.xsd
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified"
+	xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+	targetNamespace="http://www.omg.org/spec/DMN/20180521/MODEL/">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+	            schemaLocation="DMNDI12.xsd">
+		<xsd:annotation>
+			<xsd:documentation>
+				Include the DMN Diagram Interchange (DI) schema
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:import>
+
+	<xsd:element name="DMNElement" type="tDMNElement" abstract="true"/>
+	<xsd:complexType name="tDMNElement">
+		<xsd:sequence>
+			<xsd:element name="description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="extensionElements" minOccurs="0" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="label" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:element name="namedElement" type="tNamedElement" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tNamedElement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tDMNElementReference">
+		<xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="definitions" type="tDefinitions" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="itemDefinition" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="drgElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="elementCollection" type="tElementCollection" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="businessContextElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dmndi:DMNDI" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/DMN/20180521/FEEL/"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/DMN/20180521/FEEL/"/>
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="exporter" type="xsd:string" use="optional"/>
+				<xsd:attribute name="exporterVersion" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="import" type="tImport" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tImport">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="elementCollection" type="tElementCollection" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tElementCollection">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="drgElement" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="drgElement" type="tDRGElement" abstract="true" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDRGElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decision" type="tDecision" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tDecision">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="question" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="allowedAnswers" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="informationRequirement" type="tInformationRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supportedObjective" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="impactedPerformanceIndicator" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionMaker" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwner" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingProcess" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingTask" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- decisionLogic -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessContextElement" type="tBusinessContextElement" abstract="true"/>
+	<xsd:complexType name="tBusinessContextElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="performanceIndicator" type="tPerformanceIndicator" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tPerformanceIndicator">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="impactingDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="organizationUnit" type="tOrganizationUnit" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tOrganizationUnit">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="decisionMade" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwned" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocable" type="tInvocable" abstract="true" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInvocable">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessKnowledgeModel" type="tBusinessKnowledgeModel" substitutionGroup="invocable"/>
+	<xsd:complexType name="tBusinessKnowledgeModel">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="encapsulatedLogic" type="tFunctionDefinition" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="inputData" type="tInputData" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInputData">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeSource" type="tKnowledgeSource" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tKnowledgeSource">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="owner" type="tDMNElementReference" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="informationRequirement" type="tInformationRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tInformationRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:choice minOccurs="1" maxOccurs="1">
+						<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+						<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					</xsd:choice>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tKnowledgeRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="requiredKnowledge" type="tDMNElementReference" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="authorityRequirement" type="tAuthorityRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tAuthorityRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:choice minOccurs="1" maxOccurs="1">
+					<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+					<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					<xsd:element name="requiredAuthority" type="tDMNElementReference"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="expression" type="tExpression" abstract="true"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element name="typeRef" type="xsd:string"/>
+						<xsd:element name="allowedValues" type="tUnaryTests" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:element name="itemComponent" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:choice>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="literalExpression" type="tLiteralExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tLiteralExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:element name="text" type="xsd:string"/>
+					<xsd:element name="importedValues" type="tImportedValues"/>
+				</xsd:choice>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocation" type="tInvocation" substitutionGroup="expression"/>
+	<xsd:complexType name="tInvocation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- calledFunction -->
+					<xsd:element ref="expression" minOccurs="0"/>
+					<xsd:element name="binding" type="tBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tBinding">
+		<xsd:sequence>
+			<xsd:element name="parameter" type="tInformationItem" minOccurs="1" maxOccurs="1"/>
+			<!-- bindingFormula -->
+			<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="informationItem" type="tInformationItem" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tInformationItem">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionTable" type="tDecisionTable" substitutionGroup="expression"/>
+	<xsd:complexType name="tDecisionTable">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="input" type="tInputClause" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="output" type="tOutputClause" maxOccurs="unbounded"/>
+					<xsd:element name="annotation" type="tRuleAnnotationClause"  minOccurs="0" maxOccurs="unbounded"/>
+					<!-- NB: when the hit policy is FIRST or RULE ORDER, the ordering of the rules is significant and MUST be preserved -->
+					<xsd:element name="rule" type="tDecisionRule" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"/>
+				<xsd:attribute name="aggregation" type="tBuiltinAggregator" use="optional"/>
+				<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"/>
+				<xsd:attribute name="outputLabel" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputExpression" type="tLiteralExpression"/>
+					<xsd:element name="inputValues" type="tUnaryTests" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tOutputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="outputValues" type="tUnaryTests" minOccurs="0"/>
+					<xsd:element name="defaultOutputEntry" type="tLiteralExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotationClause">
+		<xsd:attribute name="name" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:complexType name="tDecisionRule">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputEntry" type="tUnaryTests" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputEntry" type="tLiteralExpression" maxOccurs="unbounded"/>
+					<xsd:element name="annotationEntry" type="tRuleAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotation">
+		<xsd:sequence>
+			<xsd:element name="text" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:simpleType name="tHitPolicy">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNIQUE"/>
+			<xsd:enumeration value="FIRST"/>
+			<xsd:enumeration value="PRIORITY"/>
+			<xsd:enumeration value="ANY"/>
+			<xsd:enumeration value="COLLECT"/>
+			<xsd:enumeration value="RULE ORDER"/>
+			<xsd:enumeration value="OUTPUT ORDER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tBuiltinAggregator">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SUM"/>
+			<xsd:enumeration value="COUNT"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tDecisionTableOrientation">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rule-as-Row"/>
+			<xsd:enumeration value="Rule-as-Column"/>
+			<xsd:enumeration value="CrossTable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="tImportedValues">
+		<xsd:complexContent>
+			<xsd:extension base="tImport">
+				<xsd:sequence>
+					<xsd:element name="importedElement" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="artifact" type="tArtifact" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tArtifact">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="tDMNElementReference"/>
+					<xsd:element name="targetRef" type="tDMNElementReference"/>
+				</xsd:sequence>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="context" type="tContext" substitutionGroup="expression"/>
+	<xsd:complexType name="tContext">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element ref="contextEntry" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="contextEntry" type="tContextEntry" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tContextEntry">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0" maxOccurs="1"/>
+					<!-- value -->
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionDefinition" type="tFunctionDefinition" substitutionGroup="expression"/>
+	<xsd:complexType name="tFunctionDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="formalParameter" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- body -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="kind" type="tFunctionKind" default="FEEL"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tFunctionKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="FEEL"/>
+			<xsd:enumeration value="Java"/>
+			<xsd:enumeration value="PMML"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="relation" type="tRelation" substitutionGroup="expression"/>
+	<xsd:complexType name="tRelation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="column" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="row" type="tList" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="list" type="tList" substitutionGroup="expression"/>
+	<xsd:complexType name="tList">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- element -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tUnaryTests">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionService" type="tDecisionService" substitutionGroup="invocable"/>
+	<xsd:complexType name="tDecisionService">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="outputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="encapsulatedDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputData" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DMNDI12.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20180521/DMNDI12.xsd
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+            elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DI/"
+	            schemaLocation="DI.xsd"/>
+
+	<xsd:element name="DMNDI" type="dmndi:DMNDI"/>
+	<xsd:element name="DMNDiagram" type="dmndi:DMNDiagram"/>
+	<xsd:element name="DMNDiagramElement" type="di:DiagramElement">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="DMNShape" type="dmndi:DMNShape" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNEdge" type="dmndi:DMNEdge" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNStyle" type="dmndi:DMNStyle" substitutionGroup="di:Style"/>
+	<xsd:element name="DMNLabel" type="dmndi:DMNLabel"/>
+	<xsd:element name="DMNDecisionServiceDividerLine" type="dmndi:DMNDecisionServiceDividerLine"/>
+
+	<xsd:complexType name="DMNDI">
+		<xsd:sequence>
+			<xsd:element ref="dmndi:DMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="dmndi:DMNStyle" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDiagramElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDecisionServiceDividerLine" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="isListedInputData" type="xsd:boolean" use="optional"/>
+				<xsd:attribute name="isCollapsed" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+		<xsd:complexType name="DMNDecisionServiceDividerLine">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element name="FillColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="StrokeColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="FontColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="fontFamily" type="xsd:string"/>
+				<xsd:attribute name="fontSize" type="xsd:double"/>
+				<xsd:attribute name="fontItalic" type="xsd:boolean"/>
+				<xsd:attribute name="fontBold" type="xsd:boolean"/>
+				<xsd:attribute name="fontUnderline" type="xsd:boolean"/>
+				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean"/>
+				<xsd:attribute name="labelHorizontalAlignement" type="dc:AlignmentKind"/>
+				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -339,9 +339,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testDMNv1_2_ch11() {
         // DROOLS-2832
-        List<DMNMessage> validate = validator.validate(getReader("DMNv12_ch11.dmn"),
-                                                       // DROOLS-2893: VALIDATE_SCHEMA, 
-                                                       VALIDATE_MODEL);
+        List<DMNMessage> validate = validator.validate(getReader("DMNv12_ch11.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL);
 
         // DMN v1.2 CH11 example for Adjudication does not define decision logic nor typeRef:
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -330,7 +330,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     public void testDMNv1_2_ch11Modified() {
         // DROOLS-2832
         List<DMNMessage> validate = validator.validate(getReader("v1_2/ch11MODIFIED.dmn", DMNRuntimeTest.class),
-                                                       // DROOLS-2893: VALIDATE_SCHEMA, 
+                                                       VALIDATE_SCHEMA, 
                                                        VALIDATE_MODEL,
                                                        VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));


### PR DESCRIPTION
/cc @etirelli @baldimir @jiripetrlik

As the XSDs has been published on omg.org website:

![image](https://user-images.githubusercontent.com/1699252/47001770-8df14b80-d12b-11e8-825c-f37289e39187.png)

![image](https://user-images.githubusercontent.com/1699252/47001778-95185980-d12b-11e8-841a-472b6a709ca1.png)

![image](https://user-images.githubusercontent.com/1699252/47001786-99dd0d80-d12b-11e8-8f61-87f180b7c4bf.png)

![image](https://user-images.githubusercontent.com/1699252/47001795-9ea1c180-d12b-11e8-9b34-3414856bcc23.png)

I am reverting the original commit which omitted XSDs until publication on omg.org website, plus minor adjustments.