### PR TITLE
DROOLS-3314: Add method to configure WorkItemManagerFactory programmatically

### DIFF
--- a/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
@@ -88,6 +88,7 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
     public abstract Map<String, WorkItemHandler> getWorkItemHandlers();
     public abstract Map<String, WorkItemHandler> getWorkItemHandlers(Map<String, Object> params);
     public abstract WorkItemManagerFactory getWorkItemManagerFactory();
+    public abstract void setWorkItemManagerFactory(WorkItemManagerFactory workItemManagerFactory);
 
     public abstract String getProcessInstanceManagerFactory();
 

--- a/drools-core/src/main/java/org/drools/core/SessionConfigurationImpl.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfigurationImpl.java
@@ -327,6 +327,11 @@ public class SessionConfigurationImpl extends SessionConfiguration {
         return this.workItemManagerFactory;
     }
 
+    @Override
+    public void setWorkItemManagerFactory(WorkItemManagerFactory workItemManagerFactory) {
+        this.workItemManagerFactory = workItemManagerFactory;
+    }
+
     @SuppressWarnings("unchecked")
     private void initWorkItemManagerFactory() {
         String className = this.chainedProperties.getProperty( "drools.workItemManagerFactory",


### PR DESCRIPTION
Trivial setter method so that it is possible to set this factory programmatically, instead of using a property. Will be used in the Process Units prototype to intercept task signals, and redirect them to the correct process unit instance