### PR TITLE
DROOLS-3432 : While using the same template key with difference objects/attributes causes an exception when switching to the Data tab in a Guided Rule Template

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/InterpolationVariable.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/InterpolationVariable.java
@@ -82,6 +82,10 @@ public class InterpolationVariable {
         return dataType;
     }
 
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
+    }
+
     public String getFactField() {
         return factField;
     }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/RuleModel.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/RuleModel.java
@@ -28,6 +28,8 @@ import org.kie.soup.project.datamodel.packages.HasPackageName;
 public class RuleModel implements HasImports,
                                   HasPackageName {
 
+    public static final String DEFAULT_TYPE = "DEFAULT_TYPE";
+
     /**
      * This name is generally not used - the asset name or the file name is
      * preferred (ie it could get out of sync with the name of the file it is

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/util/InterpolationVariableCollector.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/util/InterpolationVariableCollector.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.models.datamodel.rule.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+
+import static org.drools.workbench.models.datamodel.rule.RuleModel.DEFAULT_TYPE;
+
+public class InterpolationVariableCollector {
+
+    private final String defaultType;
+    private final Map<Integer, InterpolationVariable> byColumn = new TreeMap<Integer, InterpolationVariable>();
+
+    public InterpolationVariableCollector(final Map<InterpolationVariable, Integer> map,
+                                          final String defaultType) {
+        this.defaultType = defaultType;
+        removeDuplicates(map);
+    }
+
+    public InterpolationVariableCollector(final Map<InterpolationVariable, Integer> map) {
+        this(map,
+             DEFAULT_TYPE);
+    }
+
+    private void removeDuplicates(Map<InterpolationVariable, Integer> map) {
+        for (Map.Entry<InterpolationVariable, Integer> entry : map.entrySet()) {
+
+            final InterpolationVariable newVar = entry.getKey();
+            final Optional<InterpolationVariable> oldColumnData = findByVariable(byColumn,
+                                                                                 newVar);
+
+            if (oldColumnData.isPresent()) {
+                if (isThereANeedToSetDefaultType(newVar, oldColumnData.get())) {
+                    oldColumnData.get().setDataType(defaultType);
+                }
+            } else {
+                InterpolationVariable variable = new InterpolationVariable(newVar.getVarName(),
+                                                                           newVar.getDataType(),
+                                                                           newVar.getFactType(),
+                                                                           newVar.getFactField());
+                variable.setOperator(newVar.getOperator());
+                byColumn.put(entry.getValue(),
+                             variable);
+            }
+        }
+    }
+
+    public boolean isThereANeedToSetDefaultType(final InterpolationVariable newVar,
+                                                final InterpolationVariable oldVar) {
+        if (Objects.equals(newVar.getDataType(), oldVar.getDataType())
+                && Objects.equals(newVar.getFactType(), oldVar.getFactType())
+                && Objects.equals(newVar.getFactField(), oldVar.getFactField())) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private Optional<InterpolationVariable> findByVariable(final Map<Integer, InterpolationVariable> result,
+                                                           final InterpolationVariable newVar) {
+        for (final InterpolationVariable columnData : result.values()) {
+            if (Objects.equals(columnData.getVarName(), newVar.getVarName())) {
+
+                return Optional.of(columnData);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public Map<InterpolationVariable, Integer> getMap() {
+        final HashMap<InterpolationVariable, Integer> result = new HashMap<InterpolationVariable, Integer>();
+
+        int index = 0;
+        for (Integer integer : byColumn.keySet()) {
+            result.put(byColumn.get(integer),
+                       index);
+            index++;
+        }
+
+        return result;
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/util/InterpolationVariableCollectorTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/util/InterpolationVariableCollectorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.models.datamodel.rule.util;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+import static org.drools.workbench.models.datamodel.rule.RuleModel.DEFAULT_TYPE;
+import static org.junit.Assert.assertEquals;
+
+public class InterpolationVariableCollectorTest {
+
+    @Test
+    public void merge() {
+        final HashMap<InterpolationVariable, Integer> map = new HashMap<>();
+
+        map.put(new InterpolationVariable("var",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "birthday"), 1);
+        map.put(new InterpolationVariable("var",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "dateOfDeath"), 2);
+
+        final Map<InterpolationVariable, Integer> result = new InterpolationVariableCollector(map).getMap();
+        assertEquals(1, result.size());
+        final InterpolationVariable var = result.keySet().iterator().next();
+        assertEquals("var", var.getVarName());
+        assertEquals(DEFAULT_TYPE, var.getDataType());
+    }
+
+    @Test
+    public void orderTopDown() {
+        final HashMap<InterpolationVariable, Integer> map = new HashMap<>();
+
+        map.put(new InterpolationVariable("var",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "birthday"), 0);
+        map.put(new InterpolationVariable("var",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "dateOfDeath"), 1);
+        map.put(new InterpolationVariable("p",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "dateOfDeath"), 2);
+
+        final Map<InterpolationVariable, Integer> result = new InterpolationVariableCollector(map).getMap();
+        assertEquals(2, result.size());
+        final Iterator<Integer> iterator = result.values().iterator();
+        assertEquals(1, (int) iterator.next());
+        assertEquals(0, (int) iterator.next());
+    }
+
+    @Test
+    /**
+     * The map numbers can go from higher to lower or from lower to higher.
+     * After merge make sure the numbers are not skipping any.
+     */
+    public void orderBottomUp() {
+        final HashMap<InterpolationVariable, Integer> map = new HashMap<>();
+
+        map.put(new InterpolationVariable("var",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "birthday"), 2);
+        map.put(new InterpolationVariable("var",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "dateOfDeath"), 1);
+        map.put(new InterpolationVariable("p",
+                                          DataType.TYPE_DATE,
+                                          "Person",
+                                          "dateOfDeath"), 0);
+
+        final Map<InterpolationVariable, Integer> result = new InterpolationVariableCollector(map).getMap();
+        assertEquals(2, result.size());
+        final Iterator<Integer> iterator = result.values().iterator();
+        assertEquals(0, (int) iterator.next());
+        assertEquals(1, (int) iterator.next());
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/shared/TemplateModel.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/shared/TemplateModel.java
@@ -20,10 +20,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.models.datamodel.rule.util.InterpolationVariableCollector;
 import org.drools.workbench.models.datamodel.rule.visitors.RuleModelVisitor;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
@@ -42,7 +46,6 @@ public class TemplateModel
 
     /**
      * Append a row of data
-     *
      * @param rowId
      * @param row
      * @return
@@ -79,7 +82,6 @@ public class TemplateModel
 
     /**
      * Add a row of data at the specified index
-     *
      * @param index
      * @param row
      * @return
@@ -134,8 +136,11 @@ public class TemplateModel
     }
 
     private Map<InterpolationVariable, Integer> getInterpolationVariables() {
-        Map<InterpolationVariable, Integer> result = new HashMap<InterpolationVariable, Integer>();
-        new RuleModelVisitor(result).visit(this);
+        final Map<InterpolationVariable, Integer> variables = new HashMap<InterpolationVariable, Integer>();
+
+        new RuleModelVisitor(variables).visit(this);
+
+        final Map<InterpolationVariable, Integer> result = new InterpolationVariableCollector(variables).getMap();
 
         InterpolationVariable id = new InterpolationVariable(ID_COLUMN_NAME,
                                                              DataType.TYPE_NUMERIC_LONG);
@@ -256,4 +261,5 @@ public class TemplateModel
     public void setIdCol(final int idCol) {
         this.idCol = idCol;
     }
+
 }

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/shared/TemplateModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/shared/TemplateModelTest.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.models.guided.template.shared;
 
 import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.rule.IPattern;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,5 +49,91 @@ public class TemplateModelTest {
         } catch (IllegalArgumentException iae) {
             assertEquals("Invalid numbers of columns: 0 expected: 1", iae.getMessage());
         }
+    }
+
+    @Test
+    public void sameFieldSameVariable() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default", "=="));
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default", "=="));
+
+        assertEquals(1, m.getInterpolationVariablesList().length);
+        assertEquals("Integer", m.getInterpolationVariablesList()[0].getDataType());
+    }
+
+    @Test
+    public void sameVariableFroTwoDifferentTypes() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default", "=="));
+        factPattern.addConstraint(makeConstraint("Applicant", "name", "String", "$default", "=="));
+
+        assertEquals(1, m.getInterpolationVariablesList().length);
+        assertEquals(TemplateModel.DEFAULT_TYPE, m.getInterpolationVariablesList()[0].getDataType());
+    }
+
+    @Test
+    public void sameVariableFroTwoDifferentOperatorsSameType() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default", "=="));
+        factPattern.addConstraint(makeConstraint("Applicant", "name", "Integer", "$default", "!="));
+
+        assertEquals(1, m.getInterpolationVariablesList().length);
+        assertEquals(TemplateModel.DEFAULT_TYPE, m.getInterpolationVariablesList()[0].getDataType());
+    }
+
+    @Test
+    public void sameVariableFroTwoDifferentOperatorsDifferentType() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default", "=="));
+        factPattern.addConstraint(makeConstraint("Applicant", "name", "String", "$default", "!="));
+
+        assertEquals(1, m.getInterpolationVariablesList().length);
+        assertEquals(TemplateModel.DEFAULT_TYPE, m.getInterpolationVariablesList()[0].getDataType());
+    }
+
+    @Test
+    public void separateVariableNames() throws Exception {
+        TemplateModel m = new TemplateModel();
+        m.name = "t1";
+        m.lhs = new IPattern[1];
+        FactPattern factPattern = new FactPattern();
+        m.lhs[0] = factPattern;
+        factPattern.addConstraint(makeConstraint("Applicant", "age", "Integer", "$default", "=="));
+        factPattern.addConstraint(makeConstraint("Applicant", "name", "String", "$other", "=="));
+
+        assertEquals(2, m.getInterpolationVariablesList().length);
+        assertEquals("Integer", m.getInterpolationVariablesList()[0].getDataType());
+        assertEquals("String", m.getInterpolationVariablesList()[1].getDataType());
+    }
+
+    private SingleFieldConstraint makeConstraint(final String factType,
+                                                 final String fieldName,
+                                                 final String fieldType,
+                                                 final String variableName,
+                                                 final String operator) {
+        SingleFieldConstraint constraint = new SingleFieldConstraint(factType,
+                                                                     fieldName,
+                                                                     fieldType,
+                                                                     null);
+        constraint.setOperator(operator);
+        constraint.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        constraint.setValue(variableName);
+        return constraint;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3432
If the same variable is used for two fields the UI defaults to String cell editor.

PRs:
https://github.com/kiegroup/drools/pull/2332
https://github.com/kiegroup/drools-wb/pull/1134