### PR TITLE
[DROOLS-3389] Created scenario simulation runtime modules

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.21.0-SNAPSHOT</version>
+    <version>7.22.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>drools-scenario-simulation</artifactId>
+    <groupId>org.drools</groupId>
+    <version>7.21.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>drools-scenario-simulation-api</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-project-datamodel-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionElement.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionElement.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Objects;
+
+/**
+ * Single element of a expression, i.e. in person.fullName.last each component is an ExpressionElement
+ */
+public class ExpressionElement {
+
+    private String step;
+
+    public ExpressionElement() {
+    }
+
+    public ExpressionElement(String step) {
+        this.step = step;
+    }
+
+    public String getStep() {
+        return step;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExpressionElement that = (ExpressionElement) o;
+        return Objects.equals(getStep(), that.getStep());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getStep());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionIdentifier.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ExpressionIdentifier.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Objects;
+
+/**
+ * Identify an expression. It is defined by a name and a type
+ */
+public class ExpressionIdentifier {
+
+    private String name;
+    private FactMappingType type;
+
+    public enum NAME {
+        Description,
+        Expected,
+        Given,
+        Index,
+        Other;
+    }
+
+    public static ExpressionIdentifier INDEX = create(NAME.Index.name(), FactMappingType.OTHER);
+    public static ExpressionIdentifier DESCRIPTION = create(NAME.Description.name(), FactMappingType.OTHER);
+
+    public ExpressionIdentifier() {
+    }
+
+    public ExpressionIdentifier(String name, FactMappingType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public FactMappingType getType() {
+        return type;
+    }
+
+    public static ExpressionIdentifier create(String name, FactMappingType type) {
+        return new ExpressionIdentifier(name, type);
+    }
+
+    @Override
+    public String toString() {
+        return "ExpressionIdentifier{" +
+                "name='" + name + '\'' +
+                ", type=" + type +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExpressionIdentifier that = (ExpressionIdentifier) o;
+        return Objects.equals(name, that.name) &&
+                type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactIdentifier.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactIdentifier.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Objects;
+
+/**
+ * A fact is identified by its name and the canonical name of its class
+ */
+public class FactIdentifier {
+
+    private String name;
+    private String className;
+
+    public static FactIdentifier INDEX = create("#", Integer.class.getCanonicalName());
+    public static FactIdentifier DESCRIPTION = create("Scenario description", String.class.getCanonicalName());
+    public static FactIdentifier EMPTY = create("Empty", Void.class.getName());
+
+    public FactIdentifier() {
+    }
+
+    public FactIdentifier(String name, String className) {
+        this.name = name;
+        this.className = className;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getClassNameWithoutPackage() {
+        if (className.contains(".")) {
+            return className.substring(className.lastIndexOf(".") + 1);
+        } else {
+            return className;
+        }
+    }
+
+    public static FactIdentifier create(String name, String className) {
+        return new FactIdentifier(name, className);
+    }
+
+    @Override
+    public String toString() {
+        return "FactIdentifier{" +
+                "name='" + name + '\'' +
+                ", className='" + className + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FactIdentifier that = (FactIdentifier) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(className, that.className);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, className);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMapping.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMapping.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * It describes how to reach a single property of a fact
+ */
+public class FactMapping {
+
+    /**
+     * Expression to reach the property. I.e. person.fullName.last
+     */
+    private List<ExpressionElement> expressionElements = new LinkedList<>();
+
+    /**
+     * Identifier of this expression (it contains the type of expression, i.e. given/expected) - it is mapped to the <b>property</b> header
+     */
+    private ExpressionIdentifier expressionIdentifier;
+
+    /**
+     * Identify the fact by name and class name - it is mapped to <b>Instance</b> header
+     */
+    private FactIdentifier factIdentifier;
+
+    /**
+     * String name of the type of the property described by this class
+     */
+    private String className;
+
+    /**
+     * Alias to customize the <b>instance</b> label
+     */
+    private String factAlias;
+
+    /**
+     * Alias to customize the <b>property</b> label
+     */
+    private String expressionAlias;
+
+    /**
+     * Generic type(s) of the given properties, where applicable (ex collections)
+     */
+    private List<String> genericTypes;
+
+    public FactMapping() {
+    }
+
+    public FactMapping(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        this(factIdentifier.getName(), factIdentifier, expressionIdentifier);
+    }
+
+    public FactMapping(String factAlias, FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        this.factAlias = factAlias;
+        this.expressionIdentifier = expressionIdentifier;
+        this.className = factIdentifier.getClassName();
+        this.factIdentifier = factIdentifier;
+    }
+
+    /**
+     * It <b>clones</b> the given <code>FactMapping</code>
+     * @param original The original <code>FactMapping</code>
+     */
+    private FactMapping(FactMapping original) {
+        original.expressionElements.forEach(expressionElement -> this.addExpressionElement(expressionElement.getStep(), original.className));
+        this.expressionIdentifier = original.expressionIdentifier;
+        this.factIdentifier = original.factIdentifier;
+        this.className = original.className;
+        this.factAlias = original.factAlias;
+        this.expressionAlias = original.expressionAlias;
+        this.genericTypes = original.genericTypes;
+    }
+
+    public String getFullExpression() {
+        return expressionElements.stream().map(ExpressionElement::getStep).collect(Collectors.joining("."));
+    }
+
+    public List<ExpressionElement> getExpressionElementsWithoutClass() {
+        if (expressionElements.size() == 0) {
+            throw new IllegalStateException("ExpressionElements malformed");
+        }
+        return expressionElements.subList(1, expressionElements.size());
+    }
+
+    public List<ExpressionElement> getExpressionElements() {
+        return expressionElements;
+    }
+
+    public void addExpressionElement(String stepName, String className) {
+        this.className = className;
+        expressionElements.add(new ExpressionElement(stepName));
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public ExpressionIdentifier getExpressionIdentifier() {
+        return expressionIdentifier;
+    }
+
+    public FactIdentifier getFactIdentifier() {
+        return factIdentifier;
+    }
+
+    public String getFactAlias() {
+        return factAlias;
+    }
+
+    public void setFactAlias(String factAlias) {
+        this.factAlias = factAlias;
+    }
+
+    public String getExpressionAlias() {
+        return expressionAlias;
+    }
+
+    public void setExpressionAlias(String expressionAlias) {
+        this.expressionAlias = expressionAlias;
+    }
+
+    public List<String> getGenericTypes() {
+        return genericTypes;
+    }
+
+    public void setGenericTypes(List<String> genericTypes) {
+        this.genericTypes = genericTypes;
+    }
+
+    /**
+     * It creates a new <code>FactMapping</code> cloning the instanced one.
+     */
+    public FactMapping cloneFactMapping() {
+        return new FactMapping(this);
+    }
+
+    public static String getPlaceHolder(FactMappingType factMappingType) {
+        return factMappingType.name();
+    }
+
+    public static String getPlaceHolder(FactMappingType factMappingType, int index) {
+        return getPlaceHolder(factMappingType) + " " + index;
+    }
+
+    public static String getInstancePlaceHolder(int index) {
+        return "INSTANCE " + index;
+    }
+
+    public static String getPropertyPlaceHolder(int index) {
+        return "PROPERTY " + index;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FactMapping that = (FactMapping) o;
+        return getExpressionElements().equals(that.getExpressionElements()) &&
+                Objects.equals(getExpressionIdentifier(), that.getExpressionIdentifier()) &&
+                Objects.equals(getFactIdentifier(), that.getFactIdentifier()) &&
+                Objects.equals(getClassName(), that.getClassName()) &&
+                Objects.equals(getFactAlias(), that.getFactAlias()) &&
+                Objects.equals(getExpressionAlias(), that.getExpressionAlias()) &&
+                Objects.equals(getGenericTypes(), that.getGenericTypes());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getExpressionElements(),
+                getExpressionIdentifier(), getFactIdentifier(), getClassName(), getFactAlias(), getExpressionAlias(), getGenericTypes());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingType.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+/**
+ * Type of fact mappings
+ */
+public enum FactMappingType {
+    GIVEN,
+    EXPECT,
+    // used to define descriptive column
+    OTHER
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValue.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/FactMappingValue.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Objects;
+
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+
+/**
+ * FactMappingValue contains the identifier of a fact mapping + the raw value
+ */
+public class FactMappingValue {
+
+    private FactIdentifier factIdentifier;
+    private ExpressionIdentifier expressionIdentifier;
+    private Object rawValue;
+    @XStreamOmitField
+    private boolean error = false;
+
+    public FactMappingValue() {
+    }
+
+    public FactMappingValue(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier, Object rawValue) {
+        this.factIdentifier = Objects.requireNonNull(factIdentifier, "FactIdentifier has to be not null");
+        this.expressionIdentifier = Objects.requireNonNull(expressionIdentifier, "ExpressionIdentifier has to be not null");
+        this.rawValue = rawValue;
+    }
+
+    public void setRawValue(Object rawValue) {
+        this.rawValue = rawValue;
+    }
+
+    public FactIdentifier getFactIdentifier() {
+        return factIdentifier;
+    }
+
+    public ExpressionIdentifier getExpressionIdentifier() {
+        return expressionIdentifier;
+    }
+
+    public Object getRawValue() {
+        return rawValue;
+    }
+
+    FactMappingValue cloneFactMappingValue() {
+        FactMappingValue cloned = new FactMappingValue();
+        cloned.expressionIdentifier = expressionIdentifier;
+        cloned.factIdentifier = factIdentifier;
+        cloned.rawValue = rawValue;
+        return cloned;
+    }
+
+    public boolean isError() {
+        return error;
+    }
+
+    public void setError(boolean error) {
+        this.error = error;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Scenario.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Scenario.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Scenario contains description and values to test in the defined scenario
+ */
+public class Scenario {
+
+    /**
+     * List of values to be used to test this scenario
+     */
+    private final List<FactMappingValue> factMappingValues = new ArrayList<>();
+
+    private SimulationDescriptor simulationDescriptor = new SimulationDescriptor();
+
+    public Scenario() {
+    }
+
+    public Scenario(SimulationDescriptor simulationDescriptor) {
+        this.simulationDescriptor = simulationDescriptor;
+    }
+
+    /**
+     * Returns an <b>unmodifiable</b> list wrapping the backed one
+     * <p>
+     * NOTE: list order could not be aligned to factMapping order. Use {@link Scenario#sort()} before call this method
+     * to ensure the order.
+     * Best way to have ordered factMappingValues is to iterate over {@link SimulationDescriptor#factMappings} and use
+     * {@link #getFactMappingValue(FactIdentifier, ExpressionIdentifier)}
+     * @return not modifiable list of FactMappingValues
+     */
+    public List<FactMappingValue> getUnmodifiableFactMappingValues() {
+        return Collections.unmodifiableList(factMappingValues);
+    }
+
+    public void removeFactMappingValueByIdentifiers(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        getFactMappingValue(factIdentifier, expressionIdentifier).ifPresent(factMappingValues::remove);
+    }
+
+    public void removeFactMappingValue(FactMappingValue toRemove) {
+        factMappingValues.remove(toRemove);
+    }
+
+    public FactMappingValue addMappingValue(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier, Object value) {
+        String factName = factIdentifier.getName();
+        if (getFactMappingValue(factIdentifier, expressionIdentifier).isPresent()) {
+            throw new IllegalArgumentException(
+                    new StringBuilder().append("A fact value for expression '").append(expressionIdentifier.getName())
+                            .append("' and fact '").append(factName).append("' already exist").toString());
+        }
+        FactMappingValue factMappingValue = new FactMappingValue(factIdentifier, expressionIdentifier, value);
+        factMappingValues.add(factMappingValue);
+        return factMappingValue;
+    }
+
+    public FactMappingValue addOrUpdateMappingValue(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier, Object value) {
+        return getFactMappingValue(factIdentifier, expressionIdentifier).map(e -> {
+            e.setRawValue(value);
+            return e;
+        }).orElseGet(() -> addMappingValue(factIdentifier, expressionIdentifier, value));
+    }
+
+    public Optional<FactMappingValue> getFactMappingValue(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        return factMappingValues.stream().filter(e -> e.getFactIdentifier().equals(factIdentifier) &&
+                e.getExpressionIdentifier().equals(expressionIdentifier)).findFirst();
+    }
+
+    public Optional<FactMappingValue> getFactMappingValueByIndex(int index) {
+        FactMapping factMappingByIndex;
+        try {
+            factMappingByIndex = simulationDescriptor.getFactMappingByIndex(index);
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(
+                    new StringBuilder().append("Impossible to retrieve FactMapping at index ").append(index).toString(), e);
+        }
+        return getFactMappingValue(factMappingByIndex.getFactIdentifier(), factMappingByIndex.getExpressionIdentifier());
+    }
+
+    public List<FactMappingValue> getFactMappingValuesByFactIdentifier(FactIdentifier factIdentifier) {
+        return factMappingValues.stream().filter(e -> e.getFactIdentifier().equals(factIdentifier)).collect(toList());
+    }
+
+    public void setDescription(String name) {
+        addOrUpdateMappingValue(FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION, name);
+    }
+
+    public String getDescription() {
+        return factMappingValues.stream()
+                .filter(e -> e.getExpressionIdentifier().equals(ExpressionIdentifier.DESCRIPTION) &&
+                        e.getFactIdentifier().equals(FactIdentifier.DESCRIPTION) &&
+                        e.getRawValue() != null)
+                .map(e -> (String) e.getRawValue())
+                .findFirst().orElse("");
+    }
+
+    public Collection<String> getFactNames() {
+        return factMappingValues.stream().map(e -> e.getFactIdentifier().getName()).collect(toSet());
+    }
+
+    public void sort() {
+        factMappingValues.sort((a, b) -> {
+            Integer aIndex = simulationDescriptor.getIndexByIdentifier(a.getFactIdentifier(), a.getExpressionIdentifier());
+            Integer bIndex = simulationDescriptor.getIndexByIdentifier(b.getFactIdentifier(), b.getExpressionIdentifier());
+            return aIndex.compareTo(bIndex);
+        });
+    }
+
+    public void resetErrors() {
+        factMappingValues.forEach(elem -> elem.setError(false));
+    }
+
+    Scenario cloneScenario() {
+        Scenario cloned = new Scenario(simulationDescriptor);
+        cloned.factMappingValues.addAll(factMappingValues.stream().map(FactMappingValue::cloneFactMappingValue).collect(toList()));
+        return cloned;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioSimulationModel.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioSimulationModel.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.api.model;
+
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import org.kie.soup.project.datamodel.imports.HasImports;
+import org.kie.soup.project.datamodel.imports.Imports;
+
+public class ScenarioSimulationModel
+        implements HasImports {
+
+    public enum Type {
+        RULE,
+        DMN
+    }
+
+    @XStreamAsAttribute()
+    private String version = "1.4";
+
+    private Simulation simulation;
+
+    private Imports imports = new Imports();
+
+    public ScenarioSimulationModel() {
+    }
+
+    public Simulation getSimulation() {
+        return simulation;
+    }
+
+    public void setSimulation(Simulation simulation) {
+        this.simulation = simulation;
+    }
+
+    @Override
+    public Imports getImports() {
+        return imports;
+    }
+
+    @Override
+    public void setImports(Imports imports) {
+        this.imports = imports;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioWithIndex.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioWithIndex.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Objects;
+
+/**
+ * Tuple with Scenario and its index
+ */
+public class ScenarioWithIndex {
+
+    protected Scenario scenario;
+    protected int index;
+
+    public ScenarioWithIndex() {
+        // CDI
+    }
+
+    public ScenarioWithIndex(int index, Scenario scenario) {
+        this.scenario = scenario;
+        this.index = index;
+    }
+
+    public Scenario getScenario() {
+        return scenario;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScenarioWithIndex that = (ScenarioWithIndex) o;
+        return index == that.index &&
+                Objects.equals(scenario, that.scenario);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scenario, index);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Simulation.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/Simulation.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils.toScenarioWithIndex;
+
+/**
+ * Envelop class that wrap the definition of the simulation and the values of the scenarios
+ */
+public class Simulation {
+
+    /**
+     * Describes structure of the simulation
+     */
+    private final SimulationDescriptor simulationDescriptor = new SimulationDescriptor();
+    /**
+     * Contains list of scenarios to test
+     */
+    private final List<Scenario> scenarios = new LinkedList<>();
+
+    /**
+     * Returns an <b>unmodifiable</b> list wrapping the backed one
+     * @return
+     */
+    public List<Scenario> getUnmodifiableScenarios() {
+        return Collections.unmodifiableList(scenarios);
+    }
+
+    public List<ScenarioWithIndex> getScenarioWithIndex() {
+        return toScenarioWithIndex(this);
+    }
+
+    public void removeScenarioByIndex(int index) {
+        scenarios.remove(index);
+    }
+
+    public void removeScenario(Scenario toRemove) {
+        scenarios.remove(toRemove);
+    }
+
+    public SimulationDescriptor getSimulationDescriptor() {
+        return simulationDescriptor;
+    }
+
+    public Scenario getScenarioByIndex(int index) {
+        return scenarios.get(index);
+    }
+
+    public Scenario addScenario() {
+        return addScenario(scenarios.size());
+    }
+
+    public Scenario addScenario(int index) {
+        if (index < 0 || index > scenarios.size()) {
+            throw new IllegalArgumentException(new StringBuilder().append("Index out of range ").append(index).toString());
+        }
+        Scenario scenario = new Scenario(simulationDescriptor);
+        scenarios.add(index, scenario);
+        return scenario;
+    }
+
+    public void replaceScenario(int index, Scenario newScenario) {
+        scenarios.set(index, newScenario);
+    }
+
+    public void removeFactMappingByIndex(int index) {
+        clearScenarios(simulationDescriptor.getFactMappingByIndex(index));
+        simulationDescriptor.removeFactMappingByIndex(index);
+    }
+
+    public void removeFactMapping(FactMapping toRemove) {
+        clearScenarios(toRemove);
+        simulationDescriptor.removeFactMapping(toRemove);
+    }
+
+    public Scenario cloneScenario(int sourceIndex, int targetIndex) {
+        if (sourceIndex < 0 || sourceIndex >= scenarios.size()) {
+            throw new IllegalArgumentException(new StringBuilder().append("SourceIndex out of range ").append(sourceIndex).toString());
+        }
+        if (targetIndex < 0 || targetIndex > scenarios.size()) {
+            throw new IllegalArgumentException(new StringBuilder().append("TargetIndex out of range ").append(targetIndex).toString());
+        }
+        Scenario scenarioByIndex = getScenarioByIndex(sourceIndex);
+        Scenario clonedScenario = scenarioByIndex.cloneScenario();
+        scenarios.add(targetIndex, clonedScenario);
+        return clonedScenario;
+    }
+
+    public void clear() {
+        simulationDescriptor.clear();
+        clearScenarios();
+    }
+
+    public void clearScenarios() {
+        scenarios.clear();
+    }
+
+    public void sort() {
+        scenarios.forEach(Scenario::sort);
+    }
+
+    public void resetErrors() {
+        scenarios.forEach(Scenario::resetErrors);
+    }
+
+    public Simulation cloneSimulation() {
+        Simulation toReturn = new Simulation();
+        toReturn.getSimulationDescriptor().setType(simulationDescriptor.getType());
+        toReturn.getSimulationDescriptor().setDmnFilePath(simulationDescriptor.getDmnFilePath());
+        toReturn.getSimulationDescriptor().setDmoSession(simulationDescriptor.getDmoSession());
+        final List<FactMapping> originalFactMappings = this.simulationDescriptor.getUnmodifiableFactMappings();
+        for (int i = 0; i < originalFactMappings.size(); i++) {
+            final FactMapping originalFactMapping = originalFactMappings.get(i);
+            toReturn.simulationDescriptor.addFactMapping(i, originalFactMapping);
+        }
+        this.scenarios.forEach(scenario -> toReturn.scenarios.add(scenario.cloneScenario()));
+        return toReturn;
+    }
+
+    private void clearScenarios(FactMapping toRemove) {
+        scenarios.forEach(e -> e.removeFactMappingValueByIdentifiers(toRemove.getFactIdentifier(), toRemove.getExpressionIdentifier()));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationDescriptor.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationDescriptor.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * SimulationDescriptor describes a template of a simulation
+ */
+public class SimulationDescriptor {
+
+    private final List<FactMapping> factMappings = new ArrayList<>();
+
+    private String dmoSession;
+
+    private String dmnFilePath;
+
+    private ScenarioSimulationModel.Type type;
+
+    private String fileName;
+
+    private String kieSession;
+
+    private String kieBase;
+
+    private String ruleFlowGroup;
+
+    private String dmnNamespace;
+
+    private String dmnName;
+
+    private boolean skipFromBuild;
+
+    /**
+     * Returns an <b>unmodifiable</b> list wrapping the backed one
+     * @return
+     */
+    public List<FactMapping> getUnmodifiableFactMappings() {
+        return Collections.unmodifiableList(factMappings);
+    }
+
+    public Set<FactIdentifier> getFactIdentifiers() {
+        return factMappings.stream().map(FactMapping::getFactIdentifier).collect(Collectors.toSet());
+    }
+
+    public String getDmoSession() {
+        return dmoSession;
+    }
+
+    public void setDmoSession(String ruleSession) {
+        this.dmoSession = ruleSession;
+    }
+
+    public String getDmnFilePath() {
+        return dmnFilePath;
+    }
+
+    public void setDmnFilePath(String dmnFilePath) {
+        this.dmnFilePath = dmnFilePath;
+    }
+
+    public ScenarioSimulationModel.Type getType() {
+        return type;
+    }
+
+    public void setType(ScenarioSimulationModel.Type type) {
+        this.type = type;
+    }
+
+    public List<FactMapping> getFactMappings() {
+        return factMappings;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getKieSession() {
+        return kieSession;
+    }
+
+    public void setKieSession(String kieSession) {
+        this.kieSession = kieSession;
+    }
+
+    public String getKieBase() {
+        return kieBase;
+    }
+
+    public void setKieBase(String kieBase) {
+        this.kieBase = kieBase;
+    }
+
+    public String getRuleFlowGroup() {
+        return ruleFlowGroup;
+    }
+
+    public void setRuleFlowGroup(String ruleFlowGroup) {
+        this.ruleFlowGroup = ruleFlowGroup;
+    }
+
+    public String getDmnNamespace() {
+        return dmnNamespace;
+    }
+
+    public void setDmnNamespace(String dmnNamespace) {
+        this.dmnNamespace = dmnNamespace;
+    }
+
+    public String getDmnName() {
+        return dmnName;
+    }
+
+    public void setDmnName(String dmnName) {
+        this.dmnName = dmnName;
+    }
+
+    public boolean isSkipFromBuild() {
+        return skipFromBuild;
+    }
+
+    public void setSkipFromBuild(boolean skipFromBuild) {
+        this.skipFromBuild = skipFromBuild;
+    }
+
+    public void moveFactMapping(int oldIndex, int newIndex) {
+        if (oldIndex < 0 || oldIndex >= factMappings.size()) {
+            throw new IllegalArgumentException(new StringBuilder().append("Index ").append(oldIndex)
+                                                       .append(" not found in the list").toString());
+        }
+        if (newIndex < 0 || newIndex >= factMappings.size()) {
+            throw new IllegalArgumentException(new StringBuilder().append("Index ").append(newIndex)
+                                                       .append(" out of range").toString());
+        }
+        FactMapping factMapping = factMappings.get(oldIndex);
+        factMappings.remove(oldIndex);
+        factMappings.add(newIndex, factMapping);
+    }
+
+    public FactMapping getFactMappingByIndex(int index) {
+        return factMappings.get(index);
+    }
+
+    void removeFactMappingByIndex(int index) {
+        factMappings.remove(index);
+    }
+
+    void removeFactMapping(FactMapping toRemove) {
+        factMappings.remove(toRemove);
+    }
+
+    public int getIndexByIdentifier(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        return IntStream.range(0, factMappings.size()).filter(index -> {
+            FactMapping factMapping = factMappings.get(index);
+            return factMapping.getExpressionIdentifier().equals(expressionIdentifier) &&
+                    factMapping.getFactIdentifier().equals(factIdentifier);
+        }).findFirst().orElseThrow(() -> new IllegalArgumentException(
+                new StringBuilder().append("Impossible to find a FactMapping with factIdentifier '").append(factIdentifier.getName())
+                        .append("' and expressionIdentifier '").append(expressionIdentifier.getName()).append("'").toString()));
+    }
+
+    public List<FactMapping> getFactMappingsByFactName(String factName) {
+        return internalFilter(e -> e.getFactIdentifier().getName().equalsIgnoreCase(factName));
+    }
+
+    public Optional<FactMapping> getFactMapping(FactIdentifier factIdentifier, ExpressionIdentifier ei) {
+        List<FactMapping> factMappings = internalFilter(e -> e.getExpressionIdentifier().equals(ei) &&
+                e.getFactIdentifier().equals(factIdentifier));
+        return factMappings.stream().findFirst();
+    }
+
+    /**
+     * This method clone the given <code>FactMapping</code> and insert the cloned instance at the specified index
+     * @param index
+     * @param toClone
+     * @return the <b>cloned</b> <code>FactMapping</code>
+     */
+    public FactMapping addFactMapping(int index, FactMapping toClone) {
+        FactMapping toReturn = toClone.cloneFactMapping();
+        factMappings.add(index, toReturn);
+        return toReturn;
+    }
+
+    public FactMapping addFactMapping(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        return addFactMapping(factMappings.size(), factIdentifier, expressionIdentifier);
+    }
+
+    public FactMapping addFactMapping(String factAlias, FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        return addFactMapping(factMappings.size(), factAlias, factIdentifier, expressionIdentifier);
+    }
+
+    public FactMapping addFactMapping(int index, FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        return addFactMapping(index, factIdentifier.getName(), factIdentifier, expressionIdentifier);
+    }
+
+    public FactMapping addFactMapping(int index, String factAlias, FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier) {
+        if (getFactMapping(factIdentifier, expressionIdentifier).isPresent()) {
+            throw new IllegalArgumentException(
+                    new StringBuilder().append("An expression with name '").append(expressionIdentifier.getName())
+                            .append("' already exists for the fact '").append(factIdentifier.getName()).append("'").toString());
+        }
+        if (index > factMappings.size()) {
+            throw new IllegalArgumentException(
+                    new StringBuilder().append("Impossible to add an element at position ").append(index)
+                            .append(" because there are only ").append(factMappings.size()).append(" elements").toString());
+        }
+        FactMapping factMapping = new FactMapping(factAlias, factIdentifier, expressionIdentifier);
+        factMappings.add(index, factMapping);
+        return factMapping;
+    }
+
+    public void clear() {
+        factMappings.clear();
+    }
+
+    private List<FactMapping> internalFilter(Predicate<FactMapping> predicate) {
+        return factMappings.stream().filter(predicate).collect(Collectors.toList());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationRunMetadata.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationRunMetadata.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregation of all metadata information about a simulation run
+ */
+public class SimulationRunMetadata {
+
+    protected int available;
+    protected int executed;
+    protected double coveragePercentage;
+
+    protected Map<String, Integer> outputCounter = new HashMap<>();
+
+    protected Map<ScenarioWithIndex, List<String>> scenarioCounter = new HashMap<>();
+
+    protected List<ScenarioWithIndex> scenarios;
+
+    public SimulationRunMetadata() {
+        // CDI
+    }
+
+    public SimulationRunMetadata(int available,
+                                 int executed,
+                                 Map<String, Integer> outputCounter,
+                                 Map<ScenarioWithIndex, List<String>> scenarioCounter) {
+        this.available = available;
+        this.executed = executed;
+        this.outputCounter.putAll(outputCounter);
+        this.scenarioCounter.putAll(scenarioCounter);
+        this.coveragePercentage = (double) executed / available;
+    }
+
+    public int getAvailable() {
+        return available;
+    }
+
+    public int getExecuted() {
+        return executed;
+    }
+
+    public double getCoveragePercentage() {
+        return (double) executed / available * 100;
+    }
+
+    public Map<String, Integer> getOutputCounter() {
+        return outputCounter;
+    }
+
+    public Map<ScenarioWithIndex, List<String>> getScenarioCounter() {
+        return scenarioCounter;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ScenarioSimulationSharedUtils.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/utils/ScenarioSimulationSharedUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.Simulation;
+
+public class ScenarioSimulationSharedUtils {
+
+    public static final String FILE_EXTENSION = "scesim";
+
+    /**
+     * Returns true if given string equals <code>List.class.getName()</code> or <code>Map.class.getName()</code>
+     * @param className
+     * @return
+     */
+    public static boolean isCollection(String className) {
+        return isList(className) || isMap(className);
+    }
+
+    /**
+     * Returns true if given string equals <code>List.class.getName()</code>
+     * @param className
+     * @return
+     */
+    public static boolean isList(String className) {
+        return List.class.getName().equals(className);
+    }
+
+    /**
+     * Returns true if given string equals <code>List.class.getName()</code>
+     * @param className
+     * @return
+     */
+    public static boolean isMap(String className) {
+        return Map.class.getName().equals(className);
+    }
+
+    public static List<ScenarioWithIndex> toScenarioWithIndex(Simulation simulation) {
+        List<ScenarioWithIndex> toReturn = new ArrayList<>();
+        List<Scenario> scenarios = simulation.getUnmodifiableScenarios();
+        for (int index = 0; index < scenarios.size(); index += 1) {
+            toReturn.add(new ScenarioWithIndex(index + 1, scenarios.get(index)));
+        }
+        return toReturn;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/resources/META-INF/ErraiApp.properties
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,27 @@
+#
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.
+errai.marshalling.serializableTypes=org.drools.scenariosimulation.api.model.ExpressionElement \
+  org.drools.scenariosimulation.api.model.ExpressionIdentifier \
+  org.drools.scenariosimulation.api.model.FactIdentifier \
+  org.drools.scenariosimulation.api.model.FactMapping \
+  org.drools.scenariosimulation.api.model.FactMappingType \
+  org.drools.scenariosimulation.api.model.FactMappingValue \
+  org.drools.scenariosimulation.api.model.Scenario \
+  org.drools.scenariosimulation.api.model.ScenarioSimulationModel \
+  org.drools.scenariosimulation.api.model.ScenarioWithIndex \
+  org.drools.scenariosimulation.api.model.Simulation \
+  org.drools.scenariosimulation.api.model.SimulationDescriptor \
+  org.drools.scenariosimulation.api.model.SimulationRunMetadata

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/resources/org/drools/scenariosimulation/ScenarioSimulationAPI.gwt.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/resources/org/drools/scenariosimulation/ScenarioSimulationAPI.gwt.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+  <source path="api"/>
+
+</module>

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/FactMappingTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/FactMappingTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.api.model;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FactMappingTest {
+
+    @Test
+    public void cloneFactMapping() {
+        FactMapping original = new FactMapping("FACT_ALIAS", new FactIdentifier("FI_TEST", "com.test.Foo"), new ExpressionIdentifier("EI_TEST", FactMappingType.GIVEN));
+        original.addExpressionElement("FIRST_STEP", String.class.getName());
+        original.setExpressionAlias("EA_TEST");
+        original.setGenericTypes(new ArrayList<>());
+        FactMapping retrieved = original.cloneFactMapping();
+        assertTrue(retrieved.equals(original));
+    }
+
+    @Test
+    public void getExpressionElementsWithoutClass() {
+        FactMapping original = new FactMapping("FACT_ALIAS", new FactIdentifier("FI_TEST", "com.test.Foo"), new ExpressionIdentifier("EI_TEST", FactMappingType.GIVEN));
+        assertThatThrownBy(original::getExpressionElementsWithoutClass)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("ExpressionElements malformed");
+        assertEquals(0, original.getExpressionElements().size());
+        original.addExpressionElement("STEP", String.class.getCanonicalName());
+
+        assertEquals(0, original.getExpressionElementsWithoutClass().size());
+        assertEquals(1, original.getExpressionElements().size());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/FactMappingValueTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/FactMappingValueTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.api.model;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class FactMappingValueTest {
+
+    @Test
+    public void emptyFactMappingValue() {
+        assertThatThrownBy(() -> new FactMappingValue(null, ExpressionIdentifier.DESCRIPTION, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("FactIdentifier has to be not null");
+
+        assertThatThrownBy(() -> new FactMappingValue(FactIdentifier.DESCRIPTION, null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("ExpressionIdentifier has to be not null");
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/ScenarioTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/ScenarioTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ScenarioTest {
+
+    SimulationDescriptor simulationDescriptor;
+    Scenario scenario;
+    FactIdentifier factIdentifier;
+    ExpressionIdentifier expressionIdentifier;
+    Simulation simulation;
+
+    @Before
+    public void init() {
+        simulation = new Simulation();
+        simulationDescriptor = simulation.getSimulationDescriptor();
+        scenario = simulation.addScenario();
+        factIdentifier = FactIdentifier.create("test fact", String.class.getCanonicalName());
+        expressionIdentifier = ExpressionIdentifier.create("test expression", FactMappingType.EXPECT);
+    }
+
+    @Test
+    public void removeFactMappingValueByIdentifiersTest() {
+        scenario.addMappingValue(factIdentifier, expressionIdentifier, "test value");
+        Optional<FactMappingValue> retrieved = scenario.getFactMappingValue(factIdentifier, expressionIdentifier);
+        assertTrue(retrieved.isPresent());
+        scenario.removeFactMappingValueByIdentifiers(factIdentifier, expressionIdentifier);
+        retrieved = scenario.getFactMappingValue(factIdentifier, expressionIdentifier);
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test
+    public void removeFactMappingValue() {
+        scenario.addMappingValue(factIdentifier, expressionIdentifier, "test value");
+        Optional<FactMappingValue> retrieved = scenario.getFactMappingValue(factIdentifier, expressionIdentifier);
+        assertTrue(retrieved.isPresent());
+        scenario.removeFactMappingValue(retrieved.get());
+        retrieved = scenario.getFactMappingValue(factIdentifier, expressionIdentifier);
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addMappingValueTest() {
+        scenario.addMappingValue(factIdentifier, expressionIdentifier, "test value");
+        // Should fail
+        scenario.addMappingValue(factIdentifier, expressionIdentifier, "test value");
+    }
+
+    @Test
+    public void getDescriptionTest() {
+        assertEquals("", scenario.getDescription());
+
+        String description = "Test Description";
+        scenario.addMappingValue(FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION, description);
+        assertEquals(description, scenario.getDescription());
+
+        Scenario scenarioWithDescriptionNull = simulation.addScenario();
+        scenarioWithDescriptionNull.setDescription(null);
+        assertEquals("", scenarioWithDescriptionNull.getDescription());
+    }
+
+    @Test
+    public void addOrUpdateMappingValue() {
+        Object value1 = "Test 1";
+        Object value2 = "Test 2";
+        FactMappingValue factMappingValue = scenario.addMappingValue(factIdentifier, expressionIdentifier, value1);
+        assertEquals(factMappingValue.getRawValue(), value1);
+        FactMappingValue factMappingValue1 = scenario.addOrUpdateMappingValue(factIdentifier, expressionIdentifier, value2);
+        assertEquals(factMappingValue, factMappingValue1);
+        assertEquals(factMappingValue1.getRawValue(), value2);
+    }
+
+    @Test
+    public void sortTest() {
+        ExpressionIdentifier expressionIdentifier2 = ExpressionIdentifier.create("Test expression 2", FactMappingType.GIVEN);
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier2);
+        scenario.addMappingValue(factIdentifier, expressionIdentifier2, "Test 2");
+        FactMappingValue factMappingValue1 = scenario.addMappingValue(factIdentifier, this.expressionIdentifier, "Test");
+
+        assertEquals(scenario.getUnmodifiableFactMappingValues().get(1), factMappingValue1);
+
+        scenario.sort();
+        assertNotEquals(scenario.getUnmodifiableFactMappingValues().get(1), factMappingValue1);
+        assertEquals(scenario.getUnmodifiableFactMappingValues().get(0), factMappingValue1);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/SimulationDescriptorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/SimulationDescriptorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SimulationDescriptorTest {
+
+    SimulationDescriptor simulationDescriptor;
+    FactIdentifier factIdentifier;
+    ExpressionIdentifier expressionIdentifier;
+
+    @Before
+    public void init() {
+        simulationDescriptor = new SimulationDescriptor();
+        factIdentifier = FactIdentifier.create("test fact", String.class.getCanonicalName());
+        expressionIdentifier = ExpressionIdentifier.create("test expression", FactMappingType.EXPECT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addFactMappingTest() {
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+
+        // Should fail
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addFactMappingIndexTest() {
+        // Should fail
+        simulationDescriptor.addFactMapping(1, factIdentifier, expressionIdentifier);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void removeFactMappingByIndex() {
+        int testingIndex = 0;
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+        assertNotNull(simulationDescriptor.getFactMappingByIndex(testingIndex));
+        simulationDescriptor.removeFactMappingByIndex(testingIndex);
+        simulationDescriptor.getFactMappingByIndex(testingIndex);
+    }
+
+    @Test
+    public void removeFactMapping() {
+        FactMapping retrieved = simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+        assertTrue(simulationDescriptor.getUnmodifiableFactMappings().contains(retrieved));
+        simulationDescriptor.removeFactMapping(retrieved);
+        assertFalse(simulationDescriptor.getUnmodifiableFactMappings().contains(retrieved));
+    }
+
+    @Test
+    public void getIndexByIdentifierTest() {
+        List<FactMapping> originalFactMappings = IntStream.range(0, 2).boxed()
+                .map(i -> simulationDescriptor
+                        .addFactMapping(FactIdentifier.create("test " + i, String.class.getCanonicalName()), this.expressionIdentifier)
+                ).collect(Collectors.toList());
+        int indexToCheck = 0;
+        int indexRetrieved = simulationDescriptor.getIndexByIdentifier(originalFactMappings.get(indexToCheck).getFactIdentifier(), this.expressionIdentifier);
+        assertEquals(indexToCheck, indexRetrieved);
+        indexToCheck = 1;
+        indexRetrieved = simulationDescriptor.getIndexByIdentifier(originalFactMappings.get(indexToCheck).getFactIdentifier(), this.expressionIdentifier);
+        assertEquals(indexToCheck, indexRetrieved);
+    }
+
+    @Test
+    public void moveFactMappingTest() {
+        ExpressionIdentifier expressionIdentifier2 = ExpressionIdentifier.create("Test expression 2", FactMappingType.GIVEN);
+        ExpressionIdentifier expressionIdentifier3 = ExpressionIdentifier.create("Test expression 3", FactMappingType.GIVEN);
+        FactMapping factMapping1 = simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+        FactMapping factMapping2 = simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier2);
+        FactMapping factMapping3 = simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier3);
+        List<FactMapping> factMappings = simulationDescriptor.getUnmodifiableFactMappings();
+
+        assertEquals(factMappings.get(0), factMapping1);
+        assertEquals(factMappings.get(1), factMapping2);
+        assertEquals(factMappings.get(2), factMapping3);
+
+        simulationDescriptor.moveFactMapping(0, 1);
+
+        factMappings = simulationDescriptor.getUnmodifiableFactMappings();
+        assertEquals(factMappings.get(0), factMapping2);
+        assertEquals(factMappings.get(1), factMapping1);
+        assertEquals(factMappings.get(2), factMapping3);
+
+        simulationDescriptor.moveFactMapping(2, 1);
+
+        factMappings = simulationDescriptor.getUnmodifiableFactMappings();
+        assertEquals(factMappings.get(0), factMapping2);
+        assertEquals(factMappings.get(1), factMapping3);
+        assertEquals(factMappings.get(2), factMapping1);
+
+        simulationDescriptor.moveFactMapping(2, 2);
+
+        factMappings = simulationDescriptor.getUnmodifiableFactMappings();
+        assertEquals(factMappings.get(0), factMapping2);
+        assertEquals(factMappings.get(1), factMapping3);
+        assertEquals(factMappings.get(2), factMapping1);
+    }
+
+    @Test
+    public void moveFactMappingOldFailTest() {
+        ExpressionIdentifier expressionIdentifier2 = ExpressionIdentifier.create("Test expression 2", FactMappingType.GIVEN);
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier);
+        simulationDescriptor.addFactMapping(factIdentifier, expressionIdentifier2);
+
+        muteException(() -> {
+                          simulationDescriptor.moveFactMapping(2, 0);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+
+        muteException(() -> {
+                          simulationDescriptor.moveFactMapping(-1, 0);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+
+        muteException(() -> {
+                          simulationDescriptor.moveFactMapping(0, 2);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+
+        muteException(() -> {
+                          simulationDescriptor.moveFactMapping(0, -1);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+    }
+
+    private <T extends Throwable> void muteException(Runnable toBeExecuted, Class<T> expected) {
+        try {
+            toBeExecuted.run();
+        } catch (Throwable t) {
+            //noinspection NonJREEmulationClassesInClientCode
+            if (!t.getClass().isAssignableFrom(expected)) {
+                throw t;
+            }
+        }
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/SimulationTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/test/java/org/drools/scenariosimulation/api/model/SimulationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.api.model;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+public class SimulationTest {
+
+    Simulation simulation;
+    Scenario originalScenario;
+
+    @Before
+    public void setup() {
+        simulation = new Simulation();
+        FactIdentifier factIdentifier = FactIdentifier.create("Test", String.class.getCanonicalName());
+        ExpressionIdentifier expressionIdentifier = ExpressionIdentifier.create("Test", FactMappingType.GIVEN);
+        simulation.getSimulationDescriptor().addFactMapping(factIdentifier, expressionIdentifier);
+
+        originalScenario = simulation.addScenario();
+        originalScenario.setDescription("Test Description");
+        originalScenario.addMappingValue(factIdentifier, expressionIdentifier, "TEST");
+    }
+
+    @Test
+    public void addScenarioTest() {
+        simulation.addScenario(1);
+
+        muteException(() -> {
+                          simulation.addScenario(-1);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+        muteException(() -> {
+                          simulation.addScenario(3);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+    }
+
+    @Test
+    public void cloneScenarioTest() {
+        Scenario clonedScenario = simulation.cloneScenario(0, 1);
+
+        assertEquals(originalScenario.getDescription(), clonedScenario.getDescription());
+        assertEquals(originalScenario.getUnmodifiableFactMappingValues().size(), clonedScenario.getUnmodifiableFactMappingValues().size());
+        assertEquals(originalScenario, simulation.getScenarioByIndex(0));
+        assertEquals(clonedScenario, simulation.getScenarioByIndex(1));
+
+        assertNotEquals(originalScenario, clonedScenario);
+        assertNotEquals(originalScenario.getUnmodifiableFactMappingValues().get(0), clonedScenario.getUnmodifiableFactMappingValues().get(0));
+    }
+
+    @Test
+    public void cloneScenarioFail() {
+
+        muteException(() -> {
+                          simulation.cloneScenario(-1, 1);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+
+        muteException(() -> {
+                          simulation.cloneScenario(2, 1);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+
+        muteException(() -> {
+                          simulation.cloneScenario(0, -1);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+
+        muteException(() -> {
+                          simulation.cloneScenario(0, 2);
+                          fail();
+                      },
+                      IllegalArgumentException.class);
+    }
+
+    @Test
+    public void removeFactMappingByIndex() {
+        assertEquals(2, simulation.getUnmodifiableScenarios().get(0).getUnmodifiableFactMappingValues().size());
+        assertEquals(1, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
+        simulation.removeFactMappingByIndex(0);
+        assertEquals(1, simulation.getUnmodifiableScenarios().get(0).getUnmodifiableFactMappingValues().size());
+        assertEquals(0, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
+    }
+
+    @Test
+    public void removeFactMapping() {
+        assertEquals(2, simulation.getUnmodifiableScenarios().get(0).getUnmodifiableFactMappingValues().size());
+        assertEquals(1, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
+        simulation.removeFactMapping(simulation.getSimulationDescriptor().getFactMappingByIndex(0));
+        assertEquals(1, simulation.getUnmodifiableScenarios().get(0).getUnmodifiableFactMappingValues().size());
+        assertEquals(0, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
+    }
+
+    private <T extends Throwable> void muteException(Runnable toBeExecuted, Class<T> expected) {
+        try {
+            toBeExecuted.run();
+        } catch (Throwable t) {
+            if (!t.getClass().isAssignableFrom(expected)) {
+                throw t;
+            }
+        }
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>drools-scenario-simulation</artifactId>
+    <groupId>org.drools</groupId>
+    <version>7.21.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>drools-scenario-simulation-backend</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-scenario-simulation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <!-- KIE API dependencies -->
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-internal</artifactId>
+    </dependency>
+
+    <!-- JSON/XML utils -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+
+    <!-- KIE soup -->
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-project-datamodel-api</artifactId>
+    </dependency>
+
+    <!-- DMN dependencies -->
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-feel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-core</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-dmn-bom</artifactId>
+        <version>${version.org.kie}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.21.0-SNAPSHOT</version>
+    <version>7.22.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils;
+
+public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator {
+
+    protected boolean commonEvaluateUnaryExpression(Object rawExpression, Object resultValue, Class<?> resultClass) {
+        if (resultClass != null && ScenarioSimulationSharedUtils.isCollection(resultClass.getCanonicalName())) {
+            return verifyResult(rawExpression, resultValue, resultClass);
+        } else {
+            return internalUnaryEvaluation((String) rawExpression, resultValue, resultClass, false);
+        }
+    }
+
+    protected Object commonEvaluationLiteralExpression(String className, List<String> genericClasses, String raw) {
+        if (ScenarioSimulationSharedUtils.isCollection(className)) {
+            return convertResult(raw, className, genericClasses);
+        } else {
+            return internalLiteralEvaluation(raw, className);
+        }
+    }
+
+    protected Object convertResult(String rawString, String className, List<String> genericClasses) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            JsonNode jsonNode = objectMapper.readTree(rawString);
+            if (jsonNode.isArray()) {
+                return createAndFillList((ArrayNode) jsonNode, new ArrayList<>(), className, genericClasses);
+            } else if (jsonNode.isObject()) {
+                return createAndFillObject((ObjectNode) jsonNode,
+                                           createObject(className, genericClasses),
+                                           className,
+                                           genericClasses);
+            }
+            throw new IllegalArgumentException("Malformed raw data");
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Malformed raw data", e);
+        }
+    }
+
+    protected List<Object> createAndFillList(ArrayNode json, List<Object> toReturn, String className, List<String> genericClasses) {
+        for (JsonNode node : json) {
+            String genericClassName = ScenarioSimulationSharedUtils.isMap(className) ? className : genericClasses.get(genericClasses.size() - 1);
+            Object listElement = createObject(genericClassName, genericClasses);
+            Object returnedObject = createAndFillObject((ObjectNode) node, listElement, genericClassName, genericClasses);
+            toReturn.add(returnedObject);
+        }
+        return toReturn;
+    }
+
+    protected Object createAndFillObject(ObjectNode json, Object toReturn, String className, List<String> genericClasses) {
+        Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
+        int numberOfFields = json.size();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> element = fields.next();
+            String key = element.getKey();
+            JsonNode jsonNode = element.getValue();
+            // if is a simple value just return the parsed result
+            if (numberOfFields == 1 && "value".equals(key)) {
+                return internalLiteralEvaluation(jsonNode.textValue(), genericClasses.get(0));
+            }
+
+            if (jsonNode.isArray()) {
+                List<Object> nestedList = new ArrayList<>();
+                Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
+                List<Object> returnedList = createAndFillList((ArrayNode) jsonNode, nestedList, fieldDescriptor.getKey(), fieldDescriptor.getValue());
+                setField(toReturn, key, returnedList);
+            } else if (jsonNode.isObject()) {
+                Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
+                Object nestedObject = createObject(fieldDescriptor.getKey(), fieldDescriptor.getValue());
+                Object returnedObject = createAndFillObject((ObjectNode) jsonNode, nestedObject, fieldDescriptor.getKey(), fieldDescriptor.getValue());
+                setField(toReturn, key, returnedObject);
+            } else if (jsonNode.textValue() != null && !jsonNode.textValue().isEmpty()) {
+                Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
+                setField(toReturn, key, internalLiteralEvaluation(jsonNode.textValue(), fieldDescriptor.getKey()));
+            } else {
+                // empty strings are skipped
+            }
+        }
+        return toReturn;
+    }
+
+    protected boolean verifyResult(Object rawValue, Object resultRaw, Class<?> resultClass) {
+        if (!(resultRaw instanceof List) && !(resultRaw instanceof Map)) {
+            throw new IllegalArgumentException("A list was expected");
+        }
+        if (!(rawValue instanceof String)) {
+            throw new IllegalArgumentException("Malformed raw data");
+        }
+        String raw = (String) rawValue;
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(raw);
+            if (jsonNode.isArray()) {
+                return verifyList((ArrayNode) jsonNode, (List) resultRaw, resultClass);
+            } else if (jsonNode.isObject()) {
+                return verifyObject((ObjectNode) jsonNode, resultRaw, resultClass);
+            }
+            throw new IllegalArgumentException("Malformed raw data");
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Malformed raw data", e);
+        }
+    }
+
+    protected boolean verifyList(ArrayNode json, List resultRaw, Class<?> resultClass) {
+
+        for (JsonNode node : json) {
+            boolean success = false;
+            for (Object result : resultRaw) {
+                if (verifyObject((ObjectNode) node, result, resultClass)) {
+                    success = true;
+                }
+            }
+            if (!success) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean verifyObject(ObjectNode json, Object result, Class<?> resultClass) {
+        Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
+        int numberOfFields = json.size();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> element = fields.next();
+            String key = element.getKey();
+            JsonNode jsonNode = element.getValue();
+            // if is a simple value just return the parsed result
+            if (numberOfFields == 1 && "value".equals(key)) {
+                return internalUnaryEvaluation(jsonNode.textValue(), result, result.getClass(), true);
+            }
+
+            Object fieldValue = extractFieldValue(result, key);
+            if (jsonNode.isArray()) {
+                if (!verifyList((ArrayNode) jsonNode, (List) fieldValue, fieldValue.getClass())) {
+                    return false;
+                }
+            } else if (jsonNode.isObject()) {
+                if (!verifyObject((ObjectNode) jsonNode, fieldValue, fieldValue.getClass())) {
+                    return false;
+                }
+            } else {
+                if (!internalUnaryEvaluation(jsonNode.textValue(), fieldValue, fieldValue.getClass(), true)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    abstract protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString);
+
+    abstract protected Object internalLiteralEvaluation(String raw, String className);
+
+    abstract protected Object extractFieldValue(Object result, String fieldName);
+
+    abstract protected Object createObject(String className, List<String> genericClasses);
+
+    abstract protected void setField(Object toReturn, String fieldName, Object fieldValue);
+
+    abstract protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses);
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.expression;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils;
+
+public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
+
+    private final ClassLoader classLoader;
+
+    public BaseExpressionEvaluator(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean evaluateUnaryExpression(Object raw, Object resultValue, Class<?> resultClass) {
+        if (!(raw instanceof String)) {
+            return BaseExpressionOperator.EQUALS.eval(raw, resultValue, resultClass, classLoader);
+        }
+
+        return commonEvaluateUnaryExpression(raw, resultValue, resultClass);
+    }
+
+    @Override
+    public Object evaluateLiteralExpression(String className, List<String> genericClasses, Object raw) {
+        if (!(raw instanceof String)) {
+            return raw;
+        }
+
+        return commonEvaluationLiteralExpression(className, genericClasses, (String) raw);
+    }
+
+    @Override
+    protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString) {
+        if (rawExpression != null && skipEmptyString && rawExpression.isEmpty()) {
+            return true;
+        }
+        return BaseExpressionOperator.findOperator(rawExpression).eval(rawExpression, resultValue, resultClass, classLoader);
+    }
+
+    @Override
+    protected Object internalLiteralEvaluation(String rawValue, String className) {
+        return BaseExpressionOperator.findOperator(rawValue).evaluateLiteralExpression(className, rawValue, classLoader);
+    }
+
+    @Override
+    protected Object extractFieldValue(Object result, String fieldName) {
+        try {
+            if (result instanceof Map) {
+                return ((Map) result).get(fieldName);
+            } else {
+                Field declaredField = result.getClass().getDeclaredField(fieldName);
+                declaredField.setAccessible(true);
+                return declaredField.get(result);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Impossible to find field: " + fieldName, e);
+        }
+    }
+
+    @Override
+    protected Object createObject(String className, List<String> genericClasses) {
+        if (ScenarioSimulationSharedUtils.isMap(className)) {
+            return new HashMap();
+        } else {
+            try {
+                return classLoader.loadClass(className).newInstance();
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Impossible to instantiate " + className, e);
+            }
+        }
+    }
+
+    @Override
+    protected void setField(Object toReturn, String fieldName, Object fieldValue) {
+        if (toReturn instanceof Map) {
+            Map returnMap = (Map) toReturn;
+            returnMap.put(fieldName, fieldValue);
+        } else {
+            try {
+                Field declaredField = toReturn.getClass().getDeclaredField(fieldName);
+                declaredField.setAccessible(true);
+                declaredField.set(toReturn, fieldValue);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Impossible to set the field " + fieldName, e);
+            }
+        }
+    }
+
+    @Override
+    protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses) {
+        try {
+            if (ScenarioSimulationSharedUtils.isMap(className)) {
+                return new AbstractMap.SimpleEntry<>(genericClasses.get(genericClasses.size() - 1), Collections.emptyList());
+            }
+            Field declaredField = element.getClass().getDeclaredField(fieldName);
+            Class<?> fieldType = declaredField.getType();
+            List<String> genericsString = new ArrayList<>();
+            if (declaredField.getGenericType() instanceof ParameterizedType) {
+                ParameterizedType generics = (ParameterizedType) declaredField.getGenericType();
+                for (Type typeArgument : generics.getActualTypeArguments()) {
+                    if (typeArgument instanceof ParameterizedType) {
+                        genericsString.add(((ParameterizedType) typeArgument).getRawType().getTypeName());
+                    } else {
+                        genericsString.add(typeArgument.getTypeName());
+                    }
+                }
+            }
+            return new AbstractMap.SimpleEntry<>(fieldType.getCanonicalName(), genericsString);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Impossible to get the field " + fieldName, e);
+        }
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Comparator.comparingInt;
+import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.convertValue;
+
+public enum BaseExpressionOperator {
+
+    LIST_OF_CONDITION(0, ";") {
+        @Override
+        protected Optional<String> match(String value) {
+            return symbols.stream().filter(value::contains).findFirst();
+        }
+
+        @Override
+        protected boolean eval(Object raw, Object resultValue, Class<?> resultClass, ClassLoader classLoader) {
+            if (!(raw instanceof String) || !match((String) raw).isPresent()) {
+                return false;
+            }
+            String rawValue = (String) raw;
+            String[] expressionParts = rawValue.split(symbols.get(0));
+            List<Boolean> results = Arrays.stream(expressionParts.length == 0 ? new String[]{""} : expressionParts)
+                    .map(elem -> findOperator(elem.trim()).eval(elem.trim(), resultValue, resultClass, classLoader))
+                    .collect(Collectors.toList());
+            return results.size() != 0 && results.stream().allMatch(a -> a);
+        }
+    },
+    LIST_OF_VALUES(1, "[") {
+        @Override
+        public boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader) {
+            List<Boolean> results = getValues(rawValue).stream()
+                    .map(e -> findOperator(e).eval(e, resultValue, resultClass, classLoader)).collect(Collectors.toList());
+            return results.stream().anyMatch(a -> a);
+        }
+
+        private List<String> getValues(Object raw) {
+            if (!(raw instanceof String) || !match((String) raw).isPresent()) {
+                return Collections.emptyList();
+            }
+            String rawValue = ((String) raw).trim();
+            if (!rawValue.endsWith("]")) {
+                throw new IllegalArgumentException(new StringBuilder().append("Malformed expression: ").append(rawValue).toString());
+            }
+            return Stream.of(rawValue.substring(1, ((String) raw).length() - 1).split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+        }
+    },
+    EQUALS(2, "=") {
+        @Override
+        protected Object evaluateLiteralExpression(String className, String value, ClassLoader classLoader) {
+            String returnValue = removeOperator(value);
+
+            // "null" string is converted to null
+            returnValue = "null".equals(returnValue) ? null : returnValue;
+
+            return convertValue(className, returnValue, classLoader);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader) {
+            Object parsedResults = rawValue;
+            if (parsedResults instanceof String) {
+                parsedResults = evaluateLiteralExpression(resultClass != null ? resultClass.getCanonicalName() : null, (String) rawValue, classLoader);
+            }
+            if (parsedResults == null) {
+                return resultValue == null;
+            }
+            if (areComparable(resultValue, parsedResults)) {
+                return ((Comparable) resultValue).compareTo(parsedResults) == 0;
+            }
+            return Objects.equals(resultValue, parsedResults);
+        }
+    },
+    NOT_EQUALS(3, "!", "!=", "<>") {
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader) {
+            Object valueToTest = rawValue;
+            BaseExpressionOperator operator = EQUALS;
+            // remove symbol to reuse EQUALS.eval
+            if (valueToTest instanceof String) {
+                String rawStringValue = (String) valueToTest;
+                valueToTest = removeOperator(rawStringValue);
+                operator = findOperator((String) valueToTest);
+            }
+
+            return !operator.eval(valueToTest, resultValue, resultClass, classLoader);
+        }
+    },
+    RANGE(4, "<", ">", "<=", ">=") {
+        @Override
+        public boolean eval(Object raw, Object resultValue, Class<?> resultClass, ClassLoader classLoader) {
+            if (!(raw instanceof String) || !match((String) raw).isPresent()) {
+                return false;
+            }
+
+            String rawValue = (String) raw;
+            String operator = match(rawValue).get();
+            String cleanValue = removeOperator(rawValue);
+            Object stepValue = convertValue(resultClass.getCanonicalName(), cleanValue, classLoader);
+            if (!areComparable(stepValue, resultValue)) {
+                return false;
+            }
+            Comparable a = (Comparable) resultValue;
+            Comparable b = (Comparable) stepValue;
+            switch (operator) {
+                case "<":
+                    return a.compareTo(b) < 0;
+                case ">":
+                    return a.compareTo(b) > 0;
+                case "<=":
+                    return a.compareTo(b) <= 0;
+                case ">=":
+                    return a.compareTo(b) >= 0;
+                default:
+                    throw new IllegalStateException(new StringBuilder().append("This should not happen ").append(operator).toString());
+            }
+        }
+    };
+
+    final List<String> symbols;
+    final int precedence;
+
+    BaseExpressionOperator(int precedence, String... symbols) {
+        this.precedence = precedence;
+        this.symbols = Arrays.asList(symbols);
+        // sort symbols by descending length to match longer symbols first
+        this.symbols.sort((a, b) -> Integer.compare(a.length(), b.length()) * -1);
+    }
+
+    public static BaseExpressionOperator findOperator(String rawValue) {
+        String value = rawValue.trim();
+        List<BaseExpressionOperator> sortedOperators = Arrays.stream(values()).sorted(comparingInt(BaseExpressionOperator::getPrecedence))
+                .collect(Collectors.toList());
+        for (BaseExpressionOperator factMappingValueOperator : sortedOperators) {
+            if (factMappingValueOperator.match(value).isPresent()) {
+                return factMappingValueOperator;
+            }
+        }
+
+        // Equals is the default
+        return BaseExpressionOperator.EQUALS;
+    }
+
+    protected abstract boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader);
+
+    protected Object evaluateLiteralExpression(String className, String value, ClassLoader classLoader) {
+        throw new IllegalStateException("This operator cannot be used into a Given clause");
+    }
+
+    protected Optional<String> match(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        value = value.trim();
+        return symbols.stream().filter(value::startsWith).findFirst();
+    }
+
+    protected String removeOperator(String fullString) {
+        Optional<String> operatorSymbol = match(fullString);
+        String value = fullString;
+        if (operatorSymbol.isPresent()) {
+            String symbolToRemove = operatorSymbol.get();
+            int index = value.indexOf(symbolToRemove);
+            value = value.substring(index + symbolToRemove.length()).trim();
+        }
+        return value == null ? null : value.trim();
+    }
+
+    private static boolean areComparable(Object a, Object b) {
+        return a instanceof Comparable && b instanceof Comparable;
+    }
+
+    private int getPrecedence() {
+        return precedence;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
+
+    private final FEEL feel = FEEL.newInstance();
+    private final ClassLoader classLoader;
+
+    public DMNFeelExpressionEvaluator(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public boolean evaluateUnaryExpression(Object rawExpression, Object resultValue, Class<?> resultClass) {
+        if (rawExpression != null && !(rawExpression instanceof String)) {
+            throw new IllegalArgumentException("Raw expression should be a string");
+        }
+
+        return commonEvaluateUnaryExpression(rawExpression, resultValue, resultClass);
+    }
+
+    @Override
+    public Object evaluateLiteralExpression(String className, List<String> genericClasses, Object raw) {
+        if (!(raw instanceof String)) {
+            return raw;
+        }
+
+        return commonEvaluationLiteralExpression(className, genericClasses, (String) raw);
+    }
+
+    private EvaluationContext newEvaluationContext() {
+        return new EvaluationContextImpl(classLoader, new FEELEventListenersManager());
+    }
+
+    @Override
+    protected Object internalLiteralEvaluation(String raw, String className) {
+        EvaluationContext evaluationContext = newEvaluationContext();
+        return feel.evaluate(raw, evaluationContext);
+    }
+
+    @Override
+    protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString) {
+        if (rawExpression != null && skipEmptyString && rawExpression.isEmpty()) {
+            return true;
+        }
+        EvaluationContext evaluationContext = newEvaluationContext();
+        List<UnaryTest> unaryTests = feel.evaluateUnaryTests(rawExpression);
+        if (unaryTests.size() < 1) {
+            throw new IllegalArgumentException("Impossible to parse the expression '" + rawExpression + "'");
+        }
+        return unaryTests.stream().allMatch(unaryTest -> unaryTest.apply(evaluationContext, resultValue));
+    }
+
+    @Override
+    protected Object extractFieldValue(Object result, String fieldName) {
+        return ((Map<String, Object>) result).get(fieldName);
+    }
+
+    @Override
+    protected Object createObject(String className, List<String> genericClasses) {
+        return new HashMap<String, Object>();
+    }
+
+    @Override
+    protected void setField(Object toReturn, String fieldName, Object fieldValue) {
+        Map<String, Object> returnMap = (Map<String, Object>) toReturn;
+        returnMap.put(fieldName, fieldValue);
+    }
+
+    /**
+     * This is not used for DMN
+     * @param element
+     * @param fieldName
+     * @param className
+     * @param genericClasses
+     * @return
+     */
+    @Override
+    protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses) {
+        return new AbstractMap.SimpleEntry<>("", Collections.singletonList(""));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/ExpressionEvaluator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.List;
+
+public interface ExpressionEvaluator {
+
+    boolean evaluateUnaryExpression(Object rawExpression, Object resultValue, Class<?> resultClass);
+
+    Object evaluateLiteralExpression(String className, List<String> genericClasses, Object raw);
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ConditionFilter.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ConditionFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.List;
+
+import org.kie.api.runtime.ObjectFilter;
+
+public class ConditionFilter implements ObjectFilter {
+
+    private final List<FactCheckerHandle> factToCheck;
+
+    public ConditionFilter(List<FactCheckerHandle> factToCheck) {
+        this.factToCheck = factToCheck;
+    }
+
+    @Override
+    public boolean accept(Object object) {
+        return factToCheck.stream()
+                .allMatch(factCheckerHandle ->
+                                  factCheckerHandle.getClazz().isAssignableFrom(object.getClass()) &&
+                                          factCheckerHandle.getCheckFuction().apply(object).isSatisfied());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/DMNScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/DMNScenarioExecutableBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.Objects;
+
+import org.drools.scenariosimulation.backend.util.DMNSimulationUtils;
+import org.kie.api.runtime.ExecutableRunner;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.internal.builder.fluent.DMNRuntimeFluent;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.command.RegistryContext;
+
+public class DMNScenarioExecutableBuilder {
+
+    public static String DEFAULT_APPLICATION = "defaultApplication";
+    public static String DMN_RESULT = "dmnResult";
+    public static String DMN_MODEL = "dmnModel";
+
+    private final DMNRuntimeFluent dmnRuntimeFluent;
+    private final ExecutableBuilder executableBuilder;
+
+    private DMNScenarioExecutableBuilder(KieContainer kieContainer, String applicationName) {
+        executableBuilder = ExecutableBuilder.create();
+
+        dmnRuntimeFluent = executableBuilder.newApplicationContext(applicationName)
+                .setKieContainer(kieContainer)
+                .newDMNRuntime();
+    }
+
+    private DMNScenarioExecutableBuilder(KieContainer kieContainer) {
+        this(kieContainer, DEFAULT_APPLICATION);
+    }
+
+    public static DMNScenarioExecutableBuilder createBuilder(KieContainer kieContainer, String applicationName) {
+        return new DMNScenarioExecutableBuilder(kieContainer, applicationName);
+    }
+
+    public static DMNScenarioExecutableBuilder createBuilder(KieContainer kieContainer) {
+        return new DMNScenarioExecutableBuilder(kieContainer);
+    }
+
+    public void setActiveModel(String path) {
+        dmnRuntimeFluent
+                .addCommand(context -> {
+                    RegistryContext registryContext = (RegistryContext) context;
+
+                    DMNRuntime dmnRuntime = registryContext.lookup(DMNRuntime.class);
+                    if (dmnRuntime == null) {
+                        throw new IllegalStateException("There is no DMNRuntime available");
+                    }
+
+                    DMNModel dmnModel = DMNSimulationUtils.extractDMNModel(dmnRuntime, path);
+                    registryContext.register(DMNModel.class, dmnModel);
+                    return dmnModel;
+                })
+                .out(DMN_MODEL);
+    }
+
+    public void setValue(String key, Object value) {
+        dmnRuntimeFluent.setInput(key, value);
+    }
+
+    public RequestContext run() {
+        Objects.requireNonNull(executableBuilder, "Executable builder is null, please invoke create(KieContainer, )");
+
+        dmnRuntimeFluent
+                .evaluateModel()
+                .out(DMN_RESULT)
+                .end();
+
+        return ExecutableRunner.create().execute(executableBuilder.getExecutable());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/FactCheckerHandle.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/FactCheckerHandle.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+
+public class FactCheckerHandle {
+
+    private final Class<?> clazz;
+    private final Function<Object, ResultWrapper> checkFuction;
+    private final ScenarioResult scenarioResult;
+
+    public FactCheckerHandle(Class<?> clazz, Function<Object, ResultWrapper> checkFuction, ScenarioResult scenarioResult) {
+        this.clazz = clazz;
+        this.checkFuction = checkFuction;
+        this.scenarioResult = scenarioResult;
+    }
+
+    public Class<?> getClazz() {
+        return clazz;
+    }
+
+    public Function<Object, ResultWrapper> getCheckFuction() {
+        return checkFuction;
+    }
+
+    public ScenarioResult getScenarioResult() {
+        return scenarioResult;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.kie.api.builder.model.KieSessionModel;
+import org.kie.api.runtime.ExecutableRunner;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieSessionFluent;
+
+public class RuleScenarioExecutableBuilder {
+
+    public static String DEFAULT_APPLICATION = "defaultApplication";
+
+    private final KieSessionFluent kieSessionFluent;
+    private final ExecutableBuilder executableBuilder;
+    private final Map<FactIdentifier, List<FactCheckerHandle>> internalConditions = new HashMap<>();
+
+    private static BiFunction<String, KieContainer, KieContainer> forcePseudoClock = (sessionName, kc) -> {
+        KieSessionModel kieSessionModel = kc.getKieSessionModel(sessionName);
+        kieSessionModel.setClockType(ClockTypeOption.get("pseudo"));
+        return kc;
+    };
+
+    private RuleScenarioExecutableBuilder(KieContainer kieContainer, String name) {
+        executableBuilder = ExecutableBuilder.create();
+
+        kieSessionFluent = executableBuilder.newApplicationContext(name)
+                .setKieContainer(kieContainer)
+                .newSessionCustomized(null, forcePseudoClock);
+    }
+
+    private RuleScenarioExecutableBuilder(KieContainer kieContainer) {
+        this(kieContainer, DEFAULT_APPLICATION);
+    }
+
+    public static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer, String name) {
+        return new RuleScenarioExecutableBuilder(kieContainer, name);
+    }
+
+    public static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer) {
+        return new RuleScenarioExecutableBuilder(kieContainer);
+    }
+
+    public void addInternalCondition(Class<?> clazz,
+                                     Function<Object, ResultWrapper> checkFunction,
+                                     ScenarioResult scenarioResult) {
+        internalConditions.computeIfAbsent(scenarioResult.getFactIdentifier(), key -> new ArrayList<>())
+                .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));
+    }
+
+    public void insert(Object element) {
+        kieSessionFluent.insert(element);
+    }
+
+    public RequestContext run() {
+        Objects.requireNonNull(executableBuilder, "Executable builder is null, please invoke create(KieContainer, )");
+
+        kieSessionFluent.fireAllRules();
+        internalConditions.values()
+                .forEach(factToCheck -> kieSessionFluent.addCommand(new ValidateFactCommand(factToCheck)));
+
+        kieSessionFluent.dispose().end();
+
+        return ExecutableRunner.create().execute(executableBuilder.getExecutable());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommand.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.kie.api.command.ExecutableCommand;
+import org.kie.api.runtime.Context;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.command.RegistryContext;
+
+public class ValidateFactCommand implements ExecutableCommand<Void> {
+
+    private final List<FactCheckerHandle> factToCheck;
+
+    public ValidateFactCommand(List<FactCheckerHandle> factToCheck) {
+        this.factToCheck = factToCheck;
+    }
+
+    @Override
+    public Void execute(Context context) {
+        KieSession ksession = ((RegistryContext) context).lookup(KieSession.class);
+        Collection<?> objects = ksession.getObjects(new ConditionFilter(factToCheck));
+        if (objects.size() > 0) {
+            factToCheck.forEach(fact -> fact.getScenarioResult().setResult(true));
+        } else {
+            factToCheck.forEach(fact -> fact.getScenarioResult().getFactMappingValue().setError(true));
+        }
+        return null;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.drools.scenariosimulation.api.model.ExpressionElement;
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingType;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioGiven;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+
+import static java.util.stream.Collectors.toList;
+
+public abstract class AbstractRunnerHelper {
+
+    public void run(KieContainer kieContainer, SimulationDescriptor simulationDescriptor, ScenarioWithIndex scenarioWithIndex, ExpressionEvaluator expressionEvaluator, ClassLoader classLoader, ScenarioRunnerData scenarioRunnerData) {
+
+        Scenario scenario = scenarioWithIndex.getScenario();
+
+        extractGivenValues(simulationDescriptor, scenario.getUnmodifiableFactMappingValues(), classLoader, expressionEvaluator)
+                .forEach(scenarioRunnerData::addGiven);
+
+        extractExpectedValues(scenario.getUnmodifiableFactMappingValues()).forEach(scenarioRunnerData::addExpect);
+
+        RequestContext requestContext = executeScenario(kieContainer,
+                                                        scenarioRunnerData,
+                                                        expressionEvaluator,
+                                                        simulationDescriptor);
+
+        scenarioRunnerData.setMetadata(extractResultMetadata(requestContext, scenarioWithIndex));
+
+        verifyConditions(simulationDescriptor,
+                         scenarioRunnerData,
+                         expressionEvaluator,
+                         requestContext);
+
+        validateAssertion(scenarioRunnerData.getResults(),
+                          scenario);
+    }
+
+    public List<ScenarioGiven> extractGivenValues(SimulationDescriptor simulationDescriptor,
+                                                  List<FactMappingValue> factMappingValues,
+                                                  ClassLoader classLoader,
+                                                  ExpressionEvaluator expressionEvaluator) {
+        List<ScenarioGiven> scenarioGiven = new ArrayList<>();
+
+        Map<FactIdentifier, List<FactMappingValue>> groupByFactIdentifier =
+                groupByFactIdentifierAndFilter(factMappingValues, FactMappingType.GIVEN);
+
+        for (Map.Entry<FactIdentifier, List<FactMappingValue>> entry : groupByFactIdentifier.entrySet()) {
+
+            FactIdentifier factIdentifier = entry.getKey();
+
+            // for each fact, create a map of path to fields and values to set
+            Map<List<String>, Object> paramsForBean = getParamsForBean(simulationDescriptor,
+                                                                       factIdentifier,
+                                                                       entry.getValue(),
+                                                                       expressionEvaluator);
+
+            Object bean = getDirectMapping(paramsForBean)
+                    .orElseGet(() -> createObject(factIdentifier.getClassName(), paramsForBean, classLoader));
+
+            scenarioGiven.add(new ScenarioGiven(factIdentifier, bean));
+        }
+
+        return scenarioGiven;
+    }
+
+    public ResultWrapper<Object> getDirectMapping(Map<List<String>, Object> params) {
+        // if a direct mapping exists (no steps to reach the field) the value itself is the object (just converted)
+        for (Map.Entry<List<String>, Object> entry : params.entrySet()) {
+            if (entry.getKey().isEmpty()) {
+                return ResultWrapper.createResult(entry.getValue());
+            }
+        }
+        return ResultWrapper.createErrorResult();
+    }
+
+    public List<ScenarioExpect> extractExpectedValues(List<FactMappingValue> factMappingValues) {
+        List<ScenarioExpect> scenarioExpect = new ArrayList<>();
+
+        Map<FactIdentifier, List<FactMappingValue>> groupByFactIdentifier =
+                groupByFactIdentifierAndFilter(factMappingValues, FactMappingType.EXPECT);
+
+        Set<FactIdentifier> inputFacts = factMappingValues.stream()
+                .filter(elem -> FactMappingType.GIVEN.equals(elem.getExpressionIdentifier().getType()))
+                .map(FactMappingValue::getFactIdentifier)
+                .collect(Collectors.toSet());
+
+        for (Map.Entry<FactIdentifier, List<FactMappingValue>> entry : groupByFactIdentifier.entrySet()) {
+
+            FactIdentifier factIdentifier = entry.getKey();
+
+            scenarioExpect.add(new ScenarioExpect(factIdentifier, entry.getValue(), !inputFacts.contains(factIdentifier)));
+        }
+
+        return scenarioExpect;
+    }
+
+    public Map<FactIdentifier, List<FactMappingValue>> groupByFactIdentifierAndFilter(List<FactMappingValue> factMappingValues,
+                                                                                      FactMappingType type) {
+        Map<FactIdentifier, List<FactMappingValue>> groupByFactIdentifier = new HashMap<>();
+        for (FactMappingValue factMappingValue : factMappingValues) {
+            FactIdentifier factIdentifier = factMappingValue.getFactIdentifier();
+
+            // null means skip
+            if (factMappingValue.getRawValue() == null) {
+                continue;
+            }
+
+            ExpressionIdentifier expressionIdentifier = factMappingValue.getExpressionIdentifier();
+            if (expressionIdentifier == null) {
+                throw new IllegalArgumentException("ExpressionIdentifier malformed");
+            }
+
+            if (!Objects.equals(expressionIdentifier.getType(), type)) {
+                continue;
+            }
+
+            groupByFactIdentifier.computeIfAbsent(factIdentifier, key -> new ArrayList<>())
+                    .add(factMappingValue);
+        }
+        return groupByFactIdentifier;
+    }
+
+    public Map<List<String>, Object> getParamsForBean(SimulationDescriptor simulationDescriptor,
+                                                      FactIdentifier factIdentifier,
+                                                      List<FactMappingValue> factMappingValues,
+                                                      ExpressionEvaluator expressionEvaluator) {
+        Map<List<String>, Object> paramsForBean = new HashMap<>();
+
+        for (FactMappingValue factMappingValue : factMappingValues) {
+            ExpressionIdentifier expressionIdentifier = factMappingValue.getExpressionIdentifier();
+
+            FactMapping factMapping = simulationDescriptor.getFactMapping(factIdentifier, expressionIdentifier)
+                    .orElseThrow(() -> new IllegalStateException("Wrong expression, this should not happen"));
+
+            List<String> pathToField = factMapping.getExpressionElementsWithoutClass().stream()
+                    .map(ExpressionElement::getStep).collect(toList());
+
+            try {
+                Object value = expressionEvaluator.evaluateLiteralExpression(factMapping.getClassName(),
+                                                                             factMapping.getGenericTypes(),
+                                                                             factMappingValue.getRawValue());
+                paramsForBean.put(pathToField, value);
+            } catch (IllegalArgumentException e) {
+                factMappingValue.setError(true);
+                throw new ScenarioException(e.getMessage(), e);
+            }
+        }
+
+        return paramsForBean;
+    }
+
+    public void validateAssertion(List<ScenarioResult> scenarioResults, Scenario scenario) {
+        boolean scenarioFailed = false;
+        for (ScenarioResult scenarioResult : scenarioResults) {
+            if (!scenarioResult.getResult()) {
+                scenarioFailed = true;
+            }
+        }
+
+        if (scenarioFailed) {
+            throw new ScenarioException("Scenario '" + scenario.getDescription() + "' failed");
+        }
+    }
+
+    protected ScenarioResult fillResult(FactMappingValue expectedResult, FactIdentifier factIdentifier, Supplier<ResultWrapper<?>> resultSupplier) {
+        ResultWrapper<?> resultValue = resultSupplier.get();
+
+        expectedResult.setError(!resultValue.isSatisfied());
+
+        return new ScenarioResult(factIdentifier, expectedResult, resultValue.getResult()).setResult(resultValue.isSatisfied());
+    }
+
+    protected ScenarioResultMetadata extractResultMetadata(RequestContext requestContext,
+                                                           ScenarioWithIndex scenarioWithIndex) {
+        return null;
+    }
+
+    public abstract RequestContext executeScenario(KieContainer kieContainer,
+                                                   ScenarioRunnerData scenarioRunnerData,
+                                                   ExpressionEvaluator expressionEvaluator,
+                                                   SimulationDescriptor simulationDescriptor);
+
+    public abstract void verifyConditions(SimulationDescriptor simulationDescriptor,
+                                          ScenarioRunnerData scenarioRunnerData,
+                                          ExpressionEvaluator expressionEvaluator,
+                                          RequestContext requestContext);
+
+    public abstract Object createObject(String className,
+                                        Map<List<String>, Object> params,
+                                        ClassLoader classLoader);
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractScenarioRunner.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractScenarioRunner.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.api.model.SimulationRunMetadata;
+import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.kie.api.runtime.KieContainer;
+
+import static org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type;
+
+public abstract class AbstractScenarioRunner extends Runner {
+
+    protected final ClassLoader classLoader;
+    protected final Function<ClassLoader, ExpressionEvaluator> expressionEvaluatorFactory;
+    protected final Description desc;
+    protected final KieContainer kieContainer;
+    protected final SimulationDescriptor simulationDescriptor;
+    protected List<ScenarioWithIndex> scenarios;
+    protected String fileName;
+    protected SimulationRunMetadataBuilder simulationRunMetadataBuilder;
+
+    public AbstractScenarioRunner(KieContainer kieContainer,
+                                  Simulation simulation,
+                                  String fileName,
+                                  Function<ClassLoader, ExpressionEvaluator> expressionEvaluatorFactory) {
+        this(kieContainer, simulation.getSimulationDescriptor(), simulation.getScenarioWithIndex(), fileName, expressionEvaluatorFactory);
+    }
+
+    public AbstractScenarioRunner(KieContainer kieContainer,
+                                  SimulationDescriptor simulationDescriptor,
+                                  List<ScenarioWithIndex> scenarios,
+                                  String fileName,
+                                  Function<ClassLoader, ExpressionEvaluator> expressionEvaluatorFactory) {
+        this.kieContainer = kieContainer;
+        this.simulationDescriptor = simulationDescriptor;
+        this.scenarios = scenarios;
+        this.fileName = fileName;
+        this.desc = getDescriptionForSimulation(getFileName(), simulationDescriptor, scenarios);
+        this.classLoader = kieContainer.getClassLoader();
+        this.expressionEvaluatorFactory = expressionEvaluatorFactory;
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        simulationRunMetadataBuilder = SimulationRunMetadataBuilder.create();
+
+        notifier.fireTestStarted(getDescription());
+        for (ScenarioWithIndex scenarioWithIndex : scenarios) {
+            singleRunScenario(scenarioWithIndex, notifier)
+                    .ifPresent(simulationRunMetadataBuilder::addScenarioResultMetadata);
+        }
+        notifier.fireTestStarted(getDescription());
+    }
+
+    @Override
+    public Description getDescription() {
+        return this.desc;
+    }
+
+    protected Optional<ScenarioResultMetadata> singleRunScenario(ScenarioWithIndex scenarioWithIndex, RunNotifier runNotifier) {
+        ScenarioRunnerData scenarioRunnerData = new ScenarioRunnerData();
+
+        int index = scenarioWithIndex.getIndex();
+        Description descriptionForScenario = getDescriptionForScenario(getFileName(), index, scenarioWithIndex.getScenario());
+        runNotifier.fireTestStarted(descriptionForScenario);
+
+        try {
+            internalRunScenario(scenarioWithIndex, scenarioRunnerData);
+        } catch (ScenarioException e) {
+            IndexedScenarioException indexedScenarioException = new IndexedScenarioException(index, e);
+            indexedScenarioException.setFileName(fileName);
+            runNotifier.fireTestFailure(new Failure(descriptionForScenario, indexedScenarioException));
+        } catch (Throwable e) {
+            IndexedScenarioException indexedScenarioException = new IndexedScenarioException(index, "Unexpected test error in scenario '" +
+                    scenarioWithIndex.getScenario().getDescription() + "'", e);
+            indexedScenarioException.setFileName(fileName);
+            runNotifier.fireTestFailure(new Failure(descriptionForScenario, indexedScenarioException));
+        }
+
+        runNotifier.fireTestFinished(descriptionForScenario);
+
+        return scenarioRunnerData.getMetadata();
+    }
+
+    protected void internalRunScenario(ScenarioWithIndex scenarioWithIndex, ScenarioRunnerData scenarioRunnerData) {
+        ExpressionEvaluator expressionEvaluator = createExpressionEvaluator();
+        newRunnerHelper(getSimulationDescriptor()).run(getKieContainer(),
+                                                       getSimulationDescriptor(),
+                                                       scenarioWithIndex,
+                                                       expressionEvaluator,
+                                                       getClassLoader(),
+                                                       scenarioRunnerData);
+    }
+
+    public ExpressionEvaluator createExpressionEvaluator() {
+        return expressionEvaluatorFactory.apply(classLoader);
+    }
+
+    public Optional<String> getFileName() {
+        return Optional.ofNullable(fileName);
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    public KieContainer getKieContainer() {
+        return kieContainer;
+    }
+
+    public SimulationDescriptor getSimulationDescriptor() {
+        return simulationDescriptor;
+    }
+
+    public Optional<SimulationRunMetadata> getLastRunResultMetadata() {
+        return this.simulationRunMetadataBuilder != null ?
+                Optional.of(this.simulationRunMetadataBuilder.build()) :
+                Optional.empty();
+    }
+
+    public static Description getDescriptionForSimulation(Optional<String> filename, Simulation simulation) {
+        return getDescriptionForSimulation(filename, simulation.getSimulationDescriptor(), simulation.getScenarioWithIndex());
+    }
+
+    public static Description getDescriptionForSimulation(Optional<String> filename, SimulationDescriptor simulationDescriptor, List<ScenarioWithIndex> scenarios) {
+        Description suiteDescription = Description.createSuiteDescription("Test Scenarios (Preview) tests");
+        scenarios.forEach(scenarioWithIndex -> suiteDescription.addChild(
+                getDescriptionForScenario(filename, scenarioWithIndex.getIndex(), scenarioWithIndex.getScenario())));
+        return suiteDescription;
+    }
+
+    public static Description getDescriptionForScenario(Optional<String> className, int index, Scenario scenario) {
+        return Description.createTestDescription(className.orElse(AbstractScenarioRunner.class.getCanonicalName()),
+                                                 String.format("#%d: %s", index, scenario.getDescription()));
+    }
+
+    public static ScenarioRunnerProvider getSpecificRunnerProvider(SimulationDescriptor simulationDescriptor) {
+        if (Type.RULE.equals(simulationDescriptor.getType())) {
+            return RuleScenarioRunner::new;
+        } else if (Type.DMN.equals(simulationDescriptor.getType())) {
+            return DMNScenarioRunner::new;
+        } else {
+            throw new IllegalArgumentException("Impossible to run simulation of type " + simulationDescriptor.getType());
+        }
+    }
+
+    protected abstract AbstractRunnerHelper newRunnerHelper(SimulationDescriptor simulationDescriptor);
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunner.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.List;
+
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.backend.expression.DMNFeelExpressionEvaluator;
+import org.kie.api.runtime.KieContainer;
+
+public class DMNScenarioRunner extends AbstractScenarioRunner {
+
+    public DMNScenarioRunner(KieContainer kieContainer, Simulation simulation) {
+        this(kieContainer, simulation, null);
+    }
+
+    public DMNScenarioRunner(KieContainer kieContainer, Simulation simulation, String fileName) {
+        this(kieContainer, simulation.getSimulationDescriptor(), simulation.getScenarioWithIndex(), fileName);
+    }
+
+    public DMNScenarioRunner(KieContainer kieContainer, SimulationDescriptor simulationDescriptor, List<ScenarioWithIndex> scenarios) {
+        this(kieContainer, simulationDescriptor, scenarios, null);
+    }
+
+    public DMNScenarioRunner(KieContainer kieContainer, SimulationDescriptor simulationDescriptor, List<ScenarioWithIndex> scenarios, String fileName) {
+        super(kieContainer, simulationDescriptor, scenarios, fileName, DMNFeelExpressionEvaluator::new);
+    }
+
+    @Override
+    protected AbstractRunnerHelper newRunnerHelper(SimulationDescriptor simulationDescriptor) {
+        return new DMNScenarioRunnerHelper();
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.scenariosimulation.api.model.ExpressionElement;
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
+import org.drools.scenariosimulation.backend.fluent.DMNScenarioExecutableBuilder;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioGiven;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+import org.kie.dmn.api.core.DMNDecisionResult;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.ast.DecisionNode;
+
+import static org.drools.scenariosimulation.backend.runner.model.ResultWrapper.createErrorResult;
+import static org.drools.scenariosimulation.backend.runner.model.ResultWrapper.createResult;
+import static org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus.SUCCEEDED;
+
+public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
+
+    @Override
+    public RequestContext executeScenario(KieContainer kieContainer,
+                                          ScenarioRunnerData scenarioRunnerData,
+                                          ExpressionEvaluator expressionEvaluator,
+                                          SimulationDescriptor simulationDescriptor) {
+        if (!ScenarioSimulationModel.Type.DMN.equals(simulationDescriptor.getType())) {
+            throw new ScenarioException("Impossible to run a not-DMN simulation with DMN runner");
+        }
+        DMNScenarioExecutableBuilder executableBuilder = DMNScenarioExecutableBuilder.createBuilder(kieContainer);
+        executableBuilder.setActiveModel(simulationDescriptor.getDmnFilePath());
+        for (ScenarioGiven input : scenarioRunnerData.getGivens()) {
+            executableBuilder.setValue(input.getFactIdentifier().getName(), input.getValue());
+        }
+
+        return executableBuilder.run();
+    }
+
+    @Override
+    protected ScenarioResultMetadata extractResultMetadata(RequestContext requestContext, ScenarioWithIndex scenarioWithIndex) {
+        DMNModel dmnModel = requestContext.getOutput(DMNScenarioExecutableBuilder.DMN_MODEL);
+        DMNResult dmnResult = requestContext.getOutput(DMNScenarioExecutableBuilder.DMN_RESULT);
+
+        ScenarioResultMetadata scenarioResultMetadata = new ScenarioResultMetadata(scenarioWithIndex);
+
+        for (DecisionNode decision : dmnModel.getDecisions()) {
+            scenarioResultMetadata.addAvailable(decision.getName());
+        }
+
+        for (DMNDecisionResult decisionResult : dmnResult.getDecisionResults()) {
+            if (SUCCEEDED.equals(decisionResult.getEvaluationStatus())) {
+                scenarioResultMetadata.addExecuted(decisionResult.getDecisionName());
+            }
+        }
+
+        return scenarioResultMetadata;
+    }
+
+    @Override
+    public void verifyConditions(SimulationDescriptor simulationDescriptor,
+                                 ScenarioRunnerData scenarioRunnerData,
+                                 ExpressionEvaluator expressionEvaluator,
+                                 RequestContext requestContext) {
+        DMNResult dmnResult = requestContext.getOutput(DMNScenarioExecutableBuilder.DMN_RESULT);
+
+        for (ScenarioExpect output : scenarioRunnerData.getExpects()) {
+            FactIdentifier factIdentifier = output.getFactIdentifier();
+            String decisionName = factIdentifier.getName();
+            DMNDecisionResult decisionResult = dmnResult.getDecisionResultByName(decisionName);
+            if (decisionResult == null) {
+                throw new ScenarioException("DMN execution has not generated a decision result with name " + decisionName);
+            }
+
+            for (FactMappingValue expectedResult : output.getExpectedResult()) {
+                ExpressionIdentifier expressionIdentifier = expectedResult.getExpressionIdentifier();
+
+                FactMapping factMapping = simulationDescriptor.getFactMapping(factIdentifier, expressionIdentifier)
+                        .orElseThrow(() -> new IllegalStateException("Wrong expression, this should not happen"));
+
+                ScenarioResult scenarioResult = fillResult(expectedResult, factIdentifier, () -> getSingleFactValueResult(factMapping, expectedResult, decisionResult, expressionEvaluator));
+
+                scenarioRunnerData.addResult(scenarioResult);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected ResultWrapper getSingleFactValueResult(FactMapping factMapping,
+                                                     FactMappingValue expectedResult,
+                                                     DMNDecisionResult decisionResult,
+                                                     ExpressionEvaluator expressionEvaluator) {
+        Object resultRaw = decisionResult.getResult();
+
+        if (!SUCCEEDED.equals(decisionResult.getEvaluationStatus())) {
+            return createErrorResult();
+        }
+
+        for (ExpressionElement expressionElement : factMapping.getExpressionElementsWithoutClass()) {
+            if (!(resultRaw instanceof Map)) {
+                throw new ScenarioException("Wrong resultRaw structure because it is not a complex type as expected");
+            }
+            Map<String, Object> result = (Map<String, Object>) resultRaw;
+            resultRaw = result.get(expressionElement.getStep());
+        }
+
+        Class<?> resultClass = resultRaw != null ? resultRaw.getClass() : null;
+
+        try {
+            return expressionEvaluator.evaluateUnaryExpression(expectedResult.getRawValue(), resultRaw, resultClass) ?
+                    createResult(resultRaw) :
+                    createErrorResult();
+        } catch (Exception e) {
+            expectedResult.setError(true);
+            throw new ScenarioException(e.getMessage(), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object createObject(String className, Map<List<String>, Object> params, ClassLoader classLoader) {
+        Map<String, Object> toReturn = new HashMap<>();
+        for (Map.Entry<List<String>, Object> listObjectEntry : params.entrySet()) {
+
+            List<String> allSteps = listObjectEntry.getKey();
+            List<String> steps = allSteps.subList(0, allSteps.size() - 1);
+            String lastStep = allSteps.get(allSteps.size() - 1);
+
+            Map<String, Object> targetMap = toReturn;
+            for (String step : steps) {
+                targetMap = (Map<String, Object>) targetMap.computeIfAbsent(step, k -> new HashMap<>());
+            }
+            targetMap.put(lastStep, listObjectEntry.getValue());
+        }
+        return toReturn;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+public class IndexedScenarioException extends ScenarioException {
+
+    private final int index;
+
+    private String fileName;
+
+    public IndexedScenarioException(int index, String message) {
+        super(message);
+        this.index = index;
+    }
+
+    public IndexedScenarioException(int index, String message, Throwable cause) {
+        super(message, cause);
+        this.index = index;
+    }
+
+    public IndexedScenarioException(int index, Throwable cause) {
+        super(cause);
+        this.index = index;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder message = new StringBuilder().append("#").append(index).append(": ").append(super.getMessage());
+        if (getFileName() != null) {
+            message.append("(").append(getFileName()).append(")");
+        }
+        return message.toString();
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunner.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.List;
+
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.backend.expression.BaseExpressionEvaluator;
+import org.kie.api.runtime.KieContainer;
+
+public class RuleScenarioRunner extends AbstractScenarioRunner {
+
+    public RuleScenarioRunner(KieContainer kieContainer, Simulation simulation) {
+        this(kieContainer, simulation, null);
+    }
+
+    public RuleScenarioRunner(KieContainer kieContainer, Simulation simulation, String fileName) {
+        this(kieContainer, simulation.getSimulationDescriptor(), simulation.getScenarioWithIndex(), fileName);
+    }
+
+    public RuleScenarioRunner(KieContainer kieContainer, SimulationDescriptor simulationDescriptor, List<ScenarioWithIndex> scenarios) {
+        this(kieContainer, simulationDescriptor, scenarios, null);
+    }
+
+    public RuleScenarioRunner(KieContainer kieContainer, SimulationDescriptor simulationDescriptor, List<ScenarioWithIndex> scenarios, String fileName) {
+        super(kieContainer, simulationDescriptor, scenarios, fileName, BaseExpressionEvaluator::new);
+    }
+
+    @Override
+    protected AbstractRunnerHelper newRunnerHelper(SimulationDescriptor simulationDescriptor) {
+        return new RuleScenarioRunnerHelper(simulationDescriptor);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.ExpressionElement;
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
+import org.drools.scenariosimulation.backend.fluent.RuleScenarioExecutableBuilder;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioGiven;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.drools.scenariosimulation.backend.util.ScenarioBeanUtil;
+import org.drools.scenariosimulation.backend.util.ScenarioBeanWrapper;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+
+import static java.util.stream.Collectors.toList;
+import static org.drools.scenariosimulation.backend.fluent.RuleScenarioExecutableBuilder.createBuilder;
+import static org.drools.scenariosimulation.backend.runner.model.ResultWrapper.createErrorResult;
+import static org.drools.scenariosimulation.backend.runner.model.ResultWrapper.createResult;
+import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.fillBean;
+
+public class RuleScenarioRunnerHelper extends AbstractRunnerHelper {
+
+    private final SimulationDescriptor simulationDescriptor;
+
+    public RuleScenarioRunnerHelper(SimulationDescriptor simulationDescriptor) {
+        this.simulationDescriptor = simulationDescriptor;
+    }
+
+    @Override
+    public RequestContext executeScenario(KieContainer kieContainer,
+                                          ScenarioRunnerData scenarioRunnerData,
+                                          ExpressionEvaluator expressionEvaluator,
+                                          SimulationDescriptor simulationDescriptor) {
+        if (!ScenarioSimulationModel.Type.RULE.equals(simulationDescriptor.getType())) {
+            throw new ScenarioException("Impossible to run a not-RULE simulation with RULE runner");
+        }
+        RuleScenarioExecutableBuilder ruleScenarioExecutableBuilder = createBuilder(kieContainer);
+        scenarioRunnerData.getGivens().stream().map(ScenarioGiven::getValue).forEach(ruleScenarioExecutableBuilder::insert);
+        // all new facts should be verified internally to the working memory
+        scenarioRunnerData.getExpects().stream()
+                .filter(ScenarioExpect::isNewFact)
+                .flatMap(output -> output.getExpectedResult().stream()
+                        .map(factMappingValue -> new ScenarioResult(output.getFactIdentifier(), factMappingValue)))
+                .forEach(scenarioResult -> {
+                    Class<?> clazz = ScenarioBeanUtil.loadClass(scenarioResult.getFactIdentifier().getClassName(), kieContainer.getClassLoader());
+                    scenarioRunnerData.addResult(scenarioResult);
+                    ruleScenarioExecutableBuilder.addInternalCondition(clazz,
+                                                                       createExtractorFunction(expressionEvaluator, scenarioResult.getFactMappingValue(), simulationDescriptor),
+                                                                       scenarioResult);
+                });
+
+        return ruleScenarioExecutableBuilder.run();
+    }
+
+    @Override
+    public void verifyConditions(SimulationDescriptor simulationDescriptor,
+                                 ScenarioRunnerData scenarioRunnerData,
+                                 ExpressionEvaluator expressionEvaluator,
+                                 RequestContext requestContext) {
+
+        for (ScenarioGiven input : scenarioRunnerData.getGivens()) {
+            FactIdentifier factIdentifier = input.getFactIdentifier();
+            List<ScenarioExpect> assertionOnFact = scenarioRunnerData.getExpects().stream()
+                    .filter(elem -> !elem.isNewFact())
+                    .filter(elem -> Objects.equals(elem.getFactIdentifier(), factIdentifier)).collect(toList());
+
+            // check if this fact has something to check
+            if (assertionOnFact.size() < 1) {
+                continue;
+            }
+
+            getScenarioResultsFromGivenFacts(simulationDescriptor, assertionOnFact, input, expressionEvaluator).forEach(scenarioRunnerData::addResult);
+        }
+    }
+
+    protected List<ScenarioResult> getScenarioResultsFromGivenFacts(SimulationDescriptor simulationDescriptor,
+                                                                    List<ScenarioExpect> scenarioOutputsPerFact,
+                                                                    ScenarioGiven input,
+                                                                    ExpressionEvaluator expressionEvaluator) {
+        FactIdentifier factIdentifier = input.getFactIdentifier();
+        Object factInstance = input.getValue();
+        List<ScenarioResult> scenarioResults = new ArrayList<>();
+        for (ScenarioExpect scenarioExpect : scenarioOutputsPerFact) {
+            if (scenarioExpect.isNewFact()) {
+                continue;
+            }
+
+            for (FactMappingValue expectedResult : scenarioExpect.getExpectedResult()) {
+
+                ScenarioResult scenarioResult = fillResult(expectedResult,
+                                                           factIdentifier,
+                                                           () -> createExtractorFunction(expressionEvaluator, expectedResult, simulationDescriptor)
+                                                                   .apply(factInstance));
+
+                scenarioResults.add(scenarioResult);
+            }
+        }
+        return scenarioResults;
+    }
+
+    protected Function<Object, ResultWrapper> createExtractorFunction(ExpressionEvaluator expressionEvaluator,
+                                                                      FactMappingValue expectedResult,
+                                                                      SimulationDescriptor simulationDescriptor) {
+        return objectToCheck -> {
+
+            ExpressionIdentifier expressionIdentifier = expectedResult.getExpressionIdentifier();
+
+            FactMapping factMapping = simulationDescriptor.getFactMapping(expectedResult.getFactIdentifier(), expressionIdentifier)
+                    .orElseThrow(() -> new IllegalStateException("Wrong expression, this should not happen"));
+
+            List<String> pathToValue = factMapping.getExpressionElementsWithoutClass().stream().map(ExpressionElement::getStep).collect(toList());
+            ScenarioBeanWrapper<?> scenarioBeanWrapper = ScenarioBeanUtil.navigateToObject(objectToCheck, pathToValue, false);
+            Object resultValue = scenarioBeanWrapper.getBean();
+
+            try {
+                return expressionEvaluator.evaluateUnaryExpression(expectedResult.getRawValue(), resultValue, scenarioBeanWrapper.getBeanClass()) ?
+                        createResult(resultValue) :
+                        createErrorResult();
+            } catch (Exception e) {
+                expectedResult.setError(true);
+                throw new ScenarioException(e.getMessage(), e);
+            }
+        };
+    }
+
+    @Override
+    public Object createObject(String className, Map<List<String>, Object> params, ClassLoader classLoader) {
+        return fillBean(className, params, classLoader);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioAssumptionViolatedException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioAssumptionViolatedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.junit.AssumptionViolatedException;
+
+public class ScenarioAssumptionViolatedException extends AssumptionViolatedException {
+
+    private final Scenario scenario;
+    private final ScenarioResult scenarioResult;
+
+    public ScenarioAssumptionViolatedException(Scenario scenario, ScenarioResult scenarioResult, String message) {
+        super(message);
+        this.scenario = scenario;
+        this.scenarioResult = scenarioResult;
+    }
+
+    public ScenarioAssumptionViolatedException(Scenario scenario, ScenarioResult scenarioResult, String assumption, Throwable t) {
+        super(assumption, t);
+        this.scenario = scenario;
+        this.scenarioResult = scenarioResult;
+    }
+
+    public Scenario getScenario() {
+        return scenario;
+    }
+
+    public ScenarioResult getScenarioResult() {
+        return scenarioResult;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+public class ScenarioException extends IllegalArgumentException {
+
+    public ScenarioException(String message) {
+        super(message);
+    }
+
+    public ScenarioException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ScenarioException(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioJunitActivator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioJunitActivator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.backend.runner.model.SimulationWithFileName;
+import org.drools.scenariosimulation.backend.util.ScenarioSimulationXMLPersistence;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieContainer;
+
+import static org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils.FILE_EXTENSION;
+import static org.drools.scenariosimulation.backend.util.ResourceHelper.getResourcesByExtension;
+
+public class ScenarioJunitActivator extends ParentRunner<SimulationWithFileName> {
+
+    public static final String ACTIVATOR_CLASS_NAME = "ScenarioJunitActivatorTest";
+
+    public static final Function<String, String> ACTIVATOR_CLASS_CODE = modulePackage ->
+            String.format("package %s;\n/**\n* Do not remove this file\n*/\n@%s(%s.class)\npublic class %s {\n}",
+                          modulePackage,
+                          RunWith.class.getCanonicalName(),
+                          ScenarioJunitActivator.class.getCanonicalName(),
+                          ScenarioJunitActivator.ACTIVATOR_CLASS_NAME);
+
+    public ScenarioJunitActivator(Class<?> testClass) throws InitializationError {
+        super(testClass);
+    }
+
+    @Override
+    protected List<SimulationWithFileName> getChildren() {
+        return getResources().map(elem -> {
+            try {
+                String rawFile = new Scanner(new File(elem)).useDelimiter("\\Z").next();
+                return new SimulationWithFileName(getXmlReader().unmarshal(rawFile).getSimulation(), elem);
+            } catch (FileNotFoundException e) {
+                throw new ScenarioException("File not found, this should not happen: " + elem, e);
+            }
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Description describeChild(SimulationWithFileName child) {
+        return AbstractScenarioRunner.getDescriptionForSimulation(Optional.of(child.getFileName()), child.getSimulation());
+    }
+
+    @Override
+    protected void runChild(SimulationWithFileName child, RunNotifier notifier) {
+        KieContainer kieClasspathContainer = getKieContainer();
+        AbstractScenarioRunner scenarioRunner = newRunner(kieClasspathContainer, child.getSimulation(), child.getFileName());
+        scenarioRunner.run(notifier);
+    }
+
+    ScenarioSimulationXMLPersistence getXmlReader() {
+        return ScenarioSimulationXMLPersistence.getInstance();
+    }
+
+    Stream<String> getResources() {
+        return getResourcesByExtension(FILE_EXTENSION);
+    }
+
+    KieContainer getKieContainer() {
+        return KieServices.get().getKieClasspathContainer();
+    }
+
+    AbstractScenarioRunner newRunner(KieContainer kieContainer, Simulation simulation, String fileName) {
+        AbstractScenarioRunner runner = AbstractScenarioRunner.getSpecificRunnerProvider(simulation.getSimulationDescriptor())
+                .create(kieContainer, simulation.getSimulationDescriptor(), simulation.getScenarioWithIndex());
+        runner.setFileName(fileName);
+        return runner;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioRunnerProvider.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/ScenarioRunnerProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.List;
+
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.kie.api.runtime.KieContainer;
+
+@FunctionalInterface
+public interface ScenarioRunnerProvider {
+
+    AbstractScenarioRunner create(KieContainer kieContainer,
+                                  SimulationDescriptor simulationDescriptor,
+                                  List<ScenarioWithIndex> scenarios);
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/SimulationRunMetadataBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/SimulationRunMetadataBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.SimulationRunMetadata;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
+
+public class SimulationRunMetadataBuilder {
+
+    protected List<ScenarioResultMetadata> scenarioResultMetadata = new ArrayList<>();
+
+    private SimulationRunMetadataBuilder() {
+    }
+
+    public SimulationRunMetadataBuilder addScenarioResultMetadata(ScenarioResultMetadata scenarioResultMetadata) {
+        this.scenarioResultMetadata.add(scenarioResultMetadata);
+        return this;
+    }
+
+    public SimulationRunMetadata build() {
+        int available = 0;
+        Map<String, Integer> outputCounter = new HashMap<>();
+        Map<ScenarioWithIndex, List<String>> scenarioCounter = new HashMap<>();
+        for (ScenarioResultMetadata scenarioResultMetadatum : scenarioResultMetadata) {
+            // this value is the same for all the scenarios
+            available = scenarioResultMetadatum.getAvailable().size();
+            scenarioResultMetadatum.getExecuted()
+                    .forEach(name -> outputCounter.compute(name,
+                                                           (key, number) -> number == null ? 1 : number + 1));
+        }
+
+        for (ScenarioResultMetadata scenarioResultMetadatum : scenarioResultMetadata) {
+            scenarioCounter.put(scenarioResultMetadatum.getScenarioWithIndex(),
+                                new ArrayList<>(scenarioResultMetadatum.getExecuted()));
+        }
+        return new SimulationRunMetadata(available, outputCounter.keySet().size(), outputCounter, scenarioCounter);
+    }
+
+    public static SimulationRunMetadataBuilder create() {
+        return new SimulationRunMetadataBuilder();
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ResultWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ResultWrapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import java.util.function.Supplier;
+
+/**
+ * java.util.Optional clone to have the null result
+ * @param <T>
+ */
+public class ResultWrapper<T> {
+
+    private final boolean satisfied;
+
+    private final T result;
+
+    private ResultWrapper(T result, boolean satisfied) {
+        this.satisfied = satisfied;
+        this.result = result;
+    }
+
+    public static <T> ResultWrapper<T> createResult(T result) {
+        return new ResultWrapper<>(result, true);
+    }
+
+    public static <T> ResultWrapper<T> createErrorResult() {
+        return new ResultWrapper<>(null, false);
+    }
+
+    public boolean isSatisfied() {
+        return satisfied;
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    public T orElse(T defaultValue) {
+        return satisfied ? result : defaultValue;
+    }
+
+    public T orElseGet(Supplier<T> defaultSupplier) {
+        return satisfied ? result : defaultSupplier.get();
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioExpect.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioExpect.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import java.util.List;
+
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+
+public class ScenarioExpect {
+
+    private final FactIdentifier factIdentifier;
+
+    private final List<FactMappingValue> expectedResult;
+
+    private final boolean isNewFact;
+
+    public ScenarioExpect(FactIdentifier factIdentifier, List<FactMappingValue> expectedResult, boolean isNewFact) {
+        this.factIdentifier = factIdentifier;
+        this.expectedResult = expectedResult;
+        this.isNewFact = isNewFact;
+    }
+
+    public ScenarioExpect(FactIdentifier factIdentifier, List<FactMappingValue> expectedResult) {
+        this(factIdentifier, expectedResult, false);
+    }
+
+    public FactIdentifier getFactIdentifier() {
+        return factIdentifier;
+    }
+
+    public List<FactMappingValue> getExpectedResult() {
+        return expectedResult;
+    }
+
+    public boolean isNewFact() {
+        return isNewFact;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioGiven.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioGiven.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+
+public class ScenarioGiven {
+
+    private final FactIdentifier factIdentifier;
+    private final Object value;
+
+    public ScenarioGiven(FactIdentifier factIdentifier, Object value) {
+        this.factIdentifier = factIdentifier;
+        this.value = value;
+    }
+
+    public FactIdentifier getFactIdentifier() {
+        return factIdentifier;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResult.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResult.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import java.util.Optional;
+
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+
+public class ScenarioResult {
+
+    private final FactIdentifier factIdentifier;
+    private final FactMappingValue factMappingValue;
+    private final Object resultValue;
+    private boolean result = false;
+
+    public ScenarioResult(FactIdentifier factIdentifier, FactMappingValue factMappingValue) {
+        this(factIdentifier, factMappingValue, null);
+    }
+
+    public ScenarioResult(FactIdentifier factIdentifier, FactMappingValue factMappingValue, Object resultValue) {
+        this.factIdentifier = factIdentifier;
+        this.factMappingValue = factMappingValue;
+        this.resultValue = resultValue;
+    }
+
+    public FactIdentifier getFactIdentifier() {
+        return factIdentifier;
+    }
+
+    public FactMappingValue getFactMappingValue() {
+        return factMappingValue;
+    }
+
+    public Optional<Object> getResultValue() {
+        return Optional.ofNullable(resultValue);
+    }
+
+    public ScenarioResult setResult(boolean result) {
+        this.result = result;
+        return this;
+    }
+
+    public boolean getResult() {
+        return result;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResultMetadata.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioResultMetadata.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+
+public class ScenarioResultMetadata {
+
+    protected final Set<String> available = new HashSet<>();
+
+    protected final Set<String> executed = new HashSet<>();
+
+    protected final ScenarioWithIndex scenarioWithIndex;
+
+    public ScenarioResultMetadata(ScenarioWithIndex scenarioWithIndex) {
+        this.scenarioWithIndex = scenarioWithIndex;
+    }
+
+    public void addAvailable(String element) {
+        available.add(element);
+    }
+
+    public void addExecuted(String element) {
+        executed.add(element);
+    }
+
+    public Set<String> getAvailable() {
+        return Collections.unmodifiableSet(available);
+    }
+
+    public Set<String> getExecuted() {
+        return Collections.unmodifiableSet(executed);
+    }
+
+    public ScenarioWithIndex getScenarioWithIndex() {
+        return scenarioWithIndex;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioRunnerData.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ScenarioRunnerData.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Class to group all runner data: given data, expected data and results
+ */
+public class ScenarioRunnerData {
+
+    private final List<ScenarioGiven> givens = new ArrayList<>();
+    private final List<ScenarioExpect> expects = new ArrayList<>();
+    private final List<ScenarioResult> results = new ArrayList<>();
+    private ScenarioResultMetadata metadata;
+
+    public void addGiven(ScenarioGiven input) {
+        givens.add(input);
+    }
+
+    public void addExpect(ScenarioExpect output) {
+        expects.add(output);
+    }
+
+    public void addResult(ScenarioResult result) {
+        results.add(result);
+    }
+
+    public void setMetadata(ScenarioResultMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public List<ScenarioGiven> getGivens() {
+        return Collections.unmodifiableList(givens);
+    }
+
+    public List<ScenarioExpect> getExpects() {
+        return Collections.unmodifiableList(expects);
+    }
+
+    public List<ScenarioResult> getResults() {
+        return Collections.unmodifiableList(results);
+    }
+
+    public Optional<ScenarioResultMetadata> getMetadata() {
+        return Optional.ofNullable(metadata);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/SimulationWithFileName.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/SimulationWithFileName.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import org.drools.scenariosimulation.api.model.Simulation;
+
+public class SimulationWithFileName {
+
+    private final Simulation simulation;
+    private final String fileName;
+
+    public SimulationWithFileName(Simulation simulation, String fileName) {
+        this.simulation = simulation;
+        this.fileName = fileName;
+    }
+
+    public Simulation getSimulation() {
+        return simulation;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DMNSimulationUtils.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DMNSimulationUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.kie.api.runtime.KieContainer;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNRuntime;
+
+public class DMNSimulationUtils {
+
+    private static String delimiter = "/";
+
+    private DMNSimulationUtils() {
+    }
+
+    public static DMNModel extractDMNModel(DMNRuntime dmnRuntime, String path) {
+        List<String> pathSplit = Arrays.asList(new StringBuilder(path).reverse().toString().split(delimiter));
+        List<DMNModel> dmnModels = dmnRuntime.getModels();
+
+        return findDMNModel(dmnModels, pathSplit, 1);
+    }
+
+    public static DMNRuntime extractDMNRuntime(KieContainer kieContainer) {
+        return kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
+    }
+
+    public static DMNModel findDMNModel(List<DMNModel> dmnModels, List<String> pathToFind, int step) {
+        List<DMNModel> result = new ArrayList<>();
+        String pathToCompare = String.join(delimiter, pathToFind.subList(0, step));
+        for (DMNModel dmnModel : dmnModels) {
+            String modelPath = new StringBuilder(dmnModel.getResource().getSourcePath()).reverse().toString();
+            if (modelPath.startsWith(pathToCompare)) {
+                result.add(dmnModel);
+            }
+        }
+        if (result.size() == 0) {
+            throw new IllegalArgumentException("Retrieving the DMNModel has failed. Make sure the used DMN asset does not " +
+                                                       "produce any compilation errors and that the project does not " +
+                                                       "contain multiple DMN assets with the same name and namespace. " +
+                                                       "After addressing the issues, build the project again.");
+        } else if (result.size() == 1) {
+            return result.get(0);
+        } else {
+            return findDMNModel(dmnModels, pathToFind, step + 1);
+        }
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/InMemoryMigrationStrategy.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/InMemoryMigrationStrategy.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.ExpressionElement;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+
+public class InMemoryMigrationStrategy implements MigrationStrategy {
+
+    @Override
+    public Function<String, String> from1_0to1_1() {
+        return rawXml -> rawXml.replaceAll("EXPECTED", "EXPECT").replaceAll("<ScenarioSimulationModel version=\"1.0\">", "<ScenarioSimulationModel version=\"1.1\">");
+    }
+
+    @Override
+    public Function<String, String> from1_1to1_2() {
+        return rawXml -> {
+            if ((rawXml.contains("<dmoSession>") || (rawXml.contains("<dmnFilePath>")) && (rawXml.contains("<type>")))) {
+                return rawXml.replaceAll("<ScenarioSimulationModel version=\"1.1\">", "<ScenarioSimulationModel version=\"1.2\">");
+            } else {
+                return rawXml.replaceAll("</simulationDescriptor>", "<dmoSession></dmoSession>\n<type>RULE</type>\n</simulationDescriptor>").replaceAll("<ScenarioSimulationModel version=\"1.1\">", "<ScenarioSimulationModel version=\"1.2\">");
+            }
+        };
+    }
+
+    @Override
+    public Function<String, String> from1_2to1_3() {
+        return rawXml -> {
+            ScenarioSimulationXMLPersistence xmlPersistence = ScenarioSimulationXMLPersistence.getInstance();
+            ScenarioSimulationModel model = xmlPersistence.unmarshal(rawXml, false);
+            for (FactMapping factMapping : model.getSimulation().getSimulationDescriptor().getUnmodifiableFactMappings()) {
+                factMapping.getExpressionElements().add(0, new ExpressionElement(factMapping.getFactIdentifier().getName()));
+            }
+            return xmlPersistence.marshal(model).replaceAll("<ScenarioSimulationModel version=\"1.2\">", "<ScenarioSimulationModel version=\"1.3\">");
+        };
+    }
+
+    @Override
+    public Function<String, String> from1_3to1_4() {
+        return rawXml -> {
+            if (rawXml.contains("<type>")) {
+                StringBuilder replacementBuilder = new StringBuilder();
+                String toReplace = null;
+                if (rawXml.contains("<type>RULE</type>")) {
+                    toReplace = "<type>RULE</type>";
+                    if (!rawXml.contains("<kieSession>")) {
+                        replacementBuilder.append("<kieSession>default</kieSession>\n");
+                    }
+                    if (!rawXml.contains("<kieBase>")) {
+                        replacementBuilder.append("<kieBase>default</kieBase>\n");
+                    }
+                    if (!rawXml.contains("<ruleFlowGroup>")) {
+                        replacementBuilder.append("<ruleFlowGroup>default</ruleFlowGroup>\n");
+                    }
+                    if (!rawXml.contains("<skipFromBuild>")) {
+                        replacementBuilder.append("<skipFromBuild>false</skipFromBuild>\n");
+                    }
+                    replacementBuilder.append("<type>RULE</type>");
+                } else if (rawXml.contains("<type>DMN</type>")) {
+                    toReplace = "<type>DMN</type>";
+                    if (!rawXml.contains("<dmnNamespace>")) {
+                        replacementBuilder.append("<dmnNamespace></dmnNamespace>\n");
+                    }
+                    if (!rawXml.contains("<dmnName>")) {
+                        replacementBuilder.append("<dmnName></dmnName>\n");
+                    }
+                    if (!rawXml.contains("<skipFromBuild>")) {
+                        replacementBuilder.append("<skipFromBuild>false</skipFromBuild>\n");
+                    }
+                    replacementBuilder.append("<type>DMN</type>");
+                }
+                String toReturn = rawXml.replaceAll("<ScenarioSimulationModel version=\"1.3\">", "<ScenarioSimulationModel version=\"1.4\">")
+                        .replaceAll("<simulationDescriptor>", "<simulationDescriptor>\n  <fileName></fileName>");
+                String replacement = replacementBuilder.toString();
+                if (toReplace != null && !toReplace.equals(replacement)) {
+                    toReturn = toReturn.replaceAll(toReplace, replacement);
+                }
+                return toReturn;
+            } else {
+                return rawXml;
+            }
+        };
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/MigrationStrategy.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/MigrationStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.util.function.Function;
+
+/**
+ * Interface to define the migration strategy for scesim files
+ */
+public interface MigrationStrategy {
+
+    /**
+     * Method to initialize migration strategy composition
+     * @return
+     */
+    default Function<String, String> start() {
+        return Function.identity();
+    }
+
+    /**
+     * Method to obtain the migration function from 1.0 to 1.1
+     * @return
+     */
+    Function<String, String> from1_0to1_1();
+
+    /**
+     * Method to obtain the migration function from 1.1 to 1.2
+     * @return
+     */
+    Function<String, String> from1_1to1_2();
+
+    /**
+     * Method to obtain the migration function from 1.2 to 1.3
+     * @return
+     */
+    Function<String, String> from1_2to1_3();
+
+    /**
+     * Method to obtain the migration function from 1.2 to 1.3
+     * @return
+     */
+    Function<String, String> from1_3to1_4();
+
+    /**
+     * Method to complete the migration. For instance it can be used to store the new value
+     * @return
+     */
+    default Function<String, String> end() {
+        return Function.identity();
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ResourceHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ResourceHelper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
+
+/**
+ * Utility that provide classPath scan to retrieve resources
+ */
+public class ResourceHelper {
+
+    private ResourceHelper() {
+    }
+
+    static String[] getClassPathElements() {
+        return System.getProperty("java.class.path", ".").split(System.getProperty("path.separator"));
+    }
+
+    /**
+     * Scan into classpath folders to find resources with the required extension
+     * @param extension to find
+     * @return stream of matching resources
+     */
+    public static Stream<String> getResourcesByExtension(String extension) {
+        return Arrays.stream(getClassPathElements())
+                .flatMap(elem -> internalGetResources(elem, Pattern.compile(".*\\." + extension + "$")));
+    }
+
+    /**
+     * This method is internal because it works only with folder to explore (classPath folder) and not with exact paths
+     * @param path to folder or jar
+     * @param pattern to find
+     * @return stream of matching resources
+     */
+    static Stream<String> internalGetResources(String path, Pattern pattern) {
+        final File file = new File(path);
+        if (!file.isDirectory()) {
+            return Stream.empty();
+        }
+        return getResourcesFromDirectory(file, pattern);
+    }
+
+    /**
+     * Scan folder to find resources that match with pattern
+     * @param directory where to start the search
+     * @param pattern to find
+     * @return stream of matching resources
+     */
+    public static Stream<String> getResourcesFromDirectory(File directory, Pattern pattern) {
+        if (directory == null || directory.listFiles() == null) {
+            return Stream.empty();
+        }
+        return Arrays.stream(directory.listFiles()).flatMap(elem -> {
+            if (elem.isDirectory()) {
+                return getResourcesFromDirectory(elem, pattern);
+            } else {
+                try {
+                    String fileName = elem.getCanonicalPath();
+                    if (pattern.matcher(fileName).matches()) {
+                        return Stream.of(fileName);
+                    }
+                } catch (final IOException e) {
+                    throw new ScenarioException("Impossible to access to resources", e);
+                }
+            }
+            return Stream.empty();
+        });
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
+
+public class ScenarioBeanUtil {
+
+    private static final Map<String, Class<?>> primitiveMap = new HashMap<>();
+
+    static {
+        primitiveMap.put("boolean", boolean.class);
+        primitiveMap.put("int", int.class);
+        primitiveMap.put("long", long.class);
+        primitiveMap.put("double", double.class);
+        primitiveMap.put("float", float.class);
+        primitiveMap.put("char", char.class);
+        primitiveMap.put("byte", byte.class);
+        primitiveMap.put("short", short.class);
+    }
+
+    private ScenarioBeanUtil() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T fillBean(String className, Map<List<String>, Object> params, ClassLoader classLoader) {
+
+        Class<T> clazz = loadClass(className, classLoader);
+        T beanToFill = newInstance(clazz);
+
+        for (Map.Entry<List<String>, Object> param : params.entrySet()) {
+            try {
+                fillProperty(beanToFill, param.getKey(), param.getValue());
+            } catch (ReflectiveOperationException e) {
+                throw new ScenarioException(new StringBuilder().append("Impossible to fill ").append(className)
+                                                    .append(" with the provided properties").toString(), e);
+            }
+        }
+
+        return beanToFill;
+    }
+
+    private static <T> void fillProperty(T beanToFill, List<String> steps, Object propertyValue) throws ReflectiveOperationException {
+        List<String> pathToProperty = steps.subList(0, steps.size() - 1);
+        String lastStep = steps.get(steps.size() - 1);
+
+        Object currentObject = beanToFill;
+        if (pathToProperty.size() > 0) {
+            ScenarioBeanWrapper<?> scenarioBeanWrapper = navigateToObject(beanToFill, pathToProperty, true);
+            currentObject = scenarioBeanWrapper.getBean();
+        }
+
+        Field last = currentObject.getClass().getDeclaredField(lastStep);
+        last.setAccessible(true);
+        last.set(currentObject, propertyValue);
+    }
+
+    public static ScenarioBeanWrapper<?> navigateToObject(Object rootObject, List<String> steps) {
+        return navigateToObject(rootObject, steps, true);
+    }
+
+    public static ScenarioBeanWrapper<?> navigateToObject(Object rootObject, List<String> steps, boolean createIfNull) {
+        Class<?> currentClass = rootObject != null ? rootObject.getClass() : null;
+        Object currentObject = rootObject;
+
+        for (String step : steps) {
+            Field declaredField = null;
+            try {
+                if (currentObject == null) {
+                    throw new ScenarioException(new StringBuilder().append("Impossible to reach field ")
+                                                        .append(step).append(" because a step is not instantiated")
+                                                        .toString());
+                }
+                declaredField = currentClass.getDeclaredField(step);
+            } catch (NoSuchFieldException e) {
+                throw new ScenarioException(new StringBuilder().append("Impossible to find field with name '")
+                                                    .append(step).append("' in class ")
+                                                    .append(currentClass.getCanonicalName()).toString(), e);
+            }
+            declaredField.setAccessible(true);
+            currentClass = declaredField.getType();
+            try {
+                currentObject = getFieldValue(declaredField, currentObject, createIfNull);
+            } catch (ReflectiveOperationException e) {
+                throw new ScenarioException(new StringBuilder().append("Impossible to get or create class ")
+                                                    .append(currentClass.getCanonicalName()).toString());
+            }
+        }
+
+        return new ScenarioBeanWrapper<>(currentObject, currentClass);
+    }
+
+    private static Object getFieldValue(Field declaredField, Object currentObject, boolean createIfNull) throws ReflectiveOperationException {
+        Object value = declaredField.get(currentObject);
+        if (value == null && createIfNull) {
+            value = newInstance(declaredField.getType());
+            declaredField.set(currentObject, value);
+        }
+        return value;
+    }
+
+    private static <T> T newInstance(Class<T> clazz) {
+        try {
+            return clazz.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new ScenarioException(new StringBuilder().append("Class ").append(clazz.getCanonicalName())
+                                                .append(" has no empty constructor").toString(), e);
+        }
+    }
+
+    public static Object convertValue(String className, Object cleanValue, ClassLoader classLoader) {
+        if (!isPrimitive(className) && cleanValue == null) {
+            return null;
+        }
+
+        Class<?> clazz = loadClass(className, classLoader);
+
+        // if it is not a String, it has to be an instance of the desired type
+        if (!(cleanValue instanceof String)) {
+            if (clazz.isInstance(cleanValue)) {
+                return cleanValue;
+            }
+            throw new IllegalArgumentException(new StringBuilder().append("Object ").append(cleanValue)
+                                                       .append(" is not a String or an instance of ").append(className).toString());
+        }
+
+        String value = (String) cleanValue;
+
+        if (clazz.isAssignableFrom(String.class)) {
+            return value;
+        } else if (clazz.isAssignableFrom(Boolean.class) || clazz.isAssignableFrom(boolean.class)) {
+            return parseBoolean(value);
+        } else if (clazz.isAssignableFrom(Integer.class) || clazz.isAssignableFrom(int.class)) {
+            return Integer.parseInt(cleanStringForNumberParsing(value));
+        } else if (clazz.isAssignableFrom(Long.class) || clazz.isAssignableFrom(long.class)) {
+            return Long.parseLong(cleanStringForNumberParsing(value));
+        } else if (clazz.isAssignableFrom(Double.class) || clazz.isAssignableFrom(double.class)) {
+            return Double.parseDouble(cleanStringForNumberParsing(value));
+        } else if (clazz.isAssignableFrom(Float.class) || clazz.isAssignableFrom(float.class)) {
+            return Float.parseFloat(cleanStringForNumberParsing(value));
+        } else if (clazz.isAssignableFrom(Character.class) || clazz.isAssignableFrom(char.class)) {
+            return parseChar(value);
+        } else if (clazz.isAssignableFrom(Byte.class) || clazz.isAssignableFrom(byte.class)) {
+            return parseByte(value);
+        } else if (clazz.isAssignableFrom(Short.class) || clazz.isAssignableFrom(short.class)) {
+            return Short.parseShort(cleanStringForNumberParsing(value));
+        }
+
+        throw new IllegalArgumentException(new StringBuilder().append("Class ").append(className)
+                                                   .append(" is not supported").toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Class<T> loadClass(String className, ClassLoader classLoader) {
+        if (isPrimitive(className)) {
+            return (Class<T>) primitiveMap.get(className);
+        }
+        try {
+            return (Class<T>) classLoader.loadClass(className);
+        } catch (ClassNotFoundException | NullPointerException e) {
+            throw new ScenarioException(new StringBuilder().append("Impossible to load class ").append(className).toString(), e);
+        }
+    }
+
+    private static boolean isPrimitive(String className) {
+        return primitiveMap.containsKey(className);
+    }
+
+    private static boolean parseBoolean(String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        } else if ("false".equalsIgnoreCase(value)) {
+            return false;
+        } else {
+            throw new IllegalArgumentException("Impossible to parse as boolean " + value);
+        }
+    }
+
+    private static char parseChar(String value) {
+        if (value == null || value.length() != 1) {
+            throw new IllegalArgumentException("Impossible to transform " + value + "as char");
+        }
+        return value.charAt(0);
+    }
+
+    private static byte parseByte(String value) {
+        if (value == null || value.length() != 1) {
+            throw new IllegalArgumentException("Impossible to transform " + value + "as byte");
+        }
+        return value.getBytes()[0];
+    }
+
+    private static String cleanStringForNumberParsing(String rawValue) {
+        return rawValue.replaceAll("(-)\\s*([0-9])", "$1$2");
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+public class ScenarioBeanWrapper<T> {
+
+    private final Object bean;
+    private final Class<T> beanClass;
+
+    public ScenarioBeanWrapper(Object bean, Class<T> beanClass) {
+        this.beanClass = beanClass;
+        this.bean = bean;
+    }
+
+    public Object getBean() {
+        return bean;
+    }
+
+    public Class<T> getBeanClass() {
+        return beanClass;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.DomDriver;
+import org.drools.scenariosimulation.api.model.ExpressionElement;
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingType;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.kie.soup.commons.xstream.XStreamUtils;
+import org.kie.soup.project.datamodel.imports.Import;
+
+public class ScenarioSimulationXMLPersistence {
+
+    private XStream xt;
+    private static final ScenarioSimulationXMLPersistence INSTANCE = new ScenarioSimulationXMLPersistence();
+    private static final String currentVersion = new ScenarioSimulationModel().getVersion();
+    private static final Pattern p = Pattern.compile("version=\"([0-9]+\\.[0-9]+)");
+    private MigrationStrategy migrationStrategy = new InMemoryMigrationStrategy();
+
+    private ScenarioSimulationXMLPersistence() {
+        xt = XStreamUtils.createTrustingXStream(new DomDriver());
+
+        xt.autodetectAnnotations(true);
+
+        xt.alias("ExpressionElement", ExpressionElement.class);
+        xt.alias("ExpressionIdentifier", ExpressionIdentifier.class);
+        xt.alias("FactIdentifier", FactIdentifier.class);
+        xt.alias("FactMapping", FactMapping.class);
+        xt.alias("FactMappingType", FactMappingType.class);
+        xt.alias("FactMappingValue", FactMappingValue.class);
+        xt.alias("Scenario", Scenario.class);
+        xt.alias("ScenarioSimulationModel", ScenarioSimulationModel.class);
+        xt.alias("Simulation", Simulation.class);
+        xt.alias("SimulationDescriptor", SimulationDescriptor.class);
+
+        xt.alias("Import", Import.class);
+    }
+
+    public static ScenarioSimulationXMLPersistence getInstance() {
+        return INSTANCE;
+    }
+
+    public String marshal(final ScenarioSimulationModel sc) {
+        return xt.toXML(sc);
+    }
+
+    public ScenarioSimulationModel unmarshal(final String rawXml) {
+        return unmarshal(rawXml, true);
+    }
+
+    public ScenarioSimulationModel unmarshal(final String rawXml, boolean migrate) {
+        if (rawXml == null) {
+            return new ScenarioSimulationModel();
+        }
+        if (rawXml.trim().equals("")) {
+            return new ScenarioSimulationModel();
+        }
+
+        String xml = migrate ? migrateIfNecessary(rawXml) : rawXml;
+
+        return internalUnmarshal(xml);
+    }
+
+    public String migrateIfNecessary(String rawXml) {
+        String fileVersion = extractVersion(rawXml);
+        Function<String, String> migrator = getMigrationStrategy().start();
+        boolean supported = currentVersion.equals(fileVersion);
+        switch (fileVersion) {
+            case "1.0":
+                migrator = migrator.andThen(getMigrationStrategy().from1_0to1_1());
+            case "1.1":
+                migrator = migrator.andThen(getMigrationStrategy().from1_1to1_2());
+            case "1.2":
+                migrator = migrator.andThen(getMigrationStrategy().from1_2to1_3());
+            case "1.3":
+                migrator = migrator.andThen(getMigrationStrategy().from1_3to1_4());
+                supported = true;
+        }
+        if (!supported) {
+            throw new IllegalArgumentException(new StringBuilder().append("Version ").append(fileVersion)
+                                                       .append(" of the file is not supported. Current version is ")
+                                                       .append(currentVersion).toString());
+        }
+        migrator = migrator.andThen(getMigrationStrategy().end());
+        return migrator.apply(rawXml);
+    }
+
+    public String extractVersion(String rawXml) {
+        Matcher m = p.matcher(rawXml);
+
+        if (m.find()) {
+            return m.group(1);
+        }
+        throw new IllegalArgumentException("Impossible to extract version from the file");
+    }
+
+    public MigrationStrategy getMigrationStrategy() {
+        return migrationStrategy;
+    }
+
+    public void setMigrationStrategy(MigrationStrategy migrationStrategy) {
+        this.migrationStrategy = migrationStrategy;
+    }
+
+    public static String getCurrentVersion() {
+        return currentVersion;
+    }
+
+    protected ScenarioSimulationModel internalUnmarshal(String xml) {
+        Object o = xt.fromXML(xml);
+        return (ScenarioSimulationModel) o;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AbstractExpressionEvaluatorTest {
+
+    JsonNodeFactory factory = JsonNodeFactory.instance;
+
+    @Test
+    public void convertList() {
+        // Test simple list
+        ArrayNode jsonNodes = new ArrayNode(factory);
+        ObjectNode objectNode = new ObjectNode(factory);
+        objectNode.put("value", "data");
+        jsonNodes.add(objectNode);
+
+        List<Object> objects = expressionEvaluatorMock.createAndFillList(jsonNodes,
+                                                                         new ArrayList<>(),
+                                                                         List.class.getCanonicalName(),
+                                                                         Collections.singletonList(String.class.getCanonicalName()));
+        assertEquals("data", objects.get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void convertObject() {
+        // single level
+        ObjectNode objectNode = new ObjectNode(factory);
+        objectNode.put("age", "1");
+
+        Object result = expressionEvaluatorMock.createAndFillObject(objectNode,
+                                                                    new HashMap<>(),
+                                                                    Map.class.getCanonicalName(),
+                                                                    Collections.singletonList(String.class.getCanonicalName()));
+
+        assertTrue(result instanceof Map);
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+
+        assertEquals("1", resultMap.get("age"));
+
+        // nested object
+        objectNode.removeAll();
+        ObjectNode nestedObject = new ObjectNode(factory);
+        objectNode.set("nested", nestedObject);
+        nestedObject.put("field", "fieldValue");
+
+        result = expressionEvaluatorMock.createAndFillObject(objectNode,
+                                                             new HashMap<>(),
+                                                             String.class.getCanonicalName(),
+                                                             Collections.emptyList());
+
+        assertTrue(result instanceof Map);
+        resultMap = (Map<String, Object>) result;
+
+        assertEquals(1, resultMap.size());
+        Map<String, Object> nested = (Map<String, Object>) resultMap.get("nested");
+        assertEquals(1, nested.size());
+        assertEquals("fieldValue", nested.get("field"));
+
+        // nested list
+        objectNode.removeAll();
+        ArrayNode jsonNodes = new ArrayNode(factory);
+        objectNode.set("listField", jsonNodes);
+        jsonNodes.add(nestedObject);
+
+        result = expressionEvaluatorMock.createAndFillObject(objectNode,
+                                                             new HashMap<>(),
+                                                             String.class.getCanonicalName(),
+                                                             Collections.emptyList());
+
+        assertTrue(result instanceof Map);
+        resultMap = (Map<String, Object>) result;
+
+        assertEquals(1, resultMap.size());
+        List<Map<String, Object>> nestedList = (List<Map<String, Object>>) resultMap.get("listField");
+        assertEquals(1, nestedList.size());
+        assertEquals("fieldValue", nestedList.get(0).get("field"));
+    }
+
+    AbstractExpressionEvaluator expressionEvaluatorMock = new AbstractExpressionEvaluator() {
+
+        @Override
+        public boolean evaluateUnaryExpression(Object rawExpression, Object resultValue, Class<?> resultClass) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object evaluateLiteralExpression(String className, List<String> genericClasses, Object raw) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Object extractFieldValue(Object result, String fieldName) {
+            return result;
+        }
+
+        @Override
+        protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString) {
+            return true;
+        }
+
+        @Override
+        protected Object internalLiteralEvaluation(String raw, String className) {
+            return raw;
+        }
+
+        @Override
+        protected Object createObject(String className, List<String> genericClasses) {
+            return new HashMap<>();
+        }
+
+        @Override
+        protected void setField(Object toReturn, String fieldName, Object fieldValue) {
+            ((Map) toReturn).put(fieldName, fieldValue);
+        }
+
+        @Override
+        protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses) {
+            return new AbstractMap.SimpleEntry<>("", Collections.singletonList(""));
+        }
+    };
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.scenariosimulation.backend.model.ListMapClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BaseExpressionEvaluatorTest {
+
+    private final static ClassLoader classLoader = BaseExpressionEvaluatorTest.class.getClassLoader();
+
+    @Test
+    public void evaluateLiteralExpression() {
+        BaseExpressionEvaluator baseExpressionEvaluator = new BaseExpressionEvaluator(classLoader);
+
+        Object raw = new Object();
+        assertEquals(raw, baseExpressionEvaluator.evaluateLiteralExpression(Object.class.getCanonicalName(), Collections.emptyList(), raw));
+
+        raw = "SimpleString";
+        assertEquals(raw, baseExpressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), raw));
+
+        raw = "= SimpleString";
+        assertEquals("SimpleString", baseExpressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), raw));
+
+        assertNull(baseExpressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), null));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void expressionTest() {
+        BaseExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
+
+        String listJsonString = "[{\"name\": \"John\"}, " +
+                "{\"name\": \"John\", \"names\" : [{\"value\": \"Anna\"}, {\"value\": \"Mario\"}]}]";
+
+        List<ListMapClass> parsedValue = (List<ListMapClass>) expressionEvaluator.convertResult(listJsonString, List.class.getCanonicalName(),
+                                                                                                Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(2, parsedValue.size());
+        assertEquals(2, parsedValue.get(1).getNames().size());
+        assertTrue(parsedValue.get(1).getNames().contains("Anna"));
+
+        String mapJsonString = "{\"first\": {\"name\": \"John\"}}";
+        Map<String, ListMapClass> parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
+                                                                                                            Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(1, parsedMap.size());
+        assertEquals("John", parsedMap.get("first").getName());
+
+        mapJsonString = "{\"first\": {\"siblings\": [{\"name\" : \"John\"}]}}";
+        parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
+                                                                                  Collections.singletonList(ListMapClass.class.getCanonicalName()));
+        assertEquals(1, parsedMap.size());
+        assertEquals("John", parsedMap.get("first").getSiblings().get(0).getName());
+
+        mapJsonString = "{\"first\": {\"phones\": {\"number\" : \"1\"}}}";
+        parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
+                                                                                  Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(1, parsedMap.size());
+        assertEquals((Integer) 1, parsedMap.get("first").getPhones().get("number"));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BaseExpressionOperatorTest {
+
+    private static final ClassLoader classLoader = BaseExpressionOperatorTest.class.getClassLoader();
+
+    @Test
+    public void evaluateLiteralExpression() {
+
+        Arrays.stream(BaseExpressionOperator.values())
+                .filter(e -> !BaseExpressionOperator.EQUALS.equals(e))
+                .forEach(operator -> {
+                    assertThatThrownBy(() -> operator.evaluateLiteralExpression(String.class.getCanonicalName(), " Test ", classLoader))
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessage("This operator cannot be used into a Given clause");
+                });
+
+        Assert.assertEquals("Test", BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= Test", classLoader));
+        Assert.assertEquals("", BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= ", classLoader));
+        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "null", classLoader));
+        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= null", classLoader));
+        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), null, classLoader));
+    }
+
+    @Test
+    public void findOperator() {
+        String rawValue = "Test";
+        assertEquals(BaseExpressionOperator.EQUALS, BaseExpressionOperator.findOperator(rawValue));
+
+        rawValue = " Test ";
+        assertEquals(BaseExpressionOperator.EQUALS, BaseExpressionOperator.findOperator(rawValue));
+
+        rawValue = "= Test ";
+        assertEquals(BaseExpressionOperator.EQUALS, BaseExpressionOperator.findOperator(rawValue));
+
+        rawValue = "!= Test ";
+        assertEquals(BaseExpressionOperator.NOT_EQUALS, BaseExpressionOperator.findOperator(rawValue));
+    }
+
+    @Test
+    public void equalsTest() {
+        MyTestClass test1 = new MyTestClass();
+        MyTestClass test2 = new MyTestClass();
+        MyComparableTestClass comparableTest1 = new MyComparableTestClass();
+
+        // Tested via Objects.equals
+        assertTrue(BaseExpressionOperator.EQUALS.eval(test1, test1, test1.getClass(), classLoader));
+        assertFalse(BaseExpressionOperator.EQUALS.eval(test1, test2, test1.getClass(), classLoader));
+        // Tested via Comparable.compareTo
+        assertTrue(BaseExpressionOperator.EQUALS.eval(comparableTest1, comparableTest1, comparableTest1.getClass(), classLoader));
+
+        assertTrue(BaseExpressionOperator.EQUALS.eval("1", 1, int.class, classLoader));
+
+        assertTrue(BaseExpressionOperator.EQUALS.eval(null, null, null, classLoader));
+    }
+
+    @Test
+    public void notEqualsTest() {
+        MyTestClass test1 = new MyTestClass();
+        MyTestClass test2 = new MyTestClass();
+        MyComparableTestClass comparableTest1 = new MyComparableTestClass();
+
+        // Tested via Objects.equals
+        assertFalse(BaseExpressionOperator.NOT_EQUALS.eval(test1, test1, test1.getClass(), classLoader));
+        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval(test1, test2, test1.getClass(), classLoader));
+        // Tested via Comparable.compareTo
+        assertFalse(BaseExpressionOperator.NOT_EQUALS.eval(comparableTest1, comparableTest1, comparableTest1.getClass(), classLoader));
+
+        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval("<> 1", 2, int.class, classLoader));
+
+        assertFalse(BaseExpressionOperator.NOT_EQUALS.eval(null, null, null, classLoader));
+
+        // NOT_EQUALS can be composed
+        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval("! <1", 2, int.class, classLoader));
+        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval("! [1, 3]", 2, int.class, classLoader));
+    }
+
+    @Test
+    public void rangeTest() {
+        Object o = new Object();
+        assertFalse(BaseExpressionOperator.RANGE.eval(o, "", o.getClass(), classLoader));
+
+        assertTrue(BaseExpressionOperator.RANGE.eval(">2", 3, int.class, classLoader));
+    }
+
+    @Test
+    public void listOfValuesTest() {
+        Object o = new Object();
+        assertFalse(BaseExpressionOperator.LIST_OF_VALUES.eval(o, "", o.getClass(), classLoader));
+
+        assertThatThrownBy(() -> BaseExpressionOperator.LIST_OF_VALUES.eval("[ 2", "", String.class, classLoader))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Malformed expression: [ 2");
+
+        assertTrue(BaseExpressionOperator.LIST_OF_VALUES.eval("[ Test, Another Test]", "Another Test", String.class, classLoader));
+    }
+
+    @Test
+    public void listOfConditionsTest() {
+        Object o = new Object();
+        assertFalse(BaseExpressionOperator.LIST_OF_CONDITION.eval(o, "", o.getClass(), classLoader));
+
+        assertTrue(BaseExpressionOperator.LIST_OF_CONDITION.eval("=1; ![2, 3]; <10", 1, int.class, classLoader));
+    }
+
+    private class MyTestClass {
+
+    }
+
+    private class MyComparableTestClass implements Comparable<MyComparableTestClass> {
+
+        @Override
+        public int compareTo(MyComparableTestClass o) {
+            return 0;
+        }
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DMNFeelExpressionEvaluatorTest {
+
+    DMNFeelExpressionEvaluator expressionEvaluator = new DMNFeelExpressionEvaluator(this.getClass().getClassLoader());
+
+    @Test
+    public void evaluateUnaryExpression() {
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("not( true )", false, boolean.class));
+        assertTrue(expressionEvaluator.evaluateUnaryExpression(">2, >5", BigDecimal.valueOf(6), BigDecimal.class));
+        assertThatThrownBy(() -> expressionEvaluator.evaluateUnaryExpression(new Object(), null, Object.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Raw expression should be a string");
+
+        assertThatThrownBy(() -> expressionEvaluator.evaluateUnaryExpression("! true", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Impossible to parse the expression '! true'");
+    }
+
+    @Test
+    public void evaluateLiteralExpression() {
+        assertEquals(BigDecimal.valueOf(5), expressionEvaluator.evaluateLiteralExpression(BigDecimal.class.getCanonicalName(), null, "2 + 3"));
+        Object nonStringObject = new Object();
+        assertEquals(nonStringObject, expressionEvaluator.evaluateLiteralExpression("class", null, nonStringObject));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void expressionTest() {
+
+        String listJsonString = "[{\"name\": \"\\\"John\\\"\"}, " +
+                "{\"name\": \"\\\"John\\\"\", \"names\" : [{\"value\": \"\\\"Anna\\\"\"}, {\"value\": \"\\\"Mario\\\"\"}]}]";
+
+        List<Map<String, Object>> parsedValue = (List<Map<String, Object>>) expressionEvaluator.convertResult(listJsonString, List.class.getCanonicalName(),
+                                                                                                              Collections.singletonList(Map.class.getCanonicalName()));
+
+        assertEquals(2, parsedValue.size());
+        assertEquals(2, ((List<Object>) parsedValue.get(1).get("names")).size());
+        assertTrue(((List<Object>) parsedValue.get(1).get("names")).contains("Anna"));
+
+        String mapJsonString = "{\"first\": {\"name\": \"\\\"John\\\"\"}}";
+        Map<String, Map<String, Object>> parsedMap = (Map<String, Map<String, Object>>) expressionEvaluator
+                .convertResult(mapJsonString, Map.class.getCanonicalName(),
+                               Arrays.asList(String.class.getCanonicalName(), Object.class.getCanonicalName()));
+
+        assertEquals(1, parsedMap.size());
+        assertEquals("John", parsedMap.get("first").get("name"));
+
+        mapJsonString = "{\"first\": {\"siblings\": [{\"name\" : \"\\\"John\\\"\"}]}}";
+        parsedMap = (Map<String, Map<String, Object>>) expressionEvaluator
+                .convertResult(mapJsonString, Map.class.getCanonicalName(),
+                               Arrays.asList(String.class.getCanonicalName(), Object.class.getCanonicalName()));
+        assertEquals(1, parsedMap.size());
+        assertEquals("John", ((List<Map<String, Object>>) parsedMap.get("first").get("siblings")).get(0).get("name"));
+
+        mapJsonString = "{\"first\": {\"phones\": {\"number\" : \"1\"}}}";
+        parsedMap = (Map<String, Map<String, Object>>) expressionEvaluator
+                .convertResult(mapJsonString, Map.class.getCanonicalName(),
+                               Arrays.asList(String.class.getCanonicalName(), Object.class.getCanonicalName()));
+
+        assertEquals(1, parsedMap.size());
+        assertEquals(BigDecimal.valueOf(1), ((Map<String, Object>) parsedMap.get("first").get("phones")).get("number"));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/ParameterizedBaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/ParameterizedBaseExpressionEvaluatorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.expression;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class ParameterizedBaseExpressionEvaluatorTest {
+
+    private final static ClassLoader classLoader = ParameterizedBaseExpressionEvaluatorTest.class.getClassLoader();
+    private final static BaseExpressionEvaluator baseExpressionEvaluator = new BaseExpressionEvaluator(classLoader);
+
+    @Parameterized.Parameters(name = "{index}: Expr \"{0} {1}\" should be true")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {true, 1, 1, int.class},
+                {true, 1, "1", int.class},
+                {true, 2, "!= 1", int.class},
+                {true, -1, "- 1", int.class},
+                {true, -2, "< -  1", int.class},
+                {true, -2L, "< -  1", long.class},
+                {true, -2D, "< -  1", double.class},
+                {true, -2F, "< -  1", float.class},
+                {true, (short) -2, "< - 1", short.class},
+                {true, "String", "<> Test", String.class},
+                {true, "Test", "= Test", String.class},
+                {true, 1, "<2", int.class},
+                {true, 1, "<2; >0", int.class},
+                {true, 2, " <= 2 ", int.class},
+                {true, 2, " >= 2", int.class},
+                {true, 1, "[ 1, 2 ,3]", int.class},
+                {true, 2, "[ 1, 2 ,3]", int.class},
+                {true, "3", "[ 1, 2 ,3]", String.class},
+                {true, 4, "![ 1, 2 ,3]", int.class},
+                {true, 4, "! < 1", int.class},
+                {true, 1, "> -1", int.class},
+                {true, 10, "!= <10;!= >11", int.class},
+                {true, 10, "= 10; >9", int.class},
+                {true, null, null, Integer.class},
+                {true, null, "!1", Integer.class},
+                {true, 'b', "!a", Character.class},
+                {true, "0".getBytes()[0], "!b", Byte.class},
+                {true, (short) 1, ">0", Short.class},
+                {true, null, "[ !false]", boolean.class},
+                {true, null, "[! false, ! true]", boolean.class},
+                {true, 10, "[> 1]", int.class},
+                {true, 10, "[< 1, > 1]", int.class},
+                {true, "", ";", String.class},
+                {false, null, ";", String.class},
+                {false, null, "=", String.class},
+                {false, null, "[]", String.class},
+                {true, Error.class, ";", boolean.class},
+                {true, Error.class, "[]", boolean.class},
+                {true, Error.class, "=", boolean.class},
+                {true, Error.class, "!= false; <> false, ! false", boolean.class},
+                {true, Error.class, "<> false, ! false", boolean.class},
+                {true, Error.class, "! tru", void.class},
+                {true, Error.class, "fals", void.class},
+                {true, Error.class, "!= fals", void.class},
+                {true, Error.class, "tru", void.class},
+                {true, Error.class, "<> fals", void.class},
+                {true, Error.class, "tru", void.class},
+                {true, Error.class, "!m= false", void.class},
+                {true, Error.class, ">> 3", void.class},
+                {true, Error.class, "< - 1 1", int.class}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public Boolean expectedResult;
+
+    @Parameterized.Parameter(1)
+    public Object resultValue;
+
+    @Parameterized.Parameter(2)
+    public Object exprToTest;
+
+    @Parameterized.Parameter(3)
+    public Class<?> clazz;
+
+    @Test
+    public void evaluateUnaryExpression() {
+
+        if (!(resultValue instanceof Class)) {
+            assertEquals(expectedResult, baseExpressionEvaluator.evaluateUnaryExpression(exprToTest, resultValue, clazz));
+        } else {
+            try {
+                baseExpressionEvaluator.evaluateUnaryExpression(exprToTest, true, clazz);
+                fail();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ConditionFilterTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ConditionFilterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+
+public class ConditionFilterTest {
+
+    @Test
+    public void acceptTest() {
+        Function<Object, ResultWrapper> alwaysMatchFunction = ResultWrapper::createResult;
+        FactMappingValue factMappingValue = new FactMappingValue(FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION, "Test");
+        ScenarioResult scenarioResult = new ScenarioResult(FactIdentifier.DESCRIPTION, factMappingValue);
+        ConditionFilter conditionFilter = new ConditionFilter(asList(new FactCheckerHandle(String.class, alwaysMatchFunction, scenarioResult)));
+
+        Assert.assertFalse(conditionFilter.accept(1));
+        Assert.assertTrue(conditionFilter.accept("String"));
+
+        Function<Object, ResultWrapper> alwaysNotMatchFunction = object -> ResultWrapper.createErrorResult();
+        ConditionFilter conditionFilterFail = new ConditionFilter(asList(new FactCheckerHandle(String.class, alwaysNotMatchFunction, scenarioResult)));
+        Assert.assertFalse(conditionFilterFail.accept("String"));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommandTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommandTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.Collections;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.ObjectFilter;
+import org.kie.internal.command.RegistryContext;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValidateFactCommandTest {
+
+    @Mock
+    private KieSession kieSession;
+
+    @Mock
+    private ScenarioResult scenarioResult;
+
+    @Mock
+    private FactMappingValue factMappingValue;
+
+    @Mock
+    private RegistryContext registryContext;
+
+    @Test
+    public void executeTest() {
+        when(registryContext.lookup(KieSession.class)).thenReturn(kieSession);
+        Function<Object, ResultWrapper> alwaysMatchFunction = ResultWrapper::createResult;
+
+        ValidateFactCommand validateFactCommand = new ValidateFactCommand(asList(new FactCheckerHandle(String.class, alwaysMatchFunction, scenarioResult)));
+
+        when(kieSession.getObjects(any(ObjectFilter.class))).thenReturn(Collections.singleton(null));
+        validateFactCommand.execute(registryContext);
+        verify(scenarioResult, times(1)).setResult(anyBoolean());
+
+        reset(scenarioResult);
+
+        boolean expectedResult = true;
+        when(kieSession.getObjects(any(ObjectFilter.class))).thenReturn(Collections.emptyList());
+        when(scenarioResult.getFactMappingValue()).thenReturn(factMappingValue);
+        when(factMappingValue.isError()).thenReturn(expectedResult);
+        validateFactCommand.execute(registryContext);
+        verify(scenarioResult, times(0)).setResult(expectedResult);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/Dispute.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/Dispute.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.model;
+
+public class Dispute {
+
+    private String description;
+    private Person creator;
+    private Person assignee;
+    private double amount;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Person getCreator() {
+        return creator;
+    }
+
+    public void setCreator(Person creator) {
+        this.creator = creator;
+    }
+
+    public Person getAssignee() {
+        return assignee;
+    }
+
+    public void setAssignee(Person assignee) {
+        this.assignee = assignee;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/ListMapClass.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/ListMapClass.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class ListMapClass {
+
+    private String name;
+    private List<String> names;
+    private List<ListMapClass> siblings;
+    private Map<String, Integer> phones;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+    public List<ListMapClass> getSiblings() {
+        return siblings;
+    }
+
+    public void setSiblings(List<ListMapClass> siblings) {
+        this.siblings = siblings;
+    }
+
+    public Map<String, Integer> getPhones() {
+        return phones;
+    }
+
+    public void setPhones(Map<String, Integer> phones) {
+        this.phones = phones;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/NotEmptyConstructor.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/NotEmptyConstructor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.model;
+
+public class NotEmptyConstructor {
+
+    private final String name;
+
+    public NotEmptyConstructor(String name) {
+        this.name = name;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/Person.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/model/Person.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.model;
+
+public class Person {
+
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/AbstractScenarioRunnerTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/AbstractScenarioRunnerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.drools.scenariosimulation.backend.expression.BaseExpressionEvaluator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunNotifier;
+import org.kie.api.runtime.KieContainer;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractScenarioRunnerTest {
+
+    @Mock
+    protected KieContainer kieContainerMock;
+
+    protected AbstractScenarioRunner abstractScenarioRunnerLocal;
+
+    @Before
+    public void setup() {
+        abstractScenarioRunnerLocal = spy(
+                new AbstractScenarioRunner(kieContainerMock,
+                                           new Simulation(),
+                                           "",
+                                           BaseExpressionEvaluator::new) {
+                    @Override
+                    protected AbstractRunnerHelper newRunnerHelper(SimulationDescriptor simulationDescriptor) {
+                        return null;
+                    }
+                });
+    }
+
+    @Test
+    public void getSpecificRunnerProvider() {
+        SimulationDescriptor simulationDescriptor = new SimulationDescriptor();
+        // all existing types should have a dedicated runner
+        for (ScenarioSimulationModel.Type value : ScenarioSimulationModel.Type.values()) {
+            simulationDescriptor.setType(value);
+            AbstractScenarioRunner.getSpecificRunnerProvider(simulationDescriptor);
+        }
+    }
+
+    @Test
+    public void testRun() {
+        assertNull(abstractScenarioRunnerLocal.simulationRunMetadataBuilder);
+        abstractScenarioRunnerLocal.run(new RunNotifier());
+        assertNotNull(abstractScenarioRunnerLocal.simulationRunMetadataBuilder);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import org.assertj.core.api.Assertions;
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingType;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.backend.expression.DMNFeelExpressionEvaluator;
+import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
+import org.drools.scenariosimulation.backend.fluent.DMNScenarioExecutableBuilder;
+import org.drools.scenariosimulation.backend.model.Dispute;
+import org.drools.scenariosimulation.backend.model.Person;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.runtime.RequestContext;
+import org.kie.dmn.api.core.DMNDecisionResult;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.ast.DecisionNode;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNScenarioRunnerHelperTest {
+
+    @Mock
+    protected RequestContext requestContextMock;
+
+    @Mock
+    protected DMNResult dmnResultMock;
+
+    @Mock
+    protected DMNDecisionResult dmnDecisionResultMock;
+
+    @Mock
+    protected DMNModel dmnModelMock;
+
+    private static final String NAME = "NAME";
+    private static final String FEEL_EXPRESSION_NAME = "\"" + NAME + "\"";
+    private static final BigDecimal AMOUNT = BigDecimal.valueOf(10);
+    private static final String TEST_DESCRIPTION = "Test description";
+    private static final ClassLoader classLoader = RuleScenarioRunnerHelperTest.class.getClassLoader();
+    private static final ExpressionEvaluator expressionEvaluator = new DMNFeelExpressionEvaluator(classLoader);
+    private static final DMNScenarioRunnerHelper runnerHelper = new DMNScenarioRunnerHelper();
+
+    private Simulation simulation;
+    private FactIdentifier personFactIdentifier;
+    private ExpressionIdentifier firstNameGivenExpressionIdentifier;
+    private FactMapping firstNameGivenFactMapping;
+    private Scenario scenario1;
+    private Scenario scenario2;
+    private ExpressionIdentifier firstNameExpectedExpressionIdentifier;
+    private FactMapping firstNameExpectedFactMapping;
+    private FactIdentifier disputeFactIdentifier;
+    private ExpressionIdentifier amountGivenExpressionIdentifier;
+    private FactMapping amountNameGivenFactMapping;
+    private ExpressionIdentifier amountExpectedExpressionIdentifier;
+    private FactMapping amountNameExpectedFactMapping;
+    private FactMappingValue amountNameExpectedFactMappingValue;
+    private FactMappingValue firstNameExpectedValue;
+
+    @Before
+    public void init() {
+        simulation = new Simulation();
+        personFactIdentifier = FactIdentifier.create("Fact 1", Person.class.getCanonicalName());
+        firstNameGivenExpressionIdentifier = ExpressionIdentifier.create("First Name Given", FactMappingType.GIVEN);
+        firstNameGivenFactMapping = simulation.getSimulationDescriptor().addFactMapping(personFactIdentifier, firstNameGivenExpressionIdentifier);
+        firstNameGivenFactMapping.addExpressionElement("Fact 1", String.class.getCanonicalName());
+        firstNameGivenFactMapping.addExpressionElement("firstName", String.class.getCanonicalName());
+
+        disputeFactIdentifier = FactIdentifier.create("Fact 2", Dispute.class.getCanonicalName());
+        amountGivenExpressionIdentifier = ExpressionIdentifier.create("Amount Given", FactMappingType.GIVEN);
+        amountNameGivenFactMapping = simulation.getSimulationDescriptor().addFactMapping(disputeFactIdentifier, amountGivenExpressionIdentifier);
+        amountNameGivenFactMapping.addExpressionElement("Fact 2", BigDecimal.class.getCanonicalName());
+        amountNameGivenFactMapping.addExpressionElement("amount", BigDecimal.class.getCanonicalName());
+
+        firstNameExpectedExpressionIdentifier = ExpressionIdentifier.create("First Name Expected", FactMappingType.EXPECT);
+        firstNameExpectedFactMapping = simulation.getSimulationDescriptor().addFactMapping(personFactIdentifier, firstNameExpectedExpressionIdentifier);
+        firstNameExpectedFactMapping.addExpressionElement("Fact 1", String.class.getCanonicalName());
+        firstNameExpectedFactMapping.addExpressionElement("firstName", String.class.getCanonicalName());
+
+        amountExpectedExpressionIdentifier = ExpressionIdentifier.create("Amount Expected", FactMappingType.EXPECT);
+        amountNameExpectedFactMapping = simulation.getSimulationDescriptor().addFactMapping(disputeFactIdentifier, amountExpectedExpressionIdentifier);
+        amountNameExpectedFactMapping.addExpressionElement("Fact 2", Double.class.getCanonicalName());
+        amountNameExpectedFactMapping.addExpressionElement("amount", Double.class.getCanonicalName());
+
+        scenario1 = simulation.addScenario();
+        scenario1.setDescription(TEST_DESCRIPTION);
+        scenario1.addMappingValue(personFactIdentifier, firstNameGivenExpressionIdentifier, FEEL_EXPRESSION_NAME);
+        firstNameExpectedValue = scenario1.addMappingValue(personFactIdentifier, firstNameExpectedExpressionIdentifier, FEEL_EXPRESSION_NAME);
+
+        scenario2 = simulation.addScenario();
+        scenario2.setDescription(TEST_DESCRIPTION);
+        scenario2.addMappingValue(personFactIdentifier, firstNameGivenExpressionIdentifier, FEEL_EXPRESSION_NAME);
+        scenario2.addMappingValue(personFactIdentifier, firstNameExpectedExpressionIdentifier, FEEL_EXPRESSION_NAME);
+        scenario2.addMappingValue(disputeFactIdentifier, amountGivenExpressionIdentifier, AMOUNT);
+        amountNameExpectedFactMappingValue = scenario2.addMappingValue(disputeFactIdentifier, amountExpectedExpressionIdentifier, AMOUNT);
+
+        when(requestContextMock.getOutput(DMNScenarioExecutableBuilder.DMN_RESULT)).thenReturn(dmnResultMock);
+        when(requestContextMock.getOutput(DMNScenarioExecutableBuilder.DMN_MODEL)).thenReturn(dmnModelMock);
+    }
+
+    @Test
+    public void verifyConditions() {
+        ScenarioRunnerData scenarioRunnerData = new ScenarioRunnerData();
+        scenarioRunnerData.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
+
+        Assertions.assertThatThrownBy(() -> runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData, expressionEvaluator, requestContextMock))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage("DMN execution has not generated a decision result with name Fact 1");
+
+        when(dmnResultMock.getDecisionResultByName(anyString())).thenReturn(dmnDecisionResultMock);
+        when(dmnDecisionResultMock.getEvaluationStatus()).thenReturn(DecisionEvaluationStatus.SUCCEEDED);
+
+        Assertions.assertThatThrownBy(() -> runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData, expressionEvaluator, requestContextMock))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage("Wrong resultRaw structure because it is not a complex type as expected");
+
+        Map<String, Object> resultMap = new HashMap<>();
+        resultMap.put("firstName", "WrongValue");
+
+        when(dmnDecisionResultMock.getResult()).thenReturn(resultMap);
+
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData, expressionEvaluator, requestContextMock);
+
+        assertEquals(1, scenarioRunnerData.getResults().size());
+        assertFalse(scenarioRunnerData.getResults().get(0).getResult());
+
+        ScenarioRunnerData newScenarioRunnerData = new ScenarioRunnerData();
+        newScenarioRunnerData.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
+        resultMap.put("firstName", NAME);
+
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), newScenarioRunnerData, expressionEvaluator, requestContextMock);
+
+        assertEquals(1, newScenarioRunnerData.getResults().size());
+        assertTrue(newScenarioRunnerData.getResults().get(0).getResult());
+
+        // verify that when expression evaluation fails the corresponding expression is marked as error
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(),
+                                      newScenarioRunnerData,
+                                      mock(ExpressionEvaluator.class),
+                                      requestContextMock);
+        assertTrue(newScenarioRunnerData.getResults().get(0).getFactMappingValue().isError());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void createObject() {
+        Map<List<String>, Object> params = new HashMap<>();
+        params.put(asList("creator", "name"), "TestName");
+        params.put(asList("creator", "surname"), "TestSurname");
+        params.put(singletonList("age"), BigDecimal.valueOf(10));
+
+        Object objectRaw = runnerHelper.createObject(String.class.getCanonicalName(), params, this.getClass().getClassLoader());
+        assertTrue(objectRaw instanceof Map);
+
+        Map<String, Object> object = (Map<String, Object>) objectRaw;
+        assertEquals(BigDecimal.valueOf(10), object.get("age"));
+        assertTrue(object.get("creator") instanceof Map);
+
+        Map<String, Object> creator = (Map<String, Object>) object.get("creator");
+        assertEquals("TestName", creator.get("name"));
+        assertEquals("TestSurname", creator.get("surname"));
+    }
+
+    @Test
+    public void extractResultMetadata() {
+        Set<DecisionNode> decisions = new HashSet<>();
+        IntStream.range(0, 5).forEach(index -> decisions.add(createDecisionMock("decision" + index)));
+        when(dmnModelMock.getDecisions()).thenReturn(decisions);
+
+        List<DMNDecisionResult> decisionResults = new ArrayList<>();
+        decisionResults.add(createDecisionResultMock("decision2", true));
+        decisionResults.add(createDecisionResultMock("decision3", false));
+        when(dmnResultMock.getDecisionResults()).thenReturn(decisionResults);
+
+        ScenarioWithIndex scenarioWithIndex = new ScenarioWithIndex(1, scenario1);
+        ScenarioResultMetadata scenarioResultMetadata = runnerHelper.extractResultMetadata(requestContextMock, scenarioWithIndex);
+
+        assertEquals(scenarioWithIndex, scenarioResultMetadata.getScenarioWithIndex());
+        assertEquals(5, scenarioResultMetadata.getAvailable().size());
+        assertTrue(scenarioResultMetadata.getAvailable().contains("decision1"));
+        assertEquals(1, scenarioResultMetadata.getExecuted().size());
+        assertTrue(scenarioResultMetadata.getExecuted().contains("decision2"));
+        assertFalse(scenarioResultMetadata.getExecuted().contains("decision3"));
+    }
+
+    private DecisionNode createDecisionMock(String decisionName) {
+        DecisionNode decisionMock = mock(DecisionNode.class);
+        when(decisionMock.getName()).thenReturn(decisionName);
+        return decisionMock;
+    }
+
+    private DMNDecisionResult createDecisionResultMock(String decisionName, boolean success) {
+        DMNDecisionResult decisionResultMock = mock(DMNDecisionResult.class);
+        when(decisionResultMock.getDecisionName()).thenReturn(decisionName);
+        when(decisionResultMock.getEvaluationStatus())
+                .thenReturn(success ? DecisionEvaluationStatus.SUCCEEDED :
+                                    DecisionEvaluationStatus.FAILED);
+        return decisionResultMock;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingType;
+import org.drools.scenariosimulation.api.model.FactMappingValue;
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.backend.expression.BaseExpressionEvaluator;
+import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
+import org.drools.scenariosimulation.backend.model.Dispute;
+import org.drools.scenariosimulation.backend.model.Person;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioGiven;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RuleScenarioRunnerHelperTest {
+
+    private static final String NAME = "NAME";
+    private static final double AMOUNT = 10;
+    private static final String TEST_DESCRIPTION = "Test description";
+    private static final ClassLoader classLoader = RuleScenarioRunnerHelperTest.class.getClassLoader();
+    private static final ExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
+    private static final RuleScenarioRunnerHelper runnerHelper = new RuleScenarioRunnerHelper(null);
+
+    private Simulation simulation;
+    private FactIdentifier personFactIdentifier;
+    private ExpressionIdentifier firstNameGivenExpressionIdentifier;
+    private FactMapping firstNameGivenFactMapping;
+    private Scenario scenario1;
+    private Scenario scenario2;
+    private ExpressionIdentifier firstNameExpectedExpressionIdentifier;
+    private FactMapping firstNameExpectedFactMapping;
+    private FactIdentifier disputeFactIdentifier;
+    private ExpressionIdentifier amountGivenExpressionIdentifier;
+    private FactMapping amountNameGivenFactMapping;
+    private ExpressionIdentifier amountExpectedExpressionIdentifier;
+    private FactMapping amountNameExpectedFactMapping;
+    private FactMappingValue amountNameExpectedFactMappingValue;
+
+    @Before
+    public void setup() {
+        simulation = new Simulation();
+        personFactIdentifier = FactIdentifier.create("Fact 1", Person.class.getCanonicalName());
+        firstNameGivenExpressionIdentifier = ExpressionIdentifier.create("First Name Given", FactMappingType.GIVEN);
+        firstNameGivenFactMapping = simulation.getSimulationDescriptor().addFactMapping(personFactIdentifier, firstNameGivenExpressionIdentifier);
+        firstNameGivenFactMapping.addExpressionElement("Fact 1", String.class.getCanonicalName());
+        firstNameGivenFactMapping.addExpressionElement("firstName", String.class.getCanonicalName());
+
+        disputeFactIdentifier = FactIdentifier.create("Fact 2", Dispute.class.getCanonicalName());
+        amountGivenExpressionIdentifier = ExpressionIdentifier.create("Amount Given", FactMappingType.GIVEN);
+        amountNameGivenFactMapping = simulation.getSimulationDescriptor().addFactMapping(disputeFactIdentifier, amountGivenExpressionIdentifier);
+        amountNameGivenFactMapping.addExpressionElement("Fact 2", Double.class.getCanonicalName());
+        amountNameGivenFactMapping.addExpressionElement("amount", Double.class.getCanonicalName());
+
+        firstNameExpectedExpressionIdentifier = ExpressionIdentifier.create("First Name Expected", FactMappingType.EXPECT);
+        firstNameExpectedFactMapping = simulation.getSimulationDescriptor().addFactMapping(personFactIdentifier, firstNameExpectedExpressionIdentifier);
+        firstNameExpectedFactMapping.addExpressionElement("Fact 1", String.class.getCanonicalName());
+        firstNameExpectedFactMapping.addExpressionElement("firstName", String.class.getCanonicalName());
+
+        amountExpectedExpressionIdentifier = ExpressionIdentifier.create("Amount Expected", FactMappingType.EXPECT);
+        amountNameExpectedFactMapping = simulation.getSimulationDescriptor().addFactMapping(disputeFactIdentifier, amountExpectedExpressionIdentifier);
+        amountNameExpectedFactMapping.addExpressionElement("Fact 2", Double.class.getCanonicalName());
+        amountNameExpectedFactMapping.addExpressionElement("amount", Double.class.getCanonicalName());
+
+        scenario1 = simulation.addScenario();
+        scenario1.setDescription(TEST_DESCRIPTION);
+        scenario1.addMappingValue(personFactIdentifier, firstNameGivenExpressionIdentifier, NAME);
+        scenario1.addMappingValue(personFactIdentifier, firstNameExpectedExpressionIdentifier, NAME);
+
+        scenario2 = simulation.addScenario();
+        scenario2.setDescription(TEST_DESCRIPTION);
+        scenario2.addMappingValue(personFactIdentifier, firstNameGivenExpressionIdentifier, NAME);
+        scenario2.addMappingValue(personFactIdentifier, firstNameExpectedExpressionIdentifier, NAME);
+        scenario2.addMappingValue(disputeFactIdentifier, amountGivenExpressionIdentifier, AMOUNT);
+        amountNameExpectedFactMappingValue = scenario2.addMappingValue(disputeFactIdentifier, amountExpectedExpressionIdentifier, AMOUNT);
+    }
+
+    @Test
+    public void extractGivenValuesTest() {
+        List<ScenarioGiven> scenario1Inputs = runnerHelper.extractGivenValues(simulation.getSimulationDescriptor(),
+                                                                              scenario1.getUnmodifiableFactMappingValues(),
+                                                                              classLoader,
+                                                                              expressionEvaluator);
+        assertEquals(1, scenario1Inputs.size());
+
+        List<ScenarioGiven> scenario2Inputs = runnerHelper.extractGivenValues(simulation.getSimulationDescriptor(),
+                                                                              scenario2.getUnmodifiableFactMappingValues(),
+                                                                              classLoader,
+                                                                              expressionEvaluator);
+        assertEquals(2, scenario2Inputs.size());
+    }
+
+    @Test
+    public void extractExpectedValuesTest() {
+        List<ScenarioExpect> scenario1Outputs = runnerHelper.extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
+        assertEquals(1, scenario1Outputs.size());
+
+        scenario2.addOrUpdateMappingValue(FactIdentifier.create("TEST", String.class.getCanonicalName()),
+                                          ExpressionIdentifier.create("TEST", FactMappingType.EXPECT),
+                                          "TEST");
+        List<ScenarioExpect> scenario2Outputs = runnerHelper.extractExpectedValues(scenario2.getUnmodifiableFactMappingValues());
+        assertEquals(3, scenario2Outputs.size());
+        assertEquals(1, scenario2Outputs.stream().filter(ScenarioExpect::isNewFact).count());
+    }
+
+    @Test
+    public void verifyConditionsTest() {
+        List<ScenarioGiven> scenario1Inputs = runnerHelper.extractGivenValues(simulation.getSimulationDescriptor(),
+                                                                              scenario1.getUnmodifiableFactMappingValues(),
+                                                                              classLoader,
+                                                                              expressionEvaluator);
+        List<ScenarioExpect> scenario1Outputs = runnerHelper.extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
+
+        ScenarioRunnerData scenarioRunnerData1 = new ScenarioRunnerData();
+        scenario1Inputs.forEach(scenarioRunnerData1::addGiven);
+        scenario1Outputs.forEach(scenarioRunnerData1::addExpect);
+
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(),
+                                      scenarioRunnerData1,
+                                      expressionEvaluator,
+                                      null);
+        assertEquals(1, scenarioRunnerData1.getResults().size());
+
+        List<ScenarioGiven> scenario2Inputs = runnerHelper.extractGivenValues(simulation.getSimulationDescriptor(),
+                                                                              scenario2.getUnmodifiableFactMappingValues(),
+                                                                              classLoader,
+                                                                              expressionEvaluator);
+        List<ScenarioExpect> scenario2Outputs = runnerHelper.extractExpectedValues(scenario2.getUnmodifiableFactMappingValues());
+
+        ScenarioRunnerData scenarioRunnerData2 = new ScenarioRunnerData();
+        scenario2Inputs.forEach(scenarioRunnerData2::addGiven);
+        scenario2Outputs.forEach(scenarioRunnerData2::addExpect);
+
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(),
+                                      scenarioRunnerData2,
+                                      expressionEvaluator,
+                                      null);
+        assertEquals(2, scenarioRunnerData2.getResults().size());
+    }
+
+    @Test
+    public void getScenarioResultsTest() {
+        List<ScenarioGiven> scenario1Inputs = runnerHelper.extractGivenValues(simulation.getSimulationDescriptor(),
+                                                                              scenario1.getUnmodifiableFactMappingValues(),
+                                                                              classLoader,
+                                                                              expressionEvaluator);
+        List<ScenarioExpect> scenario1Outputs = runnerHelper.extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
+
+        assertTrue(scenario1Inputs.size() > 0);
+
+        ScenarioGiven input1 = scenario1Inputs.get(0);
+
+        scenario1Outputs = scenario1Outputs.stream().filter(elem -> elem.getFactIdentifier().equals(input1.getFactIdentifier())).collect(toList());
+        List<ScenarioResult> scenario1Results = runnerHelper.getScenarioResultsFromGivenFacts(simulation.getSimulationDescriptor(), scenario1Outputs, input1, expressionEvaluator);
+
+        assertEquals(1, scenario1Results.size());
+        assertFalse(scenario1Outputs.get(0).getExpectedResult().get(0).isError());
+
+        List<ScenarioGiven> scenario2Inputs = runnerHelper.extractGivenValues(simulation.getSimulationDescriptor(),
+                                                                              scenario2.getUnmodifiableFactMappingValues(),
+                                                                              classLoader,
+                                                                              expressionEvaluator);
+        List<ScenarioExpect> scenario2Outputs = runnerHelper.extractExpectedValues(scenario2.getUnmodifiableFactMappingValues());
+
+        assertTrue(scenario2Inputs.size() > 0);
+
+        ScenarioGiven input2 = scenario2Inputs.get(0);
+
+        scenario2Outputs = scenario2Outputs.stream().filter(elem -> elem.getFactIdentifier().equals(input2.getFactIdentifier())).collect(toList());
+        List<ScenarioResult> scenario2Results = runnerHelper.getScenarioResultsFromGivenFacts(simulation.getSimulationDescriptor(), scenario2Outputs, input2, expressionEvaluator);
+
+        assertEquals(1, scenario2Results.size());
+        assertFalse(scenario2Outputs.get(0).getExpectedResult().get(0).isError());
+
+        List<ScenarioExpect> newFact = Collections.singletonList(new ScenarioExpect(personFactIdentifier, Collections.emptyList(), true));
+        List<ScenarioResult> scenario2NoResults = runnerHelper.getScenarioResultsFromGivenFacts(simulation.getSimulationDescriptor(), newFact, input2, expressionEvaluator);
+
+        assertEquals(0, scenario2NoResults.size());
+
+        Person person = new Person();
+        person.setFirstName("ANOTHER STRING");
+        ScenarioGiven newInput = new ScenarioGiven(personFactIdentifier, person);
+
+        List<ScenarioResult> scenario3Results = runnerHelper.getScenarioResultsFromGivenFacts(simulation.getSimulationDescriptor(), scenario1Outputs, newInput, expressionEvaluator);
+        assertTrue(scenario1Outputs.get(0).getExpectedResult().get(0).isError());
+
+        assertEquals(1, scenario3Results.size());
+    }
+
+    @Test
+    public void validateAssertionTest() {
+
+        List<ScenarioResult> scenarioFailResult = new ArrayList<>();
+        scenarioFailResult.add(new ScenarioResult(disputeFactIdentifier, amountNameExpectedFactMappingValue, "SOMETHING_ELSE"));
+        try {
+            runnerHelper.validateAssertion(scenarioFailResult, scenario2);
+            fail();
+        } catch (ScenarioException ignored) {
+        }
+
+        List<ScenarioResult> scenarioSuccessResult = new ArrayList<>();
+        scenarioSuccessResult.add(new ScenarioResult(disputeFactIdentifier, amountNameExpectedFactMappingValue, amountNameExpectedFactMappingValue.getRawValue()).setResult(true));
+        runnerHelper.validateAssertion(scenarioSuccessResult, scenario2);
+    }
+
+    @Test
+    public void groupByFactIdentifierAndFilterTest() {
+        Map<FactIdentifier, List<FactMappingValue>> scenario1Given = runnerHelper.groupByFactIdentifierAndFilter(scenario1.getUnmodifiableFactMappingValues(), FactMappingType.GIVEN);
+        Map<FactIdentifier, List<FactMappingValue>> scenario1Expected = runnerHelper.groupByFactIdentifierAndFilter(scenario1.getUnmodifiableFactMappingValues(), FactMappingType.EXPECT);
+        Map<FactIdentifier, List<FactMappingValue>> scenario2Given = runnerHelper.groupByFactIdentifierAndFilter(scenario2.getUnmodifiableFactMappingValues(), FactMappingType.GIVEN);
+        Map<FactIdentifier, List<FactMappingValue>> scenario2Expected = runnerHelper.groupByFactIdentifierAndFilter(scenario2.getUnmodifiableFactMappingValues(), FactMappingType.EXPECT);
+
+        assertEquals(1, scenario1Given.keySet().size());
+        assertEquals(1, scenario1Expected.keySet().size());
+        assertEquals(2, scenario2Given.keySet().size());
+        assertEquals(2, scenario2Expected.keySet().size());
+
+        assertEquals(1, scenario1Given.get(personFactIdentifier).size());
+        assertEquals(1, scenario1Expected.get(personFactIdentifier).size());
+        assertEquals(1, scenario2Given.get(disputeFactIdentifier).size());
+        assertEquals(1, scenario2Expected.get(disputeFactIdentifier).size());
+
+        Scenario scenario = new Scenario();
+        scenario.addMappingValue(FactIdentifier.EMPTY, ExpressionIdentifier.DESCRIPTION, null);
+        assertEquals(0, runnerHelper.groupByFactIdentifierAndFilter(scenario.getUnmodifiableFactMappingValues(), FactMappingType.GIVEN).size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void groupByFactIdentifierAndFilterFailTest() {
+        List<FactMappingValue> fail = new ArrayList<>();
+        FactMappingValue factMappingValue = new FactMappingValue();
+        factMappingValue.setRawValue("TEST");
+        fail.add(factMappingValue);
+        runnerHelper.groupByFactIdentifierAndFilter(fail, FactMappingType.GIVEN);
+    }
+
+    @Test
+    public void createExtractorFunctionTest() {
+        String personName = "Test";
+        FactMappingValue factMappingValue = new FactMappingValue(personFactIdentifier, firstNameGivenExpressionIdentifier, personName);
+        Function<Object, ResultWrapper> extractorFunction = runnerHelper.createExtractorFunction(expressionEvaluator, factMappingValue, simulation.getSimulationDescriptor());
+        Person person = new Person();
+
+        person.setFirstName(personName);
+        assertTrue(extractorFunction.apply(person).isSatisfied());
+
+        person.setFirstName("OtherString");
+        assertFalse(extractorFunction.apply(person).isSatisfied());
+
+        Function<Object, ResultWrapper> extractorFunction1 = runnerHelper.createExtractorFunction(expressionEvaluator,
+                                                                                                  new FactMappingValue(personFactIdentifier,
+                                                                                                                       firstNameGivenExpressionIdentifier,
+                                                                                                                       null),
+                                                                                                  simulation.getSimulationDescriptor());
+        ResultWrapper nullValue = extractorFunction1.apply(new Person());
+        assertTrue(nullValue.isSatisfied());
+        assertNull(nullValue.getResult());
+    }
+
+    @Test
+    public void getParamsForBeanTest() {
+        List<FactMappingValue> factMappingValues = new ArrayList<>();
+        FactMappingValue factMappingValue = new FactMappingValue(disputeFactIdentifier, amountGivenExpressionIdentifier, "NOT PARSABLE");
+        factMappingValues.add(factMappingValue);
+
+        try {
+            runnerHelper.getParamsForBean(simulation.getSimulationDescriptor(), disputeFactIdentifier, factMappingValues, expressionEvaluator);
+            fail();
+        } catch (ScenarioException ignored) {
+
+        }
+        Assert.assertTrue(factMappingValue.isError());
+    }
+
+    @Test
+    public void directMappingTest() {
+        Map<List<String>, Object> paramsToSet = new HashMap<>();
+        paramsToSet.put(Collections.emptyList(), "Test");
+
+        assertEquals("Test", runnerHelper.getDirectMapping(paramsToSet).getResult());
+
+        paramsToSet.clear();
+        paramsToSet.put(Collections.emptyList(), 1);
+
+        assertEquals(1, runnerHelper.getDirectMapping(paramsToSet).getResult());
+
+        paramsToSet.clear();
+        paramsToSet.put(Collections.emptyList(), null);
+
+        assertNull(runnerHelper.getDirectMapping(paramsToSet).getResult());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/ScenarioJunitActivatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/ScenarioJunitActivatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.backend.runner.model.SimulationWithFileName;
+import org.drools.scenariosimulation.backend.util.ResourceHelper;
+import org.drools.scenariosimulation.backend.util.ScenarioSimulationXMLPersistence;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.kie.api.runtime.KieContainer;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScenarioJunitActivatorTest {
+
+    @Mock
+    private ScenarioSimulationXMLPersistence xmlReaderMock;
+
+    @Mock
+    private KieContainer kieContainerMock;
+
+    @Mock
+    private AbstractScenarioRunner runnerMock;
+
+    @Mock
+    private Simulation simulationMock;
+
+    @Mock
+    private SimulationWithFileName simulationWithFileNameMock;
+
+    @Mock
+    private ScenarioSimulationModel scenarioSimulationModelMock;
+
+    @Mock
+    private RunNotifier runNotifierMock;
+
+    @Before
+    public void setup() {
+        when(xmlReaderMock.unmarshal(any())).thenReturn(scenarioSimulationModelMock);
+        when(scenarioSimulationModelMock.getSimulation()).thenReturn(simulationMock);
+    }
+
+    @Test
+    public void getChildrenTest() throws InitializationError {
+        List<SimulationWithFileName> children = getScenarioJunitActivator().getChildren();
+        Assert.assertEquals(1, children.size());
+    }
+
+    @Test
+    public void runChildTest() throws InitializationError {
+        getScenarioJunitActivator().runChild(simulationWithFileNameMock, runNotifierMock);
+        verify(runnerMock, times(1)).run(runNotifierMock);
+    }
+
+    private ScenarioJunitActivator getScenarioJunitActivator() throws InitializationError {
+        return new ScenarioJunitActivator(ScenarioJunitActivator.class) {
+            @Override
+            ScenarioSimulationXMLPersistence getXmlReader() {
+                return xmlReaderMock;
+            }
+
+            @Override
+            Stream<String> getResources() {
+                return ResourceHelper.getResourcesByExtension("txt");
+            }
+
+            @Override
+            KieContainer getKieContainer() {
+                return kieContainerMock;
+            }
+
+            @Override
+            AbstractScenarioRunner newRunner(KieContainer kieContainer, Simulation simulation, String path) {
+                return runnerMock;
+            }
+        };
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/SimulationRunMetadataBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/SimulationRunMetadataBuilderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.runner;
+
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.SimulationRunMetadata;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimulationRunMetadataBuilderTest {
+
+    @Test
+    public void build() {
+        ScenarioWithIndex scenarioWithIndex1 = new ScenarioWithIndex(1, new Scenario());
+        ScenarioResultMetadata result1 = new ScenarioResultMetadata(scenarioWithIndex1);
+        result1.addExecuted("d1");
+        result1.addExecuted("d2");
+        result1.addAvailable("d1");
+        result1.addAvailable("d2");
+        result1.addAvailable("d3");
+
+        ScenarioResultMetadata result2 = new ScenarioResultMetadata(new ScenarioWithIndex(2, new Scenario()));
+        result2.addExecuted("d1");
+        result2.addExecuted("d3");
+        result2.addAvailable("d1");
+        result2.addAvailable("d2");
+        result2.addAvailable("d3");
+
+        SimulationRunMetadataBuilder builder = SimulationRunMetadataBuilder.create();
+        builder.addScenarioResultMetadata(result1);
+        builder.addScenarioResultMetadata(result2);
+        SimulationRunMetadata build = builder.build();
+
+        assertEquals(3, build.getAvailable());
+        assertEquals(3, build.getExecuted());
+        assertEquals(100, build.getCoveragePercentage(), 0.1);
+        assertEquals(2, build.getOutputCounter().get("d1"), 0.1);
+        assertEquals(1, build.getOutputCounter().get("d2"), 0.1);
+        assertEquals(2, build.getScenarioCounter().get(scenarioWithIndex1).size(), 0.1);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/model/ResultWrapperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/model/ResultWrapperTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.runner.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ResultWrapperTest {
+
+    @Test
+    public void orElse() {
+        assertEquals((Integer) 1, ResultWrapper.createResult(1).orElse(3));
+        assertEquals(3, ResultWrapper.createErrorResult().orElse(3));
+        assertNull(ResultWrapper.createResult(null).orElse(3));
+    }
+
+    @Test
+    public void orElseGet() {
+        assertEquals((Integer) 1, ResultWrapper.createResult(1).orElseGet(() -> 3));
+        assertEquals(3, ResultWrapper.createErrorResult().orElseGet(() -> 3));
+        assertNull(ResultWrapper.createResult(null).orElseGet(() -> 3));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/DMNSimulationUtilsTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/DMNSimulationUtilsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.io.Resource;
+import org.kie.dmn.api.core.DMNModel;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNSimulationUtilsTest {
+
+    @Test
+    public void findDMNModel() {
+        List<String> pathToFind = Arrays.asList(new StringBuilder("to/find").reverse().toString().split("/"));
+
+        List<DMNModel> models = Stream.of("this/should/not/match", "find", "something/to/find")
+                .map(this::createDMNModelMock).collect(Collectors.toList());
+
+        DMNSimulationUtils.findDMNModel(models, pathToFind, 1);
+
+        List<String> impossibleToFind = Arrays.asList(new StringBuilder("not/find").reverse().toString().split("/"));
+
+        Assertions.assertThatThrownBy(() -> DMNSimulationUtils.findDMNModel(models, impossibleToFind, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Retrieving the DMNModel has failed. Make sure the used DMN asset does not " +
+                                    "produce any compilation errors and that the project does not " +
+                                    "contain multiple DMN assets with the same name and namespace. " +
+                                    "After addressing the issues, build the project again.");
+    }
+
+    private DMNModel createDMNModelMock(String path) {
+        DMNModel modelMock = mock(DMNModel.class);
+        Resource resourceMock = mock(Resource.class);
+        when(resourceMock.getSourcePath()).thenReturn(path);
+        when(modelMock.getResource()).thenReturn(resourceMock);
+        return modelMock;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ResourceHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ResourceHelperTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import static org.drools.scenariosimulation.backend.util.ResourceHelper.getClassPathElements;
+import static org.drools.scenariosimulation.backend.util.ResourceHelper.getResourcesByExtension;
+import static org.drools.scenariosimulation.backend.util.ResourceHelper.getResourcesFromDirectory;
+import static org.drools.scenariosimulation.backend.util.ResourceHelper.internalGetResources;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ResourceHelperTest {
+
+    @Test
+    public void getClassPathElementsTest() {
+        List<String> classPathElements = Arrays.asList(getClassPathElements());
+        List<String> notJar = classPathElements.stream().filter(elem -> !elem.contains(".jar")).collect(Collectors.toList());
+        assertTrue(notJar.stream().anyMatch(elem -> elem.contains("test-classes")));
+    }
+
+    @Test
+    public void getResourcesByExtensionTest() {
+        Stream<String> txtResources = getResourcesByExtension("txt");
+        List<String> resources = txtResources.collect(Collectors.toList());
+        assertEquals(1, resources.size());
+        assertTrue(resources.stream().anyMatch(elem -> elem.endsWith("testFile.txt")));
+    }
+
+    @Test
+    public void getResourcesFromDirectoryTest() {
+        List<String> classPathElements = Arrays.asList(getClassPathElements());
+        Optional<String> testFolder = classPathElements.stream().filter(elem -> elem.contains("test-classes")).findFirst();
+        assertTrue(testFolder.isPresent());
+        File dir = new File(testFolder.get());
+        List<String> filesFound = getResourcesFromDirectory(dir, Pattern.compile(".*testFile.txt"))
+                .collect(Collectors.toList());
+        assertEquals(1, filesFound.size());
+
+        assertEquals(0, getResourcesFromDirectory(null, null).count());
+        assertEquals(0, getResourcesFromDirectory(dir, Pattern.compile("noMatch")).count());
+    }
+
+    @Test
+    public void internalGetResourcesTest() {
+        List<String> classPathElements = Arrays.asList(getClassPathElements());
+        Optional<String> testFolder = classPathElements.stream().filter(elem -> elem.contains("test-classes")).findFirst();
+        assertTrue(testFolder.isPresent());
+        File dir = new File(testFolder.get());
+        List<String> filesFound = internalGetResources(testFolder.get(), Pattern.compile(".*\\.txt$")).collect(Collectors.toList());
+        assertEquals(1, filesFound.size());
+
+        assertEquals(0, internalGetResources(filesFound.get(0), Pattern.compile(".*\\.txt$")).count());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.drools.scenariosimulation.backend.model.Dispute;
+import org.drools.scenariosimulation.backend.model.NotEmptyConstructor;
+import org.drools.scenariosimulation.backend.model.Person;
+import org.drools.scenariosimulation.backend.runner.RuleScenarioRunnerHelperTest;
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
+import org.junit.Test;
+
+import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.convertValue;
+import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.loadClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ScenarioBeanUtilTest {
+
+    private static String FIRST_NAME = "firstNameToSet";
+    private static int AGE = 10;
+    private static ClassLoader classLoader = ScenarioBeanUtilTest.class.getClassLoader();
+
+    @Test
+    public void fillBeanTest() {
+        Map<List<String>, Object> paramsToSet = new HashMap<>();
+        paramsToSet.put(Arrays.asList("creator", "firstName"), FIRST_NAME);
+        paramsToSet.put(Arrays.asList("creator", "age"), AGE);
+
+        Object result = ScenarioBeanUtil.fillBean(Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+
+        assertTrue(result instanceof Dispute);
+
+        Dispute dispute = (Dispute) result;
+        assertEquals(dispute.getCreator().getFirstName(), FIRST_NAME);
+        assertEquals(dispute.getCreator().getAge(), AGE);
+    }
+
+    @Test(expected = ScenarioException.class)
+    public void fillBeanLoadClassTest() {
+        ScenarioBeanUtil.fillBean("FakeCanonicalName", new HashMap<>(), classLoader);
+    }
+
+    @Test(expected = ScenarioException.class)
+    public void fillBeanFailNotEmptyConstructorTest() {
+        Map<List<String>, Object> paramsToSet = new HashMap<>();
+        paramsToSet.put(Arrays.asList("name"), null);
+
+        ScenarioBeanUtil.fillBean(NotEmptyConstructor.class.getCanonicalName(), paramsToSet, classLoader);
+    }
+
+    @Test(expected = ScenarioException.class)
+    public void fillBeanFailTest() {
+        Map<List<String>, Object> paramsToSet = new HashMap<>();
+        paramsToSet.put(Arrays.asList("fakeField"), null);
+
+        ScenarioBeanUtil.fillBean(Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+    }
+
+    @Test(expected = ScenarioException.class)
+    public void fillBeanFailNullClassTest() {
+        Map<List<String>, Object> paramsToSet = new HashMap<>();
+        paramsToSet.put(Arrays.asList("fakeField"), null);
+
+        ScenarioBeanUtil.fillBean(null, paramsToSet, classLoader);
+    }
+
+    @Test
+    public void navigateToObjectTest() {
+        Dispute dispute = new Dispute();
+        Person creator = new Person();
+        creator.setFirstName(FIRST_NAME);
+        dispute.setCreator(creator);
+        List<String> pathToProperty = Arrays.asList("creator", "firstName");
+
+        ScenarioBeanWrapper<?> scenarioBeanWrapper = ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, true);
+        Object targetObject = scenarioBeanWrapper.getBean();
+
+        assertEquals(targetObject, FIRST_NAME);
+
+        assertNull(ScenarioBeanUtil.navigateToObject(null, Collections.emptyList()).getBean());
+    }
+
+    @Test
+    public void navigateToObjectFakeFieldTest() {
+        Dispute dispute = new Dispute();
+        List<String> pathToProperty = Arrays.asList("fakeField");
+
+        String message = "Impossible to find field with name 'fakeField' in class " + Dispute.class.getCanonicalName();
+        Assertions.assertThatThrownBy(() -> ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, true))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage(message);
+    }
+
+    @Test
+    public void navigateToObjectNoStepCreationTest() {
+        Dispute dispute = new Dispute();
+        List<String> pathToProperty = Arrays.asList("creator", "firstName");
+
+        String message = "Impossible to reach field firstName because a step is not instantiated";
+        Assertions.assertThatThrownBy(() -> ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, false))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage(message);
+    }
+
+    @Test
+    public void convertValueTest() {
+        assertEquals("Test", convertValue(String.class.getCanonicalName(), "Test", classLoader));
+        assertEquals(false, convertValue(boolean.class.getCanonicalName(), "false", classLoader));
+        assertEquals(true, convertValue(Boolean.class.getCanonicalName(), "true", classLoader));
+        assertEquals(1, convertValue(int.class.getCanonicalName(), "1", classLoader));
+        assertEquals(1, convertValue(Integer.class.getCanonicalName(), "1", classLoader));
+        assertEquals(1L, convertValue(long.class.getCanonicalName(), "1", classLoader));
+        assertEquals(1L, convertValue(Long.class.getCanonicalName(), "1", classLoader));
+        assertEquals(1.0D, convertValue(double.class.getCanonicalName(), "1.0", classLoader));
+        assertEquals(1.0D, convertValue(Double.class.getCanonicalName(), "1.0", classLoader));
+        assertEquals(1.0F, convertValue(float.class.getCanonicalName(), "1.0", classLoader));
+        assertEquals(1.0F, convertValue(Float.class.getCanonicalName(), "1.0", classLoader));
+        assertEquals('a', convertValue(char.class.getCanonicalName(), "a", classLoader));
+        assertEquals('a', convertValue(Character.class.getCanonicalName(), "a", classLoader));
+        assertEquals((short) 1, convertValue(short.class.getCanonicalName(), "1", classLoader));
+        assertEquals((short) 1, convertValue(Short.class.getCanonicalName(), "1", classLoader));
+        assertEquals("0".getBytes()[0], convertValue(byte.class.getCanonicalName(), "0", classLoader));
+        assertEquals("0".getBytes()[0], convertValue(Byte.class.getCanonicalName(), "0", classLoader));
+        assertNull(convertValue(Float.class.getCanonicalName(), null, classLoader));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertValueFailLoadClassTest() {
+        convertValue("my.NotExistingClass", "Test", classLoader);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertValueFailUnsupportedTest() {
+        convertValue(RuleScenarioRunnerHelperTest.class.getCanonicalName(), "Test", classLoader);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertValueFailPrimitiveNullTest() {
+        convertValue("int", null, classLoader);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void convertValueFailNotStringOrTypeTest() {
+        convertValue(RuleScenarioRunnerHelperTest.class.getCanonicalName(), 1, classLoader);
+    }
+
+    @Test
+    public void loadClassTest() {
+        assertEquals(String.class, loadClass(String.class.getCanonicalName(), classLoader));
+        assertEquals(int.class, loadClass(int.class.getCanonicalName(), classLoader));
+
+        Assertions.assertThatThrownBy(() -> loadClass(null, classLoader))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage("Impossible to load class null");
+
+        Assertions.assertThatThrownBy(() -> loadClass("NotExistingClass", classLoader))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage("Impossible to load class NotExistingClass");
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.assertj.core.api.Assertions;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.junit.Test;
+import org.kie.soup.project.datamodel.imports.Import;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ScenarioSimulationXMLPersistenceTest {
+
+    ScenarioSimulationXMLPersistence instance = ScenarioSimulationXMLPersistence.getInstance();
+
+    @Test
+    public void noFQCNUsed() throws Exception {
+        final ScenarioSimulationModel simulationModel = new ScenarioSimulationModel();
+        simulationModel.getImports().addImport(new Import("org.test.Test"));
+
+        final String xml = instance.marshal(simulationModel);
+
+        assertFalse(xml.contains("org.drools.scenariosimulation.api.model"));
+        assertFalse(xml.contains("org.kie.soup.project.datamodel.imports"));
+    }
+
+    @Test
+    public void versionAttributeExists() throws Exception {
+        final String xml = instance.marshal(new ScenarioSimulationModel());
+        assertTrue(xml.startsWith("<ScenarioSimulationModel version=\"" + ScenarioSimulationXMLPersistence.getCurrentVersion() + "\">"));
+    }
+
+    @Test
+    public void migrateIfNecessary_1_0_to_1_1() throws Exception {
+        String toMigrate = getFileContent("scesim-1-0.scesim");
+        String migrated = instance.migrateIfNecessary(toMigrate);
+        assertTrue(toMigrate.contains("<ScenarioSimulationModel version=\"1.0\">"));
+        assertFalse(migrated.contains("<ScenarioSimulationModel version=\"1.0\">"));
+        assertTrue(migrated.contains("EXPECT"));
+        assertFalse(migrated.contains("EXPECTED"));
+    }
+
+    @Test
+    public void migrateIfNecessary_1_1_to_1_2() throws Exception {
+        String toMigrate = getFileContent("scesim-1-1.scesim");
+        String migrated = instance.migrateIfNecessary(toMigrate);
+        assertTrue(toMigrate.contains("<ScenarioSimulationModel version=\"1.1\">"));
+        assertFalse(migrated.contains("<ScenarioSimulationModel version=\"1.1\">"));
+        assertTrue(migrated.contains("dmoSession></dmoSession>"));
+        assertTrue(migrated.contains("<type>RULE</type>"));
+    }
+
+    @Test
+    public void migrateIfNecessary_1_2_to_1_3() throws Exception {
+        String toMigrate = getFileContent("scesim-1-2.scesim");
+        String migrated = instance.migrateIfNecessary(toMigrate);
+        assertTrue(toMigrate.contains("<ScenarioSimulationModel version=\"1.2\">"));
+        assertFalse(migrated.contains("<ScenarioSimulationModel version=\"1.2\">"));
+        try {
+            ScenarioSimulationModel unmarshalled = instance.unmarshal(migrated, false);
+            for (FactMapping factMapping : unmarshalled.getSimulation().getSimulationDescriptor().getUnmodifiableFactMappings()) {
+                assertTrue(factMapping.getExpressionElements().size() >= 1);
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void migrateIfNecessary_1_3_to_1_4() throws Exception {
+        String toMigrate = getFileContent("scesim-1-3-rule.scesim");
+        String migrated = instance.migrateIfNecessary(toMigrate);
+        assertTrue(toMigrate.contains("<ScenarioSimulationModel version=\"1.3\">"));
+        assertFalse(migrated.contains("<ScenarioSimulationModel version=\"1.3\">"));
+        assertTrue(migrated.contains("<ScenarioSimulationModel version=\"1.4\">"));
+        assertTrue(migrated.contains("<fileName></fileName>"));
+        assertTrue(migrated.contains("<kieSession>default</kieSession>"));
+        assertTrue(migrated.contains("<kieBase>default</kieBase>"));
+        assertTrue(migrated.contains("<ruleFlowGroup>default</ruleFlowGroup>"));
+        assertTrue(migrated.contains("<dmoSession></dmoSession>"));
+        assertTrue(migrated.contains("<skipFromBuild>false</skipFromBuild>"));
+        assertTrue(migrated.contains("<type>RULE</type>"));
+        try {
+            instance.internalUnmarshal(migrated);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        toMigrate = getFileContent("scesim-1-3-dmn.scesim");
+        migrated = instance.migrateIfNecessary(toMigrate);
+        assertTrue(toMigrate.contains("<ScenarioSimulationModel version=\"1.3\">"));
+        assertFalse(migrated.contains("<ScenarioSimulationModel version=\"1.3\">"));
+        assertTrue(migrated.contains("<ScenarioSimulationModel version=\"1.4\">"));
+        assertTrue(migrated.contains("<dmnNamespace></dmnNamespace>"));
+        assertTrue(migrated.contains("<dmnName></dmnName>"));
+        assertTrue(migrated.contains("<skipFromBuild>false</skipFromBuild>"));
+        assertTrue(migrated.contains("<type>DMN</type>"));
+        try {
+            instance.internalUnmarshal(migrated);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void migrateIfNecessary() {
+        Assertions.assertThatThrownBy(() -> instance.migrateIfNecessary("<ScenarioSimulationModel version=\"9999999999.99999999999\">"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Version 9999999999.99999999999 of the file is not supported. Current version is " + ScenarioSimulationXMLPersistence.getCurrentVersion());
+
+        String noMigrationNeeded = "<ScenarioSimulationModel version=\"" + ScenarioSimulationXMLPersistence.getCurrentVersion() + "\">";
+        String afterMigration = instance.migrateIfNecessary(noMigrationNeeded);
+        assertEquals(noMigrationNeeded, afterMigration);
+    }
+
+    @Test
+    public void extractVersion() {
+        String version = instance.extractVersion("<ScenarioSimulationModel version=\"1.0\" version=\"1.1\">");
+        assertEquals("1.0", version);
+    }
+
+    @Test
+    public void unmarshalRULE() throws Exception {
+        String toUnmarshal = getFileContent("scesim-rule.scesim");
+        final ScenarioSimulationModel retrieved = ScenarioSimulationXMLPersistence.getInstance().unmarshal(toUnmarshal);
+        assertEquals(retrieved.getSimulation().getSimulationDescriptor().getType(), ScenarioSimulationModel.Type.RULE);
+        assertNotNull(retrieved.getSimulation().getSimulationDescriptor().getDmoSession());
+        assertNull(retrieved.getSimulation().getSimulationDescriptor().getDmnFilePath());
+    }
+
+    @Test
+    public void unmarshalDMN() throws Exception {
+        String toUnmarshal = getFileContent("scesim-dmn.scesim");
+        final ScenarioSimulationModel retrieved = ScenarioSimulationXMLPersistence.getInstance().unmarshal(toUnmarshal);
+        assertEquals(retrieved.getSimulation().getSimulationDescriptor().getType(), ScenarioSimulationModel.Type.DMN);
+        assertNotNull(retrieved.getSimulation().getSimulationDescriptor().getDmnFilePath());
+        assertNull(retrieved.getSimulation().getSimulationDescriptor().getDmoSession());
+    }
+
+    private String getFileContent(String fileName) throws IOException {
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+        String filePath = ResourceHelper.getResourcesByExtension(extension)
+                .filter(path -> path.endsWith(fileName))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(filePath);
+        File sourceFile = new File(filePath);
+        assertTrue(sourceFile.exists());
+        return new String(Files.readAllBytes(sourceFile.toPath()));
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-0.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-0.scesim
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ScenarioSimulationModel version="1.0">
+   <simulation>
+      <simulationDescriptor>
+         <factMappings>
+            <FactMapping>
+               <expressionElements>
+                  <ExpressionElement>
+                     <step>lengthYears</step>
+                  </ExpressionElement>
+               </expressionElements>
+               <expressionIdentifier>
+                  <name>1541680933813</name>
+                  <type>EXPECTED</type>
+               </expressionIdentifier>
+               <factIdentifier>
+                  <name>1541680933813</name>
+                  <className>mortgages.mortgages.LoanApplication</className>
+               </factIdentifier>
+               <className>java.lang.Integer</className>
+               <factAlias>LoanApplication1</factAlias>
+               <expressionAlias>lengthYears</expressionAlias>
+            </FactMapping>
+         </factMappings>
+      </simulationDescriptor>
+      <scenarios>
+         <Scenario>
+            <factMappingValues>
+               <FactMappingValue />
+            </factMappingValues>
+            <simulationDescriptor reference="../../../simulationDescriptor" />
+         </Scenario>
+      </scenarios>
+   </simulation>
+   <imports>
+      <imports />
+   </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-1.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-1.scesim
@@ -1,0 +1,38 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<ScenarioSimulationModel version="1.1">
+   <simulation>
+      <simulationDescriptor>
+         <factMappings>
+            <FactMapping>
+               <expressionElements>
+                  <ExpressionElement>
+                     <step>lengthYears</step>
+                  </ExpressionElement>
+               </expressionElements>
+               <expressionIdentifier>
+                  <name>1541680933813</name>
+                  <type>EXPECT</type>
+               </expressionIdentifier>
+               <factIdentifier>
+                  <name>1541680933813</name>
+                  <className>mortgages.mortgages.LoanApplication</className>
+               </factIdentifier>
+               <className>java.lang.Integer</className>
+               <factAlias>LoanApplication1</factAlias>
+               <expressionAlias>lengthYears</expressionAlias>
+            </FactMapping>
+         </factMappings>
+      </simulationDescriptor>
+      <scenarios>
+         <Scenario>
+            <factMappingValues>
+               <FactMappingValue />
+            </factMappingValues>
+            <simulationDescriptor reference="../../../simulationDescriptor" />
+         </Scenario>
+      </scenarios>
+   </simulation>
+   <imports>
+      <imports />
+   </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-2.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-2.scesim
@@ -1,0 +1,35 @@
+<ScenarioSimulationModel version="1.2">
+  <simulation>
+    <simulationDescriptor>
+      <factMappings>
+        <FactMapping>
+          <expressionElements />
+          <expressionIdentifier>
+            <name>1541680933813</name>
+            <type>EXPECT</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>1541680933813</name>
+            <className>mortgages.mortgages.LoanApplication</className>
+          </factIdentifier>
+          <className>java.lang.Integer</className>
+          <factAlias>LoanApplication1</factAlias>
+          <expressionAlias>lengthYears</expressionAlias>
+        </FactMapping>
+      </factMappings>
+      <dmoSession></dmoSession>
+      <type>RULE</type>
+    </simulationDescriptor>
+    <scenarios>
+      <Scenario>
+        <factMappingValues>
+          <FactMappingValue/>
+        </factMappingValues>
+        <simulationDescriptor reference="../../../simulationDescriptor"/>
+      </Scenario>
+    </scenarios>
+  </simulation>
+  <imports>
+    <imports/>
+  </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-dmn.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-dmn.scesim
@@ -1,0 +1,88 @@
+<ScenarioSimulationModel version="1.3">
+  <simulation>
+    <simulationDescriptor>
+      <factMappings>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>Index</name>
+            <type>OTHER</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>#</name>
+            <className>java.lang.Integer</className>
+          </factIdentifier>
+          <className>java.lang.Integer</className>
+          <factAlias>#</factAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>Description</name>
+            <type>OTHER</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>Scenario description</name>
+            <className>java.lang.String</className>
+          </factIdentifier>
+          <className>java.lang.String</className>
+          <factAlias>Scenario description</factAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>0|1</name>
+            <type>GIVEN</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>Empty</name>
+            <className>java.lang.Void</className>
+          </factIdentifier>
+          <className>java.lang.Void</className>
+          <factAlias>INSTANCE 1</factAlias>
+          <expressionAlias>PROPERTY 1</expressionAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>0|2</name>
+            <type>EXPECT</type>
+          </expressionIdentifier>
+          <factIdentifier reference="../../FactMapping[3]/factIdentifier"/>
+          <className>java.lang.Void</className>
+          <factAlias>INSTANCE 2</factAlias>
+          <expressionAlias>PROPERTY 2</expressionAlias>
+        </FactMapping>
+      </factMappings>
+      <dmoSession></dmoSession>
+      <type>DMN</type>
+    </simulationDescriptor>
+    <scenarios>
+      <Scenario>
+        <factMappingValues>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[2]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[2]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[4]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping/expressionIdentifier"/>
+            <rawValue class="string">1</rawValue>
+          </FactMappingValue>
+        </factMappingValues>
+        <simulationDescriptor reference="../../../simulationDescriptor"/>
+      </Scenario>
+    </scenarios>
+  </simulation>
+  <imports>
+    <imports/>
+  </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-1-3-rule.scesim
@@ -1,0 +1,35 @@
+<ScenarioSimulationModel version="1.3">
+  <simulation>
+    <simulationDescriptor>
+      <factMappings>
+        <FactMapping>
+          <expressionElements />
+          <expressionIdentifier>
+            <name>1541680933813</name>
+            <type>EXPECT</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>1541680933813</name>
+            <className>mortgages.mortgages.LoanApplication</className>
+          </factIdentifier>
+          <className>java.lang.Integer</className>
+          <factAlias>LoanApplication1</factAlias>
+          <expressionAlias>lengthYears</expressionAlias>
+        </FactMapping>
+      </factMappings>
+      <dmoSession></dmoSession>
+      <type>RULE</type>
+    </simulationDescriptor>
+    <scenarios>
+      <Scenario>
+        <factMappingValues>
+          <FactMappingValue/>
+        </factMappingValues>
+        <simulationDescriptor reference="../../../simulationDescriptor"/>
+      </Scenario>
+    </scenarios>
+  </simulation>
+  <imports>
+    <imports/>
+  </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-dmn.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-dmn.scesim
@@ -1,0 +1,88 @@
+<ScenarioSimulationModel version="1.2">
+  <simulation>
+    <simulationDescriptor>
+      <factMappings>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>Index</name>
+            <type>OTHER</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>#</name>
+            <className>java.lang.Integer</className>
+          </factIdentifier>
+          <className>java.lang.Integer</className>
+          <factAlias>#</factAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>Description</name>
+            <type>OTHER</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>Scenario description</name>
+            <className>java.lang.String</className>
+          </factIdentifier>
+          <className>java.lang.String</className>
+          <factAlias>Scenario description</factAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>0|1</name>
+            <type>GIVEN</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>Empty</name>
+            <className>java.lang.Void</className>
+          </factIdentifier>
+          <className>java.lang.Void</className>
+          <factAlias>INSTANCE 1</factAlias>
+          <expressionAlias>PROPERTY 1</expressionAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>0|2</name>
+            <type>EXPECT</type>
+          </expressionIdentifier>
+          <factIdentifier reference="../../FactMapping[3]/factIdentifier"/>
+          <className>java.lang.Void</className>
+          <factAlias>INSTANCE 2</factAlias>
+          <expressionAlias>PROPERTY 2</expressionAlias>
+        </FactMapping>
+      </factMappings>
+      <dmnFilePath>src/main/resources/com/new-def.dmn</dmnFilePath>
+      <type>DMN</type>
+    </simulationDescriptor>
+    <scenarios>
+      <Scenario>
+        <factMappingValues>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[2]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[2]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[4]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping/expressionIdentifier"/>
+            <rawValue class="string">1</rawValue>
+          </FactMappingValue>
+        </factMappingValues>
+        <simulationDescriptor reference="../../../simulationDescriptor"/>
+      </Scenario>
+    </scenarios>
+  </simulation>
+  <imports>
+    <imports/>
+  </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-rule.scesim
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/scesim-rule.scesim
@@ -1,0 +1,88 @@
+<ScenarioSimulationModel version="1.2">
+  <simulation>
+    <simulationDescriptor>
+      <factMappings>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>Index</name>
+            <type>OTHER</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>#</name>
+            <className>java.lang.Integer</className>
+          </factIdentifier>
+          <className>java.lang.Integer</className>
+          <factAlias>#</factAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>Description</name>
+            <type>OTHER</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>Scenario description</name>
+            <className>java.lang.String</className>
+          </factIdentifier>
+          <className>java.lang.String</className>
+          <factAlias>Scenario description</factAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>0|1</name>
+            <type>GIVEN</type>
+          </expressionIdentifier>
+          <factIdentifier>
+            <name>Empty</name>
+            <className>java.lang.Void</className>
+          </factIdentifier>
+          <className>java.lang.Void</className>
+          <factAlias>INSTANCE 1</factAlias>
+          <expressionAlias>PROPERTY 1</expressionAlias>
+        </FactMapping>
+        <FactMapping>
+          <expressionElements/>
+          <expressionIdentifier>
+            <name>0|2</name>
+            <type>EXPECT</type>
+          </expressionIdentifier>
+          <factIdentifier reference="../../FactMapping[3]/factIdentifier"/>
+          <className>java.lang.Void</className>
+          <factAlias>INSTANCE 2</factAlias>
+          <expressionAlias>PROPERTY 2</expressionAlias>
+        </FactMapping>
+      </factMappings>
+      <dmoSession></dmoSession>
+      <type>RULE</type>
+    </simulationDescriptor>
+    <scenarios>
+      <Scenario>
+        <factMappingValues>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[2]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[2]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[3]/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping[4]/expressionIdentifier"/>
+          </FactMappingValue>
+          <FactMappingValue>
+            <factIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping/factIdentifier"/>
+            <expressionIdentifier reference="../../../../../simulationDescriptor/factMappings/FactMapping/expressionIdentifier"/>
+            <rawValue class="string">1</rawValue>
+          </FactMappingValue>
+        </factMappingValues>
+        <simulationDescriptor reference="../../../simulationDescriptor"/>
+      </Scenario>
+    </scenarios>
+  </simulation>
+  <imports>
+    <imports/>
+  </imports>
+</ScenarioSimulationModel>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/simple-item-def.dmn
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/simple-item-def.dmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<definitions id="_simple-item-def" name="simple-item-def"
+	namespace="https://github.com/kiegroup/kie-dmn/itemdef"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:kie="https://github.com/kiegroup/kie-dmn/itemdef"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+	<itemDefinition name="tSalary" id="_tSalary">
+		<typeRef>feel:number</typeRef>
+	</itemDefinition>
+	<decision name="Yearly Salary" id="d_YearlySalary">
+		<variable name="Yearly Salary" typeRef="kie:tSalary"/>
+		<informationRequirement>
+			<requiredInput href="#i_MonthlySalary"/>
+		</informationRequirement>
+		<literalExpression>
+			<text>12 * Monthly Salary</text>
+		</literalExpression>
+	</decision>
+	<inputData name="Monthly Salary" id="i_MonthlySalary">
+		<variable name="Monthly Salary" typeRef="kie:tSalary"/>
+	</inputData>
+</definitions>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/testFile.txt
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/resources/folderToTest/testFile.txt
@@ -1,0 +1,1 @@
+testFile

--- a/drools-scenario-simulation/pom.xml
+++ b/drools-scenario-simulation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.21.0-SNAPSHOT</version>
+    <version>7.22.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/pom.xml
+++ b/drools-scenario-simulation/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>drools</artifactId>
+    <groupId>org.drools</groupId>
+    <version>7.21.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>drools-scenario-simulation</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>drools-scenario-simulation-api</module>
+    <module>drools-scenario-simulation-backend</module>
+  </modules>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <module>drools-examples-cdi</module>
     <module>drools-workbench-models</module>
     <module>drools-test-coverage</module>
+    <module>drools-scenario-simulation</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
@kkufova @gitgabrio @Rikkola 

Created two runtime modules (backend and api) in `drools` repo. This PR does not contains real new code, it is just a move from the existing modules in `drools-wb`.
The only changes are:
- removed `@Portable` annotation from API classes and replaced with `errai.marshalling.serializableTypes` property
- created a constant `FILE_EXTENSION` to avoid the usages of `ScenarioSimulationResourceTypeDefinition`

https://issues.jboss.org/browse/DROOLS-3389

NOTE: to be merged after https://github.com/kiegroup/drools-wb/pull/1126

PRs list:
- https://github.com/kiegroup/drools-wb/pull/1132
- https://github.com/kiegroup/drools/pull/2325
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/951