### PR TITLE
RHDM-961 Random test failures

### DIFF
--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/compiler/pmml_compiler.drl
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/compiler/pmml_compiler.drl
@@ -33,9 +33,16 @@ global String ruleUnitClassName;
 dialect "mvel"
 
 // the function is repeated here because of rule processDerivedField_MapValues
-    function String format(String type, String val) {
-        if (type == null) {
+    function String format(Object obj, String val) {
+        if (obj == null) {
             return val;
+        }
+        String type = null;
+        if ( obj instanceof String ) {
+           type = (String)obj;
+        }
+        if (type == null) {
+           return val;
         } else if ("Integer".equalsIgnoreCase(type)) {
 			return val;
 		} else if ("Float".equalsIgnoreCase(type)) {


### PR DESCRIPTION
The error message indicated that sometimes the format function being
called by an accumulate, in the rule "processDerivedField_MapValues",
was being called with a "type" parameter that was not a String. I
updated the function's signature to take a generic Object for the "type"
parameter, and then modified the function to check to see if the
parameter was indeed a String. If it is a String then the function works
as it was originally coded; otherwise it returns the passed in "val"
parameter, just as though the "type" parameter was null.