### PR TITLE
fix eclipse plugin class not found error

### DIFF
--- a/drools-core/src/main/resources/META-INF/WorkDefinitions.conf
+++ b/drools-core/src/main/resources/META-INF/WorkDefinitions.conf
@@ -2,7 +2,7 @@
 // The properties of the work definitions are specified as a Map<String, Object>
 // The allowed properties are name, parameters, displayName, icon and customEditor
 // The returned result should thus be of type List<Map<String, Object>>
-import org.drools.core.process.core.datatype.impl.type.StringDataType;
+import org.jbpm.process.core.datatype.impl.type.StringDataType;
 
 [
 


### PR DESCRIPTION
eclipse open *.bpmn with `BPMN2 Process Editor` throw error WorkDefinitions.conf class not found import org.drools.core.process.core.datatype.impl.type.StringDataType because that class has moved to org.jbpm.process.core.datatype.impl.type.StringDataType