### PR TITLE
DROOLS-3282: Should not move to next AgendaGroup even if current is empty

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/AgendaGroupQueueImpl.java
@@ -55,6 +55,7 @@ public class AgendaGroupQueueImpl
 
     private InternalWorkingMemory workingMemory;
     private boolean               autoDeactivate = true;
+    private boolean               keepWhenEmpty  = false;
     private Map<Long, String>     nodeInstances  = new ConcurrentHashMap<Long, String>();
 
     private volatile              boolean hasRuleFlowLister;
@@ -313,4 +314,13 @@ public class AgendaGroupQueueImpl
         return sequential;
     }
 
+    @Override
+    public void setKeepWhenEmpty(boolean keepWhenEmpty) {
+        this.keepWhenEmpty = true;
+    }
+
+    @Override
+    public boolean mustKeepWhenEmpty() {
+        return keepWhenEmpty;
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/common/InternalAgendaGroup.java
+++ b/drools-core/src/main/java/org/drools/core/common/InternalAgendaGroup.java
@@ -75,4 +75,13 @@ public interface InternalAgendaGroup extends AgendaGroup {
     boolean isRuleFlowListener();
 
     boolean isSequential();
+
+    /**
+     * Enables DROOLS-3282 behavior; will keep current agenda group
+     * even if current agenda group is empty
+     * @param keepWhenEmpty
+     */
+    void setKeepWhenEmpty(boolean keepWhenEmpty);
+
+    boolean mustKeepWhenEmpty();
 }

--- a/drools-core/src/main/java/org/drools/core/common/RuleFlowGroupImpl.java
+++ b/drools-core/src/main/java/org/drools/core/common/RuleFlowGroupImpl.java
@@ -422,4 +422,14 @@ public class RuleFlowGroupImpl
     public boolean isSequential() {
         return agendaGroup.isSequential();
     }
+
+    @Override
+    public void setKeepWhenEmpty(boolean keepWhenEmpty) {
+        agendaGroup.setKeepWhenEmpty(keepWhenEmpty);
+    }
+
+    @Override
+    public boolean mustKeepWhenEmpty() {
+        return agendaGroup.mustKeepWhenEmpty();
+    }
 }

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -18,11 +18,13 @@ package org.drools.core.phreak;
 import java.util.Comparator;
 
 import org.drools.core.base.SalienceInteger;
+import org.drools.core.common.AgendaGroupQueueImpl;
 import org.drools.core.common.AgendaItem;
 import org.drools.core.common.DefaultAgenda;
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.EventSupport;
 import org.drools.core.common.InternalAgenda;
+import org.drools.core.common.InternalAgendaGroup;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.conflict.PhreakConflictResolver;
@@ -249,6 +251,9 @@ public class RuleExecutor {
 
         // The eager list must be evaluated first, as dynamic salience rules will impact the results of peekNextRule
         agenda.evaluateEagerList();
+
+        InternalAgendaGroup nextFocus = agenda.getNextFocus();
+        if (nextFocus.mustKeepWhenEmpty()) return true; // fixme only when it is not current group
 
         RuleAgendaItem nextRule = agenda.peekNextRule();
         return nextRule != null && (!ruleAgendaItem.getAgendaGroup().equals( nextRule.getAgendaGroup() ) || !isHigherSalience(nextRule));

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleExecutor.java
@@ -253,7 +253,9 @@ public class RuleExecutor {
         agenda.evaluateEagerList();
 
         InternalAgendaGroup nextFocus = agenda.getNextFocus();
-        if (nextFocus.mustKeepWhenEmpty()) return true; // fixme only when it is not current group
+        if (nextFocus != null && nextFocus.mustKeepWhenEmpty()) {
+            return true; // fixme only when it is not current group
+        }
 
         RuleAgendaItem nextRule = agenda.peekNextRule();
         return nextRule != null && (!ruleAgendaItem.getAgendaGroup().equals( nextRule.getAgendaGroup() ) || !isHigherSalience(nextRule));


### PR DESCRIPTION
This is used for Units' scheduler-based impl. Figured we better track this feature/bug-fix in its own Jira. 

@mariofusco Not sure how to test
