### PR TITLE
RHDM-1015 Rule-based test scenarios that contain maps of simple types fail

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -84,7 +84,7 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
             JsonNode jsonNode = element.getValue();
             // if is a simple value just return the parsed result
             if (numberOfFields == 1 && "value".equals(key)) {
-                return internalLiteralEvaluation(jsonNode.textValue(), genericClasses.get(0));
+                return internalLiteralEvaluation(jsonNode.textValue(), genericClasses.isEmpty() ? className : genericClasses.get(0));
             }
 
             if (jsonNode.isArray()) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
@@ -18,8 +18,10 @@ package org.drools.scenariosimulation.backend.expression;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.LocalDate;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +35,19 @@ import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.revert
 public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
 
     private final ClassLoader classLoader;
+    /*
+     * Note: This list is similar to the SIMPLE_CLASSES_MAP found in the DataManagementStrategy interface
+     *
+    */
+    private static List<String> SIMPLE_TYPES_LIST = Arrays.asList(Boolean.class.getCanonicalName(),
+                                                                Integer.class.getCanonicalName(),
+                                                                Long.class.getCanonicalName(),
+                                                                Double.class.getCanonicalName(),
+                                                                Float.class.getCanonicalName(),
+                                                                Short.class.getCanonicalName(),
+                                                                Byte.class.getCanonicalName(),
+                                                                Character.class.getCanonicalName(),
+                                                                LocalDate.class.getCanonicalName());
 
     public BaseExpressionEvaluator(ClassLoader classLoader) {
         this.classLoader = classLoader;
@@ -96,6 +111,9 @@ public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
             return new HashMap();
         } else {
             try {
+                if (SIMPLE_TYPES_LIST.contains(className)) {
+                    return null;
+                }
                 return classLoader.loadClass(className).newInstance();
             } catch (Exception e) {
                 throw new IllegalArgumentException("Impossible to instantiate " + className, e);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
@@ -18,10 +18,8 @@ package org.drools.scenariosimulation.backend.expression;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.time.LocalDate;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -35,19 +33,6 @@ import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.revert
 public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
 
     private final ClassLoader classLoader;
-    /*
-     * Note: This list is similar to the SIMPLE_CLASSES_MAP found in the DataManagementStrategy interface
-     *
-    */
-    private static List<String> SIMPLE_TYPES_LIST = Arrays.asList(Boolean.class.getCanonicalName(),
-                                                                Integer.class.getCanonicalName(),
-                                                                Long.class.getCanonicalName(),
-                                                                Double.class.getCanonicalName(),
-                                                                Float.class.getCanonicalName(),
-                                                                Short.class.getCanonicalName(),
-                                                                Byte.class.getCanonicalName(),
-                                                                Character.class.getCanonicalName(),
-                                                                LocalDate.class.getCanonicalName());
 
     public BaseExpressionEvaluator(ClassLoader classLoader) {
         this.classLoader = classLoader;
@@ -111,9 +96,6 @@ public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
             return new HashMap();
         } else {
             try {
-                if (SIMPLE_TYPES_LIST.contains(className)) {
-                    return null;
-                }
                 return classLoader.loadClass(className).newInstance();
             } catch (Exception e) {
                 throw new IllegalArgumentException("Impossible to instantiate " + className, e);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
@@ -23,11 +23,16 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AbstractExpressionEvaluatorTest {
@@ -103,6 +108,35 @@ public class AbstractExpressionEvaluatorTest {
         List<Map<String, Object>> nestedList = (List<Map<String, Object>>) resultMap.get("listField");
         assertEquals(1, nestedList.size());
         assertEquals("fieldValue", nestedList.get(0).get("field"));
+    }
+
+    @Test
+    public void isSimpleTypeNode() {
+        assertFalse(expressionEvaluatorMock.isSimpleTypeNode(new ArrayNode(factory)));
+
+        ObjectNode jsonNode = new ObjectNode(factory);
+
+        jsonNode.set("value", new TextNode("test"));
+        assertTrue(expressionEvaluatorMock.isSimpleTypeNode(jsonNode));
+
+        jsonNode.set("otherField", new TextNode("testValue"));
+
+        assertFalse(expressionEvaluatorMock.isSimpleTypeNode(jsonNode));
+    }
+
+    @Test
+    public void getSimpleTypeNodeTextValue() {
+        Assertions.assertThatThrownBy(() -> expressionEvaluatorMock.getSimpleTypeNodeTextValue(new ArrayNode(factory)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter does not contains a simple type");
+
+        ObjectNode jsonNode = new ObjectNode(factory);
+
+        jsonNode.set("value", new TextNode("testValue"));
+        assertEquals("testValue", expressionEvaluatorMock.getSimpleTypeNodeTextValue(jsonNode));
+
+        jsonNode.set("value", new IntNode(10));
+        assertNull(expressionEvaluatorMock.getSimpleTypeNodeTextValue(jsonNode));
     }
 
     AbstractExpressionEvaluator expressionEvaluatorMock = new AbstractExpressionEvaluator() {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
@@ -17,105 +17,93 @@
 package org.drools.scenariosimulation.backend.expression;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.drools.scenariosimulation.backend.model.ListMapClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class BaseExpressionEvaluatorTest {
 
     private final static ClassLoader classLoader = BaseExpressionEvaluatorTest.class.getClassLoader();
+    private final static AbstractExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
 
     @Test
     public void evaluateLiteralExpression() {
-        BaseExpressionEvaluator baseExpressionEvaluator = new BaseExpressionEvaluator(classLoader);
-
         Object raw = new Object();
-        assertEquals(raw, baseExpressionEvaluator.evaluateLiteralExpression(Object.class.getCanonicalName(), Collections.emptyList(), raw));
+        assertEquals(raw, expressionEvaluator.evaluateLiteralExpression(Object.class.getCanonicalName(), Collections.emptyList(), raw));
 
         raw = "SimpleString";
-        assertEquals(raw, baseExpressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), raw));
+        assertEquals(raw, expressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), raw));
 
         raw = "= SimpleString";
-        assertEquals("SimpleString", baseExpressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), raw));
+        assertEquals("SimpleString", expressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), raw));
 
-        assertNull(baseExpressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), null));
+        assertNull(expressionEvaluator.evaluateLiteralExpression(String.class.getCanonicalName(), Collections.emptyList(), null));
     }
 
     @Test
-    public void createSimpleTypeObject() {
-        // Integer has no default constructor
-        BaseExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
-        Object obj = expressionEvaluator.createObject(Integer.class.getCanonicalName(), Collections.emptyList());
+    public void createObjectTest() {
+        assertNotNull(expressionEvaluator.createObject(String.class.getCanonicalName(), Collections.emptyList()));
+        assertTrue(expressionEvaluator.createObject(Map.class.getCanonicalName(), Arrays.asList(String.class.getCanonicalName(), String.class.getCanonicalName())) instanceof Map);
 
-        assertNull(obj);
+        Assertions.assertThatThrownBy(() -> expressionEvaluator.createObject("com.invalid.class.Name", Collections.emptyList())).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Impossible to instantiate com.invalid.class.Name");
     }
 
     @Test
-    public void createNonSimpleTypeObject() {
-        // String has a default constructor
-        BaseExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
-        Object obj = expressionEvaluator.createObject(String.class.getCanonicalName(), Collections.emptyList());
-
-        assertNotNull(obj);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void createObjectWithInvalidClass() {
-        String invalidClassName = "com.invalid.class.Name";
-
-        BaseExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
-        Object obj = expressionEvaluator.createObject(invalidClassName, Collections.emptyList());
-
-        // This should never be reached since the invalid class name will cause the 
-        // expected exception
-        fail();
+    public void verifyNullTest() {
+        assertFalse(expressionEvaluator.verifyResult("[]", null, List.class));
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void expressionTest() {
-        BaseExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
+    public void mapOfSimpleTypeTest() {
 
-        String likeWorkbenchMapString = "{ \"Home\": { \"value\": \"123 Any Street\" } }";
+        String givenWorkbenchMapString = "{ \"Home\": { \"value\": \"123 Any Street\" } }";
         List<String> genericClasses = new ArrayList<>();
-//        genericClasses.add(String.class.getCanonicalName());
         genericClasses.add(String.class.getCanonicalName());
-        Map<String, String> parsedWorkbench = ((Map<String, String>) expressionEvaluator.convertResult(likeWorkbenchMapString, Map.class.getCanonicalName(), genericClasses));
-        System.out.println(parsedWorkbench);
+        genericClasses.add(String.class.getCanonicalName());
+        Map<String, String> parsedWorkbench = ((Map<String, String>) expressionEvaluator.convertResult(givenWorkbenchMapString, Map.class.getCanonicalName(), genericClasses));
 
         assertEquals(1, parsedWorkbench.size());
         assertNotNull(parsedWorkbench.get("Home"));
-        assertTrue(parsedWorkbench.get("Home").equals("123 Any Street"));
+        assertEquals("123 Any Street", parsedWorkbench.get("Home"));
 
-        String likeWorkbenchMapInteger = "{ \"Home\": { \"value\": \"100\" } }";
+        String givenWorkbenchMapInteger = "{ \"Home\": { \"value\": \"100\" } }";
         genericClasses.clear();
-//        genericClasses.add(String.class.getCanonicalName());
+        genericClasses.add(String.class.getCanonicalName());
         genericClasses.add(Integer.class.getCanonicalName());
-        Map<String, Integer> parsedIntegerFromMap = ((Map<String, Integer>) expressionEvaluator.convertResult(likeWorkbenchMapInteger, Map.class.getCanonicalName(), genericClasses));
+        Map<String, Integer> parsedIntegerFromMap = ((Map<String, Integer>) expressionEvaluator.convertResult(givenWorkbenchMapInteger, Map.class.getCanonicalName(), genericClasses));
 
         assertEquals(1, parsedIntegerFromMap.size());
         assertNotNull(parsedIntegerFromMap.get("Home"));
         assertEquals(100, parsedIntegerFromMap.get("Home").intValue());
 
-        String listJsonString = "[{\"name\": \"John\"}, " +
-                "{\"name\": \"John\", \"names\" : [{\"value\": \"Anna\"}, {\"value\": \"Mario\"}]}]";
+        String expectWorkbenchMapInteger = "{ \"Home\": { \"value\": \"> 100\" } }";
+        genericClasses.clear();
+        genericClasses.add(String.class.getCanonicalName());
+        genericClasses.add(Integer.class.getCanonicalName());
+        Map<String, Integer> resultToTest = new HashMap<>();
+        resultToTest.put("Home", 120);
+        assertTrue(expressionEvaluator.verifyResult(expectWorkbenchMapInteger, resultToTest, Map.class));
+        resultToTest.put("Home", 20);
+        assertFalse(expressionEvaluator.verifyResult(expectWorkbenchMapInteger, resultToTest, Map.class));
+    }
 
-        List<ListMapClass> parsedValue = (List<ListMapClass>) expressionEvaluator.convertResult(listJsonString, List.class.getCanonicalName(),
-                                                                                                Collections.singletonList(ListMapClass.class.getCanonicalName()));
-
-        assertEquals(2, parsedValue.size());
-        assertEquals(2, parsedValue.get(1).getNames().size());
-        assertTrue(parsedValue.get(1).getNames().contains("Anna"));
-
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mapOfComplexTypeTest() {
         String mapJsonString = "{\"first\": {\"name\": \"John\"}}";
         Map<String, ListMapClass> parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
                                                                                                             Collections.singletonList(ListMapClass.class.getCanonicalName()));
@@ -135,5 +123,57 @@ public class BaseExpressionEvaluatorTest {
 
         assertEquals(1, parsedMap.size());
         assertEquals((Integer) 1, parsedMap.get("first").getPhones().get("number"));
+
+        mapJsonString = "{\"first\": {\"phones\": {\"number\" : \"> 1\"}}}";
+
+        Map<String, ListMapClass> toCheck = new HashMap<>();
+        ListMapClass element = new ListMapClass();
+        Map<String, Integer> phones = new HashMap<>();
+        phones.put("number", 10);
+        element.setPhones(phones);
+        toCheck.put("first", element);
+
+        assertTrue(expressionEvaluator.verifyResult(mapJsonString, toCheck, Map.class));
+        phones.put("number", -1);
+        assertFalse(expressionEvaluator.verifyResult(mapJsonString, toCheck, Map.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void listOfComplexTypeTest() {
+
+        String listJsonString = "[{\"name\": \"John\"}, " +
+                "{\"name\": \"John\", \"names\" : [{\"value\": \"Anna\"}, {\"value\": \"Mario\"}]}]";
+
+        List<ListMapClass> parsedValue = (List<ListMapClass>) expressionEvaluator.convertResult(listJsonString, List.class.getCanonicalName(),
+                                                                                                Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(2, parsedValue.size());
+        assertEquals(2, parsedValue.get(1).getNames().size());
+        assertTrue(parsedValue.get(1).getNames().contains("Anna"));
+
+        assertTrue(expressionEvaluator.verifyResult(listJsonString, parsedValue, List.class));
+
+        parsedValue.get(1).setNames(new ArrayList<>());
+        assertFalse(expressionEvaluator.verifyResult(listJsonString, parsedValue, List.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void listOfSimpleTypeTest() {
+        String listJsonString = "[{\"value\" : \"10\"}, {\"value\" : \"12\"}]";
+
+        List<Integer> result = (List<Integer>) expressionEvaluator.convertResult(listJsonString, List.class.getCanonicalName(), Collections.singletonList(Integer.class.getCanonicalName()));
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains(10));
+
+        listJsonString = "[{\"value\" : \"> 10\"}]";
+        List<Integer> toCheck = Collections.singletonList(13);
+
+        assertTrue(expressionEvaluator.verifyResult(listJsonString, toCheck, List.class));
+
+        listJsonString = "[{\"value\" : \"> 100\"}]";
+        assertFalse(expressionEvaluator.verifyResult(listJsonString, toCheck, List.class));
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
@@ -87,7 +87,7 @@ public class BaseExpressionEvaluatorTest {
 
         String likeWorkbenchMapString = "{ \"Home\": { \"value\": \"123 Any Street\" } }";
         List<String> genericClasses = new ArrayList<>();
-        genericClasses.add(String.class.getCanonicalName());
+//        genericClasses.add(String.class.getCanonicalName());
         genericClasses.add(String.class.getCanonicalName());
         Map<String, String> parsedWorkbench = ((Map<String, String>) expressionEvaluator.convertResult(likeWorkbenchMapString, Map.class.getCanonicalName(), genericClasses));
         System.out.println(parsedWorkbench);
@@ -98,7 +98,7 @@ public class BaseExpressionEvaluatorTest {
 
         String likeWorkbenchMapInteger = "{ \"Home\": { \"value\": \"100\" } }";
         genericClasses.clear();
-        genericClasses.add(String.class.getCanonicalName());
+//        genericClasses.add(String.class.getCanonicalName());
         genericClasses.add(Integer.class.getCanonicalName());
         Map<String, Integer> parsedIntegerFromMap = ((Map<String, Integer>) expressionEvaluator.convertResult(likeWorkbenchMapInteger, Map.class.getCanonicalName(), genericClasses));
 


### PR DESCRIPTION
* Fixed an error that was being caused by the way the workbench writes the JSON for Map objects that contain simple key/value pairs (e.g. String and String).
* Added to the tests for the expression evaluator, creating a test for a JSON string that is equivalent to one created by the workbench.