### PR TITLE
DROOLS-3500 Fix SerializationSecurityPolicyTest

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SecurityPolicyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SecurityPolicyTest.java
@@ -15,6 +15,8 @@
 
 package org.drools.compiler.integrationtests;
 
+import java.security.Policy;
+
 import org.drools.compiler.CommonTestMethodBase;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,9 +45,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
         String kiePolicy = SecurityPolicyTest.class.getResource("rules.policy").getFile();
         System.setProperty("java.security.policy", enginePolicy);
         System.setProperty("kie.security.policy", kiePolicy);
-
-        TestSecurityManager tsm = new TestSecurityManager();
-        System.setSecurityManager(tsm);
+        Policy.getPolicy().refresh();
+        System.setSecurityManager(new TestSecurityManager());
     }
 
     @After
@@ -56,7 +57,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
     
     @Test
-    public void testUntrustedJavaConsequence() throws Exception {
+    public void testUntrustedJavaConsequence() {
         String drl = "package org.foo.bar\n" +
                 "rule R1 when\n" +
                 "then\n" +
@@ -83,7 +84,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
     
     @Test
-    public void testUntrustedMvelConsequence() throws Exception {
+    public void testUntrustedMvelConsequence() {
         String drl = "package org.foo.bar\n" +
                 "rule R1 dialect \"mvel\" when\n" +
                 "then\n" +
@@ -110,7 +111,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
     
     @Test
-    public void testSerializationUntrustedMvelConsequence() throws Exception {
+    public void testSerializationUntrustedMvelConsequence() {
         String drl = "package org.foo.bar\n" +
                 "rule R1 dialect \"mvel\" when\n" +
                 "then\n" +
@@ -136,7 +137,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
     
     @Test
-    public void testUntrustedJavaSalience() throws Exception {
+    public void testUntrustedJavaSalience() {
         String drl = "package org.foo.bar\n" +
                 "import "+MaliciousExitHelper.class.getName().replace('$', '.')+" \n" +
                 "rule R1 dialect \"java\" salience( MaliciousExitHelper.exit() ) \n" +
@@ -164,7 +165,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testUntrustedMVELSalience() throws Exception {
+    public void testUntrustedMVELSalience() {
         String drl = "package org.foo.bar\n" +
                 "import "+MaliciousExitHelper.class.getName().replace('$', '.')+" \n" +
                 "rule R1 dialect \"mvel\" salience( MaliciousExitHelper.exit() ) \n" +
@@ -195,7 +196,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testCustomAccumulate() throws Exception {
+    public void testCustomAccumulate() {
         String drl = "package org.foo.bar\n" +
                 "rule testRule\n" + 
                 "    when\n" + 
@@ -227,7 +228,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testCustomAccumulateMVEL() throws Exception {
+    public void testCustomAccumulateMVEL() {
         String drl = "package org.foo.bar\n" +
                 "rule testRule dialect \"mvel\" \n" + 
                 "    when\n" + 
@@ -268,7 +269,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testAccumulateFunctionMVEL() throws Exception {
+    public void testAccumulateFunctionMVEL() {
         String drl = "package org.foo.bar\n" +
                 "import "+MaliciousExitHelper.class.getName().replace('$', '.')+" \n" +
                 "rule testRule dialect \"mvel\" \n" + 
@@ -308,7 +309,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testAccumulateFunctionJava() throws Exception {
+    public void testAccumulateFunctionJava() {
         String drl = "package org.foo.bar\n" +
                 "import "+MaliciousExitHelper.class.getName().replace('$', '.')+" \n" +
                 "rule testRule dialect \"java\" \n" + 
@@ -348,7 +349,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    public void testUntrustedEnabled() throws Exception {
+    public void testUntrustedEnabled() {
         String drl = "package org.foo.bar\n" +
                 "import "+MaliciousExitHelper.class.getName().replace('$', '.')+" \n" +
                 "rule R1 enabled( MaliciousExitHelper.isEnabled() ) \n" +
@@ -376,7 +377,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
     
     @Test
-    public void testUntrustedMVELEnabled() throws Exception {
+    public void testUntrustedMVELEnabled() {
         String drl = "package org.foo.bar\n" +
                 "import "+MaliciousExitHelper.class.getName().replace('$', '.')+" \n" +
                 "rule R1 dialect \"mvel\" enabled( MaliciousExitHelper.isEnabled() ) \n" +
@@ -418,6 +419,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     }
     
     public static class TestSecurityManager extends SecurityManager {
+
         @Override
         public void checkExit(int status) {
             super.checkExit(status);

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializationSecurityPolicyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializationSecurityPolicyTest.java
@@ -26,7 +26,6 @@ import org.drools.compiler.CommonTestMethodBase;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -58,7 +57,6 @@ public class SerializationSecurityPolicyTest extends CommonTestMethodBase {
     }
 
     @Test
-    @Ignore( "This test causes problems to surefire, so it will be disabled for now. It works when executed by itself.")
     public void testSerialization() throws IOException, ClassNotFoundException {
         final String rule =
                 " rule R " +

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializationSecurityPolicyTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/SerializationSecurityPolicyTest.java
@@ -18,6 +18,7 @@ package org.drools.compiler.integrationtests;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.Policy;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -42,10 +43,10 @@ public class SerializationSecurityPolicyTest extends CommonTestMethodBase {
 
     @Before
     public void init() {
-        final String enginePolicy = SerializationSecurityPolicyTest.class.getResource("serialization-rules.policy").getFile();
-        final String kiePolicy = SerializationSecurityPolicyTest.class.getResource("serialization-rules.policy").getFile();
-        System.setProperty("java.security.policy", enginePolicy);
-        System.setProperty("kie.security.policy", kiePolicy);
+        final String policy = SerializationSecurityPolicyTest.class.getResource("serialization-rules.policy").getFile();
+        System.setProperty("java.security.policy", policy);
+        System.setProperty("kie.security.policy", policy);
+        Policy.getPolicy().refresh();
         System.setSecurityManager(new SecurityManager());
     }
 

--- a/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/serialization-rules.policy
+++ b/drools-compiler/src/test/resources/org/drools/compiler/integrationtests/serialization-rules.policy
@@ -1,11 +1,4 @@
-grant { 
-       permission java.util.PropertyPermission "*", "read";
-       permission java.lang.RuntimePermission "accessDeclaredMembers";
-       permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
-   
+grant {
        // Only for test purposes
-       permission java.lang.RuntimePermission "setSecurityManager";
-
        permission java.security.AllPermission;
-       
 };


### PR DESCRIPTION
- Refreshes the policies after setting the policy file. 
- I tried to fix also original SecurityPolicyTest but it still fails when run from Maven as part of the whole drools-compiler test suite. When run as a single test through IDE or by providing -Dtest parameter to Maven run, it works. This needs further investigation. 

@mariofusco please review