### PR TITLE
[DROOLS-3181] fix VirtualFileSystem discovery

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.Enumeration;
@@ -412,15 +413,26 @@ public class ClasspathKieProject extends AbstractKieProject {
                 log.warn( "Found virtual file " + url + " but org.jboss.vfs.VirtualFile is not available on the classpath" );
             }
         }
+        Method m2 = null;
+        try {
+            m2 = Class.forName("org.jboss.vfs.VFS").getMethod("getChild", URI.class);
+        } catch (Exception e) {
+            try {
+                // Try to retrieve the org.jboss.vfs.VFS class also on TCCL
+                m2 = Class.forName("org.jboss.vfs.VFS", true, Thread.currentThread().getContextClassLoader()).getMethod("getChild", URI.class);
+            } catch (Exception e1) {
+                // VFS is not available on the classpath - ignore
+                log.warn( "Found virtual file " + url + " but org.jboss.vfs.VFS is not available on the classpath" );
+            }
+        }
 
-        if (m == null) {
+        if (m == null || m2 == null) {
             return url.getPath();
         }
 
         String path = null;
         try {
-            Object content = url.openConnection().getContent();
-            File f = (File)m.invoke(content);
+            File f = (File)m.invoke( m2.invoke(null, url.toURI()) );
             path = f.getPath();
         } catch (Exception e) {
             log.error( "Error when reading virtual file from " + url.toString(), e );

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -23,10 +23,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -34,7 +32,6 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.appformer.maven.support.PomModel;
 import org.drools.compiler.kie.builder.impl.event.KieModuleDiscovered;
 import org.drools.compiler.kie.builder.impl.event.KieServicesEventListerner;
 import org.drools.compiler.kproject.ReleaseIdImpl;
@@ -45,6 +42,7 @@ import org.kie.api.KieServices;
 import org.kie.api.builder.KieRepository;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
+import org.appformer.maven.support.PomModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -421,7 +419,8 @@ public class ClasspathKieProject extends AbstractKieProject {
 
         String path = null;
         try {
-            File f = (File)m.invoke( findVirtualFile( url ) );
+            Object content = url.openConnection().getContent();
+            File f = (File)m.invoke(content);
             path = f.getPath();
         } catch (Exception e) {
             log.error( "Error when reading virtual file from " + url.toString(), e );
@@ -456,20 +455,6 @@ public class ClasspathKieProject extends AbstractKieProject {
             log.error( "Error when reading virtual file from " + url.toString(), e );
         }
         return url.getPath();
-    }
-
-    private static Object findVirtualFile( URL url ) throws IOException {
-        URLConnection urlConnection = url.openConnection();
-        try {
-            if ( urlConnection.getClass().getName().equals( "org.jboss.vfs.protocol.VirtualFileURLConnection" ) ) {
-                Field f = urlConnection.getClass().getDeclaredField( "file" );
-                f.setAccessible( true );
-                return f.get( urlConnection );
-            }
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            // ignored
-        }
-        return urlConnection.getContent();
     }
 
     public InternalKieModule getKieModuleForKBase(String kBaseName) {


### PR DESCRIPTION
- Revert "[DROOLS-3181] fix VirtualFileSystem discovery after changes in eap 6.4.21 (#2118)"
- Use the public API org.jboss.vfs.VFS to obtain VirtualFile from the url path instead of depending on the internal behavior of org.jboss.vfs.protocol.VirtualFileURLConnection