### PR TITLE
DROOLS-3836 Handle possible null date value returned from trigger

### DIFF
--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/InputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/InputMarshaller.java
@@ -241,7 +241,7 @@ public class InputMarshaller {
             case PersisterEnums.POINT_IN_TIME_TRIGGER: {
                 long startTime = inCtx.readLong();
 
-                PointInTimeTrigger trigger = new PointInTimeTrigger( startTime, null, null );
+                PointInTimeTrigger trigger = PointInTimeTrigger.createPointInTimeTrigger( startTime, null );
                 return trigger;
             }
         }

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufInputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufInputMarshaller.java
@@ -735,7 +735,7 @@ public class ProtobufInputMarshaller {
                 return trigger;
             }
             case POINT_IN_TIME : {
-                PointInTimeTrigger trigger = new PointInTimeTrigger( _trigger.getPit().getNextFireTime(), null, null );
+                PointInTimeTrigger trigger = PointInTimeTrigger.createPointInTimeTrigger( _trigger.getPit().getNextFireTime(), null );
                 return trigger;
             }
             case COMPOSITE_MAX_DURATION : {

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufOutputMarshaller.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/ProtobufOutputMarshaller.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -834,13 +835,19 @@ public class ProtobufOutputMarshaller {
                     .setInterval( _interval.build() )
                     .build();
         } else if ( trigger instanceof PointInTimeTrigger ) {
-            PointInTimeTrigger pinTrigger = (PointInTimeTrigger) trigger;
-            return ProtobufMessages.Trigger.newBuilder()
-                    .setType( ProtobufMessages.Trigger.TriggerType.POINT_IN_TIME )
-                    .setPit( ProtobufMessages.Trigger.PointInTimeTrigger.newBuilder()
-                            .setNextFireTime( pinTrigger.hasNextFireTime().getTime() )
-                            .build() )
-                    .build();
+            PointInTimeTrigger pitTrigger = (PointInTimeTrigger) trigger;
+            Date nextFireTime = pitTrigger.hasNextFireTime();
+            // There is no reason to serialize a timer when it has no future execution time.
+            if (nextFireTime != null) {
+                return ProtobufMessages.Trigger.newBuilder()
+                        .setType( ProtobufMessages.Trigger.TriggerType.POINT_IN_TIME )
+                        .setPit( ProtobufMessages.Trigger.PointInTimeTrigger.newBuilder()
+                                         .setNextFireTime( nextFireTime.getTime() )
+                                         .build() )
+                        .build();
+            } else {
+                return null;
+            }
         } else if ( trigger instanceof CompositeMaxDurationTrigger ) {
             CompositeMaxDurationTrigger cmdTrigger = (CompositeMaxDurationTrigger) trigger;
             ProtobufMessages.Trigger.CompositeMaxDurationTrigger.Builder _cmdt = ProtobufMessages.Trigger.CompositeMaxDurationTrigger.newBuilder();
@@ -851,7 +858,10 @@ public class ProtobufOutputMarshaller {
                 _cmdt.setTimerCurrentDate( cmdTrigger.getTimerCurrentDate().getTime() );
             }
             if ( cmdTrigger.getTimerTrigger() != null ) {
-                _cmdt.setTimerTrigger( writeTrigger(cmdTrigger.getTimerTrigger(), outCtx) );
+                ProtobufMessages.Trigger timerTrigger = writeTrigger(cmdTrigger.getTimerTrigger(), outCtx);
+                if (timerTrigger != null) {
+                    _cmdt.setTimerTrigger(timerTrigger);
+                }
             }
             return ProtobufMessages.Trigger.newBuilder()
                                            .setType( ProtobufMessages.Trigger.TriggerType.COMPOSITE_MAX_DURATION )

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakTimerNode.java
@@ -546,16 +546,19 @@ public class PhreakTimerNode {
                                                        MarshallerWriteContext outputCtx) {
             // TimerNodeJobContext   
             TimerNodeJobContext tnJobCtx = (TimerNodeJobContext) jobCtx;
-
-            return ProtobufMessages.Timers.Timer.newBuilder()
-                                          .setType( ProtobufMessages.Timers.TimerType.TIMER_NODE )
-                                          .setTimerNode( ProtobufMessages.Timers.TimerNodeTimer.newBuilder()
-                                                                                .setNodeId( tnJobCtx.getTimerNodeId() )
-                                                                                .setTuple( PersisterHelper.createTuple( tnJobCtx.getTuple() ) )
-                                                                                .setTrigger( ProtobufOutputMarshaller.writeTrigger( tnJobCtx.getTrigger(),
-                                                                                                                                    outputCtx ) )
-                                                                                .build() )
-                                          .build();
+            ProtobufMessages.Trigger trigger = ProtobufOutputMarshaller.writeTrigger( tnJobCtx.getTrigger(), outputCtx );
+            if (trigger != null) {
+                return ProtobufMessages.Timers.Timer.newBuilder()
+                        .setType( ProtobufMessages.Timers.TimerType.TIMER_NODE )
+                        .setTimerNode( ProtobufMessages.Timers.TimerNodeTimer.newBuilder()
+                                               .setNodeId( tnJobCtx.getTimerNodeId() )
+                                               .setTuple( PersisterHelper.createTuple( tnJobCtx.getTuple() ) )
+                                               .setTrigger( trigger )
+                                               .build() )
+                        .build();
+            } else {
+                return null;
+            }
         }
     }
 

--- a/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PropagationEntry.java
@@ -192,7 +192,7 @@ public interface PropagationEntry {
                 JobHandle jobHandle = wm.getTimerService()
                                         .scheduleJob( job,
                                                       jobctx,
-                                                      new PointInTimeTrigger( nextTimestamp, null, null ) );
+                                                      PointInTimeTrigger.createPointInTimeTrigger( nextTimestamp, null ) );
                 jobctx.setJobHandle( jobHandle );
                 eventFactHandle.addJob( jobHandle );
             }

--- a/drools-core/src/main/java/org/drools/core/rule/SlidingTimeWindow.java
+++ b/drools-core/src/main/java/org/drools/core/rule/SlidingTimeWindow.java
@@ -210,7 +210,7 @@ public class SlidingTimeWindow
                 JobContext jobctx = new BehaviorJobContext( nodeId, workingMemory, this, context);
                 JobHandle handle = clock.scheduleJob( job,
                                                       jobctx,
-                                                      new PointInTimeTrigger( nextTimestamp, null, null ) );
+                                                      PointInTimeTrigger.createPointInTimeTrigger( nextTimestamp, null ) );
                 jobctx.setJobHandle( handle );
             }
         }

--- a/drools-core/src/main/java/org/drools/core/time/impl/DefaultTimerJobInstance.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/DefaultTimerJobInstance.java
@@ -61,7 +61,7 @@ public class DefaultTimerJobInstance
     }    
 
     public Void call() throws Exception {
-        try { 
+        try {
             this.trigger.nextFireTime(); // need to pop
             if ( handle.isCancel() ) {
                 return null;

--- a/drools-core/src/main/java/org/drools/core/time/impl/DurationTimer.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/DurationTimer.java
@@ -16,6 +16,15 @@
 
 package org.drools.core.time.impl;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 import org.drools.core.common.EventFactHandle;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.rule.ConditionalElement;
@@ -25,12 +34,7 @@ import org.drools.core.spi.Tuple;
 import org.drools.core.time.Trigger;
 import org.drools.core.util.NumberUtils;
 import org.kie.api.runtime.Calendars;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Map;
+import org.kie.api.time.Calendar;
 
 public class DurationTimer extends BaseTimer
     implements
@@ -101,15 +105,11 @@ public class DurationTimer extends BaseTimer
                                  String[] calendarNames,
                                  Calendars calendars) {
         long offset = timestamp + duration;
-        if( NumberUtils.isAddOverflow( timestamp, duration, offset ) ) {
+        if (NumberUtils.isAddOverflow(timestamp, duration, offset)) {
             // this should not happen, but possible in some odd simulation scenarios, so creating a trigger for immediate execution instead
-            return new PointInTimeTrigger( timestamp,
-                                           calendarNames,
-                                           calendars );
+            return PointInTimeTrigger.createPointInTimeTrigger(timestamp, getCalendars(calendarNames, calendars));
         } else {
-            return new PointInTimeTrigger( offset,
-                                           calendarNames,
-                                           calendars );
+            return PointInTimeTrigger.createPointInTimeTrigger(offset, getCalendars(calendarNames, calendars));
         }
     }
 
@@ -147,5 +147,15 @@ public class DurationTimer extends BaseTimer
 
     public Declaration getEventFactHandleDeclaration() {
         return eventFactHandle;
+    }
+
+    private Collection<Calendar> getCalendars(final String[] calendarNames, final Calendars calendars) {
+        final List<Calendar> result = new ArrayList<>();
+        if (calendars != null && calendarNames != null && calendarNames.length > 0) {
+            for (final String calName : calendarNames) {
+                result.add(calendars.get(calName));
+            }
+        }
+        return result;
     }
 }

--- a/drools-core/src/main/java/org/drools/core/time/impl/PointInTimeTrigger.java
+++ b/drools-core/src/main/java/org/drools/core/time/impl/PointInTimeTrigger.java
@@ -19,39 +19,30 @@ package org.drools.core.time.impl;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Collection;
 import java.util.Date;
 
 import org.drools.core.time.Trigger;
-import org.kie.api.runtime.Calendars;
+import org.kie.api.time.Calendar;
 
-public class PointInTimeTrigger
-    implements
-    Trigger {
+public class PointInTimeTrigger implements Trigger {
+
     private Date timestamp;
+
+    public static PointInTimeTrigger createPointInTimeTrigger(final long timestamp, final Collection<Calendar> calendars) {
+        if (calendars != null && !calendars.isEmpty()) {
+            if (calendars.stream().noneMatch(calendar -> calendar.isTimeIncluded(timestamp))) {
+                return null;
+            }
+        }
+        return new PointInTimeTrigger(timestamp);
+    }
 
     public PointInTimeTrigger() {
     }
 
-    public PointInTimeTrigger(long timestamp,
-                              String[] calendarNames,
-                              Calendars calendars) {
-        boolean included = true;
-
-        if ( calendars != null && calendarNames != null && calendarNames.length > 0 ) {
-            for ( String calName : calendarNames ) {
-                // all calendars must not block, as soon as one blocks break
-                org.kie.api.time.Calendar cal = calendars.get( calName );
-                if ( cal != null && !cal.isTimeIncluded( timestamp ) ) {
-                    included = false;
-                    break;
-                }
-            }
-        }
-
-        if ( included ) {
-            this.timestamp = new Date( timestamp );
-        }
-
+    public PointInTimeTrigger(final long timestamp) {
+        this.timestamp = new Date(timestamp);
     }
 
     public Date hasNextFireTime() {
@@ -59,18 +50,17 @@ public class PointInTimeTrigger
     }
 
     public Date nextFireTime() {
-        Date next = timestamp;
+        final Date next = timestamp;
         this.timestamp = null;
         return next;
     }
 
-    public void readExternal(ObjectInput in) throws IOException,
-                                            ClassNotFoundException {
+    public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
         this.timestamp = (Date) in.readObject();
     }
 
-    public void writeExternal(ObjectOutput out) throws IOException {
-        out.writeObject( this.timestamp );
+    public void writeExternal(final ObjectOutput out) throws IOException {
+        out.writeObject(this.timestamp);
     }
 
     @Override

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/CepEspTest.java
@@ -2911,28 +2911,28 @@ public class CepEspTest extends AbstractCepEspTest {
     @Test
     public void testDeserializationWithTrackableTimerJob() throws InterruptedException {
         final String drl = "package org.drools.test;\n" +
-                     "import " + StockTick.class.getCanonicalName() + "; \n" +
-                     "global java.util.List list;\n" +
-                     "\n" +
-                     "declare StockTick\n" +
-                     "  @role( event )\n" +
-                     "  @expires( 1s )\n" +
-                     "end\n" +
-                     "\n" +
-                     "rule \"One\"\n" +
-                     "when\n" +
-                     "  StockTick( $id : seq, company == \"AAA\" ) over window:time( 1s )\n" +
-                     "then\n" +
-                     "  list.add( $id ); \n" +
-                     "end\n" +
-                     "\n" +
-                     "rule \"Two\"\n" +
-                     "when\n" +
-                     "  StockTick( $id : seq, company == \"BBB\" ) \n" +
-                     "then\n" +
-                     "  System.out.println( $id ); \n" +
-                     "  list.add( $id );\n" +
-                     "end";
+                "import " + StockTick.class.getCanonicalName() + "; \n" +
+                "global java.util.List list;\n" +
+                "\n" +
+                "declare StockTick\n" +
+                "  @role( event )\n" +
+                "  @expires( 1s )\n" +
+                "end\n" +
+                "\n" +
+                "rule \"One\"\n" +
+                "when\n" +
+                "  StockTick( $id : seq, company == \"AAA\" ) over window:time( 1s )\n" +
+                "then\n" +
+                "  list.add( $id ); \n" +
+                "end\n" +
+                "\n" +
+                "rule \"Two\"\n" +
+                "when\n" +
+                "  StockTick( $id : seq, company == \"BBB\" ) \n" +
+                "then\n" +
+                "  System.out.println( $id ); \n" +
+                "  list.add( $id );\n" +
+                "end";
 
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("cep-esp-test", kieBaseTestConfiguration, drl);
         final KieSessionConfiguration kieSessionConfiguration = KieSessionTestConfiguration.STATEFUL_REALTIME.getKieSessionConfiguration();
@@ -2960,6 +2960,41 @@ public class CepEspTest extends AbstractCepEspTest {
 
             assertEquals(2, list.size());
             assertEquals(Arrays.asList(2L, 3L), list);
+        } finally {
+            ks.dispose();
+        }
+    }
+
+    @Test
+    public void testDeserializationWithTrackableTimerJobShortExpiration() {
+        final String drl = "package org.drools.test;\n" +
+                "import " + StockTick.class.getCanonicalName() + "; \n" +
+                "global java.util.List list;\n" +
+                "\n" +
+                "declare StockTick\n" +
+                "  @role( event )\n" +
+                "  @expires( 1ms )\n" +
+                "end\n" +
+                "rule \"Two\"\n" +
+                "when\n" +
+                "  StockTick( $id : seq, company == \"BBB\" ) \n" +
+                "then\n" +
+                "  System.out.println( $id ); \n" +
+                "  list.add( $id );\n" +
+                "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("cep-esp-test", kieBaseTestConfiguration, drl);
+        final KieSessionConfiguration kieSessionConfiguration = KieSessionTestConfiguration.STATEFUL_REALTIME.getKieSessionConfiguration();
+        kieSessionConfiguration.setOption(TimerJobFactoryOption.get("trackable"));
+        KieSession ks = kbase.newKieSession(kieSessionConfiguration, null);
+        try {
+            ks.insert(new StockTick(2, "BBB", 1.0, 0));
+            try {
+                ks = SerializationHelper.getSerialisedStatefulKnowledgeSession(ks, true);
+            } catch (final Exception e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
         } finally {
             ks.dispose();
         }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/DROOLS-3836

@mariofusco could you please review? Especially the serialization parts in ProtobufOutputMarshaller and ObjectTypeNode.ExpireJobContextTimerOutputMarshaller. 

- Fixes the serialization - the trigger can return null from hasNextFireTime() method. 
- I also fixed other occurrences where the possible null was not handled properly. 
- Added test case reproducing the NPE. However it was a race condition between the expiration timer and the main thread, so to reproduce the issue it was necessary to run the reproducer in a loop. 