### PR TITLE
[DROOLS-3238] Reenable missing test feature

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTestCanonicalKieModule.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseInterpretedVsCompiledTestCanonicalKieModule.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
 import org.kie.api.io.Resource;
 import org.kie.dmn.core.compiler.ExecModelCompilerOption;
 
@@ -55,17 +56,17 @@ public abstract class BaseInterpretedVsCompiledTestCanonicalKieModule {
         System.clearProperty(ExecModelCompilerOption.PROPERTY_NAME);
     }
 
-    public Resource[] wrapWithDroolsModelResource(KieServices ks, Resource... original) {
+    public Resource[] wrapWithDroolsModelResource(KieServices ks, ReleaseId releaseId, Resource... original) {
         List<Resource> resources = new ArrayList<>(Arrays.asList(original));
         if(canonicalKieModule) {
-            resources.add(getDroolsModelResource(ks));
+            resources.add(getDroolsModelResource(ks, releaseId));
         }
         return resources.toArray(new Resource[0]);
     }
 
-    private Resource getDroolsModelResource(KieServices ks) {
+    private Resource getDroolsModelResource(KieServices ks, ReleaseId releaseId) {
         return ks.getResources()
                 .newClassPathResource("/org/kie/dmn/core/drools-model", this.getClass())
-                .setTargetPath(CanonicalKieModule.MODEL_FILE_DIRECTORY + CanonicalKieModule.MODEL_FILE_NAME);
+                .setTargetPath(CanonicalKieModule.getModelFileWithGAV(releaseId));
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNUpdateTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNUpdateTest.java
@@ -62,9 +62,10 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
     public void testRemoveAndAddSomething() {
         final KieServices ks = KieServices.Factory.get();
 
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         final KieContainer kieContainer = KieHelper.getKieContainer(
-                ks.newReleaseId("org.kie", "dmn-test", "1.0.0"),
-                wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                releaseId,
+                wrapWithDroolsModelResource(ks, releaseId, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
@@ -75,7 +76,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v101 = ks.newReleaseId("org.kie", "dmn-test", "1.0.1");
         KieHelper.createAndDeployJar(ks,
                                      v101,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string-itIT.dmn", this.getClass())));
+                                     wrapWithDroolsModelResource(ks, v101, ks.getResources().newClassPathResource("0001-input-data-string-itIT.dmn", this.getClass())));
 
         final Results updateResults = kieContainer.updateToVersion(v101);
         assertThat(updateResults.hasMessages(Level.ERROR), is(false));
@@ -95,9 +96,10 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
     public void testReplace() {
         final KieServices ks = KieServices.Factory.get();
 
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         final KieContainer kieContainer = KieHelper.getKieContainer(
-                ks.newReleaseId("org.kie", "dmn-test", "1.0.0"),
-                wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                releaseId,
+                wrapWithDroolsModelResource(ks, releaseId, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
@@ -110,7 +112,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         newClassPathResource.setTargetPath("0001-input-data-string.dmn");
         KieHelper.createAndDeployJar(ks,
                                      v101,
-                                     wrapWithDroolsModelResource(ks, newClassPathResource));
+                                     wrapWithDroolsModelResource(ks, v101, newClassPathResource));
 
         final Results updateResults = kieContainer.updateToVersion(v101);
         assertThat(updateResults.hasMessages(Level.ERROR), is(false));
@@ -133,7 +135,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v100 = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         KieContainer kieContainer = KieHelper.getKieContainer(
                 v100,
-                wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                wrapWithDroolsModelResource(ks, v100, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         DMNRuntime runtime = kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
         Assert.assertNotNull(runtime);
@@ -146,7 +148,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         newClassPathResource.setTargetPath("0001-input-data-string.dmn");
         KieHelper.createAndDeployJar(ks,
                                      v101,
-                                     wrapWithDroolsModelResource(ks, newClassPathResource));
+                                     wrapWithDroolsModelResource(ks, v101, newClassPathResource));
 
         Results updateResults = kieContainer.updateToVersion(v101);
         assertThat(updateResults.hasMessages(Level.ERROR), is(false));
@@ -191,7 +193,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v100 = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         KieHelper.createAndDeployJar(ks,
                                      v100,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                                     wrapWithDroolsModelResource(ks, v100, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         KieContainer kieContainer = ks.newKieContainer(v100);
 
@@ -215,7 +217,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v100 = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         KieHelper.createAndDeployJar(ks,
                                      v100,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                                     wrapWithDroolsModelResource(ks, v100, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         KieContainer kieContainer = ks.newKieContainer(v100);
 
@@ -236,7 +238,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         newClassPathResource.setTargetPath("0001-input-data-string.dmn");
         KieHelper.createAndDeployJar(ks,
                                      v101,
-                                     wrapWithDroolsModelResource(ks, newClassPathResource));
+                                     wrapWithDroolsModelResource(ks, v101, newClassPathResource));
 
         final Results updateResults = kieContainer.updateToVersion(v101);
         assertThat(updateResults.hasMessages(Level.ERROR), is(false));
@@ -253,7 +255,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v100 = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         KieHelper.createAndDeployJar(ks,
                                      v100,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                                     wrapWithDroolsModelResource(ks, v100, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         KieContainer kieContainer = ks.newKieContainer(v100);
         KieSession kieSession = kieContainer.newKieSession();
@@ -287,7 +289,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v100 = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         final KieModule kieModule = KieHelper.createAndDeployJar(ks,
                                                                  v100,
-                                                                 wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
+                                                                 wrapWithDroolsModelResource(ks, v100, ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass())));
 
         final KieContainer kieContainer = ks.newKieContainer(v100);
         final KieSession kieSession = kieContainer.newKieSession();
@@ -323,7 +325,7 @@ public class DMNUpdateTest extends BaseInterpretedVsCompiledTestCanonicalKieModu
         final ReleaseId v100 = ks.newReleaseId("org.kie", "dmn-test", "1.0.0");
         final KieModule kieModule = KieHelper.createAndDeployJar(ks,
                                                                  v100,
-                                                                 wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("v1_2/dmn-hotcold.dmn", this.getClass())));
+                                                                 wrapWithDroolsModelResource(ks, v100, ks.getResources().newClassPathResource("v1_2/dmn-hotcold.dmn", this.getClass())));
 
         final KieContainer kieContainer = ks.newKieContainer(v100);
         final KieSession kieSession = kieContainer.newKieSession();

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/incrementalcompilation/DMNIncrementalCompilationTest.java
@@ -52,7 +52,7 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
         final ReleaseId releaseId_v10 = ks.newReleaseId("org.kie", "dmn-test-PR1997", "1.0");
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v10,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/20180731-pr1997.dmn", this.getClass())
+                                     wrapWithDroolsModelResource(ks, releaseId_v10, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/20180731-pr1997.dmn", this.getClass())
                                        .setTargetPath("20180731-pr1997.dmn"),
                                      ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v1/Person.java", this.getClass())
                                        .setTargetPath("acme/Person.java")));
@@ -64,7 +64,7 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
         final ReleaseId releaseId_v11 = ks.newReleaseId("org.kie", "dmn-test-PR1997", "1.1");
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v11,
-                                     wrapWithDroolsModelResource(ks, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/20180731-pr1997.dmn", this.getClass())
+                                     wrapWithDroolsModelResource(ks, releaseId_v11, ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/20180731-pr1997.dmn", this.getClass())
                                        .setTargetPath("20180731-pr1997.dmn"),
                                      ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/v2/Person.java", this.getClass())
                                        .setTargetPath("acme/Person.java")));
@@ -109,6 +109,7 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v10,
                                      wrapWithDroolsModelResource(ks,
+                                                                 releaseId_v10,
                                                                  ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/import-itemdef-100/air-conditioning-control.dmn", this.getClass())
                                                                    .setTargetPath("air-conditioning-control.dmn"),
                                                                  ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/import-itemdef-100/air-conditioning-data-types.dmn", this.getClass())
@@ -120,6 +121,7 @@ public class DMNIncrementalCompilationTest extends BaseInterpretedVsCompiledTest
         KieHelper.createAndDeployJar(ks,
                                      releaseId_v11,
                                      wrapWithDroolsModelResource(ks,
+                                                                 releaseId_v11,
                                                                  ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/import-itemdef-101/air-conditioning-control.dmn", this.getClass())
                                                                    .setTargetPath("air-conditioning-control.dmn"),
                                                                  ks.getResources().newClassPathResource("/org/kie/dmn/core/incrementalcompilation/import-itemdef-101/air-conditioning-data-types.dmn", this.getClass())


### PR DESCRIPTION
The path of the Drools model file was wrong, it had to include GAV.

Without that file, we don't test a DMN resource running alongside the CanonicalKieModule, which is needed while using the executable model for DRL file.

Please note that these tests don't actually verify the correct behaviour of the compiled DRL files, but they only verify the DMN model.  