### PR TITLE
 [DROOLS-4292] executable-model fails with more than 5 arguments query

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
@@ -8,11 +8,16 @@ import org.drools.model.functions.Predicate2;
 import org.drools.model.functions.temporal.TemporalPredicate;
 import org.drools.model.impl.DeclarationImpl;
 import org.drools.model.impl.Query0DefImpl;
+import org.drools.model.impl.Query10DefImpl;
 import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
 import org.drools.model.impl.Query5DefImpl;
+import org.drools.model.impl.Query6DefImpl;
+import org.drools.model.impl.Query7DefImpl;
+import org.drools.model.impl.Query8DefImpl;
+import org.drools.model.impl.Query9DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.ViewBuilder;
 import org.drools.model.view.BindViewItem1;
@@ -211,75 +216,83 @@ public class FlowDSL extends DSL {
         return new Query0DefImpl( VIEW_BUILDER, pkg, name );
     }
 
-    public static <A> Query1Def<A> query( String name, Class<A> type1 ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, name, type1 );
+    public static <T1> Query1Def<T1> query(String name, Class<T1> type1, String arg1name) {
+        return new Query1DefImpl<>(VIEW_BUILDER, name, type1, arg1name);
     }
 
-    public static <A> Query1Def<A> query( String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, name, type1, arg1name);
+    public static <T1> Query1Def<T1> query(String pkg, String name, Class<T1> type1, String arg1name) {
+        return new Query1DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name);
     }
 
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1 ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1 );
+    public static <T1, T2> Query2Def<T1, T2> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        return new Query2DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name);
     }
 
-    public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, Class<B> type2 ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, type2 );
+    public static <T1, T2> Query2Def<T1, T2> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        return new Query2DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
     }
 
-    public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, Class<B> type2 ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2 );
-    }
-
-    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3 );
-    }
-
-    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3 );
-    }
-
-    public static <A,B,C, D> Query4Def<A,B,C,D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
-        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4 );
-    }
-
-    public static <A,B,C, D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
-        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
-    }
-
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name);
-    }
-
-    public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2 ,arg2name);
-    }
-
-    public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
-    }
-
-    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
         return new Query3DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
+        return new Query3DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <A,B,C,D> Query4Def<A,B,C,D> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
-        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
     }
 
-    public static <A,B,C,D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
-        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
     }
 
-    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
         return new Query5DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 
-    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
-        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        return new Query6DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        return new Query6DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        return new Query7DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        return new Query7DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        return new Query8DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        return new Query8DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        return new Query9DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        return new Query9DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        return new Query10DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        return new Query10DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
@@ -8,16 +8,11 @@ import org.drools.model.functions.Predicate2;
 import org.drools.model.functions.temporal.TemporalPredicate;
 import org.drools.model.impl.DeclarationImpl;
 import org.drools.model.impl.Query0DefImpl;
-import org.drools.model.impl.Query10DefImpl;
 import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
 import org.drools.model.impl.Query5DefImpl;
-import org.drools.model.impl.Query6DefImpl;
-import org.drools.model.impl.Query7DefImpl;
-import org.drools.model.impl.Query8DefImpl;
-import org.drools.model.impl.Query9DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.ViewBuilder;
 import org.drools.model.view.BindViewItem1;
@@ -216,83 +211,75 @@ public class FlowDSL extends DSL {
         return new Query0DefImpl( VIEW_BUILDER, pkg, name );
     }
 
-    public static <T1> Query1Def<T1> query(String name, Class<T1> type1, String arg1name) {
-        return new Query1DefImpl<>(VIEW_BUILDER, name, type1, arg1name);
+    public static <A> Query1Def<A> query( String name, Class<A> type1 ) {
+        return new Query1DefImpl<>( VIEW_BUILDER, name, type1 );
     }
 
-    public static <T1> Query1Def<T1> query(String pkg, String name, Class<T1> type1, String arg1name) {
-        return new Query1DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name);
+    public static <A> Query1Def<A> query( String name, Class<A> type1, String arg1name ) {
+        return new Query1DefImpl<>( VIEW_BUILDER, name, type1, arg1name);
     }
 
-    public static <T1, T2> Query2Def<T1, T2> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
-        return new Query2DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name);
+    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1 ) {
+        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1 );
     }
 
-    public static <T1, T2> Query2Def<T1, T2> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
-        return new Query2DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
+    public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, Class<B> type2 ) {
+        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, type2 );
     }
 
-    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
+    public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, Class<B> type2 ) {
+        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2 );
+    }
+
+    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3 );
+    }
+
+    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3 );
+    }
+
+    public static <A,B,C, D> Query4Def<A,B,C,D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4 );
+    }
+
+    public static <A,B,C, D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
+        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
+    }
+
+    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
+        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name);
+    }
+
+    public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
+        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2 ,arg2name);
+    }
+
+    public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
+        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
+    }
+
+    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
         return new Query3DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
-        return new Query3DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
+    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
+        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
-        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
+    public static <A,B,C,D> Query4Def<A,B,C,D> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
     }
 
-    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
-        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
+    public static <A,B,C,D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
     }
 
-    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
+    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
         return new Query5DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 
-    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
-        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
-        return new Query6DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
-        return new Query6DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
-        return new Query7DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
-        return new Query7DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
-        return new Query8DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
-        return new Query8DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
-        return new Query9DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
-        return new Query9DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
-        return new Query10DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
-    }
-
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
-        return new Query10DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
+    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
@@ -8,11 +8,16 @@ import org.drools.model.functions.Predicate2;
 import org.drools.model.functions.temporal.TemporalPredicate;
 import org.drools.model.impl.DeclarationImpl;
 import org.drools.model.impl.Query0DefImpl;
+import org.drools.model.impl.Query10DefImpl;
 import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
 import org.drools.model.impl.Query5DefImpl;
+import org.drools.model.impl.Query6DefImpl;
+import org.drools.model.impl.Query7DefImpl;
+import org.drools.model.impl.Query8DefImpl;
+import org.drools.model.impl.Query9DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.ViewBuilder;
 import org.drools.model.view.BindViewItem1;
@@ -211,80 +216,163 @@ public class FlowDSL extends DSL {
         return new Query0DefImpl( VIEW_BUILDER, pkg, name );
     }
 
-
-    // ----
-
-    public static <A> Query1Def<A> query( String name, Class<A> type1 ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, name, type1 );
+    public static <T1> Query1Def<T1> query(String name, Class<T1> type1) {
+        return new Query1DefImpl<>(VIEW_BUILDER, name, type1);
     }
 
-    public static <A> Query1Def<A> query( String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, name, type1, arg1name);
+    public static <T1> Query1Def<T1> query(String name, Class<T1> type1, String arg1name) {
+        return new Query1DefImpl<>(VIEW_BUILDER, name, type1, arg1name);
     }
 
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1 ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1 );
+    public static <T1> Query1Def<T1> query(String pkg, String name, Class<T1> type1) {
+        return new Query1DefImpl<>(VIEW_BUILDER, pkg, name, type1);
     }
 
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name);
+    public static <T1> Query1Def<T1> query(String pkg, String name, Class<T1> type1, String arg1name) {
+        return new Query1DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name);
     }
 
-    // -----
-
-    public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, Class<B> type2 ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, type2 );
+    public static <T1, T2> Query2Def<T1, T2> query(String name, Class<T1> type1, Class<T2> type2) {
+        return new Query2DefImpl<>(VIEW_BUILDER, name, type1, type2);
     }
 
-    public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, Class<B> type2 ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2 );
+    public static <T1, T2> Query2Def<T1, T2> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        return new Query2DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name);
     }
 
-    public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2 ,arg2name);
+    public static <T1, T2> Query2Def<T1, T2> query(String pkg, String name, Class<T1> type1, Class<T2> type2) {
+        return new Query2DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2);
     }
 
-    public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
+    public static <T1, T2> Query2Def<T1, T2> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        return new Query2DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
     }
 
-    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3 );
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3);
     }
 
-    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3 );
-    }
-
-    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
         return new Query3DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+        return new Query3DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3);
     }
 
-    public static <A,B,C, D> Query4Def<A,B,C,D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
-        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4 );
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
+        return new Query3DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <A,B,C, D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
-        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4);
     }
 
-    public static <A,B,C,D> Query4Def<A,B,C,D> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
-        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
     }
 
-    public static <A,B,C,D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
-        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4);
     }
 
-    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
+    }
+
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+        return new Query5DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5);
+    }
+
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
         return new Query5DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 
-    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
-        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5);
+    }
+
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+        return new Query6DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        return new Query6DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+        return new Query6DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        return new Query6DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+        return new Query7DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        return new Query7DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+        return new Query7DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        return new Query7DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+        return new Query8DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7, type8);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        return new Query8DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+        return new Query8DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7, type8);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        return new Query8DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+        return new Query9DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        return new Query9DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+        return new Query9DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        return new Query9DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+        return new Query10DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        return new Query10DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+        return new Query10DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        return new Query10DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
@@ -12,6 +12,7 @@ import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
+import org.drools.model.impl.Query5DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.ViewBuilder;
 import org.drools.model.view.BindViewItem1;
@@ -272,5 +273,13 @@ public class FlowDSL extends DSL {
 
     public static <A,B,C,D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {
         return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    }
+
+    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
+    }
+
+    public static <A,B,C,D,E> Query5Def<A,B,C,D,E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/FlowDSL.java
@@ -211,6 +211,9 @@ public class FlowDSL extends DSL {
         return new Query0DefImpl( VIEW_BUILDER, pkg, name );
     }
 
+
+    // ----
+
     public static <A> Query1Def<A> query( String name, Class<A> type1 ) {
         return new Query1DefImpl<>( VIEW_BUILDER, name, type1 );
     }
@@ -223,32 +226,18 @@ public class FlowDSL extends DSL {
         return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1 );
     }
 
+    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
+        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name);
+    }
+
+    // -----
+
     public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, Class<B> type2 ) {
         return new Query2DefImpl<>( VIEW_BUILDER, name, type1, type2 );
     }
 
     public static <A,B> Query2Def<A,B> query( String pkg, String name, Class<A> type1, Class<B> type2 ) {
         return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2 );
-    }
-
-    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3 );
-    }
-
-    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3 );
-    }
-
-    public static <A,B,C, D> Query4Def<A,B,C,D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
-        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4 );
-    }
-
-    public static <A,B,C, D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
-        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
-    }
-
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name);
     }
 
     public static <A,B> Query2Def<A,B> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
@@ -259,12 +248,28 @@ public class FlowDSL extends DSL {
         return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
     }
 
+    public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3 );
+    }
+
+    public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3 );
+    }
+
     public static <A,B,C> Query3Def<A,B,C> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
         return new Query3DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
     public static <A,B,C> Query3Def<A,B,C> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
         return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
+    }
+
+    public static <A,B,C, D> Query4Def<A,B,C,D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4 );
+    }
+
+    public static <A,B,C, D> Query4Def<A,B,C,D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4) {
+        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
     }
 
     public static <A,B,C,D> Query4Def<A,B,C,D> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
@@ -1347,14 +1347,6 @@ public class PatternDSL extends DSL {
         return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
     }
 
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5  ) {
-        return new Query5DefImpl<>( VIEW_BUILDER, name, type1, type2, type3, type4, type5 );
-    }
-
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5 ) {
-        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5 );
-    }
-
     public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
         return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name );
     }
@@ -1381,6 +1373,14 @@ public class PatternDSL extends DSL {
 
     public static <A, B, C, D> Query4Def<A, B, C, D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name ) {
         return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    }
+
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5  ) {
+        return new Query5DefImpl<>( VIEW_BUILDER, name, type1, type2, type3, type4, type5 );
+    }
+
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5 ) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5 );
     }
 
     public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name ) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
@@ -63,6 +63,7 @@ import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
+import org.drools.model.impl.Query5DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.ViewBuilder;
 import org.drools.model.index.AlphaIndexImpl;
@@ -1346,6 +1347,14 @@ public class PatternDSL extends DSL {
         return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
     }
 
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5  ) {
+        return new Query5DefImpl<>( VIEW_BUILDER, name, type1, type2, type3, type4, type5 );
+    }
+
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5 ) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5 );
+    }
+
     public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
         return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name );
     }
@@ -1372,6 +1381,14 @@ public class PatternDSL extends DSL {
 
     public static <A, B, C, D> Query4Def<A, B, C, D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name ) {
         return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    }
+
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name ) {
+        return new Query5DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
+    }
+
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5Name) {
+        return new Query5DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5Name);
     }
 
     // -- async --

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
@@ -1388,7 +1388,7 @@ public class PatternDSL extends DSL {
     }
 
     public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5Name) {
-        return new Query5DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5Name);
+        return new Query5DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 
     // -- async --

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
@@ -59,11 +59,16 @@ import org.drools.model.functions.temporal.TemporalPredicate;
 import org.drools.model.impl.DeclarationImpl;
 import org.drools.model.impl.Exchange;
 import org.drools.model.impl.Query0DefImpl;
+import org.drools.model.impl.Query10DefImpl;
 import org.drools.model.impl.Query1DefImpl;
 import org.drools.model.impl.Query2DefImpl;
 import org.drools.model.impl.Query3DefImpl;
 import org.drools.model.impl.Query4DefImpl;
 import org.drools.model.impl.Query5DefImpl;
+import org.drools.model.impl.Query6DefImpl;
+import org.drools.model.impl.Query7DefImpl;
+import org.drools.model.impl.Query8DefImpl;
+import org.drools.model.impl.Query9DefImpl;
 import org.drools.model.impl.RuleBuilder;
 import org.drools.model.impl.ViewBuilder;
 import org.drools.model.index.AlphaIndexImpl;
@@ -1311,84 +1316,164 @@ public class PatternDSL extends DSL {
         return new Query0DefImpl( VIEW_BUILDER, pkg, name );
     }
 
-    public static <A> Query1Def<A> query( String name, Class<A> type1 ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, name, type1 );
+    public static <T1> Query1Def<T1> query(String name, Class<T1> type1) {
+        return new Query1DefImpl<>(VIEW_BUILDER, name, type1);
     }
 
-    public static <A> Query1Def<A> query( String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, name, type1, arg1name );
+    public static <T1> Query1Def<T1> query(String pkg, String name, Class<T1> type1) {
+        return new Query1DefImpl<>(VIEW_BUILDER, pkg, name, type1);
     }
 
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1 ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1 );
+    public static <T1> Query1Def<T1> query(String name, Class<T1> type1, String arg1name) {
+        return new Query1DefImpl<>(VIEW_BUILDER, name, type1, arg1name);
     }
 
-    public static <A, B> Query2Def<A, B> query( String name, Class<A> type1, Class<B> type2 ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, type2 );
+    public static <T1> Query1Def<T1> query(String pkg, String name, Class<T1> type1, String arg1name) {
+        return new Query1DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name);
     }
 
-    public static <A, B> Query2Def<A, B> query( String pkg, String name, Class<A> type1, Class<B> type2 ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2 );
+    public static <T1, T2> Query2Def<T1, T2> query(String name, Class<T1> type1, Class<T2> type2) {
+        return new Query2DefImpl<>(VIEW_BUILDER, name, type1, type2);
     }
 
-    public static <A, B, C> Query3Def<A, B, C> query( String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, name, type1, type2, type3 );
+    public static <T1, T2> Query2Def<T1, T2> query(String pkg, String name, Class<T1> type1, Class<T2> type2) {
+        return new Query2DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2);
     }
 
-    public static <A, B, C> Query3Def<A, B, C> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3 );
+    public static <T1, T2> Query2Def<T1, T2> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        return new Query2DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name);
     }
 
-    public static <A, B, C, D> Query4Def<A, B, C, D> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4 ) {
-        return new Query4DefImpl<>( VIEW_BUILDER, name, type1, type2, type3, type4 );
+    public static <T1, T2> Query2Def<T1, T2> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        return new Query2DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name);
     }
 
-    public static <A, B, C, D> Query4Def<A, B, C, D> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4 ) {
-        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, type2, type3, type4 );
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, type2, type3);
     }
 
-    public static <A> Query1Def<A> query( String pkg, String name, Class<A> type1, String arg1name ) {
-        return new Query1DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name );
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+        return new Query3DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3);
     }
 
-    public static <A, B> Query2Def<A, B> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2, arg2name );
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
+        return new Query3DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <A, B> Query2Def<A, B> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        return new Query2DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name );
+    public static <T1, T2, T3> Query3Def<T1, T2, T3> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
+        return new Query3DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public static <A, B, C> Query3Def<A, B, C> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4);
     }
 
-    public static <A, B, C> Query3Def<A, B, C> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
-        return new Query3DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4);
     }
 
-    public static <A, B, C, D> Query4Def<A, B, C, D> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name ) {
-        return new Query4DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
     }
 
-    public static <A, B, C, D> Query4Def<A, B, C, D> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name ) {
-        return new Query4DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name );
+    public static <T1, T2, T3, T4> Query4Def<T1, T2, T3, T4> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        return new Query4DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
     }
 
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5  ) {
-        return new Query5DefImpl<>( VIEW_BUILDER, name, type1, type2, type3, type4, type5 );
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+        return new Query5DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5);
     }
 
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5 ) {
-        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5 );
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5);
     }
 
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name ) {
-        return new Query5DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
-        return new Query5DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
+    public static <T1, T2, T3, T4, T5> Query5Def<T1, T2, T3, T4, T5> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
+        return new Query5DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+        return new Query6DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+        return new Query6DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        return new Query6DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Query6Def<T1, T2, T3, T4, T5, T6> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        return new Query6DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+        return new Query7DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+        return new Query7DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        return new Query7DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Query7Def<T1, T2, T3, T4, T5, T6, T7> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        return new Query7DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+        return new Query8DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7, type8);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+        return new Query8DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7, type8);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        return new Query8DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        return new Query8DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+        return new Query9DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+        return new Query9DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        return new Query9DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        return new Query9DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+        return new Query10DefImpl<>(VIEW_BUILDER, name, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+        return new Query10DefImpl<>(VIEW_BUILDER, pkg, name, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        return new Query10DefImpl<>(VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> query(String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        return new Query10DefImpl<>(VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
     }
 
     // -- async --

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/PatternDSL.java
@@ -1387,7 +1387,7 @@ public class PatternDSL extends DSL {
         return new Query5DefImpl<>( VIEW_BUILDER, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name );
     }
 
-    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5Name) {
+    public static <A, B, C, D, E> Query5Def<A, B, C, D, E> query( String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
         return new Query5DefImpl<>( VIEW_BUILDER, pkg, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query0Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query0Def.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2005 JBoss Inc
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.drools.model;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query10Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query10Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,23 +26,23 @@ public interface Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Que
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9, Argument<T10> var10);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 
-    public Variable<T5> getArg5();
+    Variable<T5> getArg5();
 
-    public Variable<T6> getArg6();
+    Variable<T6> getArg6();
 
-    public Variable<T7> getArg7();
+    Variable<T7> getArg7();
 
-    public Variable<T8> getArg8();
+    Variable<T8> getArg8();
 
-    public Variable<T9> getArg9();
+    Variable<T9> getArg9();
 
-    public Variable<T10> getArg10();
+    Variable<T10> getArg10();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query10Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query10Def.java
@@ -1,0 +1,32 @@
+package org.drools.model;
+
+import org.drools.model.view.QueryCallViewItem;
+
+public interface Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends QueryDef {
+
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9, Argument<T10> var10) {
+        return call(true, var1, var2, var3, var4, var5, var6, var7, var8, var9, var10);
+    }
+
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9, Argument<T10> var10);
+
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
+
+    public Variable<T5> getArg5();
+
+    public Variable<T6> getArg6();
+
+    public Variable<T7> getArg7();
+
+    public Variable<T8> getArg8();
+
+    public Variable<T9> getArg9();
+
+    public Variable<T10> getArg10();
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query1Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query1Def.java
@@ -1,30 +1,14 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
 
-public interface Query1Def<A> extends QueryDef {
+public interface Query1Def<T1> extends QueryDef {
 
-    default QueryCallViewItem call( Argument<A> aVar) {
-        return call( true, aVar );
+    default QueryCallViewItem call(Argument<T1> var1) {
+        return call(true, var1);
     }
 
-    QueryCallViewItem call(boolean open, Argument<A> aVar);
+    QueryCallViewItem call(boolean open, Argument<T1> var1);
 
-    Variable<A> getArg1();
+    public Variable<T1> getArg1();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query1Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query1Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,5 +26,5 @@ public interface Query1Def<T1> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query2Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query2Def.java
@@ -1,31 +1,16 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
 
-public interface Query2Def<A, B> extends QueryDef {
+public interface Query2Def<T1, T2> extends QueryDef {
 
-    default QueryCallViewItem call( Argument<A> aVar, Argument<B> bVar ) {
-        return call( true, aVar, bVar );
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2) {
+        return call(true, var1, var2);
     }
 
-    QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar );
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2);
 
-    Variable<A> getArg1();
-    Variable<B> getArg2();
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query2Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query2Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,7 +26,7 @@ public interface Query2Def<T1, T2> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,9 +26,9 @@ public interface Query3Def<T1, T2, T3> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query3Def.java
@@ -1,32 +1,18 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
 
-public interface Query3Def<A, B, C> extends QueryDef {
+public interface Query3Def<T1, T2, T3> extends QueryDef {
 
-    default QueryCallViewItem call(Argument<A> aVar, Argument<B> bVar, Argument<C> cVar) {
-        return call( true, aVar, bVar, cVar);
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3) {
+        return call(true, var1, var2, var3);
     }
 
-    QueryCallViewItem call(boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar);
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3);
 
-    Variable<A> getArg1();
-    Variable<B> getArg2();
-    Variable<C> getArg3();
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
@@ -1,33 +1,20 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
 
-public interface Query4Def<A, B, C, D> extends QueryDef {
+public interface Query4Def<T1, T2, T3, T4> extends QueryDef {
 
-    default QueryCallViewItem call(Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar) {
-        return call( true, aVar, bVar, cVar, dVar);
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4) {
+        return call(true, var1, var2, var3, var4);
     }
 
-    QueryCallViewItem call(boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar);
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4);
 
-    Variable<A> getArg1();
-    Variable<B> getArg2();
-    Variable<C> getArg3();
-    Variable<D> getArg4();
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query4Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,11 +26,11 @@ public interface Query4Def<T1, T2, T3, T4> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,13 +26,13 @@ public interface Query5Def<T1, T2, T3, T4, T5> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 
-    public Variable<T5> getArg5();
+    Variable<T5> getArg5();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
@@ -1,34 +1,22 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
 
-public interface Query5Def<A, B, C, D, E> extends QueryDef {
+public interface Query5Def<T1, T2, T3, T4, T5> extends QueryDef {
 
-    default QueryCallViewItem call(Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar, Argument<E> eVar) {
-        return call( true, aVar, bVar, cVar, dVar, eVar);
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5) {
+        return call(true, var1, var2, var3, var4, var5);
     }
 
-    QueryCallViewItem call(boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar, Argument<E> eVar);
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5);
 
-    Variable<A> getArg1();
-    Variable<B> getArg2();
-    Variable<C> getArg3();
-    Variable<D> getArg4();
-    Variable<E> getArg5();
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
+
+    public Variable<T5> getArg5();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query5Def.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model;
+
+import org.drools.model.view.QueryCallViewItem;
+
+public interface Query5Def<A, B, C, D, E> extends QueryDef {
+
+    default QueryCallViewItem call(Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar, Argument<E> eVar) {
+        return call( true, aVar, bVar, cVar, dVar, eVar);
+    }
+
+    QueryCallViewItem call(boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar, Argument<E> eVar);
+
+    Variable<A> getArg1();
+    Variable<B> getArg2();
+    Variable<C> getArg3();
+    Variable<D> getArg4();
+    Variable<E> getArg5();
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query6Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query6Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,15 +26,15 @@ public interface Query6Def<T1, T2, T3, T4, T5, T6> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 
-    public Variable<T5> getArg5();
+    Variable<T5> getArg5();
 
-    public Variable<T6> getArg6();
+    Variable<T6> getArg6();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query6Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query6Def.java
@@ -1,0 +1,24 @@
+package org.drools.model;
+
+import org.drools.model.view.QueryCallViewItem;
+
+public interface Query6Def<T1, T2, T3, T4, T5, T6> extends QueryDef {
+
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6) {
+        return call(true, var1, var2, var3, var4, var5, var6);
+    }
+
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6);
+
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
+
+    public Variable<T5> getArg5();
+
+    public Variable<T6> getArg6();
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query7Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query7Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,17 +26,17 @@ public interface Query7Def<T1, T2, T3, T4, T5, T6, T7> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 
-    public Variable<T5> getArg5();
+    Variable<T5> getArg5();
 
-    public Variable<T6> getArg6();
+    Variable<T6> getArg6();
 
-    public Variable<T7> getArg7();
+    Variable<T7> getArg7();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query7Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query7Def.java
@@ -1,0 +1,26 @@
+package org.drools.model;
+
+import org.drools.model.view.QueryCallViewItem;
+
+public interface Query7Def<T1, T2, T3, T4, T5, T6, T7> extends QueryDef {
+
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7) {
+        return call(true, var1, var2, var3, var4, var5, var6, var7);
+    }
+
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7);
+
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
+
+    public Variable<T5> getArg5();
+
+    public Variable<T6> getArg6();
+
+    public Variable<T7> getArg7();
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query8Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query8Def.java
@@ -1,0 +1,28 @@
+package org.drools.model;
+
+import org.drools.model.view.QueryCallViewItem;
+
+public interface Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> extends QueryDef {
+
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8) {
+        return call(true, var1, var2, var3, var4, var5, var6, var7, var8);
+    }
+
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8);
+
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
+
+    public Variable<T5> getArg5();
+
+    public Variable<T6> getArg6();
+
+    public Variable<T7> getArg7();
+
+    public Variable<T8> getArg8();
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query8Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query8Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,19 +26,19 @@ public interface Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> extends QueryDef {
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 
-    public Variable<T5> getArg5();
+    Variable<T5> getArg5();
 
-    public Variable<T6> getArg6();
+    Variable<T6> getArg6();
 
-    public Variable<T7> getArg7();
+    Variable<T7> getArg7();
 
-    public Variable<T8> getArg8();
+    Variable<T8> getArg8();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query9Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query9Def.java
@@ -1,0 +1,30 @@
+package org.drools.model;
+
+import org.drools.model.view.QueryCallViewItem;
+
+public interface Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends QueryDef {
+
+    default QueryCallViewItem call(Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9) {
+        return call(true, var1, var2, var3, var4, var5, var6, var7, var8, var9);
+    }
+
+    QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9);
+
+    public Variable<T1> getArg1();
+
+    public Variable<T2> getArg2();
+
+    public Variable<T3> getArg3();
+
+    public Variable<T4> getArg4();
+
+    public Variable<T5> getArg5();
+
+    public Variable<T6> getArg6();
+
+    public Variable<T7> getArg7();
+
+    public Variable<T8> getArg8();
+
+    public Variable<T9> getArg9();
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query9Def.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Query9Def.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model;
 
 import org.drools.model.view.QueryCallViewItem;
@@ -10,21 +26,21 @@ public interface Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends QueryDef 
 
     QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9);
 
-    public Variable<T1> getArg1();
+    Variable<T1> getArg1();
 
-    public Variable<T2> getArg2();
+    Variable<T2> getArg2();
 
-    public Variable<T3> getArg3();
+    Variable<T3> getArg3();
 
-    public Variable<T4> getArg4();
+    Variable<T4> getArg4();
 
-    public Variable<T5> getArg5();
+    Variable<T5> getArg5();
 
-    public Variable<T6> getArg6();
+    Variable<T6> getArg6();
 
-    public Variable<T7> getArg7();
+    Variable<T7> getArg7();
 
-    public Variable<T8> getArg8();
+    Variable<T8> getArg8();
 
-    public Variable<T9> getArg9();
+    Variable<T9> getArg9();
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/QueryDef.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/QueryDef.java
@@ -23,7 +23,17 @@ import org.drools.model.view.ViewItemBuilder;
 public interface QueryDef {
 
     Class[] QUERIES_BY_ARITY = new Class[] {
-            Query0Def.class, Query1Def.class, Query2Def.class, Query3Def.class, Query4Def.class, Query5Def.class
+            Query0Def.class,
+            Query1Def.class,
+            Query2Def.class,
+            Query3Def.class,
+            Query4Def.class,
+            Query5Def.class,
+            Query6Def.class,
+            Query7Def.class,
+            Query8Def.class,
+            Query9Def.class,
+            Query10Def.class,
     };
 
     static Class getQueryClassByArity(int arity) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/QueryDef.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/QueryDef.java
@@ -23,7 +23,7 @@ import org.drools.model.view.ViewItemBuilder;
 public interface QueryDef {
 
     Class[] QUERIES_BY_ARITY = new Class[] {
-            Query0Def.class, Query1Def.class, Query2Def.class, Query3Def.class, Query4Def.class
+            Query0Def.class, Query1Def.class, Query2Def.class, Query3Def.class, Query4Def.class, Query5Def.class
     };
 
     static Class getQueryClassByArity(int arity) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query0DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query0DefImpl.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2005 JBoss Inc
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.drools.model.impl;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
@@ -1,0 +1,138 @@
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query10Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+import static org.drools.model.FlowDSL.declarationOf;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query10DefImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends QueryDefImpl implements ModelComponent, Query10Def<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
+
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    private final Variable<T5> arg5;
+
+    private final Variable<T6> arg6;
+
+    private final Variable<T7> arg7;
+
+    private final Variable<T8> arg8;
+
+    private final Variable<T9> arg9;
+
+    private final Variable<T10> arg10;
+
+    public Query10DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+    }
+
+    public Query10DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
+        this.arg5 = declarationOf(type5);
+        this.arg6 = declarationOf(type6);
+        this.arg7 = declarationOf(type7);
+        this.arg8 = declarationOf(type8);
+        this.arg9 = declarationOf(type9);
+        this.arg10 = declarationOf(type10);
+    }
+
+    public Query10DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name, type10, arg10name);
+    }
+
+    public Query10DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name, Class<T10> type10, String arg10name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
+        this.arg5 = declarationOf(type5, arg5name);
+        this.arg6 = declarationOf(type6, arg6name);
+        this.arg7 = declarationOf(type7, arg7name);
+        this.arg8 = declarationOf(type8, arg8name);
+        this.arg9 = declarationOf(type9, arg9name);
+        this.arg10 = declarationOf(type10, arg10name);
+    }
+
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9, Argument<T10> var10) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4, var5, var6, var7, var8, var9, var10);
+    }
+
+    @Override()
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 };
+    }
+
+    @Override()
+    public Variable<T1> getArg1() {
+        return arg1;
+    }
+
+    @Override()
+    public Variable<T2> getArg2() {
+        return arg2;
+    }
+
+    @Override()
+    public Variable<T3> getArg3() {
+        return arg3;
+    }
+
+    @Override()
+    public Variable<T4> getArg4() {
+        return arg4;
+    }
+
+    @Override()
+    public Variable<T5> getArg5() {
+        return arg5;
+    }
+
+    @Override()
+    public Variable<T6> getArg6() {
+        return arg6;
+    }
+
+    @Override()
+    public Variable<T7> getArg7() {
+        return arg7;
+    }
+
+    @Override()
+    public Variable<T8> getArg8() {
+        return arg8;
+    }
+
+    @Override()
+    public Variable<T9> getArg9() {
+        return arg9;
+    }
+
+    @Override()
+    public Variable<T10> getArg10() {
+        return arg10;
+    }
+
+    @Override
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query10DefImpl))
+            return false;
+        Query10DefImpl that = (Query10DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4) && ModelComponent.areEqualInModel(arg5, that.arg5) && ModelComponent.areEqualInModel(arg6, that.arg6) && ModelComponent.areEqualInModel(arg7, that.arg7) && ModelComponent.areEqualInModel(arg8, that.arg8) && ModelComponent.areEqualInModel(arg9, that.arg9) && ModelComponent.areEqualInModel(arg10, that.arg10);
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query10DefImpl.java
@@ -50,7 +50,7 @@ public class Query10DefImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Que
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
     }
 
-    public Query10DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+    public Query10DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model.impl;
 
 import org.drools.model.Argument;
@@ -21,52 +5,53 @@ import org.drools.model.Query1Def;
 import org.drools.model.Variable;
 import org.drools.model.view.QueryCallViewItem;
 import org.drools.model.view.QueryCallViewItemImpl;
-
 import static org.drools.model.FlowDSL.declarationOf;
 import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
 
-public class Query1DefImpl<A> extends QueryDefImpl implements Query1Def<A>, ModelComponent {
-    private final Variable<A> arg1;
+public class Query1DefImpl<T1> extends QueryDefImpl implements ModelComponent, Query1Def<T1> {
 
-    public Query1DefImpl( ViewBuilder viewBuilder, String name, Class<A> type1 ) {
+    private final Variable<T1> arg1;
+
+    public Query1DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1);
     }
 
-    public Query1DefImpl( ViewBuilder viewBuilder, String name, Class<A> type1, String arg1name ) {
+    public Query1DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+    }
+
+    public Query1DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name);
     }
 
-    public Query1DefImpl( ViewBuilder viewBuilder, String pkg, String name, Class<A> type1 ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1 );
+    public Query1DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
     }
 
-    public Query1DefImpl( ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, String arg1name ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1, arg1name);
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1) {
+        return new QueryCallViewItemImpl(this, open, var1);
     }
 
-    @Override
-    public QueryCallViewItem call( boolean open, Argument<A> aVar ) {
-        return new QueryCallViewItemImpl( this, open, aVar );
-    }
-
-    @Override
+    @Override()
     public Variable<?>[] getArguments() {
-        return new Variable<?>[] {arg1};
+        return new Variable<?>[] { arg1 };
     }
 
-    public Variable<A> getArg1() {
+    @Override()
+    public Variable<T1> getArg1() {
         return arg1;
     }
 
     @Override
-    public boolean isEqualTo( ModelComponent other ) {
-        if ( this == other ) return true;
-        if ( !(other instanceof Query1DefImpl) ) return false;
-
-        Query1DefImpl that = ( Query1DefImpl ) other;
-
-        return ModelComponent.areEqualInModel( arg1, that.arg1 );
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query1DefImpl))
+            return false;
+        Query1DefImpl that = (Query1DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
@@ -32,7 +32,7 @@ public class Query1DefImpl<T1> extends QueryDefImpl implements ModelComponent, Q
         this(viewBuilder, DEFAULT_PACKAGE, name, type1);
     }
 
-    public Query1DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1) {
+    public Query1DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
     }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query1DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
@@ -34,7 +34,7 @@ public class Query2DefImpl<T1, T2> extends QueryDefImpl implements ModelComponen
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2);
     }
 
-    public Query2DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2) {
+    public Query2DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query2DefImpl.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model.impl;
 
 import org.drools.model.Argument;
@@ -21,59 +5,62 @@ import org.drools.model.Query2Def;
 import org.drools.model.Variable;
 import org.drools.model.view.QueryCallViewItem;
 import org.drools.model.view.QueryCallViewItemImpl;
-
 import static org.drools.model.FlowDSL.declarationOf;
 import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
 
-public class Query2DefImpl<A, B> extends QueryDefImpl implements Query2Def<A, B>, ModelComponent {
-    private final Variable<A> arg1;
-    private final Variable<B> arg2;
+public class Query2DefImpl<T1, T2> extends QueryDefImpl implements ModelComponent, Query2Def<T1, T2> {
 
-    public Query2DefImpl( ViewBuilder viewBuilder, String name, Class<A> type1, Class<B> type2 ) {
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    public Query2DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2);
     }
 
-    public Query2DefImpl( ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, Class<B> type2 ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1 );
-        this.arg2 = declarationOf( type2 );
+    public Query2DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
     }
 
-    public Query2DefImpl( ViewBuilder viewBuilder, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
+    public Query2DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name);
     }
 
-    public Query2DefImpl( ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1, arg1name);
-        this.arg2 = declarationOf( type2, arg2name);
+    public Query2DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
     }
 
-    @Override
-    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar ) {
-        return new QueryCallViewItemImpl( this, open, aVar, bVar );
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2) {
+        return new QueryCallViewItemImpl(this, open, var1, var2);
     }
 
-    @Override
+    @Override()
     public Variable<?>[] getArguments() {
-        return new Variable<?>[] {arg1, arg2};
+        return new Variable<?>[] { arg1, arg2 };
     }
 
-    public Variable<A> getArg1() {
+    @Override()
+    public Variable<T1> getArg1() {
         return arg1;
     }
 
-    public Variable<B> getArg2() {
+    @Override()
+    public Variable<T2> getArg2() {
         return arg2;
     }
 
     @Override
-    public boolean isEqualTo( ModelComponent other ) {
-        if ( this == other ) return true;
-        if ( !(other instanceof Query2DefImpl) ) return false;
-
-        Query2DefImpl that = ( Query2DefImpl ) other;
-
-        return ModelComponent.areEqualInModel( arg1, that.arg1 ) && ModelComponent.areEqualInModel( arg2, that.arg2 );
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query2DefImpl))
+            return false;
+        Query2DefImpl that = (Query2DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
@@ -36,7 +36,7 @@ public class Query3DefImpl<T1, T2, T3> extends QueryDefImpl implements ModelComp
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3);
     }
 
-    public Query3DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+    public Query3DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model.impl;
 
 import org.drools.model.Argument;
@@ -21,67 +5,71 @@ import org.drools.model.Query3Def;
 import org.drools.model.Variable;
 import org.drools.model.view.QueryCallViewItem;
 import org.drools.model.view.QueryCallViewItemImpl;
-
 import static org.drools.model.FlowDSL.declarationOf;
 import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
 
-public class Query3DefImpl<A, B, C> extends QueryDefImpl implements Query3Def<A, B, C>, ModelComponent {
-    private final Variable<A> arg1;
-    private final Variable<B> arg2;
-    private final Variable<C> arg3;
+public class Query3DefImpl<T1, T2, T3> extends QueryDefImpl implements ModelComponent, Query3Def<T1, T2, T3> {
 
-    public Query3DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, Class<B> type2, Class<C> type3 ) {
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    public Query3DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3);
     }
 
-    public Query3DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3  ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1 );
-        this.arg2 = declarationOf( type2 );
-        this.arg3 = declarationOf( type3 );
+    public Query3DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
     }
 
-    public Query3DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name ) {
+    public Query3DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name);
     }
 
-    public Query3DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name  ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1, arg1name);
-        this.arg2 = declarationOf( type2, arg2name );
-        this.arg3 = declarationOf( type3, arg3name);
+    public Query3DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
     }
 
-    @Override
-    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar ) {
-        return new QueryCallViewItemImpl( this, open, aVar, bVar, cVar );
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3);
     }
 
-    @Override
+    @Override()
     public Variable<?>[] getArguments() {
-        return new Variable<?>[] {arg1, arg2, arg3};
+        return new Variable<?>[] { arg1, arg2, arg3 };
     }
 
-    public Variable<A> getArg1() {
+    @Override()
+    public Variable<T1> getArg1() {
         return arg1;
     }
 
-    public Variable<B> getArg2() {
+    @Override()
+    public Variable<T2> getArg2() {
         return arg2;
     }
 
-    @Override
-    public Variable<C> getArg3() {
+    @Override()
+    public Variable<T3> getArg3() {
         return arg3;
     }
 
     @Override
-    public boolean isEqualTo( ModelComponent other ) {
-        if ( this == other ) return true;
-        if ( !(other instanceof Query3DefImpl) ) return false;
-
-        Query3DefImpl that = ( Query3DefImpl ) other;
-
-        return ModelComponent.areEqualInModel( arg1, that.arg1 ) && ModelComponent.areEqualInModel( arg2, that.arg2 ) && ModelComponent.areEqualInModel( arg3, that.arg3 );
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query3DefImpl))
+            return false;
+        Query3DefImpl that = (Query3DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query3DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model.impl;
 
 import org.drools.model.Argument;
@@ -21,76 +5,80 @@ import org.drools.model.Query4Def;
 import org.drools.model.Variable;
 import org.drools.model.view.QueryCallViewItem;
 import org.drools.model.view.QueryCallViewItemImpl;
-
 import static org.drools.model.FlowDSL.declarationOf;
 import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
 
-public class Query4DefImpl<A, B, C, D> extends QueryDefImpl implements Query4Def<A, B, C, D>, ModelComponent {
-    private final Variable<A> arg1;
-    private final Variable<B> arg2;
-    private final Variable<C> arg3;
-    private final Variable<D> arg4;
+public class Query4DefImpl<T1, T2, T3, T4> extends QueryDefImpl implements ModelComponent, Query4Def<T1, T2, T3, T4> {
 
-    public Query4DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4 ) {
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    public Query4DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4);
     }
 
-    public Query4DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4  ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1 );
-        this.arg2 = declarationOf( type2 );
-        this.arg3 = declarationOf( type3 );
-        this.arg4 = declarationOf( type4 );
+    public Query4DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
     }
 
-    public Query4DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name ) {
+    public Query4DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name);
     }
 
-    public Query4DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name  ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1, arg1name);
-        this.arg2 = declarationOf( type2, arg2name);
-        this.arg3 = declarationOf( type3, arg3name);
-        this.arg4 = declarationOf( type4, arg4name);
+    public Query4DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
     }
 
-    @Override
-    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar) {
-        return new QueryCallViewItemImpl( this, open, aVar, bVar, cVar, dVar );
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4);
     }
 
-    @Override
+    @Override()
     public Variable<?>[] getArguments() {
-        return new Variable<?>[] {arg1, arg2, arg3, arg4};
+        return new Variable<?>[] { arg1, arg2, arg3, arg4 };
     }
 
-    public Variable<A> getArg1() {
+    @Override()
+    public Variable<T1> getArg1() {
         return arg1;
     }
 
-    public Variable<B> getArg2() {
+    @Override()
+    public Variable<T2> getArg2() {
         return arg2;
     }
 
-    @Override
-    public Variable<C> getArg3() {
+    @Override()
+    public Variable<T3> getArg3() {
         return arg3;
     }
 
-    @Override
-    public Variable<D> getArg4() {
+    @Override()
+    public Variable<T4> getArg4() {
         return arg4;
     }
 
     @Override
-    public boolean isEqualTo( ModelComponent other ) {
-        if ( this == other ) return true;
-        if ( !(other instanceof Query4DefImpl) ) return false;
-
-        Query4DefImpl that = ( Query4DefImpl ) other;
-
-        return ModelComponent.areEqualInModel( arg1, that.arg1 ) && ModelComponent.areEqualInModel( arg2, that.arg2 ) &&
-                ModelComponent.areEqualInModel( arg3, that.arg3 ) && ModelComponent.areEqualInModel( arg4, that.arg4 );
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query4DefImpl))
+            return false;
+        Query4DefImpl that = (Query4DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query4DefImpl.java
@@ -38,7 +38,7 @@ public class Query4DefImpl<T1, T2, T3, T4> extends QueryDefImpl implements Model
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4);
     }
 
-    public Query4DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+    public Query4DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query4Def;
+import org.drools.model.Query5Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+
+import static org.drools.model.FlowDSL.declarationOf;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query5DefImpl<A, B, C, D, E> extends QueryDefImpl implements Query5Def<A, B, C, D, E>, ModelComponent {
+    private final Variable<A> arg1;
+    private final Variable<B> arg2;
+    private final Variable<C> arg3;
+    private final Variable<D> arg4;
+    private final Variable<E> arg5;
+
+    public Query5DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5 ) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5);
+    }
+
+    public Query5DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5  ) {
+        super( viewBuilder, pkg, name );
+        this.arg1 = declarationOf( type1 );
+        this.arg2 = declarationOf( type2 );
+        this.arg3 = declarationOf( type3 );
+        this.arg4 = declarationOf( type4 );
+        this.arg5 = declarationOf( type5 );
+    }
+
+    public Query5DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
+    }
+
+    public Query5DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name  ) {
+        super( viewBuilder, pkg, name );
+        this.arg1 = declarationOf( type1, arg1name);
+        this.arg2 = declarationOf( type2, arg2name);
+        this.arg3 = declarationOf( type3, arg3name);
+        this.arg4 = declarationOf( type4, arg4name);
+        this.arg5 = declarationOf( type5, arg5name);
+    }
+
+    @Override
+    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar, Argument<E> eVar) {
+        return new QueryCallViewItemImpl( this, open, aVar, bVar, cVar, dVar, eVar );
+    }
+
+    @Override
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] {arg1, arg2, arg3, arg4, arg5};
+    }
+
+    public Variable<A> getArg1() {
+        return arg1;
+    }
+
+    public Variable<B> getArg2() {
+        return arg2;
+    }
+
+    @Override
+    public Variable<C> getArg3() {
+        return arg3;
+    }
+
+    @Override
+    public Variable<D> getArg4() {
+        return arg4;
+    }
+
+    @Override
+    public Variable<E> getArg5() {
+        return arg5;
+    }
+
+    @Override
+    public boolean isEqualTo( ModelComponent other ) {
+        if ( this == other ) return true;
+        if ( !(other instanceof Query5DefImpl) ) return false;
+
+        Query5DefImpl that = (Query5DefImpl) other;
+
+        return ModelComponent.areEqualInModel( arg1, that.arg1 )
+                && ModelComponent.areEqualInModel( arg2, that.arg2 )
+                && ModelComponent.areEqualInModel( arg3, that.arg3 )
+                && ModelComponent.areEqualInModel( arg4, that.arg4 )
+                && ModelComponent.areEqualInModel( arg5, that.arg5 );
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
@@ -1,108 +1,93 @@
-/*
- * Copyright 2005 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.drools.model.impl;
 
 import org.drools.model.Argument;
-import org.drools.model.Query4Def;
 import org.drools.model.Query5Def;
 import org.drools.model.Variable;
 import org.drools.model.view.QueryCallViewItem;
 import org.drools.model.view.QueryCallViewItemImpl;
-
 import static org.drools.model.FlowDSL.declarationOf;
 import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
 
-public class Query5DefImpl<A, B, C, D, E> extends QueryDefImpl implements Query5Def<A, B, C, D, E>, ModelComponent {
-    private final Variable<A> arg1;
-    private final Variable<B> arg2;
-    private final Variable<C> arg3;
-    private final Variable<D> arg4;
-    private final Variable<E> arg5;
+public class Query5DefImpl<T1, T2, T3, T4, T5> extends QueryDefImpl implements ModelComponent, Query5Def<T1, T2, T3, T4, T5> {
 
-    public Query5DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5 ) {
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    private final Variable<T5> arg5;
+
+    public Query5DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5);
     }
 
-    public Query5DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, Class<B> type2, Class<C> type3, Class<D> type4, Class<E> type5  ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1 );
-        this.arg2 = declarationOf( type2 );
-        this.arg3 = declarationOf( type3 );
-        this.arg4 = declarationOf( type4 );
-        this.arg5 = declarationOf( type5 );
+    public Query5DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
+        this.arg5 = declarationOf(type5);
     }
 
-    public Query5DefImpl(ViewBuilder viewBuilder, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name) {
+    public Query5DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name);
     }
 
-    public Query5DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<A> type1, String arg1name, Class<B> type2, String arg2name, Class<C> type3, String arg3name, Class<D> type4, String arg4name, Class<E> type5, String arg5name  ) {
-        super( viewBuilder, pkg, name );
-        this.arg1 = declarationOf( type1, arg1name);
-        this.arg2 = declarationOf( type2, arg2name);
-        this.arg3 = declarationOf( type3, arg3name);
-        this.arg4 = declarationOf( type4, arg4name);
-        this.arg5 = declarationOf( type5, arg5name);
+    public Query5DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
+        this.arg5 = declarationOf(type5, arg5name);
     }
 
-    @Override
-    public QueryCallViewItem call( boolean open, Argument<A> aVar, Argument<B> bVar, Argument<C> cVar, Argument<D> dVar, Argument<E> eVar) {
-        return new QueryCallViewItemImpl( this, open, aVar, bVar, cVar, dVar, eVar );
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4, var5);
     }
 
-    @Override
+    @Override()
     public Variable<?>[] getArguments() {
-        return new Variable<?>[] {arg1, arg2, arg3, arg4, arg5};
+        return new Variable<?>[] { arg1, arg2, arg3, arg4, arg5 };
     }
 
-    public Variable<A> getArg1() {
+    @Override()
+    public Variable<T1> getArg1() {
         return arg1;
     }
 
-    public Variable<B> getArg2() {
+    @Override()
+    public Variable<T2> getArg2() {
         return arg2;
     }
 
-    @Override
-    public Variable<C> getArg3() {
+    @Override()
+    public Variable<T3> getArg3() {
         return arg3;
     }
 
-    @Override
-    public Variable<D> getArg4() {
+    @Override()
+    public Variable<T4> getArg4() {
         return arg4;
     }
 
-    @Override
-    public Variable<E> getArg5() {
+    @Override()
+    public Variable<T5> getArg5() {
         return arg5;
     }
 
     @Override
-    public boolean isEqualTo( ModelComponent other ) {
-        if ( this == other ) return true;
-        if ( !(other instanceof Query5DefImpl) ) return false;
-
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query5DefImpl))
+            return false;
         Query5DefImpl that = (Query5DefImpl) other;
-
-        return ModelComponent.areEqualInModel( arg1, that.arg1 )
-                && ModelComponent.areEqualInModel( arg2, that.arg2 )
-                && ModelComponent.areEqualInModel( arg3, that.arg3 )
-                && ModelComponent.areEqualInModel( arg4, that.arg4 )
-                && ModelComponent.areEqualInModel( arg5, that.arg5 );
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4) && ModelComponent.areEqualInModel(arg5, that.arg5);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query5DefImpl.java
@@ -40,7 +40,7 @@ public class Query5DefImpl<T1, T2, T3, T4, T5> extends QueryDefImpl implements M
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5);
     }
 
-    public Query5DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+    public Query5DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
@@ -1,0 +1,102 @@
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query6Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+import static org.drools.model.FlowDSL.declarationOf;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query6DefImpl<T1, T2, T3, T4, T5, T6> extends QueryDefImpl implements ModelComponent, Query6Def<T1, T2, T3, T4, T5, T6> {
+
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    private final Variable<T5> arg5;
+
+    private final Variable<T6> arg6;
+
+    public Query6DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6);
+    }
+
+    public Query6DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
+        this.arg5 = declarationOf(type5);
+        this.arg6 = declarationOf(type6);
+    }
+
+    public Query6DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name);
+    }
+
+    public Query6DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
+        this.arg5 = declarationOf(type5, arg5name);
+        this.arg6 = declarationOf(type6, arg6name);
+    }
+
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4, var5, var6);
+    }
+
+    @Override()
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] { arg1, arg2, arg3, arg4, arg5, arg6 };
+    }
+
+    @Override()
+    public Variable<T1> getArg1() {
+        return arg1;
+    }
+
+    @Override()
+    public Variable<T2> getArg2() {
+        return arg2;
+    }
+
+    @Override()
+    public Variable<T3> getArg3() {
+        return arg3;
+    }
+
+    @Override()
+    public Variable<T4> getArg4() {
+        return arg4;
+    }
+
+    @Override()
+    public Variable<T5> getArg5() {
+        return arg5;
+    }
+
+    @Override()
+    public Variable<T6> getArg6() {
+        return arg6;
+    }
+
+    @Override
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query6DefImpl))
+            return false;
+        Query6DefImpl that = (Query6DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4) && ModelComponent.areEqualInModel(arg5, that.arg5) && ModelComponent.areEqualInModel(arg6, that.arg6);
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query6DefImpl.java
@@ -42,7 +42,7 @@ public class Query6DefImpl<T1, T2, T3, T4, T5, T6> extends QueryDefImpl implemen
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6);
     }
 
-    public Query6DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+    public Query6DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
@@ -1,0 +1,111 @@
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query7Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+import static org.drools.model.FlowDSL.declarationOf;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query7DefImpl<T1, T2, T3, T4, T5, T6, T7> extends QueryDefImpl implements ModelComponent, Query7Def<T1, T2, T3, T4, T5, T6, T7> {
+
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    private final Variable<T5> arg5;
+
+    private final Variable<T6> arg6;
+
+    private final Variable<T7> arg7;
+
+    public Query7DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7);
+    }
+
+    public Query7DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
+        this.arg5 = declarationOf(type5);
+        this.arg6 = declarationOf(type6);
+        this.arg7 = declarationOf(type7);
+    }
+
+    public Query7DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name);
+    }
+
+    public Query7DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
+        this.arg5 = declarationOf(type5, arg5name);
+        this.arg6 = declarationOf(type6, arg6name);
+        this.arg7 = declarationOf(type7, arg7name);
+    }
+
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4, var5, var6, var7);
+    }
+
+    @Override()
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 };
+    }
+
+    @Override()
+    public Variable<T1> getArg1() {
+        return arg1;
+    }
+
+    @Override()
+    public Variable<T2> getArg2() {
+        return arg2;
+    }
+
+    @Override()
+    public Variable<T3> getArg3() {
+        return arg3;
+    }
+
+    @Override()
+    public Variable<T4> getArg4() {
+        return arg4;
+    }
+
+    @Override()
+    public Variable<T5> getArg5() {
+        return arg5;
+    }
+
+    @Override()
+    public Variable<T6> getArg6() {
+        return arg6;
+    }
+
+    @Override()
+    public Variable<T7> getArg7() {
+        return arg7;
+    }
+
+    @Override
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query7DefImpl))
+            return false;
+        Query7DefImpl that = (Query7DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4) && ModelComponent.areEqualInModel(arg5, that.arg5) && ModelComponent.areEqualInModel(arg6, that.arg6) && ModelComponent.areEqualInModel(arg7, that.arg7);
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query7DefImpl.java
@@ -44,7 +44,7 @@ public class Query7DefImpl<T1, T2, T3, T4, T5, T6, T7> extends QueryDefImpl impl
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7);
     }
 
-    public Query7DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+    public Query7DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
@@ -1,0 +1,120 @@
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query8Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+import static org.drools.model.FlowDSL.declarationOf;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query8DefImpl<T1, T2, T3, T4, T5, T6, T7, T8> extends QueryDefImpl implements ModelComponent, Query8Def<T1, T2, T3, T4, T5, T6, T7, T8> {
+
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    private final Variable<T5> arg5;
+
+    private final Variable<T6> arg6;
+
+    private final Variable<T7> arg7;
+
+    private final Variable<T8> arg8;
+
+    public Query8DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7, type8);
+    }
+
+    public Query8DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
+        this.arg5 = declarationOf(type5);
+        this.arg6 = declarationOf(type6);
+        this.arg7 = declarationOf(type7);
+        this.arg8 = declarationOf(type8);
+    }
+
+    public Query8DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name);
+    }
+
+    public Query8DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
+        this.arg5 = declarationOf(type5, arg5name);
+        this.arg6 = declarationOf(type6, arg6name);
+        this.arg7 = declarationOf(type7, arg7name);
+        this.arg8 = declarationOf(type8, arg8name);
+    }
+
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4, var5, var6, var7, var8);
+    }
+
+    @Override()
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 };
+    }
+
+    @Override()
+    public Variable<T1> getArg1() {
+        return arg1;
+    }
+
+    @Override()
+    public Variable<T2> getArg2() {
+        return arg2;
+    }
+
+    @Override()
+    public Variable<T3> getArg3() {
+        return arg3;
+    }
+
+    @Override()
+    public Variable<T4> getArg4() {
+        return arg4;
+    }
+
+    @Override()
+    public Variable<T5> getArg5() {
+        return arg5;
+    }
+
+    @Override()
+    public Variable<T6> getArg6() {
+        return arg6;
+    }
+
+    @Override()
+    public Variable<T7> getArg7() {
+        return arg7;
+    }
+
+    @Override()
+    public Variable<T8> getArg8() {
+        return arg8;
+    }
+
+    @Override
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query8DefImpl))
+            return false;
+        Query8DefImpl that = (Query8DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4) && ModelComponent.areEqualInModel(arg5, that.arg5) && ModelComponent.areEqualInModel(arg6, that.arg6) && ModelComponent.areEqualInModel(arg7, that.arg7) && ModelComponent.areEqualInModel(arg8, that.arg8);
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query8DefImpl.java
@@ -46,7 +46,7 @@ public class Query8DefImpl<T1, T2, T3, T4, T5, T6, T7, T8> extends QueryDefImpl 
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7, type8);
     }
 
-    public Query8DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+    public Query8DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
@@ -48,7 +48,7 @@ public class Query9DefImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends QueryDefI
         this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7, type8, type9);
     }
 
-    public Query9DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+    public Query9DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
         super(viewBuilder, pkg, name);
         this.arg1 = declarationOf(type1);
         this.arg2 = declarationOf(type2);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.drools.model.impl;
 
 import org.drools.model.Argument;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/impl/Query9DefImpl.java
@@ -1,0 +1,129 @@
+package org.drools.model.impl;
+
+import org.drools.model.Argument;
+import org.drools.model.Query9Def;
+import org.drools.model.Variable;
+import org.drools.model.view.QueryCallViewItem;
+import org.drools.model.view.QueryCallViewItemImpl;
+import static org.drools.model.FlowDSL.declarationOf;
+import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;
+
+public class Query9DefImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends QueryDefImpl implements ModelComponent, Query9Def<T1, T2, T3, T4, T5, T6, T7, T8, T9> {
+
+    private final Variable<T1> arg1;
+
+    private final Variable<T2> arg2;
+
+    private final Variable<T3> arg3;
+
+    private final Variable<T4> arg4;
+
+    private final Variable<T5> arg5;
+
+    private final Variable<T6> arg6;
+
+    private final Variable<T7> arg7;
+
+    private final Variable<T8> arg8;
+
+    private final Variable<T9> arg9;
+
+    public Query9DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+    }
+
+    public Query9DefImpl(ViewBuilder viewBuilder, String name, String pkg, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1);
+        this.arg2 = declarationOf(type2);
+        this.arg3 = declarationOf(type3);
+        this.arg4 = declarationOf(type4);
+        this.arg5 = declarationOf(type5);
+        this.arg6 = declarationOf(type6);
+        this.arg7 = declarationOf(type7);
+        this.arg8 = declarationOf(type8);
+        this.arg9 = declarationOf(type9);
+    }
+
+    public Query9DefImpl(ViewBuilder viewBuilder, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        this(viewBuilder, DEFAULT_PACKAGE, name, type1, arg1name, type2, arg2name, type3, arg3name, type4, arg4name, type5, arg5name, type6, arg6name, type7, arg7name, type8, arg8name, type9, arg9name);
+    }
+
+    public Query9DefImpl(ViewBuilder viewBuilder, String pkg, String name, Class<T1> type1, String arg1name, Class<T2> type2, String arg2name, Class<T3> type3, String arg3name, Class<T4> type4, String arg4name, Class<T5> type5, String arg5name, Class<T6> type6, String arg6name, Class<T7> type7, String arg7name, Class<T8> type8, String arg8name, Class<T9> type9, String arg9name) {
+        super(viewBuilder, pkg, name);
+        this.arg1 = declarationOf(type1, arg1name);
+        this.arg2 = declarationOf(type2, arg2name);
+        this.arg3 = declarationOf(type3, arg3name);
+        this.arg4 = declarationOf(type4, arg4name);
+        this.arg5 = declarationOf(type5, arg5name);
+        this.arg6 = declarationOf(type6, arg6name);
+        this.arg7 = declarationOf(type7, arg7name);
+        this.arg8 = declarationOf(type8, arg8name);
+        this.arg9 = declarationOf(type9, arg9name);
+    }
+
+    @Override()
+    public QueryCallViewItem call(boolean open, Argument<T1> var1, Argument<T2> var2, Argument<T3> var3, Argument<T4> var4, Argument<T5> var5, Argument<T6> var6, Argument<T7> var7, Argument<T8> var8, Argument<T9> var9) {
+        return new QueryCallViewItemImpl(this, open, var1, var2, var3, var4, var5, var6, var7, var8, var9);
+    }
+
+    @Override()
+    public Variable<?>[] getArguments() {
+        return new Variable<?>[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 };
+    }
+
+    @Override()
+    public Variable<T1> getArg1() {
+        return arg1;
+    }
+
+    @Override()
+    public Variable<T2> getArg2() {
+        return arg2;
+    }
+
+    @Override()
+    public Variable<T3> getArg3() {
+        return arg3;
+    }
+
+    @Override()
+    public Variable<T4> getArg4() {
+        return arg4;
+    }
+
+    @Override()
+    public Variable<T5> getArg5() {
+        return arg5;
+    }
+
+    @Override()
+    public Variable<T6> getArg6() {
+        return arg6;
+    }
+
+    @Override()
+    public Variable<T7> getArg7() {
+        return arg7;
+    }
+
+    @Override()
+    public Variable<T8> getArg8() {
+        return arg8;
+    }
+
+    @Override()
+    public Variable<T9> getArg9() {
+        return arg9;
+    }
+
+    @Override
+    public boolean isEqualTo(ModelComponent other) {
+        if (this == other)
+            return true;
+        if (!(other instanceof Query9DefImpl))
+            return false;
+        Query9DefImpl that = (Query9DefImpl) other;
+        return true && ModelComponent.areEqualInModel(arg1, that.arg1) && ModelComponent.areEqualInModel(arg2, that.arg2) && ModelComponent.areEqualInModel(arg3, that.arg3) && ModelComponent.areEqualInModel(arg4, that.arg4) && ModelComponent.areEqualInModel(arg5, that.arg5) && ModelComponent.areEqualInModel(arg6, that.arg6) && ModelComponent.areEqualInModel(arg7, that.arg7) && ModelComponent.areEqualInModel(arg8, that.arg8) && ModelComponent.areEqualInModel(arg9, that.arg9);
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLGenerator.java
@@ -1,0 +1,149 @@
+package org.drools.modelcompiler.builder.generator.query;
+
+import java.util.stream.IntStream;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
+
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseType;
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class FlowDSLGenerator {
+
+    private final int arity;
+
+    public FlowDSLGenerator(int arity) {
+        this.arity = arity;
+    }
+
+    public CompilationUnit generate() {
+        CompilationUnit cu = new CompilationUnit("org.drools.model.impl");
+
+        ClassOrInterfaceDeclaration clazz = cu.addClass(String.format("FlowDSL", arity));
+
+        queryFirstMethod(clazz);
+        querySecondMethod(clazz);
+
+        return cu;
+    }
+
+    private void queryFirstMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+
+        query1.addParameter("String", "name");
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+            String name = stringWithIndexInside(i, "arg", "name");
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+            arguments.add(new NameExpr(name));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+            query1.addParameter(parseType("String"), name);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+
+    }
+
+    private void querySecondMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+        query1.addParameter("String", "pkg");
+        query1.addParameter("String", "name");
+
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("pkg");
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+            String name = stringWithIndexInside(i, "arg", "name");
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+            arguments.add(new NameExpr(name));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+            query1.addParameter(parseType("String"), name);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+    }
+
+    private String stringWithIndex(String pre, int i) {
+        return pre + i;
+    }
+
+    private String stringWithIndexInside(int i, String pre, String post) {
+        return pre + i + post;
+    }
+
+    private IntStream rangeArity() {
+        return IntStream.range(1, arity + 1);
+    }
+
+    private String genericType(String typeName, String genericTypeName) {
+        return typeName + "<" + genericTypeName + ">";
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
@@ -1,7 +1,5 @@
 package org.drools.modelcompiler.builder.generator.query;
 
-import java.util.stream.IntStream;
-
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -19,14 +17,14 @@ import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.ast.NodeList.nodeList;
 
-public class FlowDSLQueryGenerator {
+public class FlowDSLQueryGenerator extends Generator  {
 
     private final ClassOrInterfaceDeclaration clazz;
-    private final int arity;
 
-    public FlowDSLQueryGenerator(ClassOrInterfaceDeclaration clazz, int arity) {
+
+    FlowDSLQueryGenerator(ClassOrInterfaceDeclaration clazz, int arity) {
+        super(arity);
         this.clazz = clazz;
-        this.arity = arity;
     }
 
     public ClassOrInterfaceDeclaration generate() {
@@ -39,21 +37,21 @@ public class FlowDSLQueryGenerator {
     }
 
     private void queryNameClass(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
 
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "name");
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
 
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImpl();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("name");
 
         rangeArity().forEach(i -> {
@@ -64,7 +62,7 @@ public class FlowDSLQueryGenerator {
 
             arguments.add(new NameExpr(type));
 
-            String classGenericType = genericType("Class", genericTypeName);
+            String classGenericType = genericType(genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
 
@@ -76,45 +74,52 @@ public class FlowDSLQueryGenerator {
 
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDef();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
 
     }
 
+    private ClassOrInterfaceType queryDef() {
+        return parseClassOrInterfaceType("Query" + arity + "Def");
+    }
+
+    private ClassOrInterfaceType queryDefImpl() {
+        return parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+    }
 
     private void queryNameClassArg(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
 
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "name");
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
 
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImpl();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("name");
 
         rangeArity().forEach(i -> {
             String genericTypeName = stringWithIndex("T", i);
             String type = stringWithIndex("type", i);
-            String name = stringWithIndexInside(i, "arg", "name");
+            String name = stringWithIndexInside(i);
 
             typeArguments.add(parseType(genericTypeName));
 
             arguments.add(new NameExpr(type));
             arguments.add(new NameExpr(name));
 
-            String classGenericType = genericType("Class", genericTypeName);
+            String classGenericType = genericType(genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
-            query1.addParameter(parseType("String"), name);
+            query1.addParameter(stringType(), name);
 
             typeParameters.add(new TypeParameter(genericTypeName));
 
@@ -124,28 +129,28 @@ public class FlowDSLQueryGenerator {
 
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDef();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
 
     }
 
     private void queryPkgNameClass(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
-        query1.addParameter("String", "pkg");
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "pkg");
+        query1.addParameter(STRINGLITERAL, "name");
 
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImpl();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("pkg");
         objCreationExpr.addArgument("name");
 
@@ -157,7 +162,7 @@ public class FlowDSLQueryGenerator {
 
             arguments.add(new NameExpr(type));
 
-            String classGenericType = genericType("Class", genericTypeName);
+            String classGenericType = genericType(genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
 
@@ -167,44 +172,44 @@ public class FlowDSLQueryGenerator {
         query1.setTypeParameters(typeParameters);
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDef();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
     }
 
     private void queryPkgNameClassArg(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
-        query1.addParameter("String", "pkg");
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "pkg");
+        query1.addParameter(STRINGLITERAL, "name");
 
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImpl();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("pkg");
         objCreationExpr.addArgument("name");
 
         rangeArity().forEach(i -> {
             String genericTypeName = stringWithIndex("T", i);
             String type = stringWithIndex("type", i);
-            String name = stringWithIndexInside(i, "arg", "name");
+            String name = stringWithIndexInside(i);
 
             typeArguments.add(parseType(genericTypeName));
 
             arguments.add(new NameExpr(type));
             arguments.add(new NameExpr(name));
 
-            String classGenericType = genericType("Class", genericTypeName);
+            String classGenericType = genericType(genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
-            query1.addParameter(parseType("String"), name);
+            query1.addParameter(stringType(), name);
 
             typeParameters.add(new TypeParameter(genericTypeName));
         });
@@ -212,24 +217,8 @@ public class FlowDSLQueryGenerator {
         query1.setTypeParameters(typeParameters);
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDef();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
-    }
-
-    private String stringWithIndex(String pre, int i) {
-        return pre + i;
-    }
-
-    private String stringWithIndexInside(int i, String pre, String post) {
-        return pre + i + post;
-    }
-
-    private IntStream rangeArity() {
-        return IntStream.range(1, arity + 1);
-    }
-
-    private String genericType(String typeName, String genericTypeName) {
-        return typeName + "<" + genericTypeName + ">";
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
@@ -2,7 +2,6 @@ package org.drools.modelcompiler.builder.generator.query;
 
 import java.util.stream.IntStream;
 
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -31,13 +30,60 @@ public class FlowDSLQueryGenerator {
     }
 
     public ClassOrInterfaceDeclaration generate() {
-        queryFirstMethod(clazz);
-        querySecondMethod(clazz);
+        queryNameClass(clazz);
+        queryNameClassArg(clazz);
+        queryPkgNameClass(clazz);
+        queryPkgNameClassArg(clazz);
 
         return clazz;
     }
 
-    private void queryFirstMethod(ClassOrInterfaceDeclaration clazz) {
+    private void queryNameClass(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+
+        query1.addParameter("String", "name");
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+
+    }
+
+
+    private void queryNameClassArg(ClassOrInterfaceDeclaration clazz) {
         MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
 
@@ -84,7 +130,49 @@ public class FlowDSLQueryGenerator {
 
     }
 
-    private void querySecondMethod(ClassOrInterfaceDeclaration clazz) {
+    private void queryPkgNameClass(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+        query1.addParameter("String", "pkg");
+        query1.addParameter("String", "name");
+
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("pkg");
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+    }
+
+    private void queryPkgNameClassArg(ClassOrInterfaceDeclaration clazz) {
         MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
         query1.addParameter("String", "pkg");

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
@@ -22,21 +22,19 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 
 public class FlowDSLQueryGenerator {
 
+    private final ClassOrInterfaceDeclaration clazz;
     private final int arity;
 
-    public FlowDSLQueryGenerator(int arity) {
+    public FlowDSLQueryGenerator(ClassOrInterfaceDeclaration clazz, int arity) {
+        this.clazz = clazz;
         this.arity = arity;
     }
 
-    public CompilationUnit generate() {
-        CompilationUnit cu = new CompilationUnit("org.drools.model.impl");
-
-        ClassOrInterfaceDeclaration clazz = cu.addClass(String.format("FlowDSL", arity));
-
+    public ClassOrInterfaceDeclaration generate() {
         queryFirstMethod(clazz);
         querySecondMethod(clazz);
 
-        return cu;
+        return clazz;
     }
 
     private void queryFirstMethod(ClassOrInterfaceDeclaration clazz) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/FlowDSLQueryGenerator.java
@@ -20,11 +20,11 @@ import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.ast.NodeList.nodeList;
 
-public class FlowDSLGenerator {
+public class FlowDSLQueryGenerator {
 
     private final int arity;
 
-    public FlowDSLGenerator(int arity) {
+    public FlowDSLQueryGenerator(int arity) {
         this.arity = arity;
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/Generator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/Generator.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.drools.modelcompiler.builder.generator.query;
+
+import java.util.stream.IntStream;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseType;
+
+abstract class Generator {
+
+    final int arity;
+
+    static final String QUERY = "query";
+    static final String STRINGLITERAL = "String";
+    static final String CLASS = "Class";
+    static final String VIEWBUILDER = "VIEW_BUILDER";
+
+    Generator(int arity) {
+        this.arity = arity;
+    }
+
+    String stringWithIndex(String pre, int i) {
+        return pre + i;
+    }
+
+    String argNameWithIndex(int i) {
+        return "arg" + i + "name";
+    }
+
+    IntStream rangeArity() {
+        return IntStream.range(1, arity + 1);
+    }
+
+    String genericType(String typeName, String genericTypeName) {
+        return typeName + "<" + genericTypeName + ">";
+    }
+
+    String typeWithIndex(int i) {
+        return stringWithIndex("type", i);
+    }
+
+    void addPackageParameter(NodeWithParameters declaration) {
+        declaration.addParameter(STRINGLITERAL, "pkg");
+    }
+
+    String genericTypeName(int i) {
+        return stringWithIndex("T", i);
+    }
+
+    void addPkgValue(MethodCallExpr constructor) {
+        constructor.addArgument("pkg");
+    }
+
+    void addViewBuilderValue(MethodCallExpr constructor) {
+        constructor.addArgument("viewBuilder");
+    }
+
+    void addViewBuilderParameter(NodeWithParameters constructorDeclaration2) {
+        constructorDeclaration2.addParameter("ViewBuilder", "viewBuilder");
+    }
+
+    void addNameValue(MethodCallExpr constructor) {
+        constructor.addArgument("name");
+    }
+
+    String argIndex(int i) {
+        return stringWithIndex("arg", i);
+    }
+
+    String getArgIndex(int i) {
+        return stringWithIndex("getArg", i);
+    }
+
+    String classGenericName(int i) {
+        return classGenericParameter(genericTypeName(i));
+    }
+
+    void addDefaultPackageValue(MethodCallExpr constructor) {
+        constructor.addArgument("DEFAULT_PACKAGE");
+    }
+
+    void addNameParameter(NodeWithParameters constructor) {
+        constructor.addParameter(STRINGLITERAL, "name");
+    }
+
+    void addOverride(MethodDeclaration method) {
+        method.addAnnotation("Override");
+    }
+
+    String classGenericParameter(String genericTypeName) {
+        return genericType(CLASS, genericTypeName);
+    }
+
+    String stringWithIndexInside(int i) {
+        return "arg" + i + "name";
+    }
+
+    String genericType(String genericTypeName) {
+        return CLASS + "<" + genericTypeName + ">";
+    }
+
+    Type stringType() {
+        return parseType(STRINGLITERAL);
+    }
+
+    ClassOrInterfaceType queryDefImplType() {
+        return parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+    }
+
+    ClassOrInterfaceType queryDefType() {
+        return parseClassOrInterfaceType("Query" + arity + "Def");
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/PatternDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/PatternDSLQueryGenerator.java
@@ -22,16 +22,15 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 
 public class PatternDSLQueryGenerator {
 
+    private final ClassOrInterfaceDeclaration clazz;
     private final int arity;
 
-    public PatternDSLQueryGenerator(int arity) {
+    public PatternDSLQueryGenerator(ClassOrInterfaceDeclaration clazz, int arity) {
+        this.clazz = clazz;
         this.arity = arity;
     }
 
-    public CompilationUnit generate() {
-        CompilationUnit cu = new CompilationUnit("org.drools.model.impl");
-
-        ClassOrInterfaceDeclaration clazz = cu.addClass(String.format("FlowDSL", arity));
+    public ClassOrInterfaceDeclaration generate() {
 
         queryFirstMethodOnlyClass(clazz);
         querySecondMethodOnlyClass(clazz);
@@ -39,7 +38,7 @@ public class PatternDSLQueryGenerator {
         queryFirstMethod(clazz);
         querySecondMethod(clazz);
 
-        return cu;
+        return clazz;
     }
 
     private void queryFirstMethodOnlyClass(ClassOrInterfaceDeclaration clazz) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/PatternDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/PatternDSLQueryGenerator.java
@@ -1,8 +1,5 @@
 package org.drools.modelcompiler.builder.generator.query;
 
-import java.util.stream.IntStream;
-
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -16,18 +13,16 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.TypeParameter;
 
-import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.ast.NodeList.nodeList;
 
-public class PatternDSLQueryGenerator {
+public class PatternDSLQueryGenerator extends Generator {
 
     private final ClassOrInterfaceDeclaration clazz;
-    private final int arity;
 
-    public PatternDSLQueryGenerator(ClassOrInterfaceDeclaration clazz, int arity) {
+    PatternDSLQueryGenerator(ClassOrInterfaceDeclaration clazz, int arity) {
+        super(arity);
         this.clazz = clazz;
-        this.arity = arity;
     }
 
     public ClassOrInterfaceDeclaration generate() {
@@ -42,21 +37,20 @@ public class PatternDSLQueryGenerator {
     }
 
     private void queryFirstMethodOnlyClass(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
-
-        query1.addParameter("String", "name");
+        addNameParameter(query1);
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
 
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImplType();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("name");
 
         rangeArity().forEach(i -> {
@@ -67,7 +61,7 @@ public class PatternDSLQueryGenerator {
 
             arguments.add(new NameExpr(type));
 
-            String classGenericType = genericType("Class", genericTypeName);
+            String classGenericType = genericType(CLASS, genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
 
@@ -79,28 +73,28 @@ public class PatternDSLQueryGenerator {
 
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDefType();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
 
     }
 
     private void querySecondMethodOnlyClass(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
-        query1.addParameter("String", "pkg");
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "pkg");
+        query1.addParameter(STRINGLITERAL, "name");
 
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImplType();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("pkg");
         objCreationExpr.addArgument("name");
 
@@ -112,7 +106,7 @@ public class PatternDSLQueryGenerator {
 
             arguments.add(new NameExpr(type));
 
-            String classGenericType = genericType("Class", genericTypeName);
+            String classGenericType = genericType(CLASS, genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
 
@@ -122,33 +116,33 @@ public class PatternDSLQueryGenerator {
         query1.setTypeParameters(typeParameters);
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDefType();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
     }
 
     private void queryFirstMethod(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
 
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "name");
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
 
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImplType();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("name");
 
         rangeArity().forEach(i -> {
             String genericTypeName = stringWithIndex("T", i);
             String type = stringWithIndex("type", i);
-            String name = stringWithIndexInside(i, "arg", "name");
+            String name = argNameWithIndex(i);
 
             typeArguments.add(parseType(genericTypeName));
 
@@ -158,7 +152,7 @@ public class PatternDSLQueryGenerator {
             String classGenericType = genericType("Class", genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
-            query1.addParameter(parseType("String"), name);
+            query1.addParameter(parseType(STRINGLITERAL), name);
 
             typeParameters.add(new TypeParameter(genericTypeName));
 
@@ -168,35 +162,35 @@ public class PatternDSLQueryGenerator {
 
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDefType();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
 
     }
 
     private void querySecondMethod(ClassOrInterfaceDeclaration clazz) {
-        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        MethodDeclaration query1 = clazz.addMethod(QUERY, Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
 
-        query1.addParameter("String", "pkg");
-        query1.addParameter("String", "name");
+        query1.addParameter(STRINGLITERAL, "pkg");
+        query1.addParameter(STRINGLITERAL, "name");
 
 
         BlockStmt stmts = new BlockStmt();
         NodeList<Type> typeArguments = nodeList();
         NodeList<TypeParameter> typeParameters = nodeList();
         NodeList<Expression> arguments = nodeList();
-        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ClassOrInterfaceType queryCallViewItemImpl = queryDefImplType();
         ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
         objCreationExpr.setDiamondOperator();
         stmts.addStatement(new ReturnStmt(objCreationExpr));
-        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument(new NameExpr(VIEWBUILDER));
         objCreationExpr.addArgument("pkg");
         objCreationExpr.addArgument("name");
 
         rangeArity().forEach(i -> {
             String genericTypeName = stringWithIndex("T", i);
             String type = stringWithIndex("type", i);
-            String name = stringWithIndexInside(i, "arg", "name");
+            String name = argNameWithIndex(i);
 
             typeArguments.add(parseType(genericTypeName));
 
@@ -206,7 +200,7 @@ public class PatternDSLQueryGenerator {
             String classGenericType = genericType("Class", genericTypeName);
             Type genericType = parseType(classGenericType);
             query1.addParameter(genericType, type);
-            query1.addParameter(parseType("String"), name);
+            query1.addParameter(parseType(STRINGLITERAL), name);
 
             typeParameters.add(new TypeParameter(genericTypeName));
         });
@@ -214,24 +208,9 @@ public class PatternDSLQueryGenerator {
         query1.setTypeParameters(typeParameters);
 
         query1.setBody(stmts);
-        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        ClassOrInterfaceType type = queryDefType();
         type.setTypeArguments(typeArguments);
         query1.setType(type);
     }
 
-    private String stringWithIndex(String pre, int i) {
-        return pre + i;
-    }
-
-    private String stringWithIndexInside(int i, String pre, String post) {
-        return pre + i + post;
-    }
-
-    private IntStream rangeArity() {
-        return IntStream.range(1, arity + 1);
-    }
-
-    private String genericType(String typeName, String genericTypeName) {
-        return typeName + "<" + genericTypeName + ">";
-    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/PatternDSLQueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/PatternDSLQueryGenerator.java
@@ -1,0 +1,238 @@
+package org.drools.modelcompiler.builder.generator.query;
+
+import java.util.stream.IntStream;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
+
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseType;
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class PatternDSLQueryGenerator {
+
+    private final int arity;
+
+    public PatternDSLQueryGenerator(int arity) {
+        this.arity = arity;
+    }
+
+    public CompilationUnit generate() {
+        CompilationUnit cu = new CompilationUnit("org.drools.model.impl");
+
+        ClassOrInterfaceDeclaration clazz = cu.addClass(String.format("FlowDSL", arity));
+
+        queryFirstMethodOnlyClass(clazz);
+        querySecondMethodOnlyClass(clazz);
+
+        queryFirstMethod(clazz);
+        querySecondMethod(clazz);
+
+        return cu;
+    }
+
+    private void queryFirstMethodOnlyClass(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+
+        query1.addParameter("String", "name");
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+
+    }
+
+    private void querySecondMethodOnlyClass(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+        query1.addParameter("String", "pkg");
+        query1.addParameter("String", "name");
+
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("pkg");
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+    }
+
+    private void queryFirstMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+
+        query1.addParameter("String", "name");
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+            String name = stringWithIndexInside(i, "arg", "name");
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+            arguments.add(new NameExpr(name));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+            query1.addParameter(parseType("String"), name);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+
+    }
+
+    private void querySecondMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration query1 = clazz.addMethod("query", Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+
+        query1.addParameter("String", "pkg");
+        query1.addParameter("String", "name");
+
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Type> typeArguments = nodeList();
+        NodeList<TypeParameter> typeParameters = nodeList();
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("Query" + arity + "DefImpl<>");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        objCreationExpr.setDiamondOperator();
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new NameExpr("VIEW_BUILDER"));
+        objCreationExpr.addArgument("pkg");
+        objCreationExpr.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String type = stringWithIndex("type", i);
+            String name = stringWithIndexInside(i, "arg", "name");
+
+            typeArguments.add(parseType(genericTypeName));
+
+            arguments.add(new NameExpr(type));
+            arguments.add(new NameExpr(name));
+
+            String classGenericType = genericType("Class", genericTypeName);
+            Type genericType = parseType(classGenericType);
+            query1.addParameter(genericType, type);
+            query1.addParameter(parseType("String"), name);
+
+            typeParameters.add(new TypeParameter(genericTypeName));
+        });
+
+        query1.setTypeParameters(typeParameters);
+
+        query1.setBody(stmts);
+        ClassOrInterfaceType type = parseClassOrInterfaceType("Query" + arity + "Def");
+        type.setTypeArguments(typeArguments);
+        query1.setType(type);
+    }
+
+    private String stringWithIndex(String pre, int i) {
+        return pre + i;
+    }
+
+    private String stringWithIndexInside(int i, String pre, String post) {
+        return pre + i + post;
+    }
+
+    private IntStream rangeArity() {
+        return IntStream.range(1, arity + 1);
+    }
+
+    private String genericType(String typeName, String genericTypeName) {
+        return typeName + "<" + genericTypeName + ">";
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
@@ -108,7 +108,7 @@ public class QueryDefGenerator {
             String genericTypeName = stringWithIndex("T", i);
             String methodName = stringWithIndex("getArg", i);
 
-            MethodDeclaration methodDeclaration = clazz.addMethod(methodName, Modifier.Keyword.PUBLIC);
+            MethodDeclaration methodDeclaration = clazz.addMethod(methodName);
             methodDeclaration.setBody(null);
             methodDeclaration.setType(genericType("Variable", genericTypeName));
         });

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
@@ -1,0 +1,122 @@
+package org.drools.modelcompiler.builder.generator.query;
+
+import java.util.stream.IntStream;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.TypeParameter;
+
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseImport;
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class QueryDefGenerator {
+
+    private final int arity;
+
+    QueryDefGenerator(int arity) {
+        this.arity = arity;
+    }
+
+    public CompilationUnit generate() {
+
+        CompilationUnit cu = new CompilationUnit("org.drools.model");
+
+        cu.setImports(nodeList(
+                parseImport("import org.drools.model.view.QueryCallViewItem;")
+        ));
+
+        ClassOrInterfaceDeclaration clazz = classDeclaration(cu);
+        callMethod(clazz);
+        callMethodInterface(clazz);
+        getters(clazz);
+
+        return cu;
+    }
+
+    private ClassOrInterfaceDeclaration classDeclaration(CompilationUnit cu) {
+        ClassOrInterfaceDeclaration clazz = cu.addInterface(String.format("Query%dDef", arity), Modifier.Keyword.PUBLIC);
+
+        clazz.addExtendedType("QueryDef");
+
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+
+            clazz.addTypeParameter(new TypeParameter(genericTypeName));
+        });
+
+        return clazz;
+    }
+
+    private void callMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration method = clazz.addMethod("call", Modifier.Keyword.DEFAULT);
+        method.addParameter("boolean", "open");
+        method.setType(parseClassOrInterfaceType("QueryCallViewItem"));
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Expression> arguments = nodeList();
+        MethodCallExpr objCreationExpr = new MethodCallExpr(null, "call", arguments);
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument(new BooleanLiteralExpr(true));
+
+        rangeArity().forEach(i -> {
+            String varWithIndex = stringWithIndex("var", i);
+            String genericTypeName = stringWithIndex("T", i);
+
+            method.addParameter(genericType("Argument", genericTypeName), varWithIndex);
+
+            objCreationExpr.addArgument(varWithIndex);
+        });
+
+        method.setBody(stmts);
+    }
+
+
+    private void callMethodInterface(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration method = new MethodDeclaration(nodeList(), parseClassOrInterfaceType("QueryCallViewItem"), "call");
+        method.setBody(null);
+
+        rangeArity().forEach(i -> {
+            String varWithIndex = stringWithIndex("var", i);
+            String genericTypeName = stringWithIndex("T", i);
+
+            method.addParameter(genericType("Argument", genericTypeName), varWithIndex);
+
+        });
+
+        clazz.addMember(method);
+
+    }
+
+    private void getters(ClassOrInterfaceDeclaration clazz) {
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String methodName = stringWithIndex("getArg", i);
+
+            MethodDeclaration methodDeclaration = clazz.addMethod(methodName, Modifier.Keyword.PUBLIC);
+            methodDeclaration.setBody(null);
+            methodDeclaration.setType(genericType("Variable", genericTypeName));
+        });
+    }
+
+    private String stringWithIndex(String pre, int i) {
+        return pre + i;
+    }
+
+    private IntStream rangeArity() {
+        return IntStream.range(1, arity + 1);
+    }
+
+    private String genericType(String typeName, String genericTypeName) {
+        return typeName + "<" + genericTypeName + ">";
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
@@ -65,7 +65,6 @@ public class QueryDefGenerator {
 
     private void callMethod(ClassOrInterfaceDeclaration clazz) {
         MethodDeclaration method = clazz.addMethod("call", Modifier.Keyword.DEFAULT);
-        method.addParameter("boolean", "open");
         method.setType(parseClassOrInterfaceType("QueryCallViewItem"));
 
         BlockStmt stmts = new BlockStmt();
@@ -89,6 +88,7 @@ public class QueryDefGenerator {
 
     private void callMethodInterface(ClassOrInterfaceDeclaration clazz) {
         MethodDeclaration method = new MethodDeclaration(nodeList(), parseClassOrInterfaceType("QueryCallViewItem"), "call");
+        method.addParameter("boolean", "open");
         method.setBody(null);
 
         rangeArity().forEach(i -> {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
@@ -21,9 +21,15 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 public class QueryDefGenerator {
 
     private final int arity;
+    private String className;
 
     QueryDefGenerator(int arity) {
         this.arity = arity;
+        className = String.format("Query%dDef", arity);
+    }
+
+    public String getClassName() {
+        return className;
     }
 
     public CompilationUnit generate() {
@@ -43,7 +49,7 @@ public class QueryDefGenerator {
     }
 
     private ClassOrInterfaceDeclaration classDeclaration(CompilationUnit cu) {
-        ClassOrInterfaceDeclaration clazz = cu.addInterface(String.format("Query%dDef", arity), Modifier.Keyword.PUBLIC);
+        ClassOrInterfaceDeclaration clazz = cu.addInterface(className, Modifier.Keyword.PUBLIC);
 
         clazz.addExtendedType("QueryDef");
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefGenerator.java
@@ -1,7 +1,5 @@
 package org.drools.modelcompiler.builder.generator.query;
 
-import java.util.stream.IntStream;
-
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
@@ -18,13 +16,12 @@ import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseImport;
 import static com.github.javaparser.ast.NodeList.nodeList;
 
-public class QueryDefGenerator {
+public class QueryDefGenerator extends Generator {
 
-    private final int arity;
     private String className;
 
     QueryDefGenerator(int arity) {
-        this.arity = arity;
+        super(arity);
         className = String.format("Query%dDef", arity);
     }
 
@@ -112,17 +109,5 @@ public class QueryDefGenerator {
             methodDeclaration.setBody(null);
             methodDeclaration.setType(genericType("Variable", genericTypeName));
         });
-    }
-
-    private String stringWithIndex(String pre, int i) {
-        return pre + i;
-    }
-
-    private IntStream rangeArity() {
-        return IntStream.range(1, arity + 1);
-    }
-
-    private String genericType(String typeName, String genericTypeName) {
-        return typeName + "<" + genericTypeName + ">";
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
@@ -9,7 +9,6 @@ import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.expr.ArrayCreationExpr;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
@@ -64,10 +63,10 @@ public class QueryDefImplGenerator {
 
         ClassOrInterfaceDeclaration clazz = classDeclaration(cu);
 //        copyright(cu);
-        firstConstructor(clazz);
-        secondConstructor(clazz);
-        thirdConstructor(clazz);
-        fourthConstructor(clazz);
+        nameClassConstructor(clazz);
+        packageNameClassConstructor(clazz);
+        nameClassArgConstructor(clazz);
+        pkgNameClassArgConstructor(clazz);
         callMethod(clazz);
         getArgumentsMethod(clazz);
         getters(clazz);
@@ -99,25 +98,7 @@ public class QueryDefImplGenerator {
         return clazz;
     }
 
-    private void copyright(CompilationUnit cu) {
-        cu.addOrphanComment(new BlockComment("\n" +
-                                                     " * Copyright 2005 JBoss Inc\n" +
-                                                     " *\n" +
-                                                     " * Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
-                                                     " * you may not use this file except in compliance with the License.\n" +
-                                                     " * You may obtain a copy of the License at\n" +
-                                                     " *\n" +
-                                                     " *      http://www.apache.org/licenses/LICENSE-2.0\n" +
-                                                     " *\n" +
-                                                     " * Unless required by applicable law or agreed to in writing, software\n" +
-                                                     " * distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
-                                                     " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
-                                                     " * See the License for the specific language governing permissions and\n" +
-                                                     " * limitations under the License.\n" +
-                                                     " "));
-    }
-
-    private void firstConstructor(ClassOrInterfaceDeclaration clazz) {
+    private void nameClassConstructor(ClassOrInterfaceDeclaration clazz) {
         ConstructorDeclaration constructorDeclaration1 = clazz.addConstructor(Modifier.Keyword.PUBLIC);
         constructorDeclaration1.addParameter("ViewBuilder", "viewBuilder");
         constructorDeclaration1.addParameter("String", "name");
@@ -139,11 +120,11 @@ public class QueryDefImplGenerator {
         constructorDeclaration1.setBody(stmts);
     }
 
-    private void secondConstructor(ClassOrInterfaceDeclaration clazz) {
+    private void packageNameClassConstructor(ClassOrInterfaceDeclaration clazz) {
         ConstructorDeclaration declaration = clazz.addConstructor(Modifier.Keyword.PUBLIC);
         declaration.addParameter("ViewBuilder", "viewBuilder");
-        declaration.addParameter("String", "name");
         declaration.addParameter("String", "pkg");
+        declaration.addParameter("String", "name");
         BlockStmt stmts = new BlockStmt();
         MethodCallExpr body = new MethodCallExpr(null, "super");
         stmts.addStatement(body);
@@ -168,7 +149,7 @@ public class QueryDefImplGenerator {
         declaration.setBody(stmts);
     }
 
-    private void thirdConstructor(ClassOrInterfaceDeclaration clazz) {
+    private void nameClassArgConstructor(ClassOrInterfaceDeclaration clazz) {
         ConstructorDeclaration ctorDeclaration = clazz.addConstructor(Modifier.Keyword.PUBLIC);
         ctorDeclaration.addParameter("ViewBuilder", "viewBuilder");
         ctorDeclaration.addParameter("String", "name");
@@ -193,7 +174,7 @@ public class QueryDefImplGenerator {
         ctorDeclaration.setBody(ctor2Stmt);
     }
 
-    private void fourthConstructor(ClassOrInterfaceDeclaration clazz) {
+    private void pkgNameClassArgConstructor(ClassOrInterfaceDeclaration clazz) {
         ConstructorDeclaration constructorDeclaration2 = clazz.addConstructor(Modifier.Keyword.PUBLIC);
         constructorDeclaration2.addParameter("ViewBuilder", "viewBuilder");
         constructorDeclaration2.addParameter("String", "pkg");

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
@@ -1,0 +1,338 @@
+package org.drools.modelcompiler.builder.generator.query;
+
+import java.util.stream.IntStream;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.comments.BlockComment;
+import com.github.javaparser.ast.expr.ArrayCreationExpr;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
+
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseImport;
+import static com.github.javaparser.StaticJavaParser.parseType;
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class QueryDefImplGenerator {
+
+    private final int arity;
+
+    QueryDefImplGenerator(int arity) {
+        this.arity = arity;
+    }
+
+    public CompilationUnit generate() {
+
+        CompilationUnit cu = new CompilationUnit("org.drools.model.impl");
+
+        cu.setImports(nodeList(
+                parseImport("import org.drools.model.Argument;"),
+                parseImport(String.format("import org.drools.model.Query%dDef;", arity)),
+                parseImport("import org.drools.model.Variable;"),
+                parseImport("import org.drools.model.view.QueryCallViewItem;"),
+                parseImport("import static org.drools.model.FlowDSL.declarationOf;"),
+                parseImport("import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;")
+        ));
+
+        ClassOrInterfaceDeclaration clazz = classDeclaration(cu);
+//        copyright(cu);
+        firstConstructor(clazz);
+        secondConstructor(clazz);
+        thirdConstructor(clazz);
+        fourthConstructor(clazz);
+        callMethod(clazz);
+        getArgumentsMethod(clazz);
+        getters(clazz);
+        equals(clazz);
+
+        return cu;
+    }
+
+    private ClassOrInterfaceDeclaration classDeclaration(CompilationUnit cu) {
+        ClassOrInterfaceDeclaration clazz = cu.addClass(String.format("Query%dDefImpl", arity), Modifier.Keyword.PUBLIC);
+
+        clazz.addExtendedType("QueryDefImpl");
+        clazz.addImplementedType("ModelComponent");
+
+        ClassOrInterfaceType implement = new ClassOrInterfaceType(null, String.format("Query%dDef", arity));
+        NodeList<Type> typeArguments = nodeList();
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+
+            typeArguments.add(parseType(genericTypeName));
+            clazz.addTypeParameter(new TypeParameter(genericTypeName));
+
+            clazz.addField(parseType(genericType("Variable", genericTypeName)), stringWithIndex("arg", i), Modifier.Keyword.PRIVATE, Modifier.Keyword.FINAL);
+        });
+
+        implement.setTypeArguments(typeArguments);
+        clazz.addImplementedType(implement);
+        return clazz;
+    }
+
+    private void copyright(CompilationUnit cu) {
+        cu.addOrphanComment(new BlockComment("\n" +
+                                                     " * Copyright 2005 JBoss Inc\n" +
+                                                     " *\n" +
+                                                     " * Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                                                     " * you may not use this file except in compliance with the License.\n" +
+                                                     " * You may obtain a copy of the License at\n" +
+                                                     " *\n" +
+                                                     " *      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                                                     " *\n" +
+                                                     " * Unless required by applicable law or agreed to in writing, software\n" +
+                                                     " * distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                                                     " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                                                     " * See the License for the specific language governing permissions and\n" +
+                                                     " * limitations under the License.\n" +
+                                                     " "));
+    }
+
+    private void firstConstructor(ClassOrInterfaceDeclaration clazz) {
+        ConstructorDeclaration constructorDeclaration1 = clazz.addConstructor(Modifier.Keyword.PUBLIC);
+        constructorDeclaration1.addParameter("ViewBuilder", "viewBuilder");
+        constructorDeclaration1.addParameter("String", "name");
+        BlockStmt stmts = new BlockStmt();
+        MethodCallExpr ctorDeclaration = new MethodCallExpr(null, "this");
+        stmts.addStatement(ctorDeclaration);
+        ctorDeclaration.addArgument("viewBuilder");
+        ctorDeclaration.addArgument("DEFAULT_PACKAGE");
+        ctorDeclaration.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String typeWithIndex = stringWithIndex("type", i);
+
+            constructorDeclaration1.addParameter(genericType("Class", genericTypeName), typeWithIndex);
+            ctorDeclaration.addArgument(typeWithIndex);
+        });
+
+        constructorDeclaration1.setBody(stmts);
+    }
+
+    private void secondConstructor(ClassOrInterfaceDeclaration clazz) {
+        ConstructorDeclaration declaration = clazz.addConstructor(Modifier.Keyword.PUBLIC);
+        declaration.addParameter("ViewBuilder", "viewBuilder");
+        declaration.addParameter("String", "name");
+        declaration.addParameter("String", "pkg");
+        BlockStmt stmts = new BlockStmt();
+        MethodCallExpr body = new MethodCallExpr(null, "super");
+        stmts.addStatement(body);
+        body.addArgument("viewBuilder");
+        body.addArgument("pkg");
+        body.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String typeWithIndex = stringWithIndex("type", i);
+            String genericTypeName = stringWithIndex("T", i);
+
+
+            declaration.addParameter(genericType("Class", genericTypeName), typeWithIndex);
+
+            AssignExpr assignExpr = new AssignExpr();
+            assignExpr.setTarget(new FieldAccessExpr(new NameExpr("this"), stringWithIndex("arg", i)));
+            assignExpr.setValue(new MethodCallExpr(null, "declarationOf", nodeList(new NameExpr(typeWithIndex))));
+
+            stmts.addStatement(assignExpr);
+        });
+
+        declaration.setBody(stmts);
+    }
+
+    private void thirdConstructor(ClassOrInterfaceDeclaration clazz) {
+        ConstructorDeclaration ctorDeclaration = clazz.addConstructor(Modifier.Keyword.PUBLIC);
+        ctorDeclaration.addParameter("ViewBuilder", "viewBuilder");
+        ctorDeclaration.addParameter("String", "name");
+        BlockStmt ctor2Stmt = new BlockStmt();
+        MethodCallExpr ctorDeclarationBody = new MethodCallExpr(null, "this");
+        ctor2Stmt.addStatement(ctorDeclarationBody);
+        ctorDeclarationBody.addArgument("viewBuilder");
+        ctorDeclarationBody.addArgument("DEFAULT_PACKAGE");
+        ctorDeclarationBody.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String typeWithIndex = stringWithIndex("type", i);
+            String argWithIndex = stringWithIndexInside(i, "arg", "name");
+
+            ctorDeclaration.addParameter(genericType("Class", genericTypeName), typeWithIndex);
+            ctorDeclaration.addParameter("String", argWithIndex);
+            ctorDeclarationBody.addArgument(typeWithIndex);
+            ctorDeclarationBody.addArgument(argWithIndex);
+        });
+
+        ctorDeclaration.setBody(ctor2Stmt);
+    }
+
+    private void fourthConstructor(ClassOrInterfaceDeclaration clazz) {
+        ConstructorDeclaration constructorDeclaration2 = clazz.addConstructor(Modifier.Keyword.PUBLIC);
+        constructorDeclaration2.addParameter("ViewBuilder", "viewBuilder");
+        constructorDeclaration2.addParameter("String", "pkg");
+        constructorDeclaration2.addParameter("String", "name");
+        BlockStmt stmts = new BlockStmt();
+        MethodCallExpr ctorDeclaration = new MethodCallExpr(null, "super");
+        stmts.addStatement(ctorDeclaration);
+        ctorDeclaration.addArgument("viewBuilder");
+        ctorDeclaration.addArgument("pkg");
+        ctorDeclaration.addArgument("name");
+
+        rangeArity().forEach(i -> {
+            String typeWithIndex = stringWithIndex("type", i);
+            String genericTypeName = stringWithIndex("T", i);
+            String argWithIndex = stringWithIndexInside(i, "arg", "name");
+
+            constructorDeclaration2.addParameter(genericType("Class", genericTypeName), typeWithIndex);
+            constructorDeclaration2.addParameter("String", argWithIndex);
+
+            AssignExpr assignExpr = new AssignExpr();
+            assignExpr.setTarget(new FieldAccessExpr(new NameExpr("this"), stringWithIndex("arg", i)));
+            assignExpr.setValue(new MethodCallExpr(null, "declarationOf", nodeList(new NameExpr(typeWithIndex), new NameExpr(argWithIndex))));
+
+            stmts.addStatement(assignExpr);
+        });
+
+        constructorDeclaration2.setBody(stmts);
+    }
+
+    private void callMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration method = clazz.addMethod("call", Modifier.Keyword.PUBLIC);
+        addOverride(method);
+        method.addParameter("boolean", "open");
+        method.setType(parseClassOrInterfaceType("QueryCallViewItem"));
+
+        BlockStmt stmts = new BlockStmt();
+        NodeList<Expression> arguments = nodeList();
+        ClassOrInterfaceType queryCallViewItemImpl = parseClassOrInterfaceType("QueryCallViewItemImpl");
+        ObjectCreationExpr objCreationExpr = new ObjectCreationExpr(null, queryCallViewItemImpl, arguments);
+        stmts.addStatement(new ReturnStmt(objCreationExpr));
+        objCreationExpr.addArgument("this");
+        objCreationExpr.addArgument("open");
+
+        rangeArity().forEach(i -> {
+            String varWithIndex = stringWithIndex("var", i);
+            String genericTypeName = stringWithIndex("T", i);
+
+            method.addParameter(genericType("Argument", genericTypeName), varWithIndex);
+
+            objCreationExpr.addArgument(varWithIndex);
+        });
+
+        method.setBody(stmts);
+    }
+
+    private MethodDeclaration addOverride(MethodDeclaration method) {
+        return method.addAnnotation("Override");
+    }
+
+    private void getArgumentsMethod(ClassOrInterfaceDeclaration clazz) {
+        MethodDeclaration method = clazz.addMethod("getArguments", Modifier.Keyword.PUBLIC);
+        addOverride(method);
+        Type variableArrayType = parseType("Variable<?>[]");
+        method.setType(variableArrayType);
+
+        BlockStmt stmts = new BlockStmt();
+        ArrayInitializerExpr arrayInitializerExpr = new ArrayInitializerExpr();
+        ArrayCreationExpr arrayCreation = new ArrayCreationExpr(variableArrayType, nodeList(), arrayInitializerExpr);
+        stmts.addStatement(new ReturnStmt(arrayCreation));
+
+        NodeList<Expression> values = nodeList();
+        rangeArity().forEach(i -> {
+            String argIndex = stringWithIndex("arg", i);
+
+            values.add(new NameExpr(argIndex));
+        });
+
+        arrayInitializerExpr.setValues(values);
+
+        method.setBody(stmts);
+    }
+
+    private void getters(ClassOrInterfaceDeclaration clazz) {
+        rangeArity().forEach(i -> {
+            String genericTypeName = stringWithIndex("T", i);
+            String methodName = stringWithIndex("getArg", i);
+            String argWithIndex = stringWithIndex("arg", i);
+
+            MethodDeclaration methodDeclaration = clazz.addMethod(methodName, Modifier.Keyword.PUBLIC);
+            addOverride(methodDeclaration);
+            methodDeclaration.setType(genericType("Variable", genericTypeName));
+            methodDeclaration.setBody(new BlockStmt(nodeList(new ReturnStmt(new NameExpr(argWithIndex)))));
+        });
+    }
+
+    private void equals(ClassOrInterfaceDeclaration clazz) {
+
+
+        String template = "   @Override\n" +
+                "    public boolean isEqualTo( ModelComponent other ) {\n" +
+                "        if ( this == other ) return true;\n" +
+                "        if ( !(other instanceof DEF_IMPL_TYPE) ) return false;\n" +
+                "\n" +
+                "        DEF_IMPL_TYPE that = (DEF_IMPL_TYPE) other;\n" +
+                "\n" +
+                "        return EQUALS_CALL;\n" +
+                "    }";
+
+        BodyDeclaration<?> parse = parseBodyDeclaration(template);
+
+
+        Expression andExpr = new BooleanLiteralExpr(true);
+
+
+        for(int i : rangeArity().toArray()) {
+            String argWithIndex = stringWithIndex("arg", i);
+
+            Expression e = parseExpression(String.format("ModelComponent.areEqualInModel( %s, that.%s )", argWithIndex, argWithIndex));
+
+            andExpr = new BinaryExpr(andExpr, e, BinaryExpr.Operator.AND);
+        }
+
+        final Expression finalAndExpr = andExpr;
+
+        parse.findAll(ClassOrInterfaceType.class, n -> n.toString().equals("DEF_IMPL_TYPE"))
+                .forEach(s -> s.replace(parseType("Query" + arity + "DefImpl")));
+
+        parse.findAll(NameExpr.class, n -> n.toString().equals("EQUALS_CALL")).forEach(s -> s.replace(finalAndExpr));
+
+
+        clazz.addMember(parse);
+    }
+
+    private String stringWithIndex(String pre, int i) {
+        return pre + i;
+    }
+
+    private String stringWithIndexInside(int i, String pre, String post) {
+        return pre + i + post;
+    }
+
+    private IntStream rangeArity() {
+        return IntStream.range(1, arity + 1);
+    }
+
+    private String genericType(String typeName, String genericTypeName) {
+        return typeName + "<" + genericTypeName + ">";
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
@@ -57,6 +57,7 @@ public class QueryDefImplGenerator {
                 parseImport(String.format("import org.drools.model.Query%dDef;", arity)),
                 parseImport("import org.drools.model.Variable;"),
                 parseImport("import org.drools.model.view.QueryCallViewItem;"),
+                parseImport("import org.drools.model.view.QueryCallViewItemImpl;"),
                 parseImport("import static org.drools.model.FlowDSL.declarationOf;"),
                 parseImport("import static org.drools.model.impl.RuleBuilder.DEFAULT_PACKAGE;")
         ));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryDefImplGenerator.java
@@ -37,9 +37,15 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 public class QueryDefImplGenerator {
 
     private final int arity;
+    private final String className;
 
     QueryDefImplGenerator(int arity) {
         this.arity = arity;
+        className = String.format("Query%dDefImpl", arity);
+    }
+
+    public String getClassName() {
+        return className;
     }
 
     public CompilationUnit generate() {
@@ -70,7 +76,7 @@ public class QueryDefImplGenerator {
     }
 
     private ClassOrInterfaceDeclaration classDeclaration(CompilationUnit cu) {
-        ClassOrInterfaceDeclaration clazz = cu.addClass(String.format("Query%dDefImpl", arity), Modifier.Keyword.PUBLIC);
+        ClassOrInterfaceDeclaration clazz = cu.addClass(className, Modifier.Keyword.PUBLIC);
 
         clazz.addExtendedType("QueryDefImpl");
         clazz.addImplementedType("ModelComponent");

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -3,7 +3,10 @@ package org.drools.modelcompiler.builder.generator.query;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.stream.IntStream;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -41,7 +44,9 @@ public class QueryGenerator {
         CompilationUnit queryDefImpl = queryDefImplGenerator.generate();
         String generatedClass = new PrettyPrinter().print(queryDefImpl);
         try {
-            Files.write(Paths.get("/tmp/", "queryimpl", queryDefImplGenerator.getClassName() + ".java"), generatedClass.getBytes());
+            Path queryimpl = Paths.get("/tmp/", "queryimpl", queryDefImplGenerator.getClassName() + ".java");
+            Files.createDirectories(queryimpl.getParent());
+            Files.write(queryimpl, generatedClass.getBytes());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -52,7 +57,9 @@ public class QueryGenerator {
         CompilationUnit queryDef = queryDefGenerator.generate();
         String generatedClass = new PrettyPrinter().print(queryDef);
         try {
-            Files.write(Paths.get("/tmp/", "querydef", queryDefGenerator.getClassName() + ".java"), generatedClass.getBytes());
+            Path querydef = Paths.get("/tmp/", "querydef", queryDefGenerator.getClassName() + ".java");
+            Files.createDirectories(querydef.getParent());
+            Files.write(querydef, generatedClass.getBytes());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,12 +1,9 @@
 package org.drools.modelcompiler.builder.generator.query;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.stream.IntStream;
 
 import com.github.javaparser.ast.CompilationUnit;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,5 +1,7 @@
 package org.drools.modelcompiler.builder.generator.query;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.printer.PrettyPrinter;
 
@@ -10,8 +12,17 @@ public class QueryGenerator {
 
     public static void main(String[] args) {
         int arity = 5;
-        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
 
-        System.out.println("queryDefImpl = " + new PrettyPrinter().print(queryDefImpl));
+
+        // QueryDef
+        CompilationUnit queryDef = new QueryDefGenerator(arity).generate();
+        System.out.println("\n\n\nQueryDef");
+        System.out.println(new PrettyPrinter().print(queryDef));
+
+
+        // QueryDefImpl
+        System.out.println("\n\n\nQueryDefImpl");
+        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
+        System.out.println(new PrettyPrinter().print(queryDefImpl));
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,6 +1,9 @@
 package org.drools.modelcompiler.builder.generator.query;
 
+import java.util.stream.IntStream;
+
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.printer.PrettyPrinter;
 
 /**
@@ -9,29 +12,41 @@ import com.github.javaparser.printer.PrettyPrinter;
 public class QueryGenerator {
 
     public static void main(String[] args) {
-        int arity = 5;
+        int arity = 10;
 
 
-//        // QueryDef
-//        CompilationUnit queryDef = new QueryDefGenerator(arity).generate();
-//        System.out.println("\n\n\nQueryDef");
-//        System.out.println(new PrettyPrinter().print(queryDef));
-//
-//
-//        // QueryDefImpl
-//        System.out.println("\n\n\nQueryDefImpl");
-//        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
-//        System.out.println(new PrettyPrinter().print(queryDefImpl));
-//
-//
-//        // FlowDSL
-//        System.out.println("\n\n\nFlowDSL");
-//        CompilationUnit flowDSL = new FlowDSLQueryGenerator(arity).generate();
-//        System.out.println(new PrettyPrinter().print(flowDSL));
+//        generateQueryDef(arity);
+//        generateQueryDefImpl(arity);
+//        generateFlowDSL(arity);
+//        generatePatternDSL(arity);
 
-        // FlowDSL
-        System.out.println("\n\n\nPatternDSL");
-        CompilationUnit patternDSL = new PatternDSLQueryGenerator(arity).generate();
+
+        CompilationUnit aggregator = new CompilationUnit();
+        ClassOrInterfaceDeclaration clazz = aggregator.addClass(String.format("FlowDSL", arity));
+
+        IntStream.range(1, 11).forEach(arity1 -> generatePatternDSL(clazz, arity1));
+
+    }
+
+    private static void generatePatternDSL(ClassOrInterfaceDeclaration aggregator, int arity) {
+        ClassOrInterfaceDeclaration patternDSL = new PatternDSLQueryGenerator(aggregator, arity).generate();
         System.out.println(new PrettyPrinter().print(patternDSL));
+    }
+
+    private static void generateFlowDSL(int arity) {
+        CompilationUnit flowDSL = new FlowDSLQueryGenerator(arity).generate();
+        System.out.println(new PrettyPrinter().print(flowDSL));
+    }
+
+    private static void generateQueryDefImpl(int arity) {
+        System.out.println("\n\n\nQueryDefImpl");
+        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
+        System.out.println(new PrettyPrinter().print(queryDefImpl));
+    }
+
+    private static void generateQueryDef(int arity) {
+        CompilationUnit queryDef = new QueryDefGenerator(arity).generate();
+        System.out.println("\n\n\nQueryDef");
+        System.out.println(new PrettyPrinter().print(queryDef));
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,8 +1,6 @@
 package org.drools.modelcompiler.builder.generator.query;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.printer.PrettyPrinter;
 
 /**
@@ -14,21 +12,26 @@ public class QueryGenerator {
         int arity = 5;
 
 
-        // QueryDef
-        CompilationUnit queryDef = new QueryDefGenerator(arity).generate();
-        System.out.println("\n\n\nQueryDef");
-        System.out.println(new PrettyPrinter().print(queryDef));
-
-
-        // QueryDefImpl
-        System.out.println("\n\n\nQueryDefImpl");
-        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
-        System.out.println(new PrettyPrinter().print(queryDefImpl));
-
+//        // QueryDef
+//        CompilationUnit queryDef = new QueryDefGenerator(arity).generate();
+//        System.out.println("\n\n\nQueryDef");
+//        System.out.println(new PrettyPrinter().print(queryDef));
+//
+//
+//        // QueryDefImpl
+//        System.out.println("\n\n\nQueryDefImpl");
+//        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
+//        System.out.println(new PrettyPrinter().print(queryDefImpl));
+//
+//
+//        // FlowDSL
+//        System.out.println("\n\n\nFlowDSL");
+//        CompilationUnit flowDSL = new FlowDSLQueryGenerator(arity).generate();
+//        System.out.println(new PrettyPrinter().print(flowDSL));
 
         // FlowDSL
-        System.out.println("\n\n\nFlowDSL");
-        CompilationUnit flowDSL = new FlowDSLGenerator(arity).generate();
-        System.out.println(new PrettyPrinter().print(flowDSL));
+        System.out.println("\n\n\nPatternDSL");
+        CompilationUnit patternDSL = new PatternDSLQueryGenerator(arity).generate();
+        System.out.println(new PrettyPrinter().print(patternDSL));
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,8 +1,8 @@
 package org.drools.modelcompiler.builder.generator.query;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.printer.PrettyPrinter;
 
 /**
@@ -24,5 +24,11 @@ public class QueryGenerator {
         System.out.println("\n\n\nQueryDefImpl");
         CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
         System.out.println(new PrettyPrinter().print(queryDefImpl));
+
+
+        // FlowDSL
+        System.out.println("\n\n\nFlowDSL");
+        CompilationUnit flowDSL = new FlowDSLGenerator(arity).generate();
+        System.out.println(new PrettyPrinter().print(flowDSL));
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,6 +1,5 @@
 package org.drools.modelcompiler.builder.generator.query;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,7 +14,7 @@ import com.github.javaparser.printer.PrettyPrinter;
  */
 public class QueryGenerator {
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         int arity = 10;
 
         CompilationUnit patternDSL = new CompilationUnit();

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,0 +1,17 @@
+package org.drools.modelcompiler.builder.generator.query;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.PrettyPrinter;
+
+/**
+ * Used to generate n-arity query model, copy and paste the result in the files in comment
+ */
+public class QueryGenerator {
+
+    public static void main(String[] args) {
+        int arity = 5;
+        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
+
+        System.out.println("queryDefImpl = " + new PrettyPrinter().print(queryDefImpl));
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -14,28 +14,19 @@ public class QueryGenerator {
     public static void main(String[] args) {
         int arity = 10;
 
+        CompilationUnit patternDSL = new CompilationUnit();
+        ClassOrInterfaceDeclaration clazzPatternDSL = patternDSL.addClass("PatternDSL");
+        range(arity).forEach(arity1 -> new PatternDSLQueryGenerator(clazzPatternDSL, arity1).generate());
+        System.out.println(new PrettyPrinter().print(clazzPatternDSL));
 
-//        generateQueryDef(arity);
-//        generateQueryDefImpl(arity);
-//        generateFlowDSL(arity);
-//        generatePatternDSL(arity);
-
-
-        CompilationUnit aggregator = new CompilationUnit();
-        ClassOrInterfaceDeclaration clazz = aggregator.addClass(String.format("FlowDSL", arity));
-
-        IntStream.range(1, 11).forEach(arity1 -> generatePatternDSL(clazz, arity1));
-
+        CompilationUnit flowDSL = new CompilationUnit();
+        ClassOrInterfaceDeclaration clazzFlowDSL = flowDSL.addClass("FlowDSL");
+        range(arity).forEach(arity1 -> new FlowDSLQueryGenerator(clazzFlowDSL, arity1).generate());
+        System.out.println(new PrettyPrinter().print(clazzFlowDSL));
     }
 
-    private static void generatePatternDSL(ClassOrInterfaceDeclaration aggregator, int arity) {
-        ClassOrInterfaceDeclaration patternDSL = new PatternDSLQueryGenerator(aggregator, arity).generate();
-        System.out.println(new PrettyPrinter().print(patternDSL));
-    }
-
-    private static void generateFlowDSL(int arity) {
-        CompilationUnit flowDSL = new FlowDSLQueryGenerator(arity).generate();
-        System.out.println(new PrettyPrinter().print(flowDSL));
+    private static IntStream range(int arity) {
+        return IntStream.range(1, arity + 1);
     }
 
     private static void generateQueryDefImpl(int arity) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/query/QueryGenerator.java
@@ -1,5 +1,9 @@
 package org.drools.modelcompiler.builder.generator.query;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.stream.IntStream;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -11,7 +15,7 @@ import com.github.javaparser.printer.PrettyPrinter;
  */
 public class QueryGenerator {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         int arity = 10;
 
         CompilationUnit patternDSL = new CompilationUnit();
@@ -23,6 +27,9 @@ public class QueryGenerator {
         ClassOrInterfaceDeclaration clazzFlowDSL = flowDSL.addClass("FlowDSL");
         range(arity).forEach(arity1 -> new FlowDSLQueryGenerator(clazzFlowDSL, arity1).generate());
         System.out.println(new PrettyPrinter().print(clazzFlowDSL));
+
+        range(arity).forEach(QueryGenerator::generateQueryDef);
+        range(arity).forEach(QueryGenerator::generateQueryDefImpl);
     }
 
     private static IntStream range(int arity) {
@@ -30,14 +37,24 @@ public class QueryGenerator {
     }
 
     private static void generateQueryDefImpl(int arity) {
-        System.out.println("\n\n\nQueryDefImpl");
-        CompilationUnit queryDefImpl = new QueryDefImplGenerator(arity).generate();
-        System.out.println(new PrettyPrinter().print(queryDefImpl));
+        QueryDefImplGenerator queryDefImplGenerator = new QueryDefImplGenerator(arity);
+        CompilationUnit queryDefImpl = queryDefImplGenerator.generate();
+        String generatedClass = new PrettyPrinter().print(queryDefImpl);
+        try {
+            Files.write(Paths.get("/tmp/", "queryimpl", queryDefImplGenerator.getClassName() + ".java"), generatedClass.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void generateQueryDef(int arity) {
-        CompilationUnit queryDef = new QueryDefGenerator(arity).generate();
-        System.out.println("\n\n\nQueryDef");
-        System.out.println(new PrettyPrinter().print(queryDef));
+        QueryDefGenerator queryDefGenerator = new QueryDefGenerator(arity);
+        CompilationUnit queryDef = queryDefGenerator.generate();
+        String generatedClass = new PrettyPrinter().print(queryDef);
+        try {
+            Files.write(Paths.get("/tmp/", "querydef", queryDefGenerator.getClassName() + ".java"), generatedClass.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/QueryTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/QueryTest.java
@@ -872,12 +872,12 @@ public class QueryTest extends BaseModelTest {
     }
 
     @Test
-    public void testQuery5Args() throws IOException, ClassNotFoundException {
+    public void testQuery10Args() throws IOException, ClassNotFoundException {
         String str =
                 "package org.drools.compiler.test  \n" +
                 "import " + Person.class.getCanonicalName() + "\n" +
                 "global java.util.List list\n" +
-                "query peeps( String name, int age, long ageLong, int id, String likes ) \n" +
+                "query peeps( String name, int age, long ageLong, int id, String likes, String arg6, String arg7, String arg8, String arg9, String arg10) \n" +
                 "    Person( name := name, age := age, ageLong := ageLong, id := id, likes := likes ) \n" +
                 "end \n";
 
@@ -895,7 +895,13 @@ public class QueryTest extends BaseModelTest {
         ksession.insert( mark );
 
         List<String> list = new ArrayList<>();
-        QueryResults results = ksession.getQueryResults( "peeps", "Mario", 44, 44L, 1, "cheese" );
+        QueryResults results = ksession.getQueryResults( "peeps", "Mario", 44, 44L, 1, "cheese"
+                , "these"
+                , "arguments"
+                , "are"
+                , "ignored"
+                , "it's just for compilation"
+        );
         for (final QueryResultsRow result : results) {
             list.add((String) result.get("name"));
         }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/QueryTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/QueryTest.java
@@ -870,4 +870,36 @@ public class QueryTest extends BaseModelTest {
         assertEquals(1, list.size());
         assertEquals("Mario", list.get(0));
     }
+
+    @Test
+    public void testQuery5Args() throws IOException, ClassNotFoundException {
+        String str =
+                "package org.drools.compiler.test  \n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "global java.util.List list\n" +
+                "query peeps( String name, int age, long ageLong, int id, String likes ) \n" +
+                "    Person( name := name, age := age, ageLong := ageLong, id := id, likes := likes ) \n" +
+                "end \n";
+
+        KieSession ksession = getKieSession( str );
+
+        Person mario = new Person("Mario", 44);
+        mario.setAgeLong(44L);
+        mario.setId(1);
+        mario.setLikes("cheese");
+        ksession.insert( mario );
+        Person mark = new Person("Mark", 40);
+        mark.setAgeLong(40L);
+        mark.setId(2);
+        mark.setLikes("beer");
+        ksession.insert( mark );
+
+        List<String> list = new ArrayList<>();
+        QueryResults results = ksession.getQueryResults( "peeps", "Mario", 44, 44L, 1, "cheese" );
+        for (final QueryResultsRow result : results) {
+            list.add((String) result.get("name"));
+        }
+        assertEquals(1, list.size());
+        assertEquals("Mario", list.get(0));
+    }
 }


### PR DESCRIPTION
Support up to 10 arguments query

Query (def, impl, flow and pattern) DSL elements are generated by the QueryGenerator console application by specifing the needed arity

