### PR TITLE
DROOLS-4362 Fix date parsing in executable model on non-English locale

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -357,7 +357,7 @@ public class PackageModel {
         rulesClass.addImplementedType(Model.class);
 
         BodyDeclaration<?> dateFormatter = parseBodyDeclaration(
-                "public final static DateTimeFormatter " + DATE_TIME_FORMATTER_FIELD + " = DateTimeFormatter.ofPattern(DateUtils.getDateFormatMask());\n");
+                "public final static DateTimeFormatter " + DATE_TIME_FORMATTER_FIELD + " = DateTimeFormatter.ofPattern(DateUtils.getDateFormatMask(), Locale.ENGLISH);\n");
         rulesClass.addMember(dateFormatter);
 
         BodyDeclaration<?> string2dateMethodMethod = parseBodyDeclaration(


### PR DESCRIPTION
@mariofusco please review. I will submit this fix also to kogito-runtimes as part of backport of SonarCloud fixes. 