### PR TITLE
 [DROOLS-3598] Better error message while using the DummyKieScanner

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -157,13 +157,13 @@ public class KieBuilderImpl
             releaseId = pomModel.getReleaseId();
 
             // add all the pom dependencies to this builder ... not sure this is a good idea (?)
-            KieRepositoryImpl repository = (KieRepositoryImpl) ks.getRepository();
-            for ( AFReleaseId dep : pomModel.getDependencies( DependencyFilter.COMPILE_FILTER ) ) {
-                KieModule depModule = repository.getKieModule( adapt( dep ), pomModel );
-                if ( depModule != null ) {
-                    addKieDependency( depModule );
-                }
-            }
+//            KieRepositoryImpl repository = (KieRepositoryImpl) ks.getRepository();
+//            for ( AFReleaseId dep : pomModel.getDependencies( DependencyFilter.COMPILE_FILTER ) ) {
+//                KieModule depModule = repository.getKieModule( adapt( dep ), pomModel );
+//                if ( depModule != null ) {
+//                    addKieDependency( depModule );
+//                }
+//            }
         } else {
             // if the pomModel is null it means that the provided pom.xml is invalid so use the default releaseId
             releaseId = KieServices.Factory.get().getRepository().getDefaultReleaseId();

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -157,13 +157,13 @@ public class KieBuilderImpl
             releaseId = pomModel.getReleaseId();
 
             // add all the pom dependencies to this builder ... not sure this is a good idea (?)
-//            KieRepositoryImpl repository = (KieRepositoryImpl) ks.getRepository();
-//            for ( AFReleaseId dep : pomModel.getDependencies( DependencyFilter.COMPILE_FILTER ) ) {
-//                KieModule depModule = repository.getKieModule( adapt( dep ), pomModel );
-//                if ( depModule != null ) {
-//                    addKieDependency( depModule );
-//                }
-//            }
+            KieRepositoryImpl repository = (KieRepositoryImpl) ks.getRepository();
+            for ( AFReleaseId dep : pomModel.getDependencies( DependencyFilter.COMPILE_FILTER ) ) {
+                KieModule depModule = repository.getKieModule( adapt( dep ), pomModel );
+                if ( depModule != null ) {
+                    addKieDependency( depModule );
+                }
+            }
         } else {
             // if the pomModel is null it means that the provided pom.xml is invalid so use the default releaseId
             releaseId = KieServices.Factory.get().getRepository().getDefaultReleaseId();

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -207,23 +207,27 @@ public class KieRepositoryImpl
         public void setKieContainer(KieContainer kieContainer) { }
 
         public KieModule loadArtifact(ReleaseId releaseId) {
-            log.error( "Cannot load artifact " + releaseId + ". You need kie-ci on the classpath to perform this operation" );
+            logArtifactNotFetched(releaseId);
             return null;
         }
 
         public KieModule loadArtifact(ReleaseId releaseId, InputStream pomXML) {
-            log.error( "Cannot load artifact " + releaseId + ". You need kie-ci on the classpath to perform this operation" );
+            logArtifactNotFetched(releaseId);
             return null;
         }
 
         public KieModule loadArtifact(ReleaseId releaseId, PomModel pomModel) {
-            log.error( "Cannot load artifact " + releaseId + ". You need kie-ci on the classpath to perform this operation" );
+            logArtifactNotFetched(releaseId);
             return null;
         }
 
         public String getArtifactVersion(ReleaseId releaseId) {
-            log.error( "Cannot load artifact " + releaseId + ". You need kie-ci on the classpath to perform this operation" );
+            logArtifactNotFetched(releaseId);
             return null;
+        }
+
+        private void logArtifactNotFetched(ReleaseId releaseId) {
+            log.info("Artifact not fetched from maven: " + releaseId + ". To enable the KieScanner you need kie-ci on the classpath");
         }
 
         public ReleaseId getScannerReleaseId() {


### PR DESCRIPTION
During the buildAll phase of the kie-maven-plugin with the executable model the KieScanner is not used. 
We better not alarm the users too much