### PR TITLE
FEEL power function using non integer exponent

### DIFF
--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -46,6 +46,13 @@
         <artifactId>drlx-parser</artifactId>
     </dependency>
 
+    <!-- BigMath dependency to obtain BigDecimal advanced math -->
+    <dependency>
+        <groupId>ch.obermuhlner</groupId>
+        <artifactId>big-math</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
@@ -17,6 +17,7 @@
 package org.kie.dmn.feel.codegen.feel11;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import ch.obermuhlner.math.big.BigDecimalMath;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.drools.javaparser.JavaParser;
 import org.drools.javaparser.ast.Modifier;
@@ -521,6 +523,9 @@ public class CompiledFEELSupport {
         public FEELEvent event() { return event; }
     }
 
+    public static BigDecimal pow(BigDecimal l, BigDecimal r) {
+        return BigDecimalMath.pow( l, r, MathContext.DECIMAL128 );
+    }
 
 
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerVisitor.java
@@ -442,10 +442,10 @@ public class DirectCompilerVisitor extends FEEL_1_1BaseVisitor<DirectCompilerRes
             EnclosedExpr leftCasted = castToBigDecimal(left.getExpression());
             EnclosedExpr rightCasted = castToBigDecimal(right.getExpression());
 
-            MethodCallExpr subtractCall = new MethodCallExpr(leftCasted, "pow");
-            subtractCall.addArgument(new MethodCallExpr(rightCasted, "intValue"));
-            subtractCall.addArgument(DECIMAL_128);
-            Expression result = groundToNullIfAnyIsNull(subtractCall, leftCasted, rightCasted);
+            MethodCallExpr powCall = new MethodCallExpr(new NameExpr(CompiledFEELSupport.class.getSimpleName()), "pow");
+            powCall.addArgument(leftCasted);
+            powCall.addArgument(rightCasted);
+            Expression result = groundToNullIfAnyIsNull(powCall, leftCasted, rightCasted);
             return DirectCompilerResult.of(result, BuiltInType.NUMBER, DirectCompilerResult.mergeFDs(left, right));
         }
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
@@ -31,6 +31,7 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.function.BinaryOperator;
 
+import ch.obermuhlner.math.big.BigDecimalMath;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.Type;
@@ -174,7 +175,7 @@ public class InfixOpNode
             case DIV:
                 return div( left, right, ctx );
             case POW:
-                return math( left, right, ctx, (l, r) -> l.pow( r.intValue(), MathContext.DECIMAL128 ) );
+                return math( left, right, ctx, (l, r) -> BigDecimalMath.pow( l, r, MathContext.DECIMAL128 ) );
             case AND:
                 return and( left, right, ctx );
             case OR:

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/SqrtFunction.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/extended/SqrtFunction.java
@@ -16,6 +16,7 @@
 
 package org.kie.dmn.feel.runtime.functions.extended;
 
+import ch.obermuhlner.math.big.BigDecimalMath;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
 import org.kie.dmn.feel.runtime.functions.BaseFEELFunction;
@@ -30,8 +31,6 @@ import java.math.RoundingMode;
 public class SqrtFunction
         extends BaseFEELFunction {
     public static final SqrtFunction INSTANCE = new SqrtFunction();
-
-    private static final BigDecimal TWO = new BigDecimal( 2.0, MathContext.DECIMAL128 );
 
     SqrtFunction() {
         super("sqrt");
@@ -48,9 +47,6 @@ public class SqrtFunction
     }
 
     static BigDecimal sqrt( BigDecimal arg ) { // can be modified later to short-circuit if precision is not needed
-        final BigDecimal low = new BigDecimal( Math.sqrt( arg.doubleValue() ), MathContext.DECIMAL128 ); // 16 decimal places
-        final BigDecimal mid = low.add( arg.subtract( low.pow( 2, MathContext.DECIMAL128 ) ).divide( low.multiply( TWO ), RoundingMode.HALF_EVEN ) ); // 32 decimal places
-        final BigDecimal high = mid.add( arg.subtract( mid.pow( 2, MathContext.DECIMAL128 ) ).divide( mid.multiply( TWO ), RoundingMode.HALF_EVEN ) ); // 34 decimal places
-        return high;
+        return BigDecimalMath.sqrt(arg, MathContext.DECIMAL128);
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELMathOperationsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELMathOperationsTest.java
@@ -49,6 +49,7 @@ public class FEELMathOperationsTest extends BaseFEELTest {
                 { "5+2 ** 5", BigDecimal.valueOf( 37 ) , null},
                 { "5+2 ** 5+3", BigDecimal.valueOf( 40 ) , null},
                 { "5+2 ** (5+3)", BigDecimal.valueOf( 261 ) , null},
+                {"2 ** 3.5", new BigDecimal("11.31370849898476039041350979367758"), null},
                 { "10 + null", null , null},
                 { "null + 10", null , null},
                 { "10 - null", null , null},

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/KieFEELExtendedFunctionsTest.java
@@ -35,6 +35,8 @@ public class KieFEELExtendedFunctionsTest extends BaseFEELTest {
                 { "modulo( 4, 3 )", new BigDecimal( "1" ), null },
                 { "split( \"foo,bar,baz\", \",\" )", Arrays.asList( "foo", "bar", "baz" ), null },
                 { "split( \"foo;bar|baz\", \"[;|]\" )", Arrays.asList( "foo", "bar", "baz" ), null },
+                { "sqrt( 9 )", BigDecimal.valueOf( 3.0 ), null },
+                { "sqrt( 10 )", new BigDecimal("3.162277660168379331998893544432719"), null },
         };
         return addAdditionalParameters(cases, true);
     }


### PR DESCRIPTION
I have integrated the big-math library (https://github.com/eobermuhlner/big-math) licensed under MIT to add support for FEEL evaluation of non integer exponent in FEEL.

2 ** 3.5 would previously return 8 (same as 2 ** 3) but will now return the proper result.

This is going beyond the DMN 1.2 specification.

@etirelli You also mentioned that you used an aproximation for the sqrl() feel function, this library has a BigDecimal function for sqrt. If you want I have an additional commit that I could add to this PR to also change the sqrt FEEL function to use this new library.

I choose this library because of its license and very small footprint.

