### PR TITLE
Changed DMNAssemblerService#getDMNProfiles method visibility

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -197,7 +197,7 @@ public class DMNAssemblerService implements KieAssemblerService {
         return model;
     }
 
-    private List<DMNProfile> getDMNProfiles(KnowledgeBuilderImpl kbuilderImpl) {
+    protected List<DMNProfile> getDMNProfiles(KnowledgeBuilderImpl kbuilderImpl) {
         ChainedProperties chainedProperties = kbuilderImpl.getBuilderConfiguration().getChainedProperties();
 
         List<DMNProfile> dmnProfiles = new ArrayList<>();


### PR DESCRIPTION
Simple PR to change the visibility of a method from private to protected. I want to be able to extend this method to provide at runtime additional DMNProfiles instead of relying solely on the system preferences.

The system preferences is problematic for me because of class loader dynamic instantiation is very limited.