### PR TITLE
Serialization with SecurityManager (DROOLS-3429)

### DIFF
--- a/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
@@ -173,7 +173,7 @@ public class RuleImpl implements Externalizable,
         out.writeObject( metaAttributes );
         out.writeObject( requiredDeclarations );
 
-        if ( this.consequence instanceof CompiledInvoker) {
+        if ( isCompiledInvoker( this.consequence ) ) {
             out.writeObject( null );
             out.writeObject( null );
         } else {
@@ -195,6 +195,14 @@ public class RuleImpl implements Externalizable,
         out.writeInt(ruleFlags);
 
         out.writeObject( ruleUnitClassName );
+    }
+
+    private static boolean isCompiledInvoker( Consequence consequence ) {
+        if ( consequence instanceof CompiledInvoker ) {
+            return true;
+        }
+
+        return consequence instanceof SafeConsequence && ( (SafeConsequence) consequence ).wrapsCompiledInvoker();
     }
 
     @SuppressWarnings("unchecked")
@@ -896,6 +904,10 @@ public class RuleImpl implements Externalizable,
                     return null;
                 }
             }, KiePolicyHelper.getAccessContext());
+        }
+
+        public boolean wrapsCompiledInvoker() {
+            return this.delegate instanceof CompiledInvoker;
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
@@ -128,7 +128,7 @@ public class PredicateConstraint extends MutableTypeConstraint
 
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal( out );
-        if ( this.expression instanceof CompiledInvoker ) {
+        if ( isCompiledInvoker(this.expression) ) {
             out.writeObject( null );
         } else {
             out.writeObject( this.expression );
@@ -137,6 +137,14 @@ public class PredicateConstraint extends MutableTypeConstraint
         out.writeObject( this.previousDeclarations );
         out.writeObject( this.localDeclarations );
         out.writeObject( this.cloned );
+    }
+
+    private static boolean isCompiledInvoker(PredicateExpression expression) {
+        if ( expression instanceof CompiledInvoker ) {
+            return true;
+        }
+
+        return expression instanceof SafePredicateExpression && ( (SafePredicateExpression) expression ).wrapsCompiledInvoker();
     }
 
     public Declaration[] getRequiredDeclarations() {
@@ -413,6 +421,10 @@ public class PredicateConstraint extends MutableTypeConstraint
                     return delegate.evaluate(handle, tuple, previousDeclarations, localDeclarations, workingMemory, context);
                 }
             }, KiePolicyHelper.getAccessContext());
+        }
+
+        public boolean wrapsCompiledInvoker() {
+            return this.delegate instanceof CompiledInvoker;
         }
     }
 }


### PR DESCRIPTION
Serialization of rule packages always failed when using a SecurityManager; extended the special handling of CompiledInvokers to also consider SafePredicateExpression and SafeConsequence wrappers