### PR TITLE
[RHDM-867_7.23.x] force load of package-info into PMML4Compiler classloader …

### DIFF
--- a/kie-pmml/src/main/java/org/kie/pmml/assembler/PMMLAssemblerService.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/assembler/PMMLAssemblerService.java
@@ -111,6 +111,9 @@ public class PMMLAssemblerService implements KieAssemblerService {
                 }
             }
         }
+        pmmlCompiler.getResults().forEach(result -> {
+            kbuilder.addBuilderResult(result);
+        });
     }
 
     /**

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
@@ -757,6 +757,11 @@ public class PMML4Compiler {
             XMLStreamReader reader = null;
             try {
                 Thread.currentThread().setContextClassLoader(PMML4Compiler.class.getClassLoader());
+
+                // Workaround: in Java 9+ Maven does not load the package-info class during plugin execution
+                // see https://hibernate.atlassian.net/browse/HHH-12893
+                PMML4Compiler.class.getClassLoader().loadClass("org.dmg.pmml.pmml_4_2.descr.package-info");
+
                 Class c = PMML4Compiler.class.getClassLoader().loadClass("org.dmg.pmml.pmml_4_2.descr.PMML");
                 jc = JAXBContext.newInstance(c);
                 XMLInputFactory xif = XMLInputFactory.newFactory();


### PR DESCRIPTION
Backport of fix for problem unmarshalling PMML in Java 11