### PR TITLE
[DROOLS-3775] Implement stateless kieSession runner support in test scenario

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationDescriptor.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/model/SimulationDescriptor.java
@@ -50,6 +50,7 @@ public class SimulationDescriptor {
     private String dmnName;
 
     private boolean skipFromBuild = false;
+    private boolean stateless = false;
 
     /**
      * Returns an <b>unmodifiable</b> list wrapping the backed one
@@ -245,5 +246,13 @@ public class SimulationDescriptor {
 
     private List<FactMapping> internalFilter(Predicate<FactMapping> predicate) {
         return factMappings.stream().filter(predicate).collect(Collectors.toList());
+    }
+
+    public boolean isStateless() {
+        return stateless;
+    }
+
+    public void setStateless(boolean stateless) {
+        this.stateless = stateless;
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
@@ -16,92 +16,38 @@
 
 package org.drools.scenariosimulation.backend.fluent;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.drools.scenariosimulation.api.model.FactIdentifier;
-import org.drools.scenariosimulation.backend.runner.ScenarioException;
 import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
-import org.kie.api.builder.model.KieSessionModel;
-import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.RequestContext;
-import org.kie.api.runtime.conf.ClockTypeOption;
-import org.kie.internal.builder.fluent.ExecutableBuilder;
-import org.kie.internal.builder.fluent.KieSessionFluent;
 
-public class RuleScenarioExecutableBuilder {
+public interface RuleScenarioExecutableBuilder {
 
-    public static String DEFAULT_APPLICATION = "defaultApplication";
+    String DEFAULT_APPLICATION = "defaultApplication";
 
-    private final KieSessionFluent kieSessionFluent;
-    private final ExecutableBuilder executableBuilder;
-    private final Map<FactIdentifier, List<FactCheckerHandle>> internalConditions = new HashMap<>();
-
-    protected static final BiFunction<String, KieContainer, KieContainer> forcePseudoClock = (sessionName, kc) -> {
-        KieSessionModel kieSessionModel = kc.getKieSessionModel(sessionName);
-        if (kieSessionModel == null) {
-            throw new ScenarioException("Impossible to find a KieSession with name " + sessionName);
+    static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer, String kieSessionName, boolean stateless) {
+        if(stateless) {
+            return new RuleStatelessScenarioExecutableBuilder(kieContainer, kieSessionName);
+        } else {
+            return new RuleStatefulScenarioExecutableBuilder(kieContainer, kieSessionName);
         }
-        kieSessionModel.setClockType(ClockTypeOption.get("pseudo"));
-        return kc;
-    };
-
-    private RuleScenarioExecutableBuilder(KieContainer kieContainer, String kieSessionName) {
-        executableBuilder = ExecutableBuilder.create();
-
-        kieSessionFluent = executableBuilder
-                .newApplicationContext(DEFAULT_APPLICATION)
-                .setKieContainer(kieContainer)
-                .newSessionCustomized(kieSessionName, forcePseudoClock);
     }
 
-    private RuleScenarioExecutableBuilder(KieContainer kieContainer) {
-        this(kieContainer, null);
+    static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer) {
+        return new RuleStatefulScenarioExecutableBuilder(kieContainer);
     }
 
-    public static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer, String kieSessionName) {
-        return new RuleScenarioExecutableBuilder(kieContainer, kieSessionName);
-    }
-
-    public static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer) {
-        return new RuleScenarioExecutableBuilder(kieContainer);
-    }
-
-    public void addInternalCondition(Class<?> clazz,
+    void addInternalCondition(Class<?> clazz,
                                      Function<Object, ResultWrapper> checkFunction,
-                                     ScenarioResult scenarioResult) {
-        internalConditions.computeIfAbsent(scenarioResult.getFactIdentifier(), key -> new ArrayList<>())
-                .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));
-    }
+                                     ScenarioResult scenarioResult);
 
-    public void setActiveAgendaGroup(String agendaGroup) {
-        kieSessionFluent.setActiveAgendaGroup(agendaGroup);
-    }
+    void setActiveAgendaGroup(String agendaGroup);
 
-    public void setActiveRuleFlowGroup(String ruleFlowGroup) {
-        kieSessionFluent.setActiveRuleFlowGroup(ruleFlowGroup);
-    }
+    void setActiveRuleFlowGroup(String ruleFlowGroup);
 
-    public void insert(Object element) {
-        kieSessionFluent.insert(element);
-    }
+    void insert(Object element);
 
-    public RequestContext run() {
-        Objects.requireNonNull(executableBuilder, "Executable builder is null, please invoke create(KieContainer, )");
-
-        kieSessionFluent.fireAllRules();
-        internalConditions.values()
-                .forEach(factToCheck -> kieSessionFluent.addCommand(new ValidateFactCommand(factToCheck)));
-
-        kieSessionFluent.dispose().end();
-
-        return ExecutableRunner.create().execute(executableBuilder.getExecutable());
-    }
+    RequestContext run();
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
@@ -25,10 +25,8 @@ import org.kie.api.runtime.RequestContext;
 
 public interface RuleScenarioExecutableBuilder {
 
-    String DEFAULT_APPLICATION = "defaultApplication";
-
     static RuleScenarioExecutableBuilder createBuilder(KieContainer kieContainer, String kieSessionName, boolean stateless) {
-        if(stateless) {
+        if (stateless) {
             return new RuleStatelessScenarioExecutableBuilder(kieContainer, kieSessionName);
         } else {
             return new RuleStatefulScenarioExecutableBuilder(kieContainer, kieSessionName);
@@ -40,8 +38,8 @@ public interface RuleScenarioExecutableBuilder {
     }
 
     void addInternalCondition(Class<?> clazz,
-                                     Function<Object, ResultWrapper> checkFunction,
-                                     ScenarioResult scenarioResult);
+                              Function<Object, ResultWrapper> checkFunction,
+                              ScenarioResult scenarioResult);
 
     void setActiveAgendaGroup(String agendaGroup);
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
@@ -38,6 +38,8 @@ import org.kie.internal.builder.fluent.KieSessionFluent;
 
 public class RuleStatefulScenarioExecutableBuilder implements RuleScenarioExecutableBuilder {
 
+    private final static String DEFAULT_APPLICATION = "defaultApplication";
+
     private final KieSessionFluent kieSessionFluent;
     private final ExecutableBuilder executableBuilder;
     private final Map<FactIdentifier, List<FactCheckerHandle>> internalConditions = new HashMap<>();
@@ -52,7 +54,7 @@ public class RuleStatefulScenarioExecutableBuilder implements RuleScenarioExecut
     };
 
     protected RuleStatefulScenarioExecutableBuilder(KieContainer kieContainer, String kieSessionName) {
-        executableBuilder = ExecutableBuilder.create();
+        executableBuilder = createExecutableBuilder();
 
         kieSessionFluent = executableBuilder
                 .newApplicationContext(DEFAULT_APPLICATION)
@@ -97,6 +99,14 @@ public class RuleStatefulScenarioExecutableBuilder implements RuleScenarioExecut
 
         kieSessionFluent.dispose().end();
 
-        return ExecutableRunner.create().execute(executableBuilder.getExecutable());
+        return createExecutableRunner().execute(executableBuilder.getExecutable());
+    }
+
+    protected ExecutableBuilder createExecutableBuilder() {
+        return ExecutableBuilder.create();
+    }
+
+    protected ExecutableRunner<RequestContext> createExecutableRunner() {
+        return ExecutableRunner.create();
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
@@ -38,11 +38,11 @@ import org.kie.internal.builder.fluent.KieSessionFluent;
 
 public class RuleStatefulScenarioExecutableBuilder implements RuleScenarioExecutableBuilder {
 
-    private final static String DEFAULT_APPLICATION = "defaultApplication";
-
     private final KieSessionFluent kieSessionFluent;
     private final ExecutableBuilder executableBuilder;
     private final Map<FactIdentifier, List<FactCheckerHandle>> internalConditions = new HashMap<>();
+
+    private final static String DEFAULT_APPLICATION = "defaultApplication";
 
     protected static final BiFunction<String, KieContainer, KieContainer> forcePseudoClock = (sessionName, kc) -> {
         KieSessionModel kieSessionModel = kc.getKieSessionModel(sessionName);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.kie.api.builder.model.KieSessionModel;
+import org.kie.api.runtime.ExecutableRunner;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieSessionFluent;
+
+public class RuleStatefulScenarioExecutableBuilder implements RuleScenarioExecutableBuilder {
+
+    private final KieSessionFluent kieSessionFluent;
+    private final ExecutableBuilder executableBuilder;
+    private final Map<FactIdentifier, List<FactCheckerHandle>> internalConditions = new HashMap<>();
+
+    protected static final BiFunction<String, KieContainer, KieContainer> forcePseudoClock = (sessionName, kc) -> {
+        KieSessionModel kieSessionModel = kc.getKieSessionModel(sessionName);
+        if (kieSessionModel == null) {
+            throw new ScenarioException("Impossible to find a KieSession with name " + sessionName);
+        }
+        kieSessionModel.setClockType(ClockTypeOption.get("pseudo"));
+        return kc;
+    };
+
+    protected RuleStatefulScenarioExecutableBuilder(KieContainer kieContainer, String kieSessionName) {
+        executableBuilder = ExecutableBuilder.create();
+
+        kieSessionFluent = executableBuilder
+                .newApplicationContext(DEFAULT_APPLICATION)
+                .setKieContainer(kieContainer)
+                .newSessionCustomized(kieSessionName, forcePseudoClock);
+    }
+
+    protected RuleStatefulScenarioExecutableBuilder(KieContainer kieContainer) {
+        this(kieContainer, null);
+    }
+
+    @Override
+    public void addInternalCondition(Class<?> clazz,
+                                     Function<Object, ResultWrapper> checkFunction,
+                                     ScenarioResult scenarioResult) {
+        internalConditions.computeIfAbsent(scenarioResult.getFactIdentifier(), key -> new ArrayList<>())
+                .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));
+    }
+
+    @Override
+    public void setActiveAgendaGroup(String agendaGroup) {
+        kieSessionFluent.setActiveAgendaGroup(agendaGroup);
+    }
+
+    @Override
+    public void setActiveRuleFlowGroup(String ruleFlowGroup) {
+        kieSessionFluent.setActiveRuleFlowGroup(ruleFlowGroup);
+    }
+
+    @Override
+    public void insert(Object element) {
+        kieSessionFluent.insert(element);
+    }
+
+    @Override
+    public RequestContext run() {
+        Objects.requireNonNull(executableBuilder, "Executable builder is null, please invoke create(KieContainer, )");
+
+        kieSessionFluent.fireAllRules();
+        internalConditions.values()
+                .forEach(factToCheck -> kieSessionFluent.addCommand(new ValidateFactCommand(factToCheck)));
+
+        kieSessionFluent.dispose().end();
+
+        return ExecutableRunner.create().execute(executableBuilder.getExecutable());
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
+import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.kie.api.KieServices;
+import org.kie.api.builder.model.KieSessionModel;
+import org.kie.api.command.Command;
+import org.kie.api.command.KieCommands;
+import org.kie.api.runtime.ExecutionResults;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+import org.kie.api.runtime.StatelessKieSession;
+import org.kie.api.runtime.conf.ClockTypeOption;
+
+public class RuleStatelessScenarioExecutableBuilder implements RuleScenarioExecutableBuilder {
+
+    private final KieContainer kieContainer;
+    private final String sessionName;
+    private final List<Object> inputs = new ArrayList<>();
+    private final Map<FactIdentifier, List<FactCheckerHandle>> internalConditions = new HashMap<>();
+    private final KieCommands commands = KieServices.get().getCommands();
+
+    private String agendaGroup;
+
+    protected RuleStatelessScenarioExecutableBuilder(KieContainer kieContainer, String sessionName) {
+        this.kieContainer = kieContainer;
+        this.sessionName = sessionName;
+    }
+
+    public void addInternalCondition(Class<?> clazz,
+                                     Function<Object, ResultWrapper> checkFunction,
+                                     ScenarioResult scenarioResult) {
+        internalConditions.computeIfAbsent(scenarioResult.getFactIdentifier(), key -> new ArrayList<>())
+                .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));
+    }
+
+    public void setActiveAgendaGroup(String agendaGroup) {
+        this.agendaGroup = agendaGroup;
+    }
+
+    public void setActiveRuleFlowGroup(String ruleFlowGroup) {
+        this.agendaGroup = ruleFlowGroup;
+    }
+
+    public void insert(Object element) {
+        inputs.add(element);
+    }
+
+    public RequestContext run() {
+        KieSessionModel kieSessionModel = kieContainer.getKieSessionModel(sessionName);
+        if (kieSessionModel == null) {
+            throw new ScenarioException("Impossible to find a KieSession with name " + sessionName);
+        }
+        kieSessionModel.setClockType(ClockTypeOption.get("pseudo"));
+
+        StatelessKieSession statelessKieSession = kieContainer.newStatelessKieSession(sessionName);
+
+        statelessKieSession.execute(generateCommands());
+
+        return null;
+    }
+
+    protected Command<ExecutionResults> generateCommands() {
+
+        List<Command<?>> toReturn = new ArrayList<>();
+        if (agendaGroup != null) {
+            toReturn.add(commands.newAgendaGroupSetFocus(agendaGroup));
+        }
+
+        if (inputs.size() > 0) {
+            toReturn.add(commands.newInsertElements(inputs));
+        }
+        toReturn.add(commands.newFireAllRules());
+        internalConditions.values()
+                .forEach(factToCheck -> toReturn.add(new ValidateFactCommand(factToCheck)));
+
+        return commands.newBatchExecution(toReturn);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
@@ -51,6 +51,7 @@ public class RuleStatelessScenarioExecutableBuilder implements RuleScenarioExecu
         this.sessionName = sessionName;
     }
 
+    @Override
     public void addInternalCondition(Class<?> clazz,
                                      Function<Object, ResultWrapper> checkFunction,
                                      ScenarioResult scenarioResult) {
@@ -58,18 +59,22 @@ public class RuleStatelessScenarioExecutableBuilder implements RuleScenarioExecu
                 .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));
     }
 
+    @Override
     public void setActiveAgendaGroup(String agendaGroup) {
         this.agendaGroup = agendaGroup;
     }
 
+    @Override
     public void setActiveRuleFlowGroup(String ruleFlowGroup) {
         this.agendaGroup = ruleFlowGroup;
     }
 
+    @Override
     public void insert(Object element) {
         inputs.add(element);
     }
 
+    @Override
     public RequestContext run() {
         KieSessionModel kieSessionModel = kieContainer.getKieSessionModel(sessionName);
         if (kieSessionModel == null) {
@@ -91,7 +96,7 @@ public class RuleStatelessScenarioExecutableBuilder implements RuleScenarioExecu
             toReturn.add(commands.newAgendaGroupSetFocus(agendaGroup));
         }
 
-        if (inputs.size() > 0) {
+        if (!inputs.isEmpty()) {
             toReturn.add(commands.newInsertElements(inputs));
         }
         toReturn.add(commands.newFireAllRules());

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
@@ -64,7 +64,8 @@ public class RuleScenarioRunnerHelper extends AbstractRunnerHelper {
             throw new ScenarioException("Impossible to run a not-RULE simulation with RULE runner");
         }
         RuleScenarioExecutableBuilder ruleScenarioExecutableBuilder = createBuilder(kieContainer,
-                                                                                    simulationDescriptor.getDmoSession());
+                                                                                    simulationDescriptor.getDmoSession(),
+                                                                                    simulationDescriptor.isStateless());
 
         if (simulationDescriptor.getRuleFlowGroup() != null) {
             ruleScenarioExecutableBuilder.setActiveRuleFlowGroup(simulationDescriptor.getRuleFlowGroup());

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.backend.fluent;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RuleScenarioExecutableBuilderTest {
+
+    @Test
+    public void createBuilder() {
+        RuleScenarioExecutableBuilder builder = RuleScenarioExecutableBuilder.createBuilder(null, null, true);
+        assertTrue(builder instanceof RuleStatelessScenarioExecutableBuilder);
+
+        builder = RuleScenarioExecutableBuilder.createBuilder(null, null, false);
+        assertTrue(builder instanceof RuleStatefulScenarioExecutableBuilder);
+
+        builder = RuleScenarioExecutableBuilder.createBuilder(null);
+        assertTrue(builder instanceof RuleStatefulScenarioExecutableBuilder);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilderTest.java
@@ -27,14 +27,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RuleScenarioExecutableBuilderTest {
+public class RuleStatefulScenarioExecutableBuilderTest {
 
     @Test
     public void testPseudoClock() {
         KieContainer kieContainerMock = mock(KieContainer.class);
         when(kieContainerMock.getKieSessionModel(anyString())).thenReturn(null);
-        assertThatThrownBy(() -> RuleScenarioExecutableBuilder.forcePseudoClock.apply(null, kieContainerMock))
+        assertThatThrownBy(() -> RuleStatefulScenarioExecutableBuilder.forcePseudoClock.apply(null, kieContainerMock))
                 .isInstanceOf(ScenarioException.class);
     }
-
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilderTest.java
@@ -15,19 +15,45 @@
  */
 package org.drools.scenariosimulation.backend.fluent;
 
+import org.drools.scenariosimulation.api.model.FactIdentifier;
 import org.drools.scenariosimulation.backend.runner.ScenarioException;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.api.builder.model.KieSessionModel;
+import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.RequestContext;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieContainerFluent;
+import org.kie.internal.builder.fluent.KieSessionFluent;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RuleStatefulScenarioExecutableBuilderTest {
+
+    @Mock
+    private ExecutableBuilder executableBuilderMock;
+
+    @Mock
+    private ExecutableRunner<RequestContext> executableRunnerMock;
+
+    @Mock
+    private KieContainerFluent kieContainerFluent;
+
+    @Mock
+    private KieSessionFluent kieSessionFluentMock;
 
     @Test
     public void testPseudoClock() {
@@ -35,5 +61,52 @@ public class RuleStatefulScenarioExecutableBuilderTest {
         when(kieContainerMock.getKieSessionModel(anyString())).thenReturn(null);
         assertThatThrownBy(() -> RuleStatefulScenarioExecutableBuilder.forcePseudoClock.apply(null, kieContainerMock))
                 .isInstanceOf(ScenarioException.class);
+
+        when(kieContainerMock.getKieSessionModel(anyString())).thenReturn(mock(KieSessionModel.class));
+        RuleStatefulScenarioExecutableBuilder.forcePseudoClock.apply(null, kieContainerMock);
+    }
+
+    @Test
+    public void testBuilder() {
+        when(executableBuilderMock.newApplicationContext(anyString())).thenReturn(executableBuilderMock);
+        when(executableBuilderMock.setKieContainer(any(KieContainer.class))).thenReturn(kieContainerFluent);
+        when(kieContainerFluent.newSessionCustomized(anyString(), any())).thenReturn(kieSessionFluentMock);
+        when(kieSessionFluentMock.dispose()).thenReturn(executableBuilderMock);
+
+        RuleStatefulScenarioExecutableBuilder builder = new RuleStatefulScenarioExecutableBuilder(null, null) {
+            @Override
+            protected ExecutableBuilder createExecutableBuilder() {
+                return executableBuilderMock;
+            }
+
+            @Override
+            protected ExecutableRunner<RequestContext> createExecutableRunner() {
+                return executableRunnerMock;
+            }
+        };
+
+        Object toInsert = new Object();
+        String agendaGroup = "agendaGroup";
+        String ruleFlowGroup = "ruleFlowGroup";
+
+        FactIdentifier indexFI = FactIdentifier.INDEX;
+
+        builder.setActiveAgendaGroup(agendaGroup);
+        verify(kieSessionFluentMock, times(1)).setActiveAgendaGroup(eq(agendaGroup));
+        reset(kieContainerFluent);
+
+        builder.setActiveRuleFlowGroup(ruleFlowGroup);
+        verify(kieSessionFluentMock, times(1)).setActiveAgendaGroup(eq(agendaGroup));
+        reset(kieContainerFluent);
+
+        builder.insert(toInsert);
+        verify(kieSessionFluentMock, times(1)).insert(eq(toInsert));
+        reset(kieContainerFluent);
+
+        builder.addInternalCondition(String.class, obj -> null, new ScenarioResult(indexFI, null));
+        builder.run();
+
+        verify(kieSessionFluentMock, times(1)).fireAllRules();
+        verify(kieSessionFluentMock, times(1)).addCommand(any(ValidateFactCommand.class));
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.scenariosimulation.backend.fluent;
+
+import java.util.List;
+
+import org.drools.core.command.runtime.rule.AgendaGroupSetFocusCommand;
+import org.drools.core.command.runtime.rule.FireAllRulesCommand;
+import org.drools.core.command.runtime.rule.InsertElementsCommand;
+import org.drools.core.fluent.impl.Batch;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.junit.Test;
+import org.kie.api.command.Command;
+import org.kie.api.runtime.ExecutionResults;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RuleStatelessScenarioExecutableBuilderTest {
+
+    @Test
+    public void generateCommands() {
+        RuleStatelessScenarioExecutableBuilder builder = new RuleStatelessScenarioExecutableBuilder(null, null);
+
+        Command<ExecutionResults> batchCommand = builder.generateCommands();
+        assertTrue(verifyCommand(batchCommand, FireAllRulesCommand.class));
+        assertFalse(verifyCommand(batchCommand, AgendaGroupSetFocusCommand.class));
+        assertFalse(verifyCommand(batchCommand, InsertElementsCommand.class));
+        assertFalse(verifyCommand(batchCommand, ValidateFactCommand.class));
+
+        builder.setActiveAgendaGroup("test");
+        batchCommand = builder.generateCommands();
+
+        assertTrue(verifyCommand(batchCommand, FireAllRulesCommand.class));
+        assertTrue(verifyCommand(batchCommand, AgendaGroupSetFocusCommand.class));
+        assertFalse(verifyCommand(batchCommand, InsertElementsCommand.class));
+        assertFalse(verifyCommand(batchCommand, ValidateFactCommand.class));
+
+        builder.insert(new Object());
+        batchCommand = builder.generateCommands();
+        assertTrue(verifyCommand(batchCommand, FireAllRulesCommand.class));
+        assertTrue(verifyCommand(batchCommand, AgendaGroupSetFocusCommand.class));
+        assertTrue(verifyCommand(batchCommand, InsertElementsCommand.class));
+        assertFalse(verifyCommand(batchCommand, ValidateFactCommand.class));
+
+        builder.addInternalCondition(String.class, obj -> null, new ScenarioResult(FactIdentifier.EMPTY, null));
+        batchCommand = builder.generateCommands();
+        assertTrue(verifyCommand(batchCommand, FireAllRulesCommand.class));
+        assertTrue(verifyCommand(batchCommand, AgendaGroupSetFocusCommand.class));
+        assertTrue(verifyCommand(batchCommand, InsertElementsCommand.class));
+        assertTrue(verifyCommand(batchCommand, ValidateFactCommand.class));
+    }
+
+    private boolean verifyCommand(Command<ExecutionResults> batchCommand, Class<?> classToFind) {
+        if (!(batchCommand instanceof Batch)) {
+            fail();
+        }
+
+        List<Command> commands = ((Batch) batchCommand).getCommands();
+
+        return commands.stream().anyMatch(classToFind::isInstance);
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilderTest.java
@@ -23,16 +23,53 @@ import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.InsertElementsCommand;
 import org.drools.core.fluent.impl.Batch;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.StatelessKieSession;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RuleStatelessScenarioExecutableBuilderTest {
+
+    @Mock
+    private KieContainer kieContainerMock;
+
+    @Mock
+    private StatelessKieSession statelessKieSessionMock;
+
+    @Test
+    public void testBuilder() {
+        String sessionName = "sessionName";
+        when(kieContainerMock.newStatelessKieSession(anyString())).thenReturn(statelessKieSessionMock);
+        RuleStatelessScenarioExecutableBuilder builder = new RuleStatelessScenarioExecutableBuilder(kieContainerMock, sessionName);
+
+        when(kieContainerMock.getKieSessionModel(anyString())).thenReturn(null);
+        assertThatThrownBy(builder::run)
+                .isInstanceOf(ScenarioException.class);
+
+        when(kieContainerMock.getKieSessionModel(anyString())).thenReturn(mock(KieSessionModel.class));
+
+        builder.run();
+        verify(kieContainerMock, times(1)).newStatelessKieSession(eq(sessionName));
+    }
 
     @Test
     public void generateCommands() {


### PR DESCRIPTION
This PR adds runner support for stateless kieSession testing.

@kkufova @Rikkola @gitgabrio @yesamer 

https://issues.jboss.org/browse/DROOLS-3775

PR list:
- https://github.com/kiegroup/drools/pull/2405
- https://github.com/kiegroup/drools-wb/pull/1174