### PR TITLE
DROOLS-3228: Rules don't produce the correct result anymore after a session reset

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -167,7 +167,7 @@ public class AgendaGroupQueueImpl
     }
 
     public void add(final Activation activation) {
-        if ( lastRemoved != null ) {
+        if ( lastRemoved != null && !sequential) {
             // this will only be set if sequential. Do not add Match's that are higher in salience + load order than the lastRemoved (fired)
             if ( lastRemoved == activation || lastRemoved  == visited || PhreakConflictResolver.doCompare( lastRemoved, activation ) < 0 ) {
                 return;

--- a/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
+++ b/drools-core/src/main/java/org/drools/core/common/ConcurrentNodeMemories.java
@@ -57,14 +57,14 @@ public class ConcurrentNodeMemories implements NodeMemories {
         for (int i = 0; i < memories.length(); i++) {
             Memory memory = memories.get(i);
             if (memory != null) {
-                if (memory.getSegmentMemory() != null) {
-                    SegmentMemory smem = memory.getSegmentMemory();
+                SegmentMemory smem = memory.getSegmentMemory();
+                memory.reset();
+                if (smem != null) {
                     smem.reset(kBase.getSegmentPrototype(smem));
                     if ( smem.isSegmentLinked() ) {
                         smem.notifyRuleLinkSegment((InternalWorkingMemory)session);
                     }
                 }
-                memory.reset();
             }
         }
     }

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -1122,6 +1122,8 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         this.processRuntime = null;
 
         this.initialFactHandle = initInitialFact(kBase, null);
+
+        this.alive = true;
     }
 
     public void reset(int handleId,


### PR DESCRIPTION
Hello,

I did some further investigations on the issue reported with https://issues.jboss.org/browse/DROOLS-3228 . For the main issue it seems that just the order _memory.getSegmentMemory()_ and  _memory.reset()_ must be maintained (as it was with Drools 7.12.0.Final). 

I've also found another issue with session reset in that a sequential session can't be used anymore after a reset as it refuses to add new elements to the agend group queue. 

Executing https://github.com/liebharc/JavaRules/blob/master/src/test/java/com/github/liebharc/JavaRules/UnitTestBase.java should show all the described issues as test failures.

There doesn't seem to be specific test cases for AgendaGroupQueueImpl and ConcurrentNodeMemories - or at least I couldn't find them. 

I'm looking forward to hear your thoughts.