### PR TITLE
Fine-tune Sonar exclusions

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -368,6 +368,13 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>report-code-coverage</id>
+      <properties>
+        <!-- Generated classes should not show up in Sonar. -->
+        <sonar.exclusions>**/*Lexer.java</sonar.exclusions>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -369,7 +369,7 @@
       </build>
     </profile>
     <profile>
-      <id>report-code-coverage</id>
+      <id>sonarcloud-analysis</id>
       <properties>
         <!-- Generated classes should not show up in Sonar. -->
         <sonar.exclusions>**/*Lexer.java</sonar.exclusions>

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -232,6 +232,13 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>report-code-coverage</id>
+      <properties>
+        <!-- Generated classes should not show up in Sonar. -->
+        <sonar.exclusions>**/ProtobufMessages.java</sonar.exclusions>
+      </properties>
+    </profile>
   </profiles>
 
   <build>

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -233,7 +233,7 @@
       </build>
     </profile>
     <profile>
-      <id>report-code-coverage</id>
+      <id>sonarcloud-analysis</id>
       <properties>
         <!-- Generated classes should not show up in Sonar. -->
         <sonar.exclusions>**/ProtobufMessages.java</sonar.exclusions>

--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -61,7 +61,7 @@
 
   <profiles>
     <profile>
-      <id>report-code-coverage</id>
+      <id>sonarcloud-analysis</id>
       <properties>
         <!-- Excluding the entire module from coverage statistics. API modules like this one contain only interfaces
              and enums, thus nothing JaCoCo can measure. -->

--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -58,4 +58,15 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>report-code-coverage</id>
+      <properties>
+        <!-- Excluding the entire module from coverage statistics. API modules like this one contain only interfaces
+             and enums, thus nothing JaCoCo can measure. -->
+        <sonar.coverage.exclusions>**/*.java</sonar.coverage.exclusions>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Excluding generated classes (completely) and the entire kie-dmn-api module (just from coverage statistics).