### PR TITLE
[7.23.x] [DROOLS-3805] All line separators in RHS in spreadsheet are escaped

### DIFF
--- a/drools-decisiontables/src/test/java/org/drools/decisiontable/LineBreakXLSTest.java
+++ b/drools-decisiontables/src/test/java/org/drools/decisiontable/LineBreakXLSTest.java
@@ -12,6 +12,8 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -40,5 +42,33 @@ public class LineBreakXLSTest {
         ksession.dispose();
 
         assertTrue(fd.getエラーメッセージ().contains("値には0以上を指定してください。\n指定された値："));
+    }
+
+    @Test
+    public void testMultipleLinesInAction() {
+
+        // DROOLS-3805
+        DecisionTableConfiguration dtconf = KnowledgeBuilderFactory.newDecisionTableConfiguration();
+        dtconf.setInputType(DecisionTableInputType.XLS);
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add(ResourceFactory.newClassPathResource("MultiLinesInAction.xls", getClass()), ResourceType.DTABLE, dtconf);
+        if (kbuilder.hasErrors()) {
+            fail(kbuilder.getErrors().toString());
+        }
+        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addPackages(kbuilder.getKnowledgePackages());
+
+        KieSession ksession = kbase.newKieSession();
+
+        Person john = new Person("John");
+        john.setAge(20);
+        john.setAlive(true);
+        ksession.insert(john);
+        ksession.fireAllRules();
+
+        ksession.dispose();
+
+        assertEquals(30, john.getAge());
+        assertFalse(john.isAlive());
     }
 }


### PR DESCRIPTION
Cherry-pick of #2293 

