### PR TITLE
DROOLS-4021 Fix executable model file path on Windows

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
@@ -676,9 +676,6 @@ public class CanonicalKieModule implements InternalKieModule {
     }
 
     public static String getModelFileWithGAV(ReleaseId releaseId) {
-        return Paths.get(MODEL_FILE_DIRECTORY,
-                              releaseId.getGroupId(),
-                              releaseId.getArtifactId(),
-                              MODEL_FILE_NAME).toString();
+        return MODEL_FILE_DIRECTORY + "/" + releaseId.getGroupId() + "/" + releaseId.getArtifactId() + "/" + MODEL_FILE_NAME;
     }
 }


### PR DESCRIPTION
@mariofusco @lucamolteni please review. 

The original form was causing all executable model tests to fail when run on Windows. The reason is that our memory filesystem doesn't support Windows file separator. 