### PR TITLE
[DROOLS-3806] Improve error reporting messages + minor bug

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
@@ -169,7 +169,7 @@ public enum BaseExpressionOperator {
     protected abstract boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader);
 
     protected Object evaluateLiteralExpression(String className, String value, ClassLoader classLoader) {
-        throw new IllegalStateException("This operator cannot be used into a Given clause");
+        throw new IllegalStateException(name() + " (" + String.join(",", symbols) + ") operator cannot be used into a Given clause");
     }
 
     protected Optional<String> match(String value) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
@@ -194,7 +194,7 @@ public enum BaseExpressionOperator {
     protected abstract boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader);
 
     protected Object evaluateLiteralExpression(String className, String value, ClassLoader classLoader) {
-        throw new IllegalStateException(toString() + " operator cannot be used into a Given clause");
+        throw new IllegalStateException(toString() + " operator cannot be used in a GIVEN clause");
     }
 
     protected Optional<String> match(String value) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperator.java
@@ -46,6 +46,11 @@ public enum BaseExpressionOperator {
                     .collect(Collectors.toList());
             return results.size() != 0 && results.stream().allMatch(a -> a);
         }
+
+        @Override
+        public String toString() {
+            return "AND ( ; )";
+        }
     },
     LIST_OF_VALUES(1, "[") {
         @Override
@@ -66,6 +71,11 @@ public enum BaseExpressionOperator {
             return Stream.of(rawValue.substring(1, ((String) raw).length() - 1).split(","))
                     .map(String::trim)
                     .collect(Collectors.toList());
+        }
+
+        @Override
+        public String toString() {
+            return "OR ( [ ] )";
         }
     },
     EQUALS(2, "=") {
@@ -94,6 +104,11 @@ public enum BaseExpressionOperator {
             }
             return Objects.equals(resultValue, parsedResults);
         }
+
+        @Override
+        public String toString() {
+            return "Equal ( = )";
+        }
     },
     NOT_EQUALS(3, "!", "!=", "<>") {
         @SuppressWarnings("unchecked")
@@ -109,6 +124,11 @@ public enum BaseExpressionOperator {
             }
 
             return !operator.eval(valueToTest, resultValue, resultClass, classLoader);
+        }
+
+        @Override
+        public String toString() {
+            return "Not Equal ( !, !=, <> )";
         }
     },
     RANGE(4, "<", ">", "<=", ">=") {
@@ -140,6 +160,11 @@ public enum BaseExpressionOperator {
                     throw new IllegalStateException(new StringBuilder().append("This should not happen ").append(operator).toString());
             }
         }
+
+        @Override
+        public String toString() {
+            return "Range ( <, >, <=, >= )";
+        }
     };
 
     final List<String> symbols;
@@ -169,7 +194,7 @@ public enum BaseExpressionOperator {
     protected abstract boolean eval(Object rawValue, Object resultValue, Class<?> resultClass, ClassLoader classLoader);
 
     protected Object evaluateLiteralExpression(String className, String value, ClassLoader classLoader) {
-        throw new IllegalStateException(name() + " (" + String.join(",", symbols) + ") operator cannot be used into a Given clause");
+        throw new IllegalStateException(toString() + " operator cannot be used into a Given clause");
     }
 
     protected Optional<String> match(String value) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
@@ -178,7 +178,7 @@ public abstract class AbstractRunnerHelper {
                                                                              factMapping.getGenericTypes(),
                                                                              factMappingValue.getRawValue());
                 paramsForBean.put(pathToField, value);
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | IllegalStateException e) {
                 factMappingValue.setExceptionMessage(e.getMessage());
                 throw new ScenarioException(e.getMessage(), e);
             }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
@@ -178,7 +178,7 @@ public abstract class AbstractRunnerHelper {
                                                                              factMapping.getGenericTypes(),
                                                                              factMappingValue.getRawValue());
                 paramsForBean.put(pathToField, value);
-            } catch (IllegalArgumentException | IllegalStateException e) {
+            } catch (RuntimeException e) {
                 factMappingValue.setExceptionMessage(e.getMessage());
                 throw new ScenarioException(e.getMessage(), e);
             }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
@@ -132,12 +132,17 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
                                                              evaluationStatus);
         }
 
-        for (ExpressionElement expressionElement : factMapping.getExpressionElementsWithoutClass()) {
-            if (!(resultRaw instanceof Map)) {
-                throw new ScenarioException("Wrong resultRaw structure because it is not a complex type as expected");
+        List<ExpressionElement> elementsWithoutClass = factMapping.getExpressionElementsWithoutClass();
+
+        // DMN engine doesn't generate the whole object when no entry of the decision table match
+        if(resultRaw != null) {
+            for (ExpressionElement expressionElement : elementsWithoutClass) {
+                if (!(resultRaw instanceof Map)) {
+                    throw new ScenarioException("Wrong resultRaw structure because it is not a complex type as expected");
+                }
+                Map<String, Object> result = (Map<String, Object>) resultRaw;
+                resultRaw = result.get(expressionElement.getStep());
             }
-            Map<String, Object> result = (Map<String, Object>) resultRaw;
-            resultRaw = result.get(expressionElement.getStep());
         }
 
         Class<?> resultClass = resultRaw != null ? resultRaw.getClass() : null;

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioException.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/IndexedScenarioException.java
@@ -47,7 +47,8 @@ public class IndexedScenarioException extends ScenarioException {
 
     @Override
     public String getMessage() {
-        StringBuilder message = new StringBuilder().append("#").append(index).append(": ").append(super.getMessage());
+        String errorMessage = getCause() != null ? getCause().getMessage() : super.getMessage();
+        StringBuilder message = new StringBuilder().append("#").append(index).append(": ").append(errorMessage);
         if (getFileName() != null) {
             message.append("(").append(getFileName()).append(")");
         }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DMNSimulationUtils.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DMNSimulationUtils.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieRuntimeFactory;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNRuntime;
 
@@ -39,7 +40,7 @@ public class DMNSimulationUtils {
     }
 
     public static DMNRuntime extractDMNRuntime(KieContainer kieContainer) {
-        return kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
+        return KieRuntimeFactory.of(kieContainer.getKieBase()).get(DMNRuntime.class);
     }
 
     public static DMNModel findDMNModel(List<DMNModel> dmnModels, List<String> pathToFind, int step) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
@@ -18,6 +18,7 @@ package org.drools.scenariosimulation.backend.expression;
 
 import java.util.Arrays;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class BaseExpressionOperatorTest {
 
@@ -43,12 +43,10 @@ public class BaseExpressionOperatorTest {
         Arrays.stream(values())
                 .filter(e -> !EQUALS.equals(e))
                 .forEach(operator -> {
-                    try {
-                        operator.evaluateLiteralExpression(String.class.getCanonicalName(), " Test ", classLoader);
-                        fail();
-                    } catch (IllegalStateException e) {
-                        assertTrue(e.getMessage().endsWith(" cannot be used into a Given clause"));
-                    }
+                    Assertions.assertThatThrownBy(
+                            () -> operator.evaluateLiteralExpression(String.class.getCanonicalName(), " Test ", classLoader))
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageEndingWith(" cannot be used into a Given clause");
                 });
 
         assertEquals("Test", EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= Test", classLoader));

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
@@ -18,13 +18,20 @@ package org.drools.scenariosimulation.backend.expression;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.drools.scenariosimulation.backend.expression.BaseExpressionOperator.EQUALS;
+import static org.drools.scenariosimulation.backend.expression.BaseExpressionOperator.LIST_OF_CONDITION;
+import static org.drools.scenariosimulation.backend.expression.BaseExpressionOperator.LIST_OF_VALUES;
+import static org.drools.scenariosimulation.backend.expression.BaseExpressionOperator.NOT_EQUALS;
+import static org.drools.scenariosimulation.backend.expression.BaseExpressionOperator.RANGE;
+import static org.drools.scenariosimulation.backend.expression.BaseExpressionOperator.values;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BaseExpressionOperatorTest {
 
@@ -33,34 +40,37 @@ public class BaseExpressionOperatorTest {
     @Test
     public void evaluateLiteralExpression() {
 
-        Arrays.stream(BaseExpressionOperator.values())
-                .filter(e -> !BaseExpressionOperator.EQUALS.equals(e))
+        Arrays.stream(values())
+                .filter(e -> !EQUALS.equals(e))
                 .forEach(operator -> {
-                    assertThatThrownBy(() -> operator.evaluateLiteralExpression(String.class.getCanonicalName(), " Test ", classLoader))
-                            .isInstanceOf(IllegalStateException.class)
-                            .hasMessage("This operator cannot be used into a Given clause");
+                    try {
+                        operator.evaluateLiteralExpression(String.class.getCanonicalName(), " Test ", classLoader);
+                        fail();
+                    } catch (IllegalStateException e) {
+                        assertTrue(e.getMessage().endsWith(" cannot be used into a Given clause"));
+                    }
                 });
 
-        Assert.assertEquals("Test", BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= Test", classLoader));
-        Assert.assertEquals("", BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= ", classLoader));
-        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "null", classLoader));
-        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= null", classLoader));
-        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), null, classLoader));
+        assertEquals("Test", EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= Test", classLoader));
+        assertEquals("", EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= ", classLoader));
+        assertNull(EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "null", classLoader));
+        assertNull(EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= null", classLoader));
+        assertNull(EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), null, classLoader));
     }
 
     @Test
     public void findOperator() {
         String rawValue = "Test";
-        assertEquals(BaseExpressionOperator.EQUALS, BaseExpressionOperator.findOperator(rawValue));
+        assertEquals(EQUALS, BaseExpressionOperator.findOperator(rawValue));
 
         rawValue = " Test ";
-        assertEquals(BaseExpressionOperator.EQUALS, BaseExpressionOperator.findOperator(rawValue));
+        assertEquals(EQUALS, BaseExpressionOperator.findOperator(rawValue));
 
         rawValue = "= Test ";
-        assertEquals(BaseExpressionOperator.EQUALS, BaseExpressionOperator.findOperator(rawValue));
+        assertEquals(EQUALS, BaseExpressionOperator.findOperator(rawValue));
 
         rawValue = "!= Test ";
-        assertEquals(BaseExpressionOperator.NOT_EQUALS, BaseExpressionOperator.findOperator(rawValue));
+        assertEquals(NOT_EQUALS, BaseExpressionOperator.findOperator(rawValue));
     }
 
     @Test
@@ -70,14 +80,14 @@ public class BaseExpressionOperatorTest {
         MyComparableTestClass comparableTest1 = new MyComparableTestClass();
 
         // Tested via Objects.equals
-        assertTrue(BaseExpressionOperator.EQUALS.eval(test1, test1, test1.getClass(), classLoader));
-        assertFalse(BaseExpressionOperator.EQUALS.eval(test1, test2, test1.getClass(), classLoader));
+        assertTrue(EQUALS.eval(test1, test1, test1.getClass(), classLoader));
+        assertFalse(EQUALS.eval(test1, test2, test1.getClass(), classLoader));
         // Tested via Comparable.compareTo
-        assertTrue(BaseExpressionOperator.EQUALS.eval(comparableTest1, comparableTest1, comparableTest1.getClass(), classLoader));
+        assertTrue(EQUALS.eval(comparableTest1, comparableTest1, comparableTest1.getClass(), classLoader));
 
-        assertTrue(BaseExpressionOperator.EQUALS.eval("1", 1, int.class, classLoader));
+        assertTrue(EQUALS.eval("1", 1, int.class, classLoader));
 
-        assertTrue(BaseExpressionOperator.EQUALS.eval(null, null, null, classLoader));
+        assertTrue(EQUALS.eval(null, null, null, classLoader));
     }
 
     @Test
@@ -87,46 +97,46 @@ public class BaseExpressionOperatorTest {
         MyComparableTestClass comparableTest1 = new MyComparableTestClass();
 
         // Tested via Objects.equals
-        assertFalse(BaseExpressionOperator.NOT_EQUALS.eval(test1, test1, test1.getClass(), classLoader));
-        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval(test1, test2, test1.getClass(), classLoader));
+        assertFalse(NOT_EQUALS.eval(test1, test1, test1.getClass(), classLoader));
+        assertTrue(NOT_EQUALS.eval(test1, test2, test1.getClass(), classLoader));
         // Tested via Comparable.compareTo
-        assertFalse(BaseExpressionOperator.NOT_EQUALS.eval(comparableTest1, comparableTest1, comparableTest1.getClass(), classLoader));
+        assertFalse(NOT_EQUALS.eval(comparableTest1, comparableTest1, comparableTest1.getClass(), classLoader));
 
-        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval("<> 1", 2, int.class, classLoader));
+        assertTrue(NOT_EQUALS.eval("<> 1", 2, int.class, classLoader));
 
-        assertFalse(BaseExpressionOperator.NOT_EQUALS.eval(null, null, null, classLoader));
+        assertFalse(NOT_EQUALS.eval(null, null, null, classLoader));
 
         // NOT_EQUALS can be composed
-        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval("! <1", 2, int.class, classLoader));
-        assertTrue(BaseExpressionOperator.NOT_EQUALS.eval("! [1, 3]", 2, int.class, classLoader));
+        assertTrue(NOT_EQUALS.eval("! <1", 2, int.class, classLoader));
+        assertTrue(NOT_EQUALS.eval("! [1, 3]", 2, int.class, classLoader));
     }
 
     @Test
     public void rangeTest() {
         Object o = new Object();
-        assertFalse(BaseExpressionOperator.RANGE.eval(o, "", o.getClass(), classLoader));
+        assertFalse(RANGE.eval(o, "", o.getClass(), classLoader));
 
-        assertTrue(BaseExpressionOperator.RANGE.eval(">2", 3, int.class, classLoader));
+        assertTrue(RANGE.eval(">2", 3, int.class, classLoader));
     }
 
     @Test
     public void listOfValuesTest() {
         Object o = new Object();
-        assertFalse(BaseExpressionOperator.LIST_OF_VALUES.eval(o, "", o.getClass(), classLoader));
+        assertFalse(LIST_OF_VALUES.eval(o, "", o.getClass(), classLoader));
 
-        assertThatThrownBy(() -> BaseExpressionOperator.LIST_OF_VALUES.eval("[ 2", "", String.class, classLoader))
+        assertThatThrownBy(() -> LIST_OF_VALUES.eval("[ 2", "", String.class, classLoader))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Malformed expression: [ 2");
 
-        assertTrue(BaseExpressionOperator.LIST_OF_VALUES.eval("[ Test, Another Test]", "Another Test", String.class, classLoader));
+        assertTrue(LIST_OF_VALUES.eval("[ Test, Another Test]", "Another Test", String.class, classLoader));
     }
 
     @Test
     public void listOfConditionsTest() {
         Object o = new Object();
-        assertFalse(BaseExpressionOperator.LIST_OF_CONDITION.eval(o, "", o.getClass(), classLoader));
+        assertFalse(LIST_OF_CONDITION.eval(o, "", o.getClass(), classLoader));
 
-        assertTrue(BaseExpressionOperator.LIST_OF_CONDITION.eval("=1; ![2, 3]; <10", 1, int.class, classLoader));
+        assertTrue(LIST_OF_CONDITION.eval("=1; ![2, 3]; <10", 1, int.class, classLoader));
     }
 
     private class MyTestClass {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionOperatorTest.java
@@ -46,7 +46,7 @@ public class BaseExpressionOperatorTest {
                     Assertions.assertThatThrownBy(
                             () -> operator.evaluateLiteralExpression(String.class.getCanonicalName(), " Test ", classLoader))
                             .isInstanceOf(IllegalStateException.class)
-                            .hasMessageEndingWith(" cannot be used into a Given clause");
+                            .hasMessageEndingWith(" operator cannot be used in a GIVEN clause");
                 });
 
         assertEquals("Test", EQUALS.evaluateLiteralExpression(String.class.getCanonicalName(), "= Test", classLoader));

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
-import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.runtime.events.FEELEventBase;
 import org.kie.dmn.feel.runtime.events.SyntaxErrorEvent;
 
@@ -123,40 +123,40 @@ public class DMNFeelExpressionEvaluatorTest {
     }
 
     @Test
-    public void newEvaluationContextTest() {
+    public void listenerTest() {
         FEELEvent syntaxErrorEvent = new SyntaxErrorEvent(Severity.ERROR, "test", null, 0, 0, null);
         FEELEvent genericError = new FEELEventBase(Severity.ERROR, "error", null);
         FEELEvent notError = new FEELEventBase(Severity.INFO, "info", null);
 
         AtomicReference<FEELEvent> error = new AtomicReference<>();
-        EvaluationContext evaluationContext = expressionEvaluator.newEvaluationContext(error);
+        FEEL feel = expressionEvaluator.newFeelEvaluator(error);
 
         // Only a single error of type syntax
-        applyEvents(Collections.singletonList(syntaxErrorEvent), evaluationContext);
+        applyEvents(Collections.singletonList(syntaxErrorEvent), feel);
         assertEquals(syntaxErrorEvent, error.get());
 
         error.set(null);
 
         // Syntax error as second
-        applyEvents(Arrays.asList(genericError, syntaxErrorEvent), evaluationContext);
+        applyEvents(Arrays.asList(genericError, syntaxErrorEvent), feel);
         assertEquals(syntaxErrorEvent, error.get());
 
         error.set(null);
 
         // Syntax error as first
-        applyEvents(Arrays.asList(syntaxErrorEvent, genericError), evaluationContext);
+        applyEvents(Arrays.asList(syntaxErrorEvent, genericError), feel);
         assertEquals(syntaxErrorEvent, error.get());
 
         error.set(null);
 
         // Not error
-        applyEvents(Collections.singletonList(notError), evaluationContext);
+        applyEvents(Collections.singletonList(notError), feel);
         assertNull(error.get());
     }
 
-    private void applyEvents(List<FEELEvent> events, EvaluationContext evaluationContext) {
+    private void applyEvents(List<FEELEvent> events, FEEL feel) {
         for (FEELEvent event : events) {
-            evaluationContext.getListeners().forEach(listener -> listener.onEvent(event));
+            feel.getListeners().forEach(listener -> listener.onEvent(event));
         }
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import org.assertj.core.api.Assertions;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
 import org.drools.scenariosimulation.api.model.FactMapping;
@@ -58,7 +57,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
@@ -58,6 +58,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -148,17 +149,27 @@ public class DMNScenarioRunnerHelperTest {
 
     @Test
     public void verifyConditions() {
-        ScenarioRunnerData scenarioRunnerData = new ScenarioRunnerData();
-        scenarioRunnerData.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
+        ScenarioRunnerData scenarioRunnerData1 = new ScenarioRunnerData();
+        scenarioRunnerData1.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
 
-        Assertions.assertThatThrownBy(() -> runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData, expressionEvaluator, requestContextMock))
+        // test 1 - no decision generated for specific decisionName
+        assertThatThrownBy(() -> runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData1, expressionEvaluator, requestContextMock))
                 .isInstanceOf(ScenarioException.class)
                 .hasMessage("DMN execution has not generated a decision result with name Fact 1");
 
         when(dmnResultMock.getDecisionResultByName(anyString())).thenReturn(dmnDecisionResultMock);
         when(dmnDecisionResultMock.getEvaluationStatus()).thenReturn(DecisionEvaluationStatus.SUCCEEDED);
 
-        Assertions.assertThatThrownBy(() -> runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData, expressionEvaluator, requestContextMock))
+        // test 2 - when decisionResult contains a null value skip the steps and just do the comparison (that should be false in this case)
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData1, expressionEvaluator, requestContextMock);
+
+        assertEquals(1, scenarioRunnerData1.getResults().size());
+        assertFalse(scenarioRunnerData1.getResults().get(0).getResult());
+
+        when(dmnDecisionResultMock.getResult()).thenReturn("");
+
+        // test 3 - now result is not null but data structure is wrong (expected steps but data is a simple string)
+        assertThatThrownBy(() -> runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData1, expressionEvaluator, requestContextMock))
                 .isInstanceOf(ScenarioException.class)
                 .hasMessage("Wrong resultRaw structure because it is not a complex type as expected");
 
@@ -167,26 +178,31 @@ public class DMNScenarioRunnerHelperTest {
 
         when(dmnDecisionResultMock.getResult()).thenReturn(resultMap);
 
-        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData, expressionEvaluator, requestContextMock);
+        ScenarioRunnerData scenarioRunnerData2 = new ScenarioRunnerData();
+        scenarioRunnerData2.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
 
-        assertEquals(1, scenarioRunnerData.getResults().size());
-        assertFalse(scenarioRunnerData.getResults().get(0).getResult());
+        // test 4 - check are performed (but fail)
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData2, expressionEvaluator, requestContextMock);
 
-        ScenarioRunnerData newScenarioRunnerData = new ScenarioRunnerData();
-        newScenarioRunnerData.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
+        assertEquals(1, scenarioRunnerData2.getResults().size());
+        assertFalse(scenarioRunnerData2.getResults().get(0).getResult());
+
+        ScenarioRunnerData scenarioRunnerData3 = new ScenarioRunnerData();
+        scenarioRunnerData3.addExpect(new ScenarioExpect(personFactIdentifier, Collections.singletonList(firstNameExpectedValue)));
         resultMap.put("firstName", NAME);
 
-        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), newScenarioRunnerData, expressionEvaluator, requestContextMock);
+        // test 5 - check are performed (but success)
+        runnerHelper.verifyConditions(simulation.getSimulationDescriptor(), scenarioRunnerData3, expressionEvaluator, requestContextMock);
 
-        assertEquals(1, newScenarioRunnerData.getResults().size());
-        assertTrue(newScenarioRunnerData.getResults().get(0).getResult());
+        assertEquals(1, scenarioRunnerData3.getResults().size());
+        assertTrue(scenarioRunnerData3.getResults().get(0).getResult());
 
-        // verify that when expression evaluation fails the corresponding expression is marked as error
+        // test 6 - verify that when expression evaluation fails the corresponding expression is marked as error
         runnerHelper.verifyConditions(simulation.getSimulationDescriptor(),
-                                      newScenarioRunnerData,
+                                      scenarioRunnerData3,
                                       mock(ExpressionEvaluator.class),
                                       requestContextMock);
-        assertEquals(newScenarioRunnerData.getResults().get(0).getFactMappingValue().getStatus(), FactMappingValueStatus.FAILED_WITH_ERROR);
+        assertEquals(scenarioRunnerData3.getResults().get(0).getFactMappingValue().getStatus(), FactMappingValueStatus.FAILED_WITH_ERROR);
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/fluent/NewDMNRuntimeCommand.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/fluent/NewDMNRuntimeCommand.java
@@ -19,6 +19,7 @@ package org.kie.dmn.core.fluent;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieRuntimeFactory;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.internal.command.RegistryContext;
 
@@ -31,7 +32,7 @@ public class NewDMNRuntimeCommand implements ExecutableCommand<DMNRuntime> {
         if (kieContainer == null) {
             throw new IllegalStateException("There is no existing KieContainer assigned to the Registry");
         }
-        DMNRuntime dmnRuntime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
+        DMNRuntime dmnRuntime = KieRuntimeFactory.of(kieContainer.getKieBase()).get(DMNRuntime.class);
 
         registryContext.register(DMNRuntime.class, dmnRuntime);
         return dmnRuntime;


### PR DESCRIPTION
This PR cover what is described in the corresponding ticket ( https://issues.jboss.org/browse/DROOLS-3806 ) plus some other improvements in error reporting area:
- (DMN) now if FEEL has a parsing error in Given section the error is properly reported and the evaluation is stopped
- (RULE) when an unsupported operator is used in Given section (i.e. `> 3`) a proper message is provideda and the cell is highlighted
- (General) alert error messages improvement: i.e. if the specified KieSession doesn't exist the error is what it come from the KieContainer (` Impossible to find a KieSession with name test`)
- (General) migrate scenario activator Junit class for project created before backend/api refactoring (move some of them into `drools` repo). You just need to open and save one scesim file
- (DMN) minor performance improvement on model evaluation: moved to new `KieRuntimeFactory` API to avoid creation of an unnecessary `KieSession` just to obtain `DMNRuntime` 

@jomarko @gitgabrio @Rikkola 

NOTE: this PR should fix also https://issues.jboss.org/browse/DROOLS-4059

PS: PR description is probably longer than code changes :)

PRs list:
- https://github.com/kiegroup/drools-wb/pull/1146
- https://github.com/kiegroup/drools/pull/2355