### PR TITLE
DROOLS-3628 Ignore KieScannerMemoryTest

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/memory/KieScannerMemoryTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/memory/KieScannerMemoryTest.java
@@ -30,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.Ignore;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;
 import org.kie.api.builder.KieScanner;

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/memory/KieScannerMemoryTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/memory/KieScannerMemoryTest.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertFalse;
 
+@Ignore("DROOLS-3628 Ignoring, because it can be useful when run locally, however due to unpredictable GC behaviour, unstable in automation.")
 @Category(TurtleTestCategory.class)
 public class KieScannerMemoryTest {
 


### PR DESCRIPTION
See reasoning in issue https://issues.jboss.org/browse/DROOLS-3628.

@mariofusco please review. 