### PR TITLE
Fix the DMN 1.2 parsing of an DMNDI:DMNLabel DMNDI:TEXT child element

### DIFF
--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNLabelConverter.java
@@ -18,41 +18,27 @@ package org.kie.dmn.backend.marshalling.v1_2.xstream;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.MarshallingContext;
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.dmn.model.api.dmndi.DMNLabel;
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
-
 
 public class DMNLabelConverter extends ShapeConverter {
 
-    private static final String TEXT = "Text";
+    public static final String TEXT = "Text";
 
     public DMNLabelConverter(XStream xstream) {
         super(xstream);
     }
 
     @Override
-    protected void parseElements(HierarchicalStreamReader reader, UnmarshallingContext context, Object parent) {
-        while ( reader.hasMoreChildren() ) {
-            reader.moveDown();
-            String nodeName = reader.getNodeName();
-            if (nodeName.equals(TEXT)) {
-                ((DMNLabel)parent).setText(reader.getValue());
-            } else {
-              Object object = readItem(
-                      reader,
-                      context,
-                      null );
-              if( object instanceof DMNModelInstrumentedBase ) {
-                  ((KieDMNModelInstrumentedBase) object).setParent((KieDMNModelInstrumentedBase) parent);
-                  ((KieDMNModelInstrumentedBase) parent).addChildren((KieDMNModelInstrumentedBase) object);
-              }
-              assignChildElement( parent, nodeName, object );
-            }
-            reader.moveUp();
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNLabel concrete = (DMNLabel) parent;
+
+        if (nodeName.equals(TEXT)) {
+            concrete.setText((String) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
         }
     }
 

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNLabelConverter.java
@@ -18,10 +18,13 @@ package org.kie.dmn.backend.marshalling.v1_2.xstream;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.dmn.model.api.dmndi.DMNLabel;
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
 
 public class DMNLabelConverter extends ShapeConverter {
 
@@ -32,13 +35,24 @@ public class DMNLabelConverter extends ShapeConverter {
     }
 
     @Override
-    protected void assignChildElement(Object parent, String nodeName, Object child) {
-        DMNLabel concrete = (DMNLabel) parent;
-
-        if (nodeName.equals(TEXT)) {
-            concrete.setText((String) child);
-        } else {
-            super.assignChildElement(parent, nodeName, child);
+    protected void parseElements(HierarchicalStreamReader reader, UnmarshallingContext context, Object parent) {
+        while ( reader.hasMoreChildren() ) {
+            reader.moveDown();
+            String nodeName = reader.getNodeName();
+            if (nodeName.equals(TEXT)) {
+                ((DMNLabel)parent).setText(reader.getValue());
+            } else {
+              Object object = readItem(
+                      reader,
+                      context,
+                      null );
+              if( object instanceof DMNModelInstrumentedBase ) {
+                  ((KieDMNModelInstrumentedBase) object).setParent((KieDMNModelInstrumentedBase) parent);
+                  ((KieDMNModelInstrumentedBase) parent).addChildren((KieDMNModelInstrumentedBase) object);
+              }
+              assignChildElement( parent, nodeName, object );
+            }
+            reader.moveUp();
         }
     }
 

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNModelInstrumentedBaseConverter.java
@@ -98,7 +98,7 @@ public abstract class DMNModelInstrumentedBaseConverter
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNEdge", dmndiPrefix), "DMNEdge");
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNDecisionServiceDividerLine", dmndiPrefix), "DMNDecisionServiceDividerLine");
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNLabel", dmndiPrefix), "DMNLabel");
-            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "Text", dmndiPrefix), "Text");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, DMNLabelConverter.TEXT, dmndiPrefix), DMNLabelConverter.TEXT);
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "Size", dmndiPrefix), "Size");
 
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "FillColor", dmndiPrefix), "FillColor");

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/DMNModelInstrumentedBaseConverter.java
@@ -98,6 +98,7 @@ public abstract class DMNModelInstrumentedBaseConverter
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNEdge", dmndiPrefix), "DMNEdge");
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNDecisionServiceDividerLine", dmndiPrefix), "DMNDecisionServiceDividerLine");
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNLabel", dmndiPrefix), "DMNLabel");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "Text", dmndiPrefix), "Text");
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "Size", dmndiPrefix), "Size");
 
             staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "FillColor", dmndiPrefix), "FillColor");

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/XStreamMarshaller.java
@@ -319,6 +319,7 @@ public class XStreamMarshaller
         xStream.alias("waypoint", Point.class);
         xStream.registerConverter(new PointConverter(xStream));
         xStream.alias("extension", DiagramElement.Extension.class);
+        xStream.alias(DMNLabelConverter.TEXT, String.class);
 
         xStream.registerConverter(new AssociationConverter( xStream ) );
         xStream.registerConverter(new AuthorityRequirementConverter( xStream ) );

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
@@ -110,6 +110,11 @@ public class UnmarshalMarshalTest {
         assertEquals(21d, shape0sharedStyle.getFontSize(), 0.0d);
     }
 
+    @Test
+    public void test_DMNLabel_Text() throws Exception {
+        testRoundTripV12("org/kie/dmn/backend/marshalling/v1_2/", "DMNLabel-Text.dmn");
+    }
+
     public void testRoundTripV12(String subdir, String xmlfile) throws Exception {
         testRoundTrip(subdir, xmlfile, MARSHALLER, DMN12_SCHEMA_SOURCE);
     }

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_2/DMNLabel-Text.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_2/DMNLabel-Text.dmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"  xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns="http://www.trisotech.com/definitions/_9e005ed6-4e16-446f-92d2-360988638c1b" id="_9e005ed6-4e16-446f-92d2-360988638c1b" name="Drawing 1" namespace="http://www.trisotech.com/definitions/_9e005ed6-4e16-446f-92d2-360988638c1b" exporter="DMN Modeler" exporterVersion="6.2.5.201907032309" triso:logoChoice="Default">
+    <semantic:decision id="_c81f2688-84ba-422c-9a40-8bfd62052a9c" name="Text">
+        <semantic:variable name="Text" id="_9a4286cb-536e-43a2-945f-569cf794972d" typeRef="Any"/>
+    </semantic:decision>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_9188246b-bdb6-42b1-9017-b344c958bca7" triso:modelElementRef="_850f6e9d-25ac-4b06-a427-00c831cb547e" name="Page 1">
+            <di:extension/>
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_2da82f9a-f625-4338-b597-4be80692d9f3" dmnElementRef="_c81f2688-84ba-422c-9a40-8bfd62052a9c">
+                <dc:Bounds x="481.5" y="233" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9e005ed6-4e16-446f-92d2-360988638c1b_0" trisodmn:defaultBounds="true">
+                    <dmndi:Text>Alternate Text</dmndi:Text>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_9e005ed6-4e16-446f-92d2-360988638c1b_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>


### PR DESCRIPTION
There is currently and issue with the DMN parsing of the DMNDI:Text child element. The current parser code would fail to pass a valid (XSD) model that contained that element.

This PR contains a code fix as well as a unit test to validate the fix.