### PR TITLE
DROOLS-3412: Reuse process runtime on session reset to avoid memory leak in conjunction with JBPM

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -1097,8 +1097,6 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         timerService.reset();
 
-        this.processRuntime = null;
-
         this.initialFactHandle = initInitialFact(kBase, null);
     }
 


### PR DESCRIPTION
DROOLS-3412 seems to appear if Drools session pools are used together with JBPM. Drools sets the process runtime to null without disposing it and it addition JBPMs ProcessRuntimeImpl registers listeners in AgendaEventSupport which don't get cleared. Therefore if sessions are reused then event listeners accumulate over time and ProcessRuntimeIImpls can't be garbaged collected.

I see two options to fix this and will open PRs for both options to leave the choice to you:
1. Reuse the previous process runtime instance on session reset: This appears to be faster, I haven't found issues with it yet but I think it requires more testing
2. Dispose the process runtime and clear all event listeners even if a session is returned to the pool.

**This PR implements option 1**. This PR and https://github.com/kiegroup/drools/pull/2186 are mutual exclusive.

In order to reproduce this issue you can either:
1. Run https://github.com/liebharc/JavaRules/blob/master/src/test/java/com/github/liebharc/JavaRules/JpbmDroolsEnginePerfTest.java . On my machine it executes in around 20 seconds with the fix applied, without the fix it runs 5 minutes and I aborted it at that point.
2. Run https://github.com/liebharc/kie-benchmarks/tree/master/drools-benchmarks/src/main/java/org/drools/benchmarks/session/sessionpool . I've updated the benchmark to show this issue. 

**DisposeSessionBenchmark.getKieSessionFromContainer without fix**
```
Result "org.drools.benchmarks.session.sessionpool.DisposeSessionBenchmark.getKieSessionFromContainer":
  N = 25000
  mean =      1,120 ±(99.9%) 0,052 us/op

  Histogram, us/op:
    [  0,000,  25,000) = 24991 
    [ 25,000,  50,000) = 0 
    [ 50,000,  75,000) = 4 
    [ 75,000, 100,000) = 1 
    [100,000, 125,000) = 1 
    [125,000, 150,000) = 0 
    [150,000, 175,000) = 2 
    [175,000, 200,000) = 0 
    [200,000, 225,000) = 0 
    [225,000, 250,000) = 1 
    [250,000, 275,000) = 0 

  Percentiles, us/op:
      p(0,0000) =      0,300 us/op
     p(50,0000) =      0,902 us/op
     p(90,0000) =      1,202 us/op
     p(95,0000) =      1,503 us/op
     p(99,0000) =      2,104 us/op
     p(99,9000) =     15,324 us/op
     p(99,9900) =    159,848 us/op
     p(99,9990) =    234,066 us/op
     p(99,9999) =    234,066 us/op
    p(100,0000) =    234,066 us/op


# Run complete. Total time: 00:08:47

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                           (initialSessionPoolSize)  (numberOfFacts)  (numberOfRules)  (usePool)  Mode    Cnt  Score   Error  Units
DisposeSessionBenchmark.getKieSessionFromContainer                         1               10               10       true    ss  25000  6,897 ± 0,245  us/op
DisposeSessionBenchmark.getKieSessionFromContainer                         1               10               10      false    ss  25000  1,120 ± 0,052  us/op
```

**DisposeSessionBenchmark.getKieSessionFromContainer with fix**
```
Result "org.drools.benchmarks.session.sessionpool.DisposeSessionBenchmark.getKieSessionFromContainer":
  N = 25000
  mean =      1,024 ±(99.9%) 0,045 us/op

  Histogram, us/op:
    [  0,000,  25,000) = 24988 
    [ 25,000,  50,000) = 5 
    [ 50,000,  75,000) = 2 
    [ 75,000, 100,000) = 4 
    [100,000, 125,000) = 0 
    [125,000, 150,000) = 0 
    [150,000, 175,000) = 0 
    [175,000, 200,000) = 0 
    [200,000, 225,000) = 0 
    [225,000, 250,000) = 0 
    [250,000, 275,000) = 1 

  Percentiles, us/op:
      p(0,0000) =      0,300 us/op
     p(50,0000) =      0,901 us/op
     p(90,0000) =      1,202 us/op
     p(95,0000) =      1,502 us/op
     p(99,0000) =      2,404 us/op
     p(99,9000) =     15,324 us/op
     p(99,9900) =     88,037 us/op
     p(99,9990) =    256,601 us/op
     p(99,9999) =    256,601 us/op
    p(100,0000) =    256,601 us/op


# Run complete. Total time: 00:01:12

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                           (initialSessionPoolSize)  (numberOfFacts)  (numberOfRules)  (usePool)  Mode    Cnt  Score   Error  Units
DisposeSessionBenchmark.getKieSessionFromContainer                         1               10               10       true    ss  25000  2,324 ± 0,066  us/op
DisposeSessionBenchmark.getKieSessionFromContainer                         1               10               10      false    ss  25000  1,024 ± 0,045  us/op

Process finished with exit code 0
```
