### PR TITLE
Remove unused dependency org.eclipse.aether:aether-spi

### DIFF
--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -124,10 +124,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-transport-wagon</artifactId>
     </dependency>
     <dependency>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -168,12 +168,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -68,10 +68,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
     </dependency>
     <dependency>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -112,10 +112,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-impl</artifactId>
     </dependency>
     <dependency>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -127,10 +127,6 @@
       <artifactId>aether-transport-file</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-http</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
       <exclusions>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -149,10 +149,6 @@
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.sonatype.plexus</groupId>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -124,10 +124,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.ant</groupId>
-      <artifactId>ant</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -123,10 +123,6 @@
       <artifactId>aether-transport-wagon</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
       <exclusions>

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -56,10 +56,6 @@
 
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is an attempt to fix the failing [master nightly build](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/PROD/job/rhpam-master-nightly-release-pipeline/job/y-rhpam-master-drools-wb/).