### PR TITLE
DROOLS-3328 PhreakAsyncSendNode triggers service discovery even when it's not used

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncSendNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAsyncSendNode.java
@@ -36,7 +36,9 @@ import org.kie.internal.concurrent.ExecutorProviderFactory;
 
 public class PhreakAsyncSendNode {
 
-    private static final Executor executor = ExecutorProviderFactory.getExecutorProvider().getExecutor();
+    private Executor executor() {
+        return ExecutorProviderFactory.getExecutorProvider().getExecutor();
+    }
 
     public void doNode(AsyncSendNode node,
                        AsyncSendMemory memory,
@@ -78,7 +80,7 @@ public class PhreakAsyncSendNode {
 
             LeftTuple finalLeftTuple = leftTuple;
 
-            executor.execute( () -> {
+            executor().execute( () -> {
                 // TODO context is not thread safe, it needs to be cloned
                 fetchAndSendResults( node, memory, wm, context, betaConstraints, alphaConstraints, dataProvider,
                         resultClass, finalLeftTuple, propagationContext );


### PR DESCRIPTION
Solution: turn the field into a method, everyone's happy (the service is cached anyway)