### PR TITLE
DROOLS-3419: Bump heap size for findbugs in drools-compiler Maven build

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -174,6 +174,7 @@
           <artifactId>findbugs-maven-plugin</artifactId>
           <configuration>
             <excludeFilterFile>${project.basedir}/src/main/findbugs/findbugs-exclude.xml</excludeFilterFile>
+            <maxHeap>1024</maxHeap> <!-- MB -->
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
- add config param to bump to 1GB [(default is 512MB)](https://gleclaire.github.io/findbugs-maven-plugin/findbugs-mojo.html#maxHeap)
- reference: https://stackoverflow.com/questions/13876912/can-not-execute-findbugs-java-lang-outofmemoryerror-java-heap-space-while-run/13879398#13879398