### PR TITLE
[DROOLS-4376] Abbreviated comparison with Map fails in executable-model

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -1888,4 +1888,22 @@ public class CompilerTest extends BaseModelTest {
         assertEquals("Mario is very old", result.getValue());
 
     }
+
+    @Test
+    public void testMapAbbreviatedComparison() {
+        final String drl1 =
+                "import java.util.Map;\n" +
+                "rule R1 when\n" +
+                "    Map(this['money'] >= 65 && <= 75)\n" +
+                "then\n" +
+                "end\n";
+
+        KieSession ksession = getKieSession( drl1 );
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("money", new BigDecimal(70));
+
+        ksession.insert( map );
+        assertEquals( 1, ksession.fireAllRules() );
+    }
 }


### PR DESCRIPTION
- Unit test

This test case may contain 2 factors (I was not able to split the JIRA nicely):
- Abbreviated comparison with Map
- Comparison coercion between BigDecimal and primitive type

Anyway, the customer hopes to build this kind of rule.