### PR TITLE
[DROOLS-4018] Add support for LocalDate in Rule based test scenarios

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -166,7 +166,7 @@ public class ScenarioBeanUtil {
         } else if (clazz.isAssignableFrom(Short.class) || clazz.isAssignableFrom(short.class)) {
             return Short.parseShort(cleanStringForNumberParsing(value));
         } else if (clazz.isAssignableFrom(LocalDate.class)) {
-            return LocalDate.parse(value, DateTimeFormatter.ofPattern("MM-dd-yyyy"));
+            return LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         }
 
         throw new IllegalArgumentException(new StringBuilder().append("Class ").append(className)
@@ -200,7 +200,7 @@ public class ScenarioBeanUtil {
             return String.valueOf(cleanValue);
         } else if (clazz.isAssignableFrom(LocalDate.class)) {
             LocalDate localDate = (LocalDate) cleanValue;
-            return String.format("%02d-%02d-%04d", localDate.getMonthValue(), localDate.getDayOfMonth(), localDate.getYear());
+            return String.format("%04d-%02d-%02d", localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth());
         } else {
             return String.valueOf(cleanValue);
         }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -17,6 +17,8 @@
 package org.drools.scenariosimulation.backend.util;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,6 +165,8 @@ public class ScenarioBeanUtil {
             return parseByte(value);
         } else if (clazz.isAssignableFrom(Short.class) || clazz.isAssignableFrom(short.class)) {
             return Short.parseShort(cleanStringForNumberParsing(value));
+        } else if (clazz.isAssignableFrom(LocalDate.class)) {
+            return LocalDate.parse(value, DateTimeFormatter.ofPattern("MM-dd-yyyy"));
         }
 
         throw new IllegalArgumentException(new StringBuilder().append("Class ").append(className)
@@ -194,6 +198,9 @@ public class ScenarioBeanUtil {
             return String.valueOf(cleanValue);
         } else if (clazz.isAssignableFrom(Short.class) || clazz.isAssignableFrom(short.class)) {
             return String.valueOf(cleanValue);
+        } else if (clazz.isAssignableFrom(LocalDate.class)) {
+            LocalDate localDate = (LocalDate) cleanValue;
+            return String.format("%2d-%2d-%4d", localDate.getMonthValue(), localDate.getDayOfMonth(), localDate.getYear());
         } else {
             return String.valueOf(cleanValue);
         }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -200,7 +200,7 @@ public class ScenarioBeanUtil {
             return String.valueOf(cleanValue);
         } else if (clazz.isAssignableFrom(LocalDate.class)) {
             LocalDate localDate = (LocalDate) cleanValue;
-            return String.format("%2d-%2d-%4d", localDate.getMonthValue(), localDate.getDayOfMonth(), localDate.getYear());
+            return String.format("%02d-%02d-%04d", localDate.getMonthValue(), localDate.getDayOfMonth(), localDate.getYear());
         } else {
             return String.valueOf(cleanValue);
         }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.scenariosimulation.backend.util;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -144,6 +145,7 @@ public class ScenarioBeanUtilTest {
         assertEquals((short) 1, convertValue(Short.class.getCanonicalName(), "1", classLoader));
         assertEquals("0".getBytes()[0], convertValue(byte.class.getCanonicalName(), "0", classLoader));
         assertEquals("0".getBytes()[0], convertValue(Byte.class.getCanonicalName(), "0", classLoader));
+        assertEquals(LocalDate.of(2018, 10, 20), convertValue(LocalDate.class.getCanonicalName(), "10-20-2018", classLoader));
         assertNull(convertValue(Float.class.getCanonicalName(), null, classLoader));
     }
 
@@ -159,6 +161,7 @@ public class ScenarioBeanUtilTest {
         assertEquals("1", revertValue((short) 1));
         assertEquals(String.valueOf("0".getBytes()[0]), revertValue("0".getBytes()[0]));
         assertEquals("null", revertValue(null));
+        assertEquals("10-20-2018", revertValue(LocalDate.of(2018, 10, 20)));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -145,7 +145,7 @@ public class ScenarioBeanUtilTest {
         assertEquals((short) 1, convertValue(Short.class.getCanonicalName(), "1", classLoader));
         assertEquals("0".getBytes()[0], convertValue(byte.class.getCanonicalName(), "0", classLoader));
         assertEquals("0".getBytes()[0], convertValue(Byte.class.getCanonicalName(), "0", classLoader));
-        assertEquals(LocalDate.of(2018, 5, 20), convertValue(LocalDate.class.getCanonicalName(), "05-20-2018", classLoader));
+        assertEquals(LocalDate.of(2018, 5, 20), convertValue(LocalDate.class.getCanonicalName(), "2018-05-20", classLoader));
         assertNull(convertValue(Float.class.getCanonicalName(), null, classLoader));
     }
 
@@ -161,7 +161,7 @@ public class ScenarioBeanUtilTest {
         assertEquals("1", revertValue((short) 1));
         assertEquals(String.valueOf("0".getBytes()[0]), revertValue("0".getBytes()[0]));
         assertEquals("null", revertValue(null));
-        assertEquals("10-20-2018", revertValue(LocalDate.of(2018, 10, 20)));
+        assertEquals("2018-10-20", revertValue(LocalDate.of(2018, 10, 20)));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -145,7 +145,7 @@ public class ScenarioBeanUtilTest {
         assertEquals((short) 1, convertValue(Short.class.getCanonicalName(), "1", classLoader));
         assertEquals("0".getBytes()[0], convertValue(byte.class.getCanonicalName(), "0", classLoader));
         assertEquals("0".getBytes()[0], convertValue(Byte.class.getCanonicalName(), "0", classLoader));
-        assertEquals(LocalDate.of(2018, 10, 20), convertValue(LocalDate.class.getCanonicalName(), "10-20-2018", classLoader));
+        assertEquals(LocalDate.of(2018, 5, 20), convertValue(LocalDate.class.getCanonicalName(), "05-20-2018", classLoader));
         assertNull(convertValue(Float.class.getCanonicalName(), null, classLoader));
     }
 


### PR DESCRIPTION
This PR introduce a basic support for `LocalDate` class to Rule based scenario.
`LocalDate` parsing supports only `yyyy-MM-dd` format at the moment

https://issues.jboss.org/browse/DROOLS-4018

@jomarko @gitgabrio @Rikkola 

PRs list:
- https://github.com/kiegroup/drools-wb/pull/1148
- https://github.com/kiegroup/drools/pull/2359