### PR TITLE
[DROOLS-3716] Use jboss annotations api instead of javax

### DIFF
--- a/drools-model/drools-constraint-parser/pom.xml
+++ b/drools-model/drools-constraint-parser/pom.xml
@@ -22,8 +22,8 @@
       <artifactId>javaparser-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
To align with WildFly/EAP