### PR TITLE
DROOLS-3958 Unexpected Conflicting rows on rules analysis using date-effective and date-expires on Guided Decision Tables

### DIFF
--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspector.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/cache/inspectors/RuleInspector.java
@@ -225,6 +225,7 @@ public class RuleInspector
     @Override
     public boolean isRedundant(final Object other) {
         return other instanceof RuleInspector
+                && rule.getActivationTime().overlaps(((RuleInspector) other).rule.getActivationTime())
                 && brlConditionsInspectors.isRedundant(((RuleInspector) other).brlConditionsInspectors)
                 && brlActionInspectors.isRedundant(((RuleInspector) other).brlActionInspectors)
                 && getActionsInspectors().isRedundant(((RuleInspector) other).getActionsInspectors())
@@ -234,6 +235,7 @@ public class RuleInspector
     @Override
     public boolean subsumes(final Object other) {
         return other instanceof RuleInspector
+                && rule.getActivationTime().overlaps(((RuleInspector) other).rule.getActivationTime())
                 && brlActionInspectors.subsumes(((RuleInspector) other).brlActionInspectors)
                 && brlConditionsInspectors.subsumes(((RuleInspector) other).brlConditionsInspectors)
                 && getActionsInspectors().subsumes(((RuleInspector) other).getActionsInspectors())
@@ -242,7 +244,7 @@ public class RuleInspector
 
     @Override
     public boolean conflicts(final Object other) {
-        if (other instanceof RuleInspector) {
+        if (other instanceof RuleInspector && rule.getActivationTime().overlaps(((RuleInspector) other).rule.getActivationTime())) {
             if (getActionsInspectors().conflicts(((RuleInspector) other).getActionsInspectors())) {
                 if (getConditionsInspectors().subsumes(((RuleInspector) other).getConditionsInspectors())
                         && getBrlConditionsInspectors().subsumes(((RuleInspector) other).getBrlConditionsInspectors())) {

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/SingleHitCheck.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/checks/SingleHitCheck.java
@@ -42,7 +42,8 @@ public class SingleHitCheck
     @Override
     public boolean check() {
         return hasIssues =
-                ruleInspector.getConditionsInspectors().subsumes(other.getConditionsInspectors())
+                ruleInspector.getRule().getActivationTime().overlaps(other.getRule().getActivationTime())
+                        && ruleInspector.getConditionsInspectors().subsumes(other.getConditionsInspectors())
                         && ruleInspector.getBrlConditionsInspectors().subsumes(other.getBrlConditionsInspectors
                         ());
     }

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ActivationTime.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/ActivationTime.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.core.index.model;
+
+import java.util.Date;
+
+public class ActivationTime {
+
+    private final Date start;
+    private final Date end;
+
+    /**
+     * Accepts null. Null is infinite
+     */
+    public ActivationTime(final Date start,
+                          final Date end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public Date getStart() {
+        return start;
+    }
+
+    public Date getEnd() {
+        return end;
+    }
+
+    public boolean overlaps(final ActivationTime other) {
+        final Date max = findMaxDate(start, other.start);
+        final Date min = findMinDate(end, other.end);
+
+        if (min == null || max == null) {
+            return true;
+        } else {
+            return min.compareTo(max) >= 0;
+        }
+    }
+
+    private Date findMaxDate(final Date date,
+                             final Date other) {
+        if (date == null && other == null) {
+            return null;
+        } else if (other == null || (date != null && date.after(other))) {
+            return date;
+        } else {
+            return other;
+        }
+    }
+
+    private Date findMinDate(final Date date,
+                             final Date other) {
+        if (date == null && other == null) {
+            return null;
+        } else if (other == null || (date != null && date.before(other))) {
+            return date;
+        } else {
+            return other;
+        }
+    }
+}

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateEffectiveRuleAttribute.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateEffectiveRuleAttribute.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.core.index.model;
+
+import java.util.Date;
+
+public class DateEffectiveRuleAttribute
+        implements RuleAttribute {
+
+    public static String NAME = "date-effective";
+
+    private final int index;
+    private final Date value;
+
+    public DateEffectiveRuleAttribute(final int index,
+                                      final Date value) {
+        this.index = index;
+        this.value = value;
+    }
+
+    public Date getValue() {
+        return value;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateExpiresRuleAttribute.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/DateExpiresRuleAttribute.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.core.index.model;
+
+import java.util.Date;
+
+public class DateExpiresRuleAttribute
+        implements RuleAttribute {
+
+    public static String NAME = "date-expires";
+
+    private final int index;
+    private final Date value;
+
+    public DateExpiresRuleAttribute(final int index,
+                                    final Date value) {
+        this.index = index;
+        this.value = value;
+    }
+
+    public Date getValue() {
+        return value;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Rule.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/Rule.java
@@ -15,6 +15,10 @@
  */
 package org.drools.verifier.core.index.model;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.drools.verifier.core.configuration.AnalyzerConfiguration;
 import org.drools.verifier.core.index.keys.IndexKey;
 import org.drools.verifier.core.index.keys.Key;
@@ -36,10 +40,10 @@ public class Rule
     private final Patterns patterns = new Patterns();
     private final Actions actions = new Actions();
     private final Conditions conditions = new Conditions();
-
     private final UUIDKey uuidKey;
-
+    private final Map<String, RuleAttribute> ruleAttributes = new HashMap<String, RuleAttribute>();
     private UpdatableKey<Rule> indexKey;
+    private ActivationTime activationTime = null;
 
     public Rule(final Integer rowNumber,
                 final AnalyzerConfiguration configuration) {
@@ -63,6 +67,15 @@ public class Rule
         };
     }
 
+    public void addRuleAttribute(final RuleAttribute ruleAttribute) {
+        ruleAttributes.put(ruleAttribute.getName(), ruleAttribute);
+        setActivationTime();
+    }
+
+    public Map<String, RuleAttribute> getRuleAttributes() {
+        return ruleAttributes;
+    }
+
     public Integer getRowNumber() {
         return getIndex();
     }
@@ -77,6 +90,28 @@ public class Rule
 
     public Actions getActions() {
         return actions;
+    }
+
+    public ActivationTime getActivationTime() {
+        if (activationTime == null) {
+            setActivationTime();
+        }
+        return activationTime;
+    }
+
+    private void setActivationTime() {
+        Date start = null;
+        Date end = null;
+
+        if (ruleAttributes.containsKey(DateEffectiveRuleAttribute.NAME)) {
+            start = ((DateEffectiveRuleAttribute) ruleAttributes.get(DateEffectiveRuleAttribute.NAME)).getValue();
+        }
+        if (ruleAttributes.containsKey(DateExpiresRuleAttribute.NAME)) {
+            end = ((DateExpiresRuleAttribute) ruleAttributes.get(DateExpiresRuleAttribute.NAME)).getValue();
+        }
+
+        activationTime = new ActivationTime(start,
+                                            end);
     }
 
     @Override

--- a/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/RuleAttribute.java
+++ b/drools-verifier/drools-verifier-core/src/main/java/org/drools/verifier/core/index/model/RuleAttribute.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.core.index.model;
+
+public interface RuleAttribute {
+
+    int getIndex();
+
+    String getName();
+
+}

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/RuleInspectorCacheTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/RuleInspectorCacheTest.java
@@ -19,16 +19,15 @@ package org.drools.verifier.core;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.drools.verifier.core.cache.RuleInspectorCache;
 import org.drools.verifier.core.cache.inspectors.RuleInspector;
-import org.drools.verifier.core.AnalyzerConfigurationMock;
 import org.drools.verifier.core.configuration.AnalyzerConfiguration;
 import org.drools.verifier.core.index.Index;
 import org.drools.verifier.core.index.IndexImpl;
 import org.drools.verifier.core.index.model.Rule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/model/ActivationTimeTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/core/index/model/ActivationTimeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.core.index.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class ActivationTimeTest {
+
+    private final ActivationTime start;
+    private final ActivationTime end;
+    private final boolean expected;
+
+    public ActivationTimeTest(final ActivationTime start,
+                              final ActivationTime end,
+                              final boolean expected) {
+        this.start = start;
+        this.end = end;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> testData() {
+        return Arrays.asList(new Object[][]{
+                {new ActivationTime(new Date(0), new Date(10)), new ActivationTime(new Date(0), new Date(10)), true},
+                {new ActivationTime(new Date(0), new Date(10)), new ActivationTime(new Date(10), new Date(100)), true},
+                {new ActivationTime(new Date(10), new Date(20)), new ActivationTime(new Date(0), new Date(100)), true},
+                {new ActivationTime(new Date(0), new Date(100)), new ActivationTime(new Date(10), new Date(20)), true},
+                {new ActivationTime(new Date(0), new Date(100)), new ActivationTime(new Date(0), new Date(20)), true},
+                {new ActivationTime(new Date(0), new Date(100)), new ActivationTime(new Date(0), new Date(20)), true},
+                {new ActivationTime(new Date(0), new Date(100)), new ActivationTime(new Date(10), new Date(100)), true},
+                {new ActivationTime(new Date(10), new Date(100)), new ActivationTime(new Date(0), new Date(100)), true},
+                {new ActivationTime(new Date(10), new Date(100)), new ActivationTime(new Date(0), new Date(10)), true},
+                {new ActivationTime(new Date(0), new Date(10)), new ActivationTime(new Date(100), new Date(110)), false},
+                {new ActivationTime(new Date(100), new Date(110)), new ActivationTime(new Date(0), new Date(10)), false},
+                {new ActivationTime(null, new Date(100)), new ActivationTime(new Date(10), null), true},
+                {new ActivationTime(null, new Date(10)), new ActivationTime(new Date(100), null), false},
+                {new ActivationTime(new Date(10), null), new ActivationTime(null, new Date(100)), true},
+                {new ActivationTime(new Date(100), null), new ActivationTime(null, new Date(10)), false},
+                {new ActivationTime(null, null), new ActivationTime(null, null), true},
+                {new ActivationTime(null, null), new ActivationTime(new Date(100), new Date(110)), true},
+                {new ActivationTime(new Date(100), new Date(110)), new ActivationTime(null, null), true},
+                {new ActivationTime(null, null), new ActivationTime(null, new Date(110)), true},
+                {new ActivationTime(null, new Date(110)), new ActivationTime(null, null), true},
+                {new ActivationTime(null, null), new ActivationTime(new Date(100), null), true},
+                {new ActivationTime(new Date(100), null), new ActivationTime(null, null), true},
+        });
+    }
+
+    @Test
+    public void testOverlaps() {
+        assertEquals(expected, start.overlaps(end));
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3958

@jomarko @manstis You two might be the best to review. Thank you.

PRs:
https://github.com/kiegroup/drools/pull/2324
https://github.com/kiegroup/drools-wb/pull/1131