### PR TITLE
[DROOLS-4291] ModelWriter: refactor to smaller classes

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/AccumulateClassWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/AccumulateClassWriter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder;
+
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+public class AccumulateClassWriter {
+
+    protected final ClassOrInterfaceDeclaration generatedPojo;
+    protected final PackageModel pkgModel;
+    private final GeneratedClassWithPackage generatedClassWithPackage;
+    private final String name;
+
+    public AccumulateClassWriter(GeneratedClassWithPackage pojo, PackageModel packageModel) {
+        ClassOrInterfaceDeclaration genClass = pojo.getGeneratedClass();
+        this.generatedPojo = genClass;
+        this.name = genClass.getNameAsString();
+        this.pkgModel = packageModel;
+        this.generatedClassWithPackage = pojo;
+    }
+
+    public String getSource() {
+        String source = JavaParserCompiler.toPojoSource(
+                pkgModel.getName(),
+                generatedClassWithPackage.getImports(),
+                pkgModel.getStaticImports(),
+                generatedClassWithPackage.getGeneratedClass());
+        pkgModel.logRule(source);
+        return source;
+    }
+
+    public String getName() {
+        return pkgModel.getPathName() + "/" + name;
+    }
+
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/AccumulateClassWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/AccumulateClassWriter.java
@@ -45,7 +45,6 @@ public class AccumulateClassWriter {
     }
 
     public String getName() {
-        return pkgModel.getPathName() + "/" + name;
+        return pkgModel.getPathName() + "/" + name + ".java";
     }
-
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/DeclaredTypeWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/DeclaredTypeWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder;
+
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+public class DeclaredTypeWriter {
+
+    protected final ClassOrInterfaceDeclaration generatedPojo;
+    protected final PackageModel pkgModel;
+    private final String name;
+
+    public DeclaredTypeWriter(ClassOrInterfaceDeclaration generatedPojo, PackageModel pkgModel) {
+        this.generatedPojo = generatedPojo;
+        this.name = generatedPojo.getNameAsString();
+        this.pkgModel = pkgModel;
+    }
+
+    public String getSource() {
+        String source = JavaParserCompiler.toPojoSource(
+                pkgModel.getName(),
+                pkgModel.getImports(),
+                pkgModel.getStaticImports(),
+                generatedPojo);
+        pkgModel.logRule(source);
+        return source;
+    }
+
+    public String getName() {
+        return pkgModel.getPathName() + "/" + name;
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/DeclaredTypeWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/DeclaredTypeWriter.java
@@ -42,6 +42,6 @@ public class DeclaredTypeWriter {
     }
 
     public String getName() {
-        return pkgModel.getPathName() + "/" + name;
+        return pkgModel.getPathName() + "/" + name + ".java";
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
@@ -1,99 +1,116 @@
 package org.drools.modelcompiler.builder;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.printer.PrettyPrinter;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.core.util.Drools;
-import org.drools.modelcompiler.builder.PackageModel.RuleSourceResult;
 import org.kie.api.builder.ReleaseId;
 
 import static org.drools.modelcompiler.CanonicalKieModule.MODEL_VERSION;
 import static org.drools.modelcompiler.CanonicalKieModule.getModelFileWithGAV;
-import static org.drools.modelcompiler.builder.JavaParserCompiler.getPrettyPrinter;
 
 public class ModelWriter {
 
+    private final String basePath;
+
+    public ModelWriter() {
+        this("src/main/java");
+    }
+
+    public ModelWriter(String basePath) {
+        this.basePath = basePath;
+    }
+
     public Result writeModel(MemoryFileSystem srcMfs, Collection<PackageModel> packageModels) {
-        List<String> sourceFiles = new ArrayList<>();
+        List<GeneratedFile> generatedFiles = new ArrayList<>();
         List<String> modelFiles = new ArrayList<>();
 
-        PrettyPrinter prettyPrinter = getPrettyPrinter();
-
         for (PackageModel pkgModel : packageModels) {
-            String pkgName = pkgModel.getName();
-            String folderName = pkgName.replace( '.', '/' );
-
-            for (ClassOrInterfaceDeclaration generatedPojo : pkgModel.getGeneratedPOJOsSource()) {
-                final String source = JavaParserCompiler.toPojoSource( pkgModel.getName(), pkgModel.getImports(), pkgModel.getStaticImports(), generatedPojo );
-                pkgModel.logRule( source );
-                String pojoSourceName = "src/main/java/" + folderName + "/" + generatedPojo.getName() + ".java";
-                srcMfs.write( pojoSourceName, source.getBytes() );
-                sourceFiles.add( pojoSourceName );
+            PackageModelWriter packageModelWriter = new PackageModelWriter(pkgModel);
+            for (DeclaredTypeWriter declaredType : packageModelWriter.getDeclaredTypes()) {
+                generatedFiles.add(new GeneratedFile(declaredType.getName(), declaredType.getSource()));
             }
 
-            for (GeneratedClassWithPackage generatedPojo : pkgModel.getGeneratedAccumulateClasses()) {
-                final String source = JavaParserCompiler.toPojoSource( pkgModel.getName(), generatedPojo.getImports(), pkgModel.getStaticImports(), generatedPojo.getGeneratedClass() );
-                pkgModel.logRule( source );
-                String pojoSourceName = "src/main/java/" + folderName + "/" + generatedPojo.getGeneratedClass().getName() + ".java";
-                srcMfs.write( pojoSourceName, source.getBytes() );
-                sourceFiles.add( pojoSourceName );
+            for (AccumulateClassWriter accumulateClassWriter : packageModelWriter.getAccumulateClasses()) {
+                generatedFiles.add(new GeneratedFile(accumulateClassWriter.getName(), accumulateClassWriter.getSource()));
             }
 
-            RuleSourceResult rulesSourceResult = pkgModel.getRulesSource();
-            // main rules file:
-            String rulesFileName = pkgModel.getRulesFileName();
-            String rulesSourceName = "src/main/java/" + folderName + "/" + rulesFileName + ".java";
-            String rulesSource = prettyPrinter.print( rulesSourceResult.getMainRuleClass() );
-            pkgModel.logRule( rulesSource );
-            byte[] rulesBytes = rulesSource.getBytes();
-            srcMfs.write( rulesSourceName, rulesBytes );
-            modelFiles.add( pkgName + "." + rulesFileName );
-            sourceFiles.add( rulesSourceName );
-            // manage additional classes, please notice to not add to modelFiles.
-            for (CompilationUnit cu : rulesSourceResult.getSplitted()) {
-                final Optional<ClassOrInterfaceDeclaration> classOptional = cu.findFirst(ClassOrInterfaceDeclaration.class);
-                if (classOptional.isPresent()) {
-                    String addFileName = classOptional.get().getNameAsString();
-                    String addSourceName = "src/main/java/" + folderName + "/" + addFileName + ".java";
-                    String addSource = prettyPrinter.print( cu );
-                    pkgModel.logRule( addSource );
-                    byte[] addBytes = addSource.getBytes();
-                    srcMfs.write( addSourceName, addBytes );
-                    sourceFiles.add( addSourceName );
-                }
+            RuleWriter rules = packageModelWriter.getRules();
+            generatedFiles.add(new GeneratedFile(rules.getName(), rules.getMainSource()));
+
+            for (RuleWriter.RuleFileSource ruleSource : rules.getRuleSources()) {
+                generatedFiles.add(new GeneratedFile(ruleSource.getName(), ruleSource.getSource()));
             }
+        }
+
+        List<String> sourceFiles = new ArrayList<>();
+        for (GeneratedFile generatedFile : generatedFiles) {
+            sourceFiles.add(generatedFile.getPath());
+            srcMfs.write(generatedFile.getPath(), generatedFile.getData());
         }
 
         return new Result(sourceFiles, modelFiles);
     }
 
+    private String pojoName(String folderName, String nameAsString) {
+        return basePath + "/" + folderName + "/" + nameAsString + ".java";
+    }
+
     public void writeModelFile(Collection<String> modelSources, MemoryFileSystem trgMfs, ReleaseId releaseId) {
         String pkgNames = MODEL_VERSION + Drools.getFullVersion() + "\n";
-        if(!modelSources.isEmpty()) {
+        if (!modelSources.isEmpty()) {
             pkgNames += modelSources.stream().collect(Collectors.joining("\n"));
         }
-        trgMfs.write(getModelFileWithGAV(releaseId), pkgNames.getBytes() );
+        trgMfs.write(getModelFileWithGAV(releaseId), pkgNames.getBytes());
+    }
+
+    private static class GeneratedFile {
+
+        final String path;
+        final byte[] data;
+
+        private GeneratedFile(String path, String data) {
+            this.path = path;
+            this.data = data.getBytes(StandardCharsets.UTF_8);
+        }
+
+        private GeneratedFile(String path, byte[] data) {
+            this.path = path;
+            this.data = data;
+        }
+
+        public byte[] getData() {
+            return data;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        @Override
+        public String toString() {
+            return "GeneratedFile{" +
+                    "path='" + path + '\'' +
+                    '}';
+        }
     }
 
     public static class Result {
+
         private final List<String> sourceFiles;
         private final List<String> modelFiles;
 
-        public Result( List<String> sourceFiles, List<String> modelFiles ) {
+        public Result(List<String> sourceFiles, List<String> modelFiles) {
             this.sourceFiles = sourceFiles;
             this.modelFiles = modelFiles;
         }
 
         public String[] getSources() {
-            return sourceFiles.toArray( new String[sourceFiles.size()] );
+            return sourceFiles.toArray(new String[sourceFiles.size()]);
         }
 
         public List<String> getSourceFiles() {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
@@ -50,8 +50,9 @@ public class ModelWriter {
 
         List<String> sourceFiles = new ArrayList<>();
         for (GeneratedFile generatedFile : generatedFiles) {
-            sourceFiles.add(generatedFile.getPath());
-            srcMfs.write(generatedFile.getPath(), generatedFile.getData());
+            String path = basePath + "/" + generatedFile.getPath();
+            sourceFiles.add(path);
+            srcMfs.write(path, generatedFile.getData());
         }
 
         return new Result(sourceFiles, modelFiles);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
@@ -41,6 +41,7 @@ public class ModelWriter {
 
             RuleWriter rules = packageModelWriter.getRules();
             generatedFiles.add(new GeneratedFile(rules.getName(), rules.getMainSource()));
+            modelFiles.add( rules.getClassName() );
 
             for (RuleWriter.RuleFileSource ruleSource : rules.getRuleSources()) {
                 generatedFiles.add(new GeneratedFile(ruleSource.getName(), ruleSource.getSource()));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -155,6 +155,10 @@ public class PackageModel {
     public String getName() {
         return name;
     }
+
+    public String getPathName() {
+        return name.replace('.', '/');
+    }
     
     public DRLIdGenerator getExprIdGenerator() {
         return exprIdGenerator;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModelWriter.java
@@ -31,7 +31,7 @@ public class PackageModelWriter {
         this.packageModel = packageModel;
         this.declaredTypes = toDeclaredTypeWriters(packageModel);
         this.accumulateClasses = toAccumulateClassWriters(packageModel);
-        this.ruleWriter = new RuleWriter(packageModel.getRulesFileName(), packageModel.getRulesSource());
+        this.ruleWriter = new RuleWriter(packageModel.getRulesFileName(), packageModel.getRulesSource(), packageModel);
     }
 
     public List<DeclaredTypeWriter> getDeclaredTypes() {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModelWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PackageModelWriter {
+
+    private final PackageModel packageModel;
+    private final List<DeclaredTypeWriter> declaredTypes;
+    private final List<AccumulateClassWriter> accumulateClasses;
+    private final RuleWriter ruleWriter;
+
+    public PackageModelWriter(PackageModel packageModel) {
+        this.packageModel = packageModel;
+        this.declaredTypes = toDeclaredTypeWriters(packageModel);
+        this.accumulateClasses = toAccumulateClassWriters(packageModel);
+        this.ruleWriter = new RuleWriter(packageModel.getRulesFileName(), packageModel.getRulesSource());
+    }
+
+    public List<DeclaredTypeWriter> getDeclaredTypes() {
+        return declaredTypes;
+    }
+
+    public List<AccumulateClassWriter> getAccumulateClasses() {
+        return accumulateClasses;
+    }
+
+    public RuleWriter getRules() {
+        return ruleWriter;
+    }
+
+    private List<AccumulateClassWriter> toAccumulateClassWriters(PackageModel packageModel) {
+        return packageModel.getGeneratedAccumulateClasses().stream().map(pojo -> new AccumulateClassWriter(pojo, packageModel)).collect(Collectors.toList());
+    }
+
+    private static List<DeclaredTypeWriter> toDeclaredTypeWriters(PackageModel packageModel) {
+        return packageModel.getGeneratedPOJOsSource().stream().map(pojo -> new DeclaredTypeWriter(pojo, packageModel)).collect(Collectors.toList());
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
@@ -36,17 +36,20 @@ public class RuleWriter {
     private final String rulesFileName;
     private final PackageModel.RuleSourceResult rulesSource;
 
-    public RuleWriter(String rulesFileName, PackageModel.RuleSourceResult rulesSource) {
+    public RuleWriter(String rulesFileName, PackageModel.RuleSourceResult rulesSource, PackageModel pkgModel) {
         this.rulesFileName = rulesFileName;
         this.rulesSource = rulesSource;
         this.generatedPojo = rulesSource.getMainRuleClass();
-        this.pkgModel = null;
+        this.pkgModel = pkgModel;
     }
 
     public String getName() {
-        return pkgModel.getPathName() + "/" + rulesFileName;
+        return pkgModel.getPathName() + "/" + rulesFileName + ".java";
     }
 
+    public String getClassName() {
+        return pkgModel.getName() + "." + rulesFileName;
+    }
 
     public String getMainSource() {
         return prettyPrinter.print(generatedPojo);
@@ -77,9 +80,8 @@ public class RuleWriter {
         }
 
         public String getName() {
-            return pkgModel.getPathName() + "/" + name;
+            return pkgModel.getPathName() + "/" + name + ".java";
         }
-
 
         public String getSource() {
             String code = prettyPrinter.print(source);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.printer.PrettyPrinter;
+
+import static org.drools.modelcompiler.builder.JavaParserCompiler.getPrettyPrinter;
+
+public class RuleWriter {
+
+    private final PrettyPrinter prettyPrinter = getPrettyPrinter();
+
+    private final CompilationUnit generatedPojo;
+    private final PackageModel pkgModel;
+    private final String rulesFileName;
+    private final PackageModel.RuleSourceResult rulesSource;
+
+    public RuleWriter(String rulesFileName, PackageModel.RuleSourceResult rulesSource) {
+        this.rulesFileName = rulesFileName;
+        this.rulesSource = rulesSource;
+        this.generatedPojo = rulesSource.getMainRuleClass();
+        this.pkgModel = null;
+    }
+
+    public String getName() {
+        return pkgModel.getPathName() + "/" + rulesFileName;
+    }
+
+
+    public String getMainSource() {
+        return prettyPrinter.print(generatedPojo);
+    }
+
+    public List<RuleFileSource> getRuleSources() {
+        List<RuleFileSource> rules = new ArrayList<>();
+        for (CompilationUnit cu : rulesSource.getSplitted()) {
+            final Optional<ClassOrInterfaceDeclaration> classOptional = cu.findFirst(ClassOrInterfaceDeclaration.class);
+            if (classOptional.isPresent()) {
+
+                String addFileName = classOptional.get().getNameAsString();
+
+                rules.add(new RuleFileSource(addFileName, cu));
+            }
+        }
+        return rules;
+    }
+
+    public class RuleFileSource {
+
+        protected final CompilationUnit source;
+        private final String name;
+
+        private RuleFileSource(String name, CompilationUnit source) {
+            this.name = name;
+            this.source = source;
+        }
+
+        public String getName() {
+            return pkgModel.getPathName() + "/" + name;
+        }
+
+
+        public String getSource() {
+            String code = prettyPrinter.print(source);
+            pkgModel.logRule(code);
+            return code;
+        }
+    }
+}


### PR DESCRIPTION
ModelWriter performs most of the logic translating PackageModel into source files; then it writes the result to a virtual FS. This makes it harder to reuse common source-to-file logic. In this PR we refactor each part of the PackageModel-to-individual-source-files into separate classes, taking each one single component.

please @lucamolteni and @mariofusco review and let's merge if everything is green -- no additional features, just a refactoring