### PR TITLE
[DROOLS-1905] URLDecoder: Illegal hex characters in escape (%) pattern when a rule has a name with "%"

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
@@ -18,9 +18,7 @@ package org.drools.compiler.kie.builder.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,7 +40,6 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderError;
 
 import static java.util.Arrays.asList;
-
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.filterFileInKBase;
 
 public class KieBuilderSetImpl implements KieBuilderSet {
@@ -200,7 +197,7 @@ public class KieBuilderSetImpl implements KieBuilderSet {
 
     public static class DummyResource extends BaseResource {
         public DummyResource(String resourceName) {
-            setSourcePath( decode( resourceName ) );
+            setSourcePath(resourceName);
         }
 
         @Override
@@ -248,12 +245,5 @@ public class KieBuilderSetImpl implements KieBuilderSet {
             throw new UnsupportedOperationException();
         }
 
-        private String decode( final String resourceName ) {
-            try {
-                return URLDecoder.decode( resourceName, "UTF-8" );
-            } catch ( UnsupportedEncodingException e ) {
-                return resourceName;
-            }
-        }
     }
 }


### PR DESCRIPTION
Fixing the problem for incremental building. Now there is need to decode in this case.