### PR TITLE
DROOLS-4131: Can't use "is contained in the list" for Integer field

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-commons/pom.xml
@@ -23,10 +23,6 @@
 
     <!-- Internal dependencies -->
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -1354,7 +1354,7 @@ public class RuleModelDRLPersistenceImpl
                 constraintValueBuilder.buildLHSFieldValue(buf,
                                                           type,
                                                           DataType.TYPE_COLLECTION,
-                                                          "@{makeValueList(" + value + ")}");
+                                                          "@{makeValueList(" + value + "," + DataType.isNumeric(fieldType) + ")}");
                 buf.append(" ");
             } else {
                 buf.append(" ");

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/main/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceImpl.java
@@ -623,7 +623,7 @@ public class RuleTemplateModelDRLPersistenceImpl
                               "  value.toUpperCase();\n" +
                               "}}");
         header.append("@code{\n" +
-                              " def makeValueList(value) {\n" +
+                              " def makeValueList(value, isNumeric) {\n" +
                               "    if(value.startsWith('\"') && value.endsWith('\"')) {\n" +
                               "      value = value.substring(1, value.length() - 1);\n" +
                               "    }\n" +
@@ -642,7 +642,11 @@ public class RuleTemplateModelDRLPersistenceImpl
                               "		if ( v.endsWith( '\"' ) ) {\n" +
                               "   		v = v.substring( 0,v.length() - 1 );\n" +
                               "		}\n" +
-                              "		output+='\"'+v+'\", ';\n" +
+                              "	    if ( isNumeric ) {\n" +
+                              "         output+=v+', ';\n" +
+                              "	    } else {\n" +
+                              "	        output+='\"'+v+'\", ';\n" +
+                              "     }\n" +
                               "	}" +
                               "	output=output.substring(0,output.length()-2)+')';\n" +
                               "	output;\n" +

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceTest.java
@@ -58,6 +58,48 @@ public class RuleTemplateModelDRLPersistenceTest {
     }
 
     @Test
+    public void testInWithIntegerValues() {
+        final TemplateModel m = new TemplateModel();
+        m.name = "t1";
+
+        final FactPattern p = new FactPattern("Person");
+        final SingleFieldConstraint con = new SingleFieldConstraint();
+        con.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
+        con.setFieldName("field1");
+        con.setOperator("in");
+        con.setValue("$f1");
+        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        p.addConstraint(con);
+
+        m.addLhsItem(p);
+
+        m.addRow(new String[]{"1,2"});
+        m.addRow(new String[]{"\"3\",\"4\""});
+        m.addRow(new String[]{"(5,6)"});
+
+        final String expected = "rule \"t1_2\"" +
+                "dialect \"mvel\"\n" +
+                "when \n" +
+                "  Person( field1 in (5, 6) )" +
+                "then \n" +
+                "end" +
+                "rule \"t1_1\"" +
+                "dialect \"mvel\"\n" +
+                "when \n" +
+                "  Person( field1 in (3, 4) )" +
+                "then \n" +
+                "end" +
+                "rule \"t1_0\"" +
+                "dialect \"mvel\"\n" +
+                "when \n" +
+                "  Person( field1 in (1, 2) )" +
+                "then \n" +
+                "end";
+
+        checkMarshall(expected, m);
+    }
+
+    @Test
     public void testInWithSimpleSingleLiteralValue() {
         TemplateModel m = new TemplateModel();
         m.name = "t1";


### PR DESCRIPTION
Ensemble together with:
- https://github.com/kiegroup/drools-wb/pull/1165

This PR check what is the data type of collection used with the "is containded in the list".
If the type is a numeric one, quotes are not added into the generated drl.