### PR TITLE
[DROOLS-3401] Moved Fluent API to kie-internal

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/simulation/BatchRunFluentTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/simulation/BatchRunFluentTest.java
@@ -28,9 +28,9 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.RequestContext;
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.KieSessionFluent;
-import org.kie.api.runtime.builder.Scope;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieSessionFluent;
+import org.kie.internal.builder.fluent.Scope;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/drools-compiler/src/test/java/org/drools/compiler/simulation/BatchRunUnitFluentTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/simulation/BatchRunUnitFluentTest.java
@@ -25,9 +25,9 @@ import org.kie.api.builder.ReleaseId;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.RequestContext;
-import org.kie.api.runtime.builder.ExecutableBuilder;
 import org.kie.api.runtime.rule.DataSource;
 import org.kie.api.runtime.rule.RuleUnit;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
 
 import static org.drools.core.ruleunit.RuleUnitUtil.getUnitName;
 import static org.junit.Assert.assertEquals;

--- a/drools-core/src/main/java/org/drools/core/command/SetVariableCommandFromLastReturn.java
+++ b/drools-core/src/main/java/org/drools/core/command/SetVariableCommandFromLastReturn.java
@@ -22,13 +22,14 @@ import java.util.Map;
 import org.drools.core.common.InternalFactHandle;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
-import org.kie.api.runtime.builder.Scope;
 import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.builder.fluent.Scope;
 import org.kie.internal.command.RegistryContext;
 
 public class SetVariableCommandFromLastReturn
-    implements
-    ExecutableCommand<Object> {
+        implements
+        ExecutableCommand<Object> {
+
     private String identifier;
     private String contextName;
     private Scope scope = Scope.REQUEST;
@@ -53,34 +54,32 @@ public class SetVariableCommandFromLastReturn
 
     public Object execute(Context context) {
         Context targetCtx;
-        if ( this.contextName == null ) {
+        if (this.contextName == null) {
             targetCtx = context;
         } else {
-            targetCtx = ( (RegistryContext) context ).getContextManager().getContext( this.contextName );
+            targetCtx = ((RegistryContext) context).getContextManager().getContext(this.contextName);
         }
 
-        GetDefaultValue sim = (GetDefaultValue) context.get( "simulator" );
+        GetDefaultValue sim = (GetDefaultValue) context.get("simulator");
 
         Object o = sim.getObject();
         // for FactHandle's we store the handle on a map and the actual object as
-        if ( o instanceof FactHandle ) {
-            Map<String, FactHandle> handles = (Map<String, FactHandle>) targetCtx.get( "h" );
-            if ( handles == null ) {
+        if (o instanceof FactHandle) {
+            Map<String, FactHandle> handles = (Map<String, FactHandle>) targetCtx.get("h");
+            if (handles == null) {
                 handles = new HashMap<String, FactHandle>();
-                targetCtx.set( "h",
-                               handles );
+                targetCtx.set("h",
+                              handles);
             }
-            handles.put( identifier,
-                         (FactHandle) o );
+            handles.put(identifier,
+                        (FactHandle) o);
 
             o = ((InternalFactHandle) o).getObject();
-
         }
 
-        targetCtx.set( identifier,
-                       o );
+        targetCtx.set(identifier,
+                      o);
 
         return o;
     }
-
 }

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/BaseBatchFluent.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/BaseBatchFluent.java
@@ -22,8 +22,8 @@ import org.drools.core.command.LeaveConversationCommand;
 import org.drools.core.command.OutCommand;
 import org.drools.core.command.StartConversationCommand;
 import org.kie.api.command.ExecutableCommand;
-import org.kie.api.runtime.builder.ContextFluent;
-import org.kie.api.runtime.builder.Scope;
+import org.kie.internal.builder.fluent.ContextFluent;
+import org.kie.internal.builder.fluent.Scope;
 
 public class BaseBatchFluent<T, E> implements ContextFluent<T, E> {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/BaseBatchWithProcessFluent.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/BaseBatchWithProcessFluent.java
@@ -2,8 +2,8 @@ package org.drools.core.fluent.impl;
 
 import java.util.Map;
 
-import org.kie.api.runtime.builder.ProcessFluent;
-import org.kie.api.runtime.builder.WorkItemManagerFluent;
+import org.kie.internal.builder.fluent.ProcessFluent;
+import org.kie.internal.builder.fluent.WorkItemManagerFluent;
 
 public abstract class BaseBatchWithProcessFluent<T, E> extends BaseBatchFluent<T, E>
         implements ProcessFluent<T, E> {

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/Batch.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/Batch.java
@@ -16,10 +16,10 @@
 
 package org.drools.core.fluent.impl;
 
+import java.util.List;
+
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
-
-import java.util.List;
 
 public interface Batch extends BatchExecutionCommand {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/BatchImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/BatchImpl.java
@@ -16,12 +16,13 @@
 
 package org.drools.core.fluent.impl;
 
-import org.kie.api.command.Command;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kie.api.command.Command;
+
 public class BatchImpl implements Batch {
+
     private final long distance;
 
     private List<Command> commands = new ArrayList<Command>();

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/CommandRegister.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/CommandRegister.java
@@ -16,13 +16,13 @@
 
 package org.drools.core.fluent.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.StatelessKieSession;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class CommandRegister {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/DataSourceFluentImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/DataSourceFluentImpl.java
@@ -21,9 +21,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.drools.core.command.AddDataSourceCommand;
-import org.kie.api.runtime.builder.DataSourceFluent;
-import org.kie.api.runtime.builder.RuleUnitFluent;
 import org.kie.api.runtime.rule.DataSource;
+import org.kie.internal.builder.fluent.DataSourceFluent;
+import org.kie.internal.builder.fluent.RuleUnitFluent;
 
 public class DataSourceFluentImpl<E, U extends RuleUnitFluent> implements DataSourceFluent<E, U> {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/ExecutableBuilderImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/ExecutableBuilderImpl.java
@@ -21,8 +21,8 @@ import org.drools.core.command.SetKieContainerCommand;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.Executable;
 import org.kie.api.runtime.KieContainer;
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.KieContainerFluent;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieContainerFluent;
 
 public class ExecutableBuilderImpl extends BaseBatchFluent<ExecutableBuilder, ExecutableBuilder> implements ExecutableBuilder {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/ExecutableImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/ExecutableImpl.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kie.api.command.ExecutableCommand;
-import org.kie.api.runtime.builder.ExecutableBuilder;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
 
 public class ExecutableImpl implements InternalExecutable {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/FluentComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/FluentComponentFactory.java
@@ -16,16 +16,17 @@
 
 package org.drools.core.fluent.impl;
 
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.KieContainerFluent;
-import org.kie.api.runtime.KieContainer;
-import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.builder.KieSessionFluent;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieContainerFluent;
+import org.kie.internal.builder.fluent.KieSessionFluent;
+
 public class FluentComponentFactory {
+
     private Map<String, Class> fluents;
     private Map<String, String> fluentTargets;
 
@@ -35,14 +36,13 @@ public class FluentComponentFactory {
 
         set(KieContainerFluent.class.getName(), KieContainerFluentImpl.class, KieContainer.class.getName());
         set(KieSessionFluent.class.getName(), KieSessionFluentImpl.class, KieSession.class.getName());
-        set( ExecutableBuilder.class.getName(), ExecutableBuilderImpl.class, null );
-
+        set(ExecutableBuilder.class.getName(), ExecutableBuilderImpl.class, null);
     }
 
     public void set(String fluentType, Class fluentImpl, String fluentTarget) {
         fluents.put(fluentType, fluentImpl);
 
-        if ( fluentTarget != null ) {
+        if (fluentTarget != null) {
             // only BatchBuilderFluent is currently null
             fluentTargets.put(fluentType, fluentTarget);
         }

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/GetCommand.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/GetCommand.java
@@ -19,9 +19,10 @@ package org.drools.core.fluent.impl;
 import org.drools.core.command.RequestContextImpl;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
-import org.kie.api.runtime.builder.Scope;
+import org.kie.internal.builder.fluent.Scope;
 
 public class GetCommand<T> implements ExecutableCommand<T> {
+
     private String name;
     private Scope scope;
 
@@ -29,17 +30,17 @@ public class GetCommand<T> implements ExecutableCommand<T> {
         this.name = name;
     }
 
-    public  GetCommand(String name, Scope scope) {
+    public GetCommand(String name, Scope scope) {
         this.name = name;
         this.scope = scope;
     }
 
     @Override
     public T execute(Context context) {
-        RequestContextImpl reqContext = (RequestContextImpl)context;
+        RequestContextImpl reqContext = (RequestContextImpl) context;
 
         T object = null;
-        if ( reqContext.has(name)) {
+        if (reqContext.has(name)) {
             object = (T) reqContext.get(name);
             reqContext.setLastSetOrGet(name);
         }
@@ -50,8 +51,8 @@ public class GetCommand<T> implements ExecutableCommand<T> {
     @Override
     public String toString() {
         return "SetCommand{" +
-               "name='" + name + '\'' +
-               ", scope=" + scope +
-               '}';
+                "name='" + name + '\'' +
+                ", scope=" + scope +
+                '}';
     }
 }

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/GetContextCommand.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/GetContextCommand.java
@@ -22,6 +22,7 @@ import org.kie.api.runtime.Context;
 import org.kie.internal.command.RegistryContext;
 
 public class GetContextCommand<Void> implements ExecutableCommand<Void> {
+
     private String name;
 
     public GetContextCommand(String name) {
@@ -30,15 +31,15 @@ public class GetContextCommand<Void> implements ExecutableCommand<Void> {
 
     @Override
     public Void execute(Context context) {
-        Context returned = ( (RegistryContext) context ).getContextManager().getContext( name );
-        ((RequestContextImpl)context).setApplicationContext(returned);
+        Context returned = ((RegistryContext) context).getContextManager().getContext(name);
+        ((RequestContextImpl) context).setApplicationContext(returned);
         return null;
     }
 
     @Override
     public String toString() {
         return "GetContextCommand{" +
-               "name='" + name + '\'' +
-               '}';
+                "name='" + name + '\'' +
+                '}';
     }
 }

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/InternalExecutable.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/InternalExecutable.java
@@ -31,7 +31,7 @@ public interface InternalExecutable extends Executable {
                 .flatMap(batch -> batch.getCommands().stream())
                 .noneMatch(NotTransactionalCommand.class::isInstance);
     }
-    
+
     default boolean requiresDispose() {
         return getBatches().stream()
                 .flatMap(batch -> batch.getCommands().stream())

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/KieContainerFluentImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/KieContainerFluentImpl.java
@@ -21,10 +21,10 @@ import java.util.function.BiFunction;
 import org.drools.core.command.NewKieSessionCommand;
 import org.drools.core.command.NewRuleUnitExecutorCommand;
 import org.kie.api.runtime.KieContainer;
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.KieContainerFluent;
-import org.kie.api.runtime.builder.KieSessionFluent;
-import org.kie.api.runtime.builder.RuleUnitExecutorFluent;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieContainerFluent;
+import org.kie.internal.builder.fluent.KieSessionFluent;
+import org.kie.internal.builder.fluent.RuleUnitExecutorFluent;
 
 public class KieContainerFluentImpl extends BaseBatchFluent<ExecutableBuilder, ExecutableBuilder> implements KieContainerFluent {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/KieSessionFluentImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/KieSessionFluentImpl.java
@@ -20,9 +20,9 @@ import org.drools.core.command.runtime.DisposeCommand;
 import org.drools.core.command.runtime.GetGlobalCommand;
 import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.KieSessionFluent;
 import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieSessionFluent;
 
 public class KieSessionFluentImpl extends BaseBatchWithProcessFluent<KieSessionFluent, ExecutableBuilder> implements KieSessionFluent {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/NewContextCommand.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/NewContextCommand.java
@@ -22,6 +22,7 @@ import org.kie.api.runtime.Context;
 import org.kie.internal.command.RegistryContext;
 
 public class NewContextCommand<Void> implements ExecutableCommand<Void> {
+
     private String name;
 
     public NewContextCommand(String name) {
@@ -30,8 +31,8 @@ public class NewContextCommand<Void> implements ExecutableCommand<Void> {
 
     @Override
     public Void execute(Context context) {
-        Context returned = ( (RegistryContext) context ).getContextManager().createContext( name );
-        ((RequestContextImpl)context).setApplicationContext(returned);
+        Context returned = ((RegistryContext) context).getContextManager().createContext(name);
+        ((RequestContextImpl) context).setApplicationContext(returned);
         return null;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/RuleUnitExecutorFluentImpl.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/RuleUnitExecutorFluentImpl.java
@@ -24,10 +24,10 @@ import org.drools.core.command.RunUnitCommand;
 import org.drools.core.command.runtime.DisposeCommand;
 import org.drools.core.command.runtime.GetGlobalCommand;
 import org.kie.api.runtime.Context;
-import org.kie.api.runtime.builder.DataSourceFluent;
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.RuleUnitExecutorFluent;
 import org.kie.api.runtime.rule.RuleUnit;
+import org.kie.internal.builder.fluent.DataSourceFluent;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.RuleUnitExecutorFluent;
 
 public class RuleUnitExecutorFluentImpl extends BaseBatchWithProcessFluent<RuleUnitExecutorFluent, ExecutableBuilder> implements RuleUnitExecutorFluent {
 

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/SetCommand.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/SetCommand.java
@@ -19,9 +19,10 @@ package org.drools.core.fluent.impl;
 import org.drools.core.command.RequestContextImpl;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
-import org.kie.api.runtime.builder.Scope;
+import org.kie.internal.builder.fluent.Scope;
 
 public class SetCommand<T> implements ExecutableCommand<T> {
+
     private String name;
     private Scope scope = Scope.REQUEST;
 
@@ -36,32 +37,32 @@ public class SetCommand<T> implements ExecutableCommand<T> {
 
     @Override
     public T execute(Context context) {
-        RequestContextImpl reqContext = (RequestContextImpl)context;
+        RequestContextImpl reqContext = (RequestContextImpl) context;
         T returned = (T) reqContext.getResult();
 
-        if ( scope == Scope.REQUEST ) {
+        if (scope == Scope.REQUEST) {
             reqContext.set(name, returned);
-        } else if ( scope == Scope.CONVERSATION ) {
-            if ( reqContext.getConversationContext() == null ) {
+        } else if (scope == Scope.CONVERSATION) {
+            if (reqContext.getConversationContext() == null) {
                 throw new IllegalStateException("No Conversation Context Exists");
             }
             reqContext.getConversationContext().set(name, returned);
-        } else  if ( scope == Scope.APPLICATION ) {
-            if ( reqContext.getApplicationContext() == null ) {
+        } else if (scope == Scope.APPLICATION) {
+            if (reqContext.getApplicationContext() == null) {
                 throw new IllegalStateException("No Application Context Exists");
             }
             reqContext.getApplicationContext().set(name, returned);
         }
 
-        ((RequestContextImpl)context).setLastSetOrGet(name);
+        ((RequestContextImpl) context).setLastSetOrGet(name);
         return returned;
     }
 
     @Override
     public String toString() {
         return "SetCommand{" +
-               "name='" + name + '\'' +
-               ", scope=" + scope +
-               '}';
+                "name='" + name + '\'' +
+                ", scope=" + scope +
+                '}';
     }
 }

--- a/drools-core/src/main/java/org/drools/core/fluent/impl/SetVarAsRegistryEntry.java
+++ b/drools-core/src/main/java/org/drools/core/fluent/impl/SetVarAsRegistryEntry.java
@@ -23,6 +23,7 @@ import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 
 public class SetVarAsRegistryEntry<Void> implements ExecutableCommand<Void> {
+
     private String registryName;
     private String varName;
 
@@ -35,15 +36,15 @@ public class SetVarAsRegistryEntry<Void> implements ExecutableCommand<Void> {
     public Void execute(Context context) {
         Object o = context.get(varName);
 
-        ((Map<String, Object>)context.get(ContextImpl.REGISTRY)).put(registryName, o);
+        ((Map<String, Object>) context.get(ContextImpl.REGISTRY)).put(registryName, o);
         return null;
     }
 
     @Override
     public String toString() {
         return "SetVarAsRegistryEntry{" +
-               "registryName='" + registryName + '\'' +
-               ", varName='" + varName + '\'' +
-               '}';
+                "registryName='" + registryName + '\'' +
+                ", varName='" + varName + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
As discussed, this PR move to kie-internal the fluent API because it is still experimental

@mariofusco @mdproctor @kkufova 

PRs list:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/349
https://github.com/kiegroup/drools/pull/2177
https://github.com/kiegroup/drools-wb/pull/1016
https://github.com/kiegroup/droolsjbpm-integration/pull/1661