### PR TITLE
DROOLS-3429 Fix serialization of compiled invokers when SecurityManager is enabled

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/mvel/MVELEvalBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/dialect/mvel/MVELEvalBuilder.java
@@ -31,11 +31,11 @@ import org.drools.core.base.mvel.MVELEvalExpression;
 import org.drools.core.reteoo.RuleTerminalNode.SortDeclarations;
 import org.drools.core.rule.Declaration;
 import org.drools.core.rule.EvalCondition;
-import org.drools.core.rule.EvalCondition.SafeEvalExpression;
 import org.drools.core.rule.MVELDialectRuntimeData;
 import org.drools.core.rule.Pattern;
 import org.drools.core.rule.RuleConditionElement;
 import org.drools.core.spi.DeclarationScopeResolver;
+import org.drools.core.spi.EvalExpression.SafeEvalExpression;
 import org.drools.core.spi.KnowledgeHelper;
 import org.kie.internal.security.KiePolicyHelper;
 

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializationSecurityPolicyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializationSecurityPolicyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.drools.compiler.CommonTestMethodBase;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializationSecurityPolicyTest extends CommonTestMethodBase {
+
+    @Before
+    public void init() {
+        final String enginePolicy = SerializationSecurityPolicyTest.class.getResource("serialization-rules.policy").getFile();
+        final String kiePolicy = SerializationSecurityPolicyTest.class.getResource("serialization-rules.policy").getFile();
+        System.setProperty("java.security.policy", enginePolicy);
+        System.setProperty("kie.security.policy", kiePolicy);
+        System.setSecurityManager(new SecurityManager());
+    }
+
+    @After
+    public void close() {
+        System.setSecurityManager(null);
+        System.setProperty("java.security.policy", "");
+        System.setProperty("kie.security.policy", "");
+    }
+
+    @Test
+    public void testSerialization() throws IOException, ClassNotFoundException {
+        final String rule =
+                " rule R " +
+                " when " +
+                " then " +
+                "     System.out.println(\"consequence!\"); " +
+                " end";
+
+        final KieServices kieServices = KieServices.get();
+        final Resource drlResource = kieServices.getResources().newByteArrayResource(
+                rule.getBytes(StandardCharsets.UTF_8.name()), StandardCharsets.UTF_8.name());
+        drlResource.setResourceType(ResourceType.DRL);
+        drlResource.setTargetPath("test.drl");
+        final KieFileSystem kieFileSystem = kieServices.newKieFileSystem();
+        kieFileSystem.write(drlResource);
+        final KieBuilder kieBuilder = kieServices.newKieBuilder(kieFileSystem);
+        kieBuilder.buildAll();
+
+        final KieBase kieBase = kieServices.newKieContainer(kieBuilder.getKieModule().getReleaseId()).getKieBase();
+
+        final Collection<KiePackage> kpkgs = kieBase.getKiePackages();
+        final Collection<KiePackage> newCollection = new ArrayList<>();
+        for (KiePackage kpkg : kpkgs) {
+            kpkg = SerializationHelper.serializeObject(kpkg);
+            newCollection.add(kpkg);
+        }
+        ((InternalKnowledgeBase) kieBase).addPackages(newCollection);
+
+        final KieSession kieSession = kieBase.newKieSession();
+        assertThat(kieSession.fireAllRules()).isEqualTo(1);
+    }
+}

--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/serialization-rules.policy
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/serialization-rules.policy
@@ -1,0 +1,11 @@
+grant { 
+       permission java.util.PropertyPermission "*", "read";
+       permission java.lang.RuntimePermission "accessDeclaredMembers";
+       permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+   
+       // Only for test purposes
+       permission java.lang.RuntimePermission "setSecurityManager";
+
+       permission java.security.AllPermission;
+       
+};

--- a/drools-core/src/main/java/org/drools/core/base/accumulators/JavaAccumulatorFunctionExecutor.java
+++ b/drools-core/src/main/java/org/drools/core/base/accumulators/JavaAccumulatorFunctionExecutor.java
@@ -29,7 +29,6 @@ import org.drools.core.WorkingMemory;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.rule.Declaration;
 import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.ReturnValueExpression;
 import org.drools.core.spi.ReturnValueExpression.SafeReturnValueExpression;
 import org.drools.core.spi.Tuple;
@@ -66,7 +65,7 @@ public class JavaAccumulatorFunctionExecutor
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        if ( this.expression instanceof CompiledInvoker ) {
+        if ( ReturnValueExpression.isCompiledInvoker(this.expression) ) {
             out.writeObject( null );
         } else {
             out.writeObject( this.expression );

--- a/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
@@ -23,7 +23,6 @@ import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -46,7 +45,6 @@ import org.drools.core.rule.LogicTransformer;
 import org.drools.core.rule.QueryImpl;
 import org.drools.core.rule.RuleConditionElement;
 import org.drools.core.spi.AgendaGroup;
-import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Consequence;
 import org.drools.core.spi.Enabled;
 import org.drools.core.spi.KnowledgeHelper;
@@ -173,7 +171,7 @@ public class RuleImpl implements Externalizable,
         out.writeObject( metaAttributes );
         out.writeObject( requiredDeclarations );
 
-        if ( isCompiledInvoker( this.consequence ) ) {
+        if ( Consequence.isCompiledInvoker( this.consequence ) ) {
             out.writeObject( null );
             out.writeObject( null );
         } else {
@@ -195,14 +193,6 @@ public class RuleImpl implements Externalizable,
         out.writeInt(ruleFlags);
 
         out.writeObject( ruleUnitClassName );
-    }
-
-    private static boolean isCompiledInvoker( Consequence consequence ) {
-        if ( consequence instanceof CompiledInvoker ) {
-            return true;
-        }
-
-        return consequence instanceof SafeConsequence && ( (SafeConsequence) consequence ).wrapsCompiledInvoker();
     }
 
     @SuppressWarnings("unchecked")
@@ -612,7 +602,7 @@ public class RuleImpl implements Externalizable,
 
     public void wire(Object object) {
         if ( object instanceof Consequence ) {
-            Consequence c = KiePolicyHelper.isPolicyEnabled() ? new SafeConsequence((Consequence) object) : (Consequence) object;
+            Consequence c = KiePolicyHelper.isPolicyEnabled() ? new Consequence.SafeConsequence((Consequence) object) : (Consequence) object;
             if ( DEFAULT_CONSEQUENCE_NAME.equals( c.getName() ) ) {
                 setConsequence( c );
             } else {
@@ -881,34 +871,6 @@ public class RuleImpl implements Externalizable,
 
     public boolean hasRuleUnit() {
         return ruleUnitClassName != null;
-    }
-
-    public static class SafeConsequence implements Consequence, Serializable {
-        private static final long serialVersionUID = -8109957972163261899L;
-        private final Consequence delegate;
-        public SafeConsequence( Consequence delegate ) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public String getName() {
-            return this.delegate.getName();
-        }
-
-        @Override
-        public void evaluate(final KnowledgeHelper knowledgeHelper, final WorkingMemory workingMemory) throws Exception {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                @Override
-                public Object run() throws Exception {
-                    delegate.evaluate(knowledgeHelper, workingMemory);
-                    return null;
-                }
-            }, KiePolicyHelper.getAccessContext());
-        }
-
-        public boolean wrapsCompiledInvoker() {
-            return this.delegate instanceof CompiledInvoker;
-        }
     }
 
     public static class SafeSalience implements Salience, Serializable {

--- a/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/rule/impl/RuleImpl.java
@@ -173,7 +173,7 @@ public class RuleImpl implements Externalizable,
         out.writeObject( metaAttributes );
         out.writeObject( requiredDeclarations );
 
-        if ( this.consequence instanceof CompiledInvoker) {
+        if ( isCompiledInvoker( this.consequence ) ) {
             out.writeObject( null );
             out.writeObject( null );
         } else {
@@ -195,6 +195,14 @@ public class RuleImpl implements Externalizable,
         out.writeInt(ruleFlags);
 
         out.writeObject( ruleUnitClassName );
+    }
+
+    private static boolean isCompiledInvoker( Consequence consequence ) {
+        if ( consequence instanceof CompiledInvoker ) {
+            return true;
+        }
+
+        return consequence instanceof SafeConsequence && ( (SafeConsequence) consequence ).wrapsCompiledInvoker();
     }
 
     @SuppressWarnings("unchecked")
@@ -896,6 +904,10 @@ public class RuleImpl implements Externalizable,
                     return null;
                 }
             }, KiePolicyHelper.getAccessContext());
+        }
+
+        public boolean wrapsCompiledInvoker() {
+            return this.delegate instanceof CompiledInvoker;
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/rule/EvalCondition.java
+++ b/drools-core/src/main/java/org/drools/core/rule/EvalCondition.java
@@ -16,26 +16,21 @@
 
 package org.drools.core.rule;
 
-import org.drools.core.WorkingMemory;
-import org.drools.core.base.mvel.MVELEvalExpression;
-import org.drools.core.spi.CompiledInvoker;
-import org.drools.core.spi.EvalExpression;
-import org.drools.core.spi.Tuple;
-import org.drools.core.spi.Wireable;
-import org.kie.internal.security.KiePolicyHelper;
-
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import org.drools.core.WorkingMemory;
+import org.drools.core.base.mvel.MVELEvalExpression;
+import org.drools.core.spi.EvalExpression;
+import org.drools.core.spi.Tuple;
+import org.drools.core.spi.Wireable;
+import org.kie.internal.security.KiePolicyHelper;
 
 public class EvalCondition extends ConditionalElement
     implements
@@ -80,7 +75,7 @@ public class EvalCondition extends ConditionalElement
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        if ( this.expression instanceof CompiledInvoker ) {
+        if ( EvalExpression.isCompiledInvoker(this.expression) ) {
             out.writeObject( null );
         } else {
             out.writeObject( this.expression );
@@ -94,7 +89,7 @@ public class EvalCondition extends ConditionalElement
     }
 
     public void wire(Object object) {
-        EvalExpression expression = KiePolicyHelper.isPolicyEnabled() ? new SafeEvalExpression((EvalExpression) object) : (EvalExpression) object;
+        EvalExpression expression = KiePolicyHelper.isPolicyEnabled() ? new EvalExpression.SafeEvalExpression((EvalExpression) object) : (EvalExpression) object;
         setEvalExpression( expression );
         for ( EvalCondition clone : this.cloned ) {
             clone.wireClone( expression );
@@ -220,46 +215,5 @@ public class EvalCondition extends ConditionalElement
     @Override
     public String toString() {
         return this.expression.toString();
-    }
-
-    public static class SafeEvalExpression implements EvalExpression, Serializable {
-        private static final long serialVersionUID = -5682290553015978731L;
-        private EvalExpression delegate;
-        public SafeEvalExpression(EvalExpression delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public Object createContext() {
-            return AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                @Override
-                public Object run() {
-                    return delegate.createContext();
-                }
-            }, KiePolicyHelper.getAccessContext());
-        }
-
-        @Override
-        public boolean evaluate(final Tuple tuple, 
-                final Declaration[] requiredDeclarations, 
-                final WorkingMemory workingMemory, 
-                final Object context) throws Exception {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<Boolean>() {
-                @Override
-                public Boolean run() throws Exception {
-                    return delegate.evaluate(tuple, requiredDeclarations, workingMemory, context);
-                }
-            }, KiePolicyHelper.getAccessContext());
-        }
-
-        @Override
-        public void replaceDeclaration(Declaration declaration, Declaration resolved) {
-            delegate.replaceDeclaration(declaration, resolved);
-        }
-        
-        @Override
-        public SafeEvalExpression clone() {
-            return new SafeEvalExpression( this.delegate.clone() );
-        }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/rule/MultiAccumulate.java
+++ b/drools-core/src/main/java/org/drools/core/rule/MultiAccumulate.java
@@ -25,7 +25,6 @@ import org.drools.core.WorkingMemory;
 import org.drools.core.base.accumulators.MVELAccumulatorFunctionExecutor;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Tuple;
 import org.drools.core.spi.Wireable;
 import org.kie.internal.security.KiePolicyHelper;
@@ -54,11 +53,11 @@ public class MultiAccumulate extends Accumulate {
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal(out);
         out.writeInt( accumulators.length );
-        for ( Accumulator acc : accumulators ) {
-            if ( acc instanceof CompiledInvoker) {
-                out.writeObject( null );
+        for (Accumulator acc : accumulators) {
+            if (Accumulator.isCompiledInvoker(acc)) {
+                out.writeObject(null);
             } else {
-                out.writeObject( acc );
+                out.writeObject(acc);
             }
         }
     }

--- a/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
@@ -16,11 +16,18 @@
 
 package org.drools.core.rule;
 
-import org.drools.core.WorkingMemory;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.reteoo.LeftTuple;
-import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Evaluator;
 import org.drools.core.spi.InternalReadAccessor;
 import org.drools.core.spi.PredicateExpression;
@@ -28,19 +35,6 @@ import org.drools.core.spi.Restriction;
 import org.drools.core.spi.Tuple;
 import org.drools.core.spi.Wireable;
 import org.kie.internal.security.KiePolicyHelper;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.io.Serializable;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A predicate can be written as a top level constraint or be nested
@@ -128,7 +122,7 @@ public class PredicateConstraint extends MutableTypeConstraint
 
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal( out );
-        if ( isCompiledInvoker(this.expression) ) {
+        if ( PredicateExpression.isCompiledInvoker(this.expression) ) {
             out.writeObject( null );
         } else {
             out.writeObject( this.expression );
@@ -137,14 +131,6 @@ public class PredicateConstraint extends MutableTypeConstraint
         out.writeObject( this.previousDeclarations );
         out.writeObject( this.localDeclarations );
         out.writeObject( this.cloned );
-    }
-
-    private static boolean isCompiledInvoker(PredicateExpression expression) {
-        if ( expression instanceof CompiledInvoker ) {
-            return true;
-        }
-
-        return expression instanceof SafePredicateExpression && ( (SafePredicateExpression) expression ).wrapsCompiledInvoker();
     }
 
     public Declaration[] getRequiredDeclarations() {
@@ -171,7 +157,7 @@ public class PredicateConstraint extends MutableTypeConstraint
     }
 
     public void wire(Object object) {
-        setPredicateExpression( KiePolicyHelper.isPolicyEnabled() ? new SafePredicateExpression( (PredicateExpression) object ):(PredicateExpression) object );
+        setPredicateExpression( KiePolicyHelper.isPolicyEnabled() ? new PredicateExpression.SafePredicateExpression((PredicateExpression) object ):(PredicateExpression) object );
         for ( PredicateConstraint clone : this.cloned ) {
             clone.wire( object );
         }
@@ -390,41 +376,5 @@ public class PredicateConstraint extends MutableTypeConstraint
 
     public Evaluator getEvaluator() {
         return null;
-    }
-
-    public static class SafePredicateExpression implements PredicateExpression, Serializable {
-        private static final long serialVersionUID = -4570820770000524010L;
-        private PredicateExpression delegate;
-
-        public SafePredicateExpression(PredicateExpression delegate) {
-            this.delegate = delegate;
-        }
-
-        public Object createContext() {
-            return AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                @Override
-                public Object run() {
-                    return delegate.createContext();
-                }
-            }, KiePolicyHelper.getAccessContext());
-        }
-
-        public boolean evaluate(final InternalFactHandle handle,
-                final Tuple tuple, 
-                final Declaration[] previousDeclarations, 
-                final Declaration[] localDeclarations, 
-                final WorkingMemory workingMemory, 
-                final Object context) throws Exception {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<Boolean>() {
-                @Override
-                public Boolean run() throws Exception {
-                    return delegate.evaluate(handle, tuple, previousDeclarations, localDeclarations, workingMemory, context);
-                }
-            }, KiePolicyHelper.getAccessContext());
-        }
-
-        public boolean wrapsCompiledInvoker() {
-            return this.delegate instanceof CompiledInvoker;
-        }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
@@ -128,7 +128,7 @@ public class PredicateConstraint extends MutableTypeConstraint
 
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal( out );
-        if ( this.expression instanceof CompiledInvoker ) {
+        if ( isCompiledInvoker(this.expression) ) {
             out.writeObject( null );
         } else {
             out.writeObject( this.expression );
@@ -137,6 +137,14 @@ public class PredicateConstraint extends MutableTypeConstraint
         out.writeObject( this.previousDeclarations );
         out.writeObject( this.localDeclarations );
         out.writeObject( this.cloned );
+    }
+
+    private static boolean isCompiledInvoker(PredicateExpression expression) {
+        if ( expression instanceof CompiledInvoker ) {
+            return true;
+        }
+
+        return expression instanceof SafePredicateExpression && ( (SafePredicateExpression) expression ).wrapsCompiledInvoker();
     }
 
     public Declaration[] getRequiredDeclarations() {
@@ -413,6 +421,10 @@ public class PredicateConstraint extends MutableTypeConstraint
                     return delegate.evaluate(handle, tuple, previousDeclarations, localDeclarations, workingMemory, context);
                 }
             }, KiePolicyHelper.getAccessContext());
+        }
+
+        public boolean wrapsCompiledInvoker() {
+            return this.delegate instanceof CompiledInvoker;
         }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/rule/ReturnValueRestriction.java
+++ b/drools-core/src/main/java/org/drools/core/rule/ReturnValueRestriction.java
@@ -16,12 +16,19 @@
 
 package org.drools.core.rule;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.drools.core.WorkingMemory;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.reteoo.LeftTuple;
 import org.drools.core.spi.AcceptsReadAccessor;
-import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Evaluator;
 import org.drools.core.spi.FieldValue;
 import org.drools.core.spi.InternalReadAccessor;
@@ -32,14 +39,6 @@ import org.drools.core.spi.ReturnValueExpression.SafeReturnValueExpression;
 import org.drools.core.spi.Tuple;
 import org.drools.core.spi.Wireable;
 import org.kie.internal.security.KiePolicyHelper;
-
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public class ReturnValueRestriction
     implements
@@ -142,7 +141,7 @@ public class ReturnValueRestriction
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        if ( this.expression instanceof CompiledInvoker ) {
+        if ( ReturnValueExpression.isCompiledInvoker(this.expression) ) {
             out.writeObject( null );
         } else {
             out.writeObject( this.expression );

--- a/drools-core/src/main/java/org/drools/core/rule/SingleAccumulate.java
+++ b/drools-core/src/main/java/org/drools/core/rule/SingleAccumulate.java
@@ -25,7 +25,6 @@ import org.drools.core.WorkingMemory;
 import org.drools.core.base.accumulators.MVELAccumulatorFunctionExecutor;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.spi.Accumulator;
-import org.drools.core.spi.CompiledInvoker;
 import org.drools.core.spi.Tuple;
 import org.drools.core.spi.Wireable;
 import org.kie.internal.security.KiePolicyHelper;
@@ -55,10 +54,10 @@ public class SingleAccumulate extends Accumulate {
 
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal(out);
-        if ( accumulator instanceof CompiledInvoker) {
-            out.writeObject( null );
+        if (Accumulator.isCompiledInvoker(accumulator)) {
+            out.writeObject(null);
         } else {
-            out.writeObject( accumulator );
+            out.writeObject(accumulator);
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/spi/Accumulator.java
+++ b/drools-core/src/main/java/org/drools/core/spi/Accumulator.java
@@ -227,7 +227,14 @@ public interface Accumulator
             }, KiePolicyHelper.getAccessContext());
         }
         
-        
+        public boolean wrapsCompiledInvoker() {
+            return delegate instanceof CompiledInvoker;
+        }
+    }
+
+    public static boolean isCompiledInvoker(final Accumulator accumulator) {
+        return (accumulator instanceof CompiledInvoker)
+                || (accumulator instanceof SafeAccumulator && ((SafeAccumulator) accumulator).wrapsCompiledInvoker());
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/spi/ReturnValueExpression.java
+++ b/drools-core/src/main/java/org/drools/core/spi/ReturnValueExpression.java
@@ -76,7 +76,13 @@ public interface ReturnValueExpression
             delegate.replaceDeclaration(declaration, resolved);
         }
 
+        public boolean wrapsCompiledInvoker() {
+            return delegate instanceof CompiledInvoker;
+        }
     }
 
-    
+    public static boolean isCompiledInvoker(final ReturnValueExpression expression) {
+        return (expression instanceof CompiledInvoker)
+                || (expression instanceof SafeReturnValueExpression && ((SafeReturnValueExpression) expression).wrapsCompiledInvoker());
+    }
 }


### PR DESCRIPTION
- Extension of fix proposed here: https://github.com/kiegroup/drools/pull/2198
- Added test case

There were more "Safe*" classes that wrap CompiledInvoker instances, therefore I applied similar fix everywhere where needed. 

@mariofusco could you please review? @aboukhal please also take a look. I made changes to your proposed code. 