### PR TITLE
DROOLS-3379: RuntimeService API should not require a KieRuntime to create an instance

### DIFF
--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeImpl.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeImpl.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,58 +11,34 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.drools.beliefs.bayes.runtime;
+
+import java.util.Map;
 
 import org.drools.beliefs.bayes.BayesInstance;
 import org.drools.beliefs.bayes.JunctionTree;
 import org.drools.beliefs.bayes.assembler.BayesPackage;
-import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.definitions.InternalKnowledgePackage;
+import org.kie.api.KieBase;
 import org.kie.api.internal.io.ResourceTypePackage;
-
 import org.kie.api.io.ResourceType;
 
-import java.util.Map;
-
 public class BayesRuntimeImpl implements BayesRuntime {
-    private InternalKnowledgeRuntime runtime;
 
-    //private Map<String, BayesInstance> instances;
+    private KieBase kieBase;
 
-    public BayesRuntimeImpl(InternalKnowledgeRuntime runtime) {
-        this.runtime = runtime;
-        //this.instances = new HashMap<String, BayesInstance>();
+    public BayesRuntimeImpl(KieBase kieBase) {
+        this.kieBase = kieBase;
     }
 
-//    @Override
-//    public BayesInstance createBayesFact(Class cls) {
-//        // using the two-tone pattern, to ensure only one is created
-//        BayesInstance instance = instances.get( cls.getName() );
-//        if ( instance == null ) {
-//            instance = createInstance(cls);
-//        }
-//
-//        return instance;
-//    }
-
-    public  BayesInstance createInstance(Class cls) {
-        // synchronised using the two-tone pattern, to ensure only one is created
-//        BayesInstance instance = instances.get( cls.getName() );
-//        if ( instance != null ) {
-//            return instance;
-//        }
-
-
-        InternalKnowledgePackage kpkg = (InternalKnowledgePackage) runtime.getKieBase().getKiePackage( cls.getPackage().getName() );
+    public BayesInstance createInstance(Class cls) {
+        InternalKnowledgePackage kpkg = (InternalKnowledgePackage) kieBase.getKiePackage(cls.getPackage().getName());
         Map<ResourceType, ResourceTypePackage> map = kpkg.getResourceTypePackages();
-        BayesPackage bayesPkg  = (BayesPackage) map.get( ResourceType.BAYES );
-        JunctionTree jtree =  bayesPkg.getJunctionTree(cls.getSimpleName());
+        BayesPackage bayesPkg = (BayesPackage) map.get(ResourceType.BAYES);
+        JunctionTree jtree = bayesPkg.getJunctionTree(cls.getSimpleName());
 
-        BayesInstance instance = new BayesInstance( jtree, cls );
-//        instances.put( cls.getName() , instance );
-
-        return instance;
+        return new BayesInstance(jtree, cls);
     }
 }

--- a/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeService.java
+++ b/drools-beliefs/src/main/java/org/drools/beliefs/bayes/runtime/BayesRuntimeService.java
@@ -15,14 +15,13 @@
 
 package org.drools.beliefs.bayes.runtime;
 
-import org.drools.core.common.InternalKnowledgeRuntime;
+import org.kie.api.KieBase;
 import org.kie.api.internal.runtime.KieRuntimeService;
-import org.kie.api.runtime.KieRuntime;
 
 public class BayesRuntimeService implements KieRuntimeService<BayesRuntime> {
     @Override
-    public BayesRuntime newKieRuntime(KieRuntime session ) {
-        return new BayesRuntimeImpl( (InternalKnowledgeRuntime) session );
+    public BayesRuntime newKieRuntime(KieBase kieBase) {
+        return new BayesRuntimeImpl( kieBase );
     }
 
     @Override

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/runtime/DMNRuntimeService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/runtime/DMNRuntimeService.java
@@ -16,6 +16,8 @@
 
 package org.kie.dmn.core.runtime;
 
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.kie.api.KieBase;
 import org.kie.api.internal.runtime.KieRuntimeService;
 import org.kie.api.runtime.KieRuntime;
 import org.kie.dmn.api.core.DMNRuntime;
@@ -24,8 +26,9 @@ import org.kie.dmn.core.impl.DMNRuntimeImpl;
 public class DMNRuntimeService implements KieRuntimeService<DMNRuntime> {
 
     @Override
-    public DMNRuntime newKieRuntime(KieRuntime session ) {
-        return new DMNRuntimeImpl( session );
+    public DMNRuntime newKieRuntime(KieBase kieBase) {
+        InternalKnowledgeBase kb = (InternalKnowledgeBase) kieBase;
+        return new DMNRuntimeImpl( kb );
     }
 
     @Override


### PR DESCRIPTION
Reflecting changes in https://github.com/kiegroup/droolsjbpm-knowledge/pull/347, we use the new API in the (known) runtimes: 

1. cleaned up Bayes, updated DMN.
2. updated StatefulKnowledgeSessionImpl so that it forwards to the new KieRuntimeFactory public API in `kie-api`

@mariofusco @tarilabs 