### PR TITLE
DROOLS-3432 : While using the same template key with difference objects/attributes causes an exception when switching to the Data tab in a Guided Rule Template

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/InterpolationVariable.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/InterpolationVariable.java
@@ -82,6 +82,10 @@ public class InterpolationVariable {
         return dataType;
     }
 
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
+    }
+
     public String getFactField() {
         return factField;
     }

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/shared/TemplateModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/shared/TemplateModelTest.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.models.guided.template.shared;
 
 import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.rule.IPattern;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,5 +49,61 @@ public class TemplateModelTest {
         } catch (IllegalArgumentException iae) {
             assertEquals("Invalid numbers of columns: 0 expected: 1", iae.getMessage());
         }
+    }
+
+    @Test
+    public void sameFieldSameVariable() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default"));
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default"));
+
+        assertEquals(1, m.getInterpolationVariablesList().length);
+        assertEquals("Integer", m.getInterpolationVariablesList()[0].getDataType());
+    }
+
+    @Test
+    public void sameVariableFroTwoDifferentTypes() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default"));
+        factPattern.addConstraint(makeConstraint("Applicant", "name", "String", "$default"));
+
+        assertEquals(1, m.getInterpolationVariablesList().length);
+        assertEquals(TemplateModel.DEFAULT_TYPE, m.getInterpolationVariablesList()[0].getDataType());
+    }
+
+    @Test
+    public void separateVariableNames() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default"));
+        factPattern.addConstraint(makeConstraint("Applicant", "name", "String", "$other"));
+
+        assertEquals(2, m.getInterpolationVariablesList().length);
+        assertEquals("Integer", m.getInterpolationVariablesList()[0].getDataType());
+        assertEquals("String", m.getInterpolationVariablesList()[1].getDataType());
+    }
+
+    private SingleFieldConstraint makeConstraint(final String factType,
+                                                 final String fieldName,
+                                                 final String fieldType,
+                                                 final String variableName) {
+        SingleFieldConstraint constraint = new SingleFieldConstraint(factType,
+                                                                     fieldName,
+                                                                     fieldType,
+                                                                     null);
+        constraint.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        constraint.setValue(variableName);
+        return constraint;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3432

If the same variable is used for two fields the UI defaults to String cell editor.

