### PR TITLE
DROOLS-3841: [DMN Designer] Included Models - An error is raised when a DMN file with imports is saved

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
@@ -83,10 +83,8 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
         final ReleaseId releaseId_v10 = ks.newReleaseId("org.kie", "dmn-test-DROOLS-3841", "1.0");
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v10,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/DROOLS-3841a.dmn", this.getClass())
-                                                                         .setTargetPath("DROOLS-3841a.dmn"),
-                                                                 ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/DROOLS-3841b.dmn", this.getClass())
-                                                                         .setTargetPath("DROOLS-3841b.dmn")));
+                                     ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/DROOLS-3841a.dmn", this.getClass()),
+                                     ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/DROOLS-3841b.dmn", this.getClass()));
 
         ks.newKieContainer(releaseId_v10);
     }
@@ -100,15 +98,13 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
         final ReleaseId releaseId_v10 = ks.newReleaseId("org.kie", "dmn-test-DROOLS-3841", "1.0");
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v10,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/DROOLS-3841a.dmn", this.getClass())
-                                             .setTargetPath("DROOLS-3841a.dmn")));
+                                     ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/DROOLS-3841a.dmn", this.getClass()));
         final KieContainer kieContainer = ks.newKieContainer(releaseId_v10);
 
         final ReleaseId releaseId_v11 = ks.newReleaseId("org.kie", "dmn-test-DROOLS-3841", "1.1");
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v11,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/DROOLS-3841b.dmn", this.getClass())
-                                             .setTargetPath("DROOLS-3841b.dmn")));
+                                     ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/DROOLS-3841b.dmn", this.getClass()));
         final Results results = kieContainer.updateToVersion(releaseId_v11);
 
         assertThat(results.getMessages().isEmpty(), is(true));

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v1/DROOLS-3841a.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v1/DROOLS-3841a.dmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/kiegroup/drools/kie-dmn/_E084990F-18BF-4D46-8617-56CF6D8B86B6" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_F325E2BC-2565-45DD-A8E9-77A0D37F0875" name="dmn1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/kiegroup/drools/kie-dmn/_E084990F-18BF-4D46-8617-56CF6D8B86B6">
+  <dmn:extensionElements></dmn:extensionElements>
+  <dmn:decision id="_8DDC5332-1141-4338-B413-D6F217B8F937" name="Import me">
+    <dmn:variable id="_323CB438-6468-456A-8235-3EBF2F3D7100" name="Import me"></dmn:variable>
+    <dmn:literalExpression id="_ED4FF7B2-7A47-4814-995E-B8903BB8C013">
+      <dmn:text>1</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_ED4FF7B2-7A47-4814-995E-B8903BB8C013">
+            <kie:width>130.0</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_8DDC5332-1141-4338-B413-D6F217B8F937" dmnElementRef="_8DDC5332-1141-4338-B413-D6F217B8F937" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"></dmndi:FillColor>
+          <dmndi:StrokeColor red="0" green="0" blue="0"></dmndi:StrokeColor>
+          <dmndi:FontColor red="0" green="0" blue="0"></dmndi:FontColor>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="254" y="146" width="100" height="50"></dc:Bounds>
+        <dmndi:DMNLabel></dmndi:DMNLabel>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v2/DROOLS-3841b.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/incrementalcompilation/v2/DROOLS-3841b.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/kiegroup/drools/kie-dmn/_A496D41E-074B-415A-98CB-08833A7A7A7B" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:imported="https://github.com/kiegroup/drools/kie-dmn/_E084990F-18BF-4D46-8617-56CF6D8B86B6" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_D127BE9B-D616-4850-A67A-F5E4F875ECDA" name="dmn2" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/kiegroup/drools/kie-dmn/_A496D41E-074B-415A-98CB-08833A7A7A7B">
+  <dmn:extensionElements></dmn:extensionElements>
+  <dmn:import id="_26A5DCEC-FCC0-4859-8EDB-80F3E4CE6710" name="imported" namespace="https://github.com/kiegroup/drools/kie-dmn/_E084990F-18BF-4D46-8617-56CF6D8B86B6" locationURI="default://master@MySpace/example-Mortgages/src/main/resources/mortgages/mortgages/dmn1.dmn" importType="http://www.omg.org/spec/DMN/20180521/MODEL/"></dmn:import>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension></kie:ComponentsWidthsExtension>
+      </di:extension>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3841

Hi @tarilabs this PR contains a failing test for incremental compilation of a KJAR with a DMN file being added that contains an _import_. If the KJAR is built with both files initially present (i.e. no incremental compilation) there are no errors.

The workbench does things a little differently to the test (it uses `KieFileSystem` and `KieBuilder` direct) but the error message when the second file is added to the `KieFileSystem` is the same.. and a full build of the project in the workbench also removes the compilation error.

The expectation is that adding a second DMN file to a KJAR that contains an _import_ does not result in a compilation error message. 