### PR TITLE
Drools 4035 Remove kie-soup-project-datamodel-api dependency from drools-scenario-simulation-api

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -19,11 +19,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-project-datamodel-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/HasImports.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/HasImports.java
@@ -1,0 +1,12 @@
+package org.drools.scenariosimulation.api.imports;
+
+/**
+ * Models marked with this interface support Imports.
+ */
+public interface HasImports {
+
+    Imports getImports();
+
+    void setImports( final Imports imports );
+
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/HasImports.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/HasImports.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.scenariosimulation.api.imports;
 
 /**

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Import.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Import.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.scenariosimulation.api.imports;
 
 public class Import {

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Import.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Import.java
@@ -1,0 +1,50 @@
+package org.drools.scenariosimulation.api.imports;
+
+public class Import {
+
+    private String type;
+
+    public Import() {
+
+    }
+
+    public Import(String t) {
+        this.type = t;
+    }
+
+    public Import(Class<?> clazz) {
+        this(clazz.getName());
+    }
+
+    public String getType() {
+        return this.type;
+    }   
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        // Must do instanceof check because there is a subtype of this class in drools-workbench-models-datamodel-api
+        if (!(o instanceof Import)) {
+            return false;
+        }
+
+        Import anImport = (Import) o;
+
+        if (type != null ? !type.equals(anImport.type) : anImport.type != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public int hashCode() {
+        return type != null ? type.hashCode() : 0;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Imports.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Imports.java
@@ -1,0 +1,76 @@
+package org.drools.scenariosimulation.api.imports;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Imports {
+
+    private ArrayList<Import> imports = new ArrayList<Import>();
+
+    public Imports() {
+    }
+
+    public Imports(final List<Import> imports) {
+        this.imports = new ArrayList<>(imports);
+    }
+
+    public List<Import> getImports() {
+        return imports;
+    }
+
+    public Set<String> getImportStrings() {
+        Set<String> strings = new HashSet<>();
+
+        for (Import item : imports) {
+            strings.add(item.getType());
+        }
+
+        return strings;
+    }
+
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        for (final Import i : imports) {
+            sb.append("import ").append(i.getType()).append(";\n");
+        }
+
+        return sb.toString();
+    }
+
+    public void addImport(final Import item) {
+        imports.add(item);
+    }
+
+    public void removeImport(final Import item) {
+        imports.remove(item);
+    }
+
+    public boolean contains(final Import item) {
+        return imports.contains(item);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Imports imports1 = (Imports) o;
+
+        if (imports != null ? !imports.equals(imports1.imports) : imports1.imports != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return imports != null ? imports.hashCode() : 0;
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Imports.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/imports/Imports.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.drools.scenariosimulation.api.imports;
 
 import java.util.ArrayList;

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioSimulationModel.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/ScenarioSimulationModel.java
@@ -17,11 +17,10 @@
 package org.drools.scenariosimulation.api.model;
 
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import org.kie.soup.project.datamodel.imports.HasImports;
-import org.kie.soup.project.datamodel.imports.Imports;
+import org.drools.scenariosimulation.api.imports.HasImports;
+import org.drools.scenariosimulation.api.imports.Imports;
 
-public class ScenarioSimulationModel
-        implements HasImports {
+public class ScenarioSimulationModel implements HasImports {
 
     public enum Type {
         RULE,

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -47,10 +47,6 @@
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-project-datamodel-api</artifactId>
-    </dependency>
 
     <!-- DMN dependencies -->
     <dependency>

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.DomDriver;
+import org.drools.scenariosimulation.api.imports.Import;
 import org.drools.scenariosimulation.api.model.ExpressionElement;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
@@ -33,7 +34,6 @@ import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
 import org.drools.scenariosimulation.api.model.Simulation;
 import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.kie.soup.commons.xstream.XStreamUtils;
-import org.kie.soup.project.datamodel.imports.Import;
 
 public class ScenarioSimulationXMLPersistence {
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.assertj.core.api.Assertions;
+import org.drools.scenariosimulation.api.imports.Import;
 import org.drools.scenariosimulation.api.model.FactMapping;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
 import org.junit.Test;
-import org.kie.soup.project.datamodel.imports.Import;
 
 import static org.drools.scenariosimulation.backend.TestUtils.getFileContent;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
@danielezonca @yesamer  @jomarko 

See https://issues.jboss.org/browse/DROOLS-4035