### PR TITLE
[DROOLS-1905] URLDecoder: Illegal hex characters in escape (%) pattern when a rule has a name with "%" 

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java
@@ -42,7 +42,6 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderError;
 
 import static java.util.Arrays.asList;
-
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.filterFileInKBase;
 
 public class KieBuilderSetImpl implements KieBuilderSet {
@@ -200,7 +199,7 @@ public class KieBuilderSetImpl implements KieBuilderSet {
 
     public static class DummyResource extends BaseResource {
         public DummyResource(String resourceName) {
-            setSourcePath( decode( resourceName ) );
+            setSourcePath(decode(resourceName));
         }
 
         @Override
@@ -248,10 +247,10 @@ public class KieBuilderSetImpl implements KieBuilderSet {
             throw new UnsupportedOperationException();
         }
 
-        private String decode( final String resourceName ) {
+        private String decode(final String resourceName) {
             try {
-                return URLDecoder.decode( resourceName, "UTF-8" );
-            } catch ( UnsupportedEncodingException e ) {
+                return URLDecoder.decode(resourceName, "UTF-8");
+            } catch (UnsupportedEncodingException | IllegalArgumentException e) {
                 return resourceName;
             }
         }

--- a/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImplTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImplTest.java
@@ -74,6 +74,12 @@ public class KieBuilderSetImplTest extends CommonTestMethodBase {
         assertEquals( testResource, dummyResource );
     }
 
+    @Test
+    public void testDummyResourceWithWrongEncodedFileName() {
+        final Resource dummyResource = new KieBuilderSetImpl.DummyResource("Dummy 100%");
+        assertEquals(dummyResource.getSourcePath(), "Dummy 100%");
+    }
+
     private KieBuilderImpl kieBuilder( final KieServices ks,
                                        final KieFileSystem kfs ) {
         final KieBuilder kieBuilder = ks.newKieBuilder( kfs );


### PR DESCRIPTION
fixing the problem for incremental build