### PR TITLE
DROOLS-3230 DMN - Fix generating paths on Windows for executable model

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
@@ -16,7 +16,6 @@
 
 package org.kie.dmn.core.compiler.execmodelbased;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -125,7 +124,7 @@ public class ExecModelDMNEvaluatorCompiler extends DMNEvaluatorCompiler {
         for (int i = 0; i < fileNames.length; i++) {
             GeneratorsEnum generator = GeneratorsEnum.values()[i];
             String className = dTableModel.getGeneratedClassName(generator);
-            String fileName = Paths.get("src/main/java", className.replace('.', '/') + ".java").toString();
+            String fileName = "src/main/java" + className.replace( '.', '/' ) + ".java";
             String javaSource = generator.sourceGenerator.generate(ctx, ctx.getFeelHelper(), dTableModel);
             fileNames[i] = fileName;
             generatedSources.add(new GeneratedSource(fileName, javaSource));

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
@@ -124,7 +124,7 @@ public class ExecModelDMNEvaluatorCompiler extends DMNEvaluatorCompiler {
         for (int i = 0; i < fileNames.length; i++) {
             GeneratorsEnum generator = GeneratorsEnum.values()[i];
             String className = dTableModel.getGeneratedClassName(generator);
-            String fileName = "src/main/java" + className.replace( '.', '/' ) + ".java";
+            String fileName = "src/main/java/" + className.replace( '.', '/' ) + ".java";
             String javaSource = generator.sourceGenerator.generate(ctx, ctx.getFeelHelper(), dTableModel);
             fileNames[i] = fileName;
             generatedSources.add(new GeneratedSource(fileName, javaSource));


### PR DESCRIPTION
@tarilabs @etirelli @lucamolteni please review. MemoryFileSystem works just with "/", so this didn't work on Windows, because Path.toString() produces OS dependent paths. 