### PR TITLE
DROOLS-3764 Raise timeout for a test

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CompositeAgendaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CompositeAgendaTest.java
@@ -43,7 +43,7 @@ public class CompositeAgendaTest {
         }
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testCreateHaltDisposeAgenda() {
         final String drl = " import " + A.class.getCanonicalName() + ";\n" +
                 " declare A @role( event ) end\n" +


### PR DESCRIPTION
@mariofusco could you please review. What I am seeing recently in our CI, is that it sometimes happens that a machine, on which a build runs, runs slowly. In that case it can happen that this test can fail on timeout. I tested the test locally and it works fine. 

Therefore I suggest to merge this to raise the timeout for this test and check if there is any timeout error in the future. 