### PR TITLE
[DROOLS-3112] FEEL Compiler: modularize FEELImpl compiler/interpreter vs. DMNFEELHelper

### DIFF
--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -73,6 +73,10 @@
       <artifactId>drools-model-compiler</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drlx-parser</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNLiteralExpressionEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/ast/DMNLiteralExpressionEvaluator.java
@@ -26,8 +26,8 @@ import org.kie.dmn.core.api.EvaluatorResult.ResultType;
 import org.kie.dmn.core.compiler.DMNProfile;
 import org.kie.dmn.core.impl.DMNRuntimeImpl;
 import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.codegen.feel11.ProcessedExpression;
 import org.kie.dmn.feel.lang.CompiledExpression;
-import org.kie.dmn.feel.lang.ast.FunctionDefNode;
 import org.kie.dmn.feel.lang.impl.CompiledExpressionImpl;
 
 /**
@@ -36,13 +36,22 @@ import org.kie.dmn.feel.lang.impl.CompiledExpressionImpl;
 public class DMNLiteralExpressionEvaluator
         implements DMNExpressionEvaluator {
     private CompiledExpression expression;
+    private boolean isFunctionDef;
 
     public DMNLiteralExpressionEvaluator(CompiledExpression expression) {
         this.expression = expression;
+        if (expression instanceof CompiledExpressionImpl) {
+            this.isFunctionDef = ((CompiledExpressionImpl) expression).isFunctionDef();
+        } else if (expression instanceof ProcessedExpression) {
+            this.isFunctionDef = ((ProcessedExpression) expression).getInterpreted().isFunctionDef();
+        } else {
+            throw new IllegalArgumentException(
+                    "Cannot create DMNLiteralExpressionEvaluator: unsupported type " + expression.getClass());
+        }
     }
 
     public boolean isFunctionDefinition() {
-        return expression instanceof CompiledExpressionImpl && ((CompiledExpressionImpl)expression).getExpression() instanceof FunctionDefNode;
+        return isFunctionDef;
     }
 
     public CompiledExpression getExpression() {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerContext.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Stack;
 
 import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.core.impl.BaseDMNTypeImpl;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.types.BuiltInType;
 
 public class DMNCompilerContext {
 
@@ -38,6 +42,23 @@ public class DMNCompilerContext {
             variables.putAll( scope.getVariables() );
         }
         return variables;
+    }
+
+    public CompilerContext toCompilerContext() {
+        CompilerContext compilerContext = feelHelper.newCompilerContext();
+        compilerContext.getListeners().clear();
+        for ( Map.Entry<String, DMNType> entry : this.getVariables().entrySet() ) {
+            compilerContext.addInputVariableType(
+                    entry.getKey(),
+                    dmnToFeelType((BaseDMNTypeImpl) entry.getValue())
+            );
+        }
+        return compilerContext;
+    }
+
+    private static Type dmnToFeelType(BaseDMNTypeImpl v) {
+        if (v.isCollection()) return BuiltInType.LIST;
+        else return v.getFeelType();
     }
 
     public DMNFEELHelper getFeelHelper() {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
@@ -10,7 +10,8 @@ import java.util.Map;
 import java.util.Queue;
 
 import org.antlr.v4.runtime.CommonToken;
-import org.antlr.v4.runtime.tree.ParseTree;
+import org.drools.javaparser.ast.CompilationUnit;
+import org.drools.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNType;
@@ -21,24 +22,14 @@ import org.kie.dmn.core.impl.DMNModelImpl;
 import org.kie.dmn.core.util.Msg;
 import org.kie.dmn.core.util.MsgUtil;
 import org.kie.dmn.feel.FEEL;
-import org.kie.dmn.feel.codegen.feel11.ASTCompilerVisitor;
-import org.kie.dmn.feel.codegen.feel11.ASTUnaryTestTransform;
-import org.kie.dmn.feel.codegen.feel11.CompiledFEELSupport;
-import org.kie.dmn.feel.codegen.feel11.CompilerBytecodeLoader;
-import org.kie.dmn.feel.codegen.feel11.DirectCompilerResult;
-import org.kie.dmn.feel.codegen.feel11.DirectCompilerVisitor;
+import org.kie.dmn.feel.codegen.feel11.ProcessedUnaryTest;
 import org.kie.dmn.feel.lang.CompiledExpression;
 import org.kie.dmn.feel.lang.CompilerContext;
 import org.kie.dmn.feel.lang.FEELProfile;
 import org.kie.dmn.feel.lang.Type;
-import org.kie.dmn.feel.lang.ast.BaseNode;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.lang.impl.FEELImpl;
-import org.kie.dmn.feel.lang.types.BuiltInType;
-import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
-import org.kie.dmn.feel.parser.feel11.FEELParser;
-import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
 import org.kie.dmn.feel.runtime.FEELFunction;
 import org.kie.dmn.feel.runtime.UnaryTest;
 import org.kie.dmn.feel.runtime.events.SyntaxErrorEvent;
@@ -95,7 +86,7 @@ public class DMNFEELHelper {
                     ctx.setValue( entry.getKey(), entry.getValue() );
                 }
             }
-    
+
             for ( UnaryTest t : unaryTests ) {
                 try {
                     Boolean applyT = t.apply( ctx, value );
@@ -240,6 +231,18 @@ public class DMNFEELHelper {
                                                                msg.getSourceId().equals( element.getId() ))) );
     }
 
+    public ClassOrInterfaceDeclaration compileUnaryTests(String unaryTests, DMNCompilerContext ctx, Type inputColumnType) {
+        CompilerContext compilerContext =
+                ctx.toCompilerContext()
+                        .addInputVariableType("?", inputColumnType);
+
+        ProcessedUnaryTest compiledUnaryTest = ((FEELImpl) feel).compileUnaryTests(unaryTests, compilerContext);
+        CompilationUnit compilationUnit = compiledUnaryTest.getSourceCode().clone();
+        return compilationUnit.getType(0)
+                .asClassOrInterfaceDeclaration()
+                .setStatic(true);
+    }
+
     public static class FEELEventsListenerImpl implements FEELEventListener {
         private final Queue<FEELEvent> feelEvents = new LinkedList<>();
 
@@ -251,36 +254,6 @@ public class DMNFEELHelper {
         public Queue<FEELEvent> getFeelEvents() {
             return feelEvents;
         }
-    }
-
-    public String getSourceForUnaryTest(String packageName, String className, String input, DMNCompilerContext ctx, Type columntype) {
-        Map<String, Type> variableTypes = new HashMap<>();
-        for ( Map.Entry<String, DMNType> entry : ctx.getVariables().entrySet() ) {
-            variableTypes.put( entry.getKey(), dmnToFeelType((BaseDMNTypeImpl) entry.getValue()) );
-        }
-        variableTypes.put( "?", columntype );
-
-        FEELEventListenersManager manager = new FEELEventListenersManager();
-        CompiledFEELSupport.SyntaxErrorListener errorListener = new CompiledFEELSupport.SyntaxErrorListener();
-        manager.addListener(errorListener);
-        FEEL_1_1Parser parser = FEELParser.parse(
-                manager, input, variableTypes, Collections.emptyMap(), (( FEELImpl ) feel).getCustomFunctions(), Collections.emptyList());
-        ParseTree tree = parser.unaryTestsRoot();
-        DirectCompilerResult result;
-        if (errorListener.isError()) {
-            result = CompiledFEELSupport.compiledErrorUnaryTest(errorListener.event().getMessage());
-        } else {
-            BaseNode ast = tree.accept(new ASTBuilderVisitor(variableTypes));
-            BaseNode rewritten = ast.accept(new ASTUnaryTestTransform()).node();
-            result = rewritten.accept(new ASTCompilerVisitor());
-        }
-        return new CompilerBytecodeLoader().getSourceForUnaryTest(packageName, className, input, result);
-    }
-
-
-    public static Type dmnToFeelType(BaseDMNTypeImpl v) {
-        if (v.isCollection()) return BuiltInType.LIST;
-        else return v.getFeelType();
     }
 
     public EvaluationContextImpl newEvaluationContext( Collection<FEELEventListener> listeners, Map<String, Object> inputVariables) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
@@ -368,9 +368,16 @@ public class ExecModelDMNEvaluatorCompiler extends DMNEvaluatorCompiler {
                     if (testClass == null) {
                         testClass = className + "r" + i + "c" + j;
                         testClassesByInput.put(input, testClass);
-                        testsBuilder.append( "\n" );
                         instancesBuilder.append( "    private static final CompiledDTTest " + testClass + "_INSTANCE = new CompiledDTTest( new " + testClass + "() );\n" );
-                        testsBuilder.append( feel.getSourceForUnaryTest( pkgName, testClass, input, ctx, dTableModel.getColumns().get(j).getType() ) );
+
+                        String sourceCode = feel.compileUnaryTests(
+                                input,
+                                ctx,
+                                dTableModel.getColumns().get(j).getType())
+                                .setName(testClass).toString();
+
+                        testsBuilder.append( "\n" );
+                        testsBuilder.append( sourceCode );
                         testsBuilder.append( "\n" );
                     }
                     testArrayBuilder.append( testClass ).append( "_INSTANCE" );

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/FEEL.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/FEEL.java
@@ -90,6 +90,16 @@ public interface FEEL {
     CompiledExpression compile(String expression, CompilerContext ctx);
 
     /**
+     * Compiles the string expression using the given
+     * compiler context.
+     *
+     * @param expression a FEEL expression for unary tests
+     * @param ctx a compiler context
+     * @return the compiled unary tests
+     */
+    CompiledExpression compileUnaryTests(String expression, CompilerContext ctx);
+
+    /**
      * Evaluates the given FEEL expression and returns
      * the result
      *

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompilerBytecodeLoader.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompilerBytecodeLoader.java
@@ -19,9 +19,7 @@ package org.kie.dmn.feel.codegen.feel11;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
@@ -89,9 +87,12 @@ public class CompilerBytecodeLoader {
         return internal_makefromJP(CompiledFEELUnaryTests.class, "/TemplateCompiledFEELUnaryTests.java", packageName, className, feelExpression, theExpression, fieldDeclarations);
     }
 
-    private <T> T internal_makefromJP(Class<T> clazz, String templateResourcePath, String cuPackage, String cuClass, String feelExpression, Expression theExpression, Set<FieldDeclaration> fieldDeclarations) {
-        CompilationUnit cu = getCompilationUnitForUnaryTests( clazz, templateResourcePath, cuPackage, cuClass, feelExpression, theExpression, fieldDeclarations );
+    public <T> T internal_makefromJP(Class<T> clazz, String templateResourcePath, String cuPackage, String cuClass, String feelExpression, Expression theExpression, Set<FieldDeclaration> fieldDeclarations) {
+        CompilationUnit cu = getCompilationUnit(clazz, templateResourcePath, cuPackage, cuClass, feelExpression, theExpression, fieldDeclarations );
+        return compileUnit(cuPackage, cuClass, cu);
+    }
 
+    public  <T> T compileUnit(String cuPackage, String cuClass, CompilationUnit cu) {
         try {
             MemoryResourceReader pReader = new MemoryResourceReader();
             pReader.add(cuPackage.replaceAll("\\.", "/") + "/" + cuClass + ".java", cu.toString().getBytes());
@@ -119,13 +120,13 @@ public class CompilerBytecodeLoader {
     }
 
     public String getSourceForUnaryTest(String packageName, String className, String feelExpression, Expression theExpression, Set<FieldDeclaration> fieldDeclarations) {
-        CompilationUnit cu = getCompilationUnitForUnaryTests( CompiledFEELUnaryTests.class, "/TemplateCompiledFEELUnaryTests.java", packageName, className, feelExpression, theExpression, fieldDeclarations );
+        CompilationUnit cu = getCompilationUnit(CompiledFEELUnaryTests.class, "/TemplateCompiledFEELUnaryTests.java", packageName, className, feelExpression, theExpression, fieldDeclarations );
         ClassOrInterfaceDeclaration classSource = cu.getClassByName( className ).get();
         classSource.setStatic( true );
         return classSource.toString();
     }
 
-    private <T> CompilationUnit getCompilationUnitForUnaryTests( Class<T> clazz, String templateResourcePath, String cuPackage, String cuClass, String feelExpression, Expression theExpression, Set<FieldDeclaration> fieldDeclarations ) {
+    public <T> CompilationUnit getCompilationUnit(Class<T> clazz, String templateResourcePath, String cuPackage, String cuClass, String feelExpression, Expression theExpression, Set<FieldDeclaration> fieldDeclarations ) {
         CompilationUnit cu = JavaParser.parse(CompilerBytecodeLoader.class.getResourceAsStream(templateResourcePath));
         cu.setPackageDeclaration(cuPackage);
         ClassOrInterfaceDeclaration classSource = cu.getClassByName( templateResourcePath.substring( 1, templateResourcePath.length()-5 ) ).get();

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
@@ -47,6 +47,7 @@ import org.kie.dmn.feel.util.EvalHelper;
 
 import static org.kie.dmn.feel.codegen.feel11.Constants.BigDecimalT;
 import static org.kie.dmn.feel.codegen.feel11.Constants.BuiltInTypeT;
+import static org.kie.dmn.feel.codegen.feel11.Constants.DECIMAL_128;
 
 public class Expressions {
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedExpression.java
@@ -1,0 +1,102 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.List;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.drools.javaparser.ast.CompilationUnit;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.impl.CompiledExecutableExpression;
+import org.kie.dmn.feel.lang.impl.CompiledExpressionImpl;
+import org.kie.dmn.feel.lang.impl.InterpretedExecutableExpression;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
+
+import static org.kie.dmn.feel.codegen.feel11.ProcessedFEELUnit.DefaultMode.Compiled;
+
+public class ProcessedExpression extends ProcessedFEELUnit {
+
+    private static final String TEMPLATE_RESOURCE = "/TemplateCompiledFEELExpression.java";
+    private static final String TEMPLATE_CLASS = "TemplateCompiledFEELExpression";
+
+    private final BaseNode ast;
+    private DirectCompilerResult compiledExpression;
+
+    private final CompilerBytecodeLoader compiler = new CompilerBytecodeLoader();
+    private CompiledFEELExpression defaultResult;
+
+    public ProcessedExpression(
+            String expression,
+            CompilerContext ctx,
+            ProcessedFEELUnit.DefaultMode defaultBackend,
+            List<FEELProfile> profiles) {
+
+        super(expression, ctx, profiles);
+
+        ParseTree tree = parser.compilation_unit();
+        ast = tree.accept(new ASTBuilderVisitor(ctx.getInputVariableTypes()));
+
+        if (defaultBackend == Compiled) {
+            defaultResult = getCompiled();
+        } else { // "legacy" interpreted AST compilation:
+            defaultResult = getInterpreted();
+        }
+    }
+
+    private DirectCompilerResult getCompilerResult() {
+        if (compiledExpression == null) {
+            if (errorListener.isError()) {
+                compiledExpression =
+                        DirectCompilerResult.of(
+                                CompiledFEELSupport.compiledErrorExpression(
+                                        errorListener.event().getMessage()),
+                                BuiltInType.UNKNOWN);
+            } else {
+                try {
+                    compiledExpression = ast.accept(new ASTCompilerVisitor());
+                } catch (FEELCompilationError e) {
+                    compiledExpression = DirectCompilerResult.of(
+                            CompiledFEELSupport.compiledErrorExpression(e.getMessage()),
+                            BuiltInType.UNKNOWN);
+                }
+            }
+        }
+        return compiledExpression;
+    }
+
+    public CompilationUnit getSourceCode() {
+        DirectCompilerResult compilerResult = getCompilerResult();
+        return compiler.getCompilationUnit(
+                CompiledFEELExpression.class,
+                TEMPLATE_RESOURCE,
+                packageName,
+                TEMPLATE_CLASS,
+                expression,
+                compilerResult.getExpression(),
+                compilerResult.getFieldDeclarations());
+    }
+
+    public InterpretedExecutableExpression getInterpreted() {
+        return new InterpretedExecutableExpression(new CompiledExpressionImpl(ast));
+    }
+
+    public CompiledExecutableExpression getCompiled() {
+        CompiledFEELExpression compiledFEELExpression =
+                compiler.compileUnit(
+                        packageName,
+                        TEMPLATE_CLASS,
+                        getSourceCode());
+        return new CompiledExecutableExpression(compiledFEELExpression);
+    }
+
+    public CompiledFEELExpression getCompiledFEELExpression() {
+        return defaultResult;
+    }
+
+    @Override
+    public Object apply(EvaluationContext evaluationContext) {
+        return getCompiledFEELExpression().apply(evaluationContext);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedFEELUnit.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedFEELUnit.java
@@ -1,0 +1,58 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.parser.feel11.FEELParser;
+import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
+
+public abstract class ProcessedFEELUnit implements CompiledFEELExpression {
+
+    protected final FEEL_1_1Parser parser;
+
+    public enum DefaultMode {
+        Compiled,
+        Interpreted;
+
+        public static DefaultMode of(boolean doCompile) {
+            return doCompile ? Compiled : Interpreted;
+        }
+
+    }
+
+    protected final String packageName;
+    protected final String expression;
+    protected final CompiledFEELSupport.SyntaxErrorListener errorListener =
+            new CompiledFEELSupport.SyntaxErrorListener();
+    protected final CompilerBytecodeLoader compiler =
+            new CompilerBytecodeLoader();
+
+    ProcessedFEELUnit(String expression,
+                      CompilerContext ctx,
+                      List<FEELProfile> profiles) {
+
+        this.expression = expression;
+        this.packageName = generateRandomPackage();
+        FEELEventListenersManager eventsManager =
+                new FEELEventListenersManager();
+
+        eventsManager.addListeners(ctx.getListeners());
+        eventsManager.addListener(errorListener);
+
+        this.parser = FEELParser.parse(
+                eventsManager,
+                expression,
+                ctx.getInputVariableTypes(),
+                ctx.getInputVariables(),
+                ctx.getFEELFunctions(),
+                profiles);
+    }
+
+    private String generateRandomPackage() {
+        String uuid = UUID.randomUUID().toString().replaceAll("-", "");
+        return this.getClass().getPackage().getName() + ".gen" + uuid;
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedUnaryTest.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedUnaryTest.java
@@ -1,0 +1,85 @@
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.drools.javaparser.ast.CompilationUnit;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.impl.CompiledExpressionImpl;
+import org.kie.dmn.feel.lang.impl.UnaryTestCompiledExecutableExpression;
+import org.kie.dmn.feel.lang.impl.UnaryTestInterpretedExecutableExpression;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+public class ProcessedUnaryTest extends ProcessedFEELUnit {
+
+    private static final String TEMPLATE_RESOURCE = "/TemplateCompiledFEELUnaryTests.java";
+    private static final String TEMPLATE_CLASS = "TemplateCompiledFEELUnaryTests";
+
+    private final BaseNode ast;
+    private DirectCompilerResult compiledExpression;
+
+    public ProcessedUnaryTest(
+            String expressions,
+            CompilerContext ctx) {
+
+        super(expressions, ctx, Collections.emptyList());
+        ParseTree tree = parser.unaryTestsRoot();
+        BaseNode initialAst = tree.accept(new ASTBuilderVisitor(ctx.getInputVariableTypes()));
+        ast = initialAst.accept(new ASTUnaryTestTransform()).node();
+    }
+
+    private DirectCompilerResult getCompilerResult() {
+        if (compiledExpression == null) {
+            if (errorListener.isError()) {
+                compiledExpression = CompiledFEELSupport.compiledErrorUnaryTest(
+                        errorListener.event().getMessage());
+            } else {
+                try {
+                    compiledExpression = ast.accept(new ASTCompilerVisitor());
+                } catch (FEELCompilationError e) {
+                    compiledExpression = CompiledFEELSupport.compiledErrorUnaryTest(e.getMessage());
+                }
+            }
+        }
+        return compiledExpression;
+    }
+
+    public CompilationUnit getSourceCode() {
+        DirectCompilerResult compilerResult = getCompilerResult();
+        return compiler.getCompilationUnit(
+                CompiledFEELUnaryTests.class,
+                TEMPLATE_RESOURCE,
+                packageName,
+                TEMPLATE_CLASS,
+                expression,
+                compilerResult.getExpression(),
+                compilerResult.getFieldDeclarations());
+    }
+
+    public UnaryTestInterpretedExecutableExpression getInterpreted() {
+        if (errorListener.isError()) {
+            return UnaryTestInterpretedExecutableExpression.EMPTY;
+        } else {
+            return new UnaryTestInterpretedExecutableExpression(new CompiledExpressionImpl(ast));
+        }
+    }
+
+    public UnaryTestCompiledExecutableExpression getCompiled() {
+        CompiledFEELUnaryTests compiledFEELExpression =
+                compiler.compileUnit(
+                        packageName,
+                        TEMPLATE_CLASS,
+                        getSourceCode());
+
+        return new UnaryTestCompiledExecutableExpression(compiledFEELExpression);
+    }
+
+    @Override
+    public List<UnaryTest> apply(EvaluationContext evaluationContext) {
+        return getInterpreted().apply(evaluationContext);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExecutableExpression.java
@@ -1,0 +1,19 @@
+package org.kie.dmn.feel.lang.impl;
+
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
+import org.kie.dmn.feel.lang.CompiledExpression;
+import org.kie.dmn.feel.lang.EvaluationContext;
+
+public class CompiledExecutableExpression implements CompiledFEELExpression {
+
+    private final CompiledFEELExpression expr;
+
+    public CompiledExecutableExpression(CompiledFEELExpression expr) {
+        this.expr = expr;
+    }
+
+    @Override
+    public Object apply(EvaluationContext evaluationContext) {
+        return expr.apply(evaluationContext);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExpressionImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/CompiledExpressionImpl.java
@@ -16,11 +16,12 @@
 
 package org.kie.dmn.feel.lang.impl;
 
-import org.kie.dmn.feel.lang.CompiledExpression;
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.ast.ASTNode;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
 
-public class CompiledExpressionImpl implements CompiledExpression {
+public class CompiledExpressionImpl implements CompiledFEELExpression {
     private ASTNode     expression;
 
     public CompiledExpressionImpl(ASTNode expression) {
@@ -31,11 +32,15 @@ public class CompiledExpressionImpl implements CompiledExpression {
         return expression;
     }
 
+    public boolean isFunctionDef() {
+        return expression instanceof FunctionDefNode;
+    }
+
     public void setExpression( ASTNode expression ) {
         this.expression = expression;
     }
 
-    public Object evaluate(EvaluationContext evaluationContext) {
+    public Object apply(EvaluationContext evaluationContext) {
         if (expression == null) {
             return null;
         }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.feel.lang.impl;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,32 +25,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.drools.javaparser.ast.expr.Expression;
 import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
 import org.kie.dmn.feel.FEEL;
-import org.kie.dmn.feel.codegen.feel11.ASTCompilerVisitor;
 import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
-import org.kie.dmn.feel.codegen.feel11.CompiledFEELSupport;
-import org.kie.dmn.feel.codegen.feel11.CompilerBytecodeLoader;
-import org.kie.dmn.feel.codegen.feel11.DirectCompilerResult;
-import org.kie.dmn.feel.codegen.feel11.FEELCompilationError;
+import org.kie.dmn.feel.codegen.feel11.ProcessedFEELUnit;
+import org.kie.dmn.feel.codegen.feel11.ProcessedUnaryTest;
+import org.kie.dmn.feel.codegen.feel11.ProcessedExpression;
 import org.kie.dmn.feel.lang.CompiledExpression;
 import org.kie.dmn.feel.lang.CompilerContext;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.FEELProfile;
 import org.kie.dmn.feel.lang.Type;
-import org.kie.dmn.feel.lang.ast.ASTNode;
-import org.kie.dmn.feel.lang.ast.BaseNode;
-import org.kie.dmn.feel.lang.ast.DashNode;
-import org.kie.dmn.feel.lang.ast.ListNode;
-import org.kie.dmn.feel.lang.ast.NameRefNode;
-import org.kie.dmn.feel.lang.ast.RangeNode;
-import org.kie.dmn.feel.lang.ast.UnaryTestListNode;
-import org.kie.dmn.feel.lang.ast.UnaryTestNode;
-import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
-import org.kie.dmn.feel.parser.feel11.FEELParser;
-import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
 import org.kie.dmn.feel.parser.feel11.profiles.DoCompileFEELProfile;
 import org.kie.dmn.feel.runtime.FEELFunction;
 import org.kie.dmn.feel.runtime.UnaryTest;
@@ -117,43 +101,16 @@ public class FEELImpl
 
     @Override
     public CompiledExpression compile(String expression, CompilerContext ctx) {
-        if (doCompile || ctx.isDoCompile()) {
-            // Use JavaParser to translate FEEL to Java:
-            Set<FEELEventListener> listeners = new HashSet<>(ctx.getListeners());
-            // add listener to syntax errors, and save them
-            CompiledFEELSupport.SyntaxErrorListener errorListener = new CompiledFEELSupport.SyntaxErrorListener();
-            listeners.add(errorListener);
-            FEEL_1_1Parser parser = FEELParser.parse(getEventsManager(listeners), expression, ctx.getInputVariableTypes(), ctx.getInputVariables(), ctx.getFEELFunctions(), profiles);
-            ParseTree tree = parser.compilation_unit();
-            if (errorListener.isError()) {
-                return CompiledFEELSupport.compiledError(expression, errorListener.event().getMessage());
-            }
-            try {
-                ASTBuilderVisitor v = new ASTBuilderVisitor(ctx.getInputVariableTypes());
-                BaseNode node = v.visit(tree);
-                DirectCompilerResult directResult = node.accept(new ASTCompilerVisitor());
-                Expression expr = directResult.getExpression();
-                return new CompilerBytecodeLoader().makeFromJPExpression(expression, expr, directResult.getFieldDeclarations());
-            } catch (FEELCompilationError e) {
-                return CompiledFEELSupport.compiledError(expression, e.getMessage());
-            }
-        } else { // "legacy" interpreted AST compilation:
-            FEEL_1_1Parser parser = FEELParser.parse(getEventsManager(ctx.getListeners()), expression, ctx.getInputVariableTypes(), ctx.getInputVariables(), ctx.getFEELFunctions(), profiles);
-            ParseTree tree = parser.compilation_unit();
-            ASTBuilderVisitor v = new ASTBuilderVisitor(ctx.getInputVariableTypes());
-            BaseNode expr = v.visit(tree);
-            CompiledExpression ce = new CompiledExpressionImpl(expr);
-            return ce;
-        }
+        return new ProcessedExpression(
+                expression,
+                ctx,
+                ProcessedFEELUnit.DefaultMode.of(doCompile || ctx.isDoCompile()),
+                profiles);
     }
 
-    public CompiledExpression compileExpressionList(String expression, CompilerContext ctx) {
-        FEEL_1_1Parser parser = FEELParser.parse(getEventsManager(ctx.getListeners()), expression, ctx.getInputVariableTypes(), ctx.getInputVariables(), ctx.getFEELFunctions(), profiles);
-        ParseTree tree = parser.unaryTestsRoot();
-        ASTBuilderVisitor v = new ASTBuilderVisitor(ctx.getInputVariableTypes());
-        BaseNode expr = v.visit(tree);
-        CompiledExpression ce = new CompiledExpressionImpl(expr);
-        return ce;
+    @Override
+    public ProcessedUnaryTest compileUnaryTests(String expressions, CompilerContext ctx) {
+        return new ProcessedUnaryTest(expressions, ctx);
     }
 
     @Override
@@ -188,20 +145,14 @@ public class FEELImpl
 
     @Override
     public Object evaluate(CompiledExpression expr, Map<String, Object> inputVariables) {
-        if (expr instanceof CompiledExpressionImpl) {
-            return ((CompiledExpressionImpl) expr).evaluate(newEvaluationContext(Collections.EMPTY_SET, inputVariables));
-        } else {
-            return ((CompiledFEELExpression) expr).apply(newEvaluationContext(Collections.EMPTY_SET, inputVariables));
-        }
+        CompiledFEELExpression e = (CompiledFEELExpression) expr;
+        return e.apply(newEvaluationContext(Collections.EMPTY_SET, inputVariables));
     }
     
     @Override
     public Object evaluate(CompiledExpression expr, EvaluationContext ctx) {
-        if (expr instanceof CompiledExpressionImpl) {
-            return ((CompiledExpressionImpl) expr).evaluate(newEvaluationContext(ctx.getListeners(), ctx.getAllValues()));
-        } else {
-            return ((CompiledFEELExpression) expr).apply(newEvaluationContext(ctx.getListeners(), ctx.getAllValues()));
-        }
+        CompiledFEELExpression e = (CompiledFEELExpression) expr;
+        return e.apply(newEvaluationContext(ctx.getListeners(), ctx.getAllValues()));
     }
 
     /**
@@ -236,53 +187,13 @@ public class FEELImpl
 
     @Override
     public List<UnaryTest> evaluateUnaryTests(String expression, Map<String, Type> variableTypes) {
-        // DMN defines a special case where, unless the expressions are unary tests
-        // or ranges, they need to be converted into an equality test unary expression.
-        // This way, we have to compile and check the low level AST nodes to properly
-        // deal with this case
-        CompilerContext ctx = newCompilerContext();
+        CompilerContext ctx = newCompilerContext(getListeners());
         for( Map.Entry<String, Type> e : variableTypes.entrySet() ) {
             ctx.addInputVariableType( e.getKey(), e.getValue() );
         }
-        CompiledExpressionImpl compiledExpression = (CompiledExpressionImpl) compileExpressionList( expression, ctx );
-        if( compiledExpression != null ) {
-            UnaryTestListNode listNode = (UnaryTestListNode) compiledExpression.getExpression();
-            List<BaseNode> tests = new ArrayList<>(  );
-            for( BaseNode o : listNode.getElements() ) {
-                if ( o == null ) {
-                    // not much we can do, so just skip it. Error was reported somewhere else
-                    continue;
-                } else if ( o instanceof UnaryTestNode || o instanceof DashNode ) {
-                    tests.add( o );
-                } else if (o instanceof RangeNode || o instanceof ListNode) {
-                    tests.add( new UnaryTestNode( UnaryTestNode.UnaryOperator.IN, o) );
-                } else if ( isExtendedUnaryTest( o ) ) {
-                    tests.add( new UnaryTestNode( UnaryTestNode.UnaryOperator.TEST, o ) );
-                } else {
-                    tests.add( new UnaryTestNode( UnaryTestNode.UnaryOperator.EQ, o ) );
-                }
-            }
-            listNode.setElements( tests );
-            compiledExpression.setExpression( listNode );
 
-            // now we can evaluate the expression to build the list of unary tests
-            List<UnaryTest> uts = (List<UnaryTest>) evaluate( compiledExpression, FEELImpl.EMPTY_INPUT );
-            return uts;
-        }
-        return Collections.emptyList();
-    }
-
-    private boolean isExtendedUnaryTest(ASTNode o) {
-        if( o instanceof NameRefNode && "?".equals(((NameRefNode)o).getText()) ) {
-            return true;
-        } else {
-            for( ASTNode bn : o.getChildrenNode() ) {
-                if( isExtendedUnaryTest( bn ) ) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return compileUnaryTests(expression, ctx)
+                .apply(newEvaluationContext(ctx.getListeners(), EMPTY_INPUT));
     }
 
     @Override

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/InterpretedExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/InterpretedExecutableExpression.java
@@ -1,0 +1,23 @@
+package org.kie.dmn.feel.lang.impl;
+
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
+
+public class InterpretedExecutableExpression implements CompiledFEELExpression {
+
+    private final CompiledExpressionImpl expr;
+
+    public InterpretedExecutableExpression(CompiledExpressionImpl expr) {
+        this.expr = expr;
+    }
+
+    public boolean isFunctionDef() {
+        return expr.getExpression() instanceof FunctionDefNode;
+    }
+
+    @Override
+    public Object apply(EvaluationContext evaluationContext) {
+        return expr.apply(evaluationContext);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestCompiledExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestCompiledExecutableExpression.java
@@ -1,0 +1,20 @@
+package org.kie.dmn.feel.lang.impl;
+
+import java.util.List;
+
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELUnaryTests;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+public class UnaryTestCompiledExecutableExpression {
+
+    private final CompiledFEELUnaryTests expr;
+
+    public UnaryTestCompiledExecutableExpression(CompiledFEELUnaryTests expr) {
+        this.expr = expr;
+    }
+
+    public List<UnaryTest> getUnaryTests() {
+        return expr.getUnaryTests();
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestInterpretedExecutableExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/UnaryTestInterpretedExecutableExpression.java
@@ -1,0 +1,27 @@
+package org.kie.dmn.feel.lang.impl;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+public class UnaryTestInterpretedExecutableExpression implements CompiledFEELExpression {
+
+    public static final UnaryTestInterpretedExecutableExpression EMPTY = new UnaryTestInterpretedExecutableExpression(null) {
+        @Override
+        public List<UnaryTest> apply(EvaluationContext evaluationContext) {
+            return Collections.emptyList();
+        }
+    };
+    private final CompiledExpressionImpl expr;
+
+    public UnaryTestInterpretedExecutableExpression(CompiledExpressionImpl expr) {
+        this.expr = expr;
+    }
+
+    public List<UnaryTest> apply(EvaluationContext evaluationContext) {
+        return (List<UnaryTest>) expr.apply(evaluationContext);
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
@@ -29,9 +29,9 @@ import java.util.stream.IntStream;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
 import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
 import org.kie.dmn.feel.lang.CompiledExpression;
 import org.kie.dmn.feel.lang.EvaluationContext;
-import org.kie.dmn.feel.lang.impl.CompiledExpressionImpl;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.runtime.UnaryTest;
 import org.kie.dmn.feel.runtime.events.DecisionTableRulesMatchedEvent;
@@ -269,8 +269,8 @@ public class DecisionTableImpl implements DecisionTable {
     private boolean matches(EvaluationContext ctx, Object[] params, DTDecisionRule rule) {
         for( int i = 0; i < params.length; i++ ) {
             CompiledExpression compiledInput = inputs.get(i).getCompiledInput();
-            if ( compiledInput instanceof CompiledExpressionImpl ) {
-                ctx.setValue("?", ((CompiledExpressionImpl) compiledInput).evaluate(ctx));
+            if ( compiledInput instanceof CompiledFEELExpression) {
+                ctx.setValue("?", ((CompiledFEELExpression) compiledInput).apply(ctx));
             }
             if( ! satisfies( ctx, params[i], rule.getInputEntry().get( i ) ) ) {
                 return false;


### PR DESCRIPTION
Waiting for #2107 to be merged before merging this

Summary:

- added new method in FEEL interface to compile unary tests
- removed most compilation-related logic from DMNFEELHelper
- reduced API surface in CompilerBytecodeLoader 
- the classes in the ProcessedFEELUnit (ProcessedExpression and ProcessedUnaryTest) provide all the methods to return the compilable, interpretable, or source code version of the given expression (or the given unary test sequence)

e.g. usage (pseudocode)

```java
CompiledExpression compiled = feel.compile(expr, compilerCtx)
var r = feel.evaluate(compiled, evalCtx) // will use current mode set in feel instance (compiled or interpreted)
// you can also explicitly request the version you want
var pe = (ProcessedExpression) compiled;
CompiledExecutableExpression cee = pe.getCompiled();
InterpretedExecutableExpression iee = pe.getInterpreted()

// we can still eval' these:
var r1 = feel.evaluate(cee, evalCtx);
var r2 = feel.evaluate(iee, evalCtx);

// we can use the source code for $stuff (e.g. used in DMN to generate wrapper classes)
CompilationUnit cu = pe.getSourceCode();

```

same as above is for UnaryTests, but 

```java
CompiledExpression compiled = feel.compile(expr, compilerCtx)
var r = feel.evaluate(compiled, evalCtx) 
```
is always **interpreted** (that's how it's working now)
you can always request the compiled or the source code version, using 

```java
var pe = (ProcessedUnaryTest) compiled;
var cut = pe.getCompiled();
var iut = pe.getInterpreted()
var cu = pe.getSourceCode();
```