### PR TITLE
Exclude drools-test-coverage/test-suite/classlist.mf from versioning

### DIFF
--- a/drools-test-coverage/test-suite/.gitignore
+++ b/drools-test-coverage/test-suite/.gitignore
@@ -9,3 +9,6 @@
 /*.ipr
 /*.iws
 /*.iml
+
+classlist.mf
+


### PR DESCRIPTION
This file gets generated when running from mvn cli

 @baldimir @jiripetrlik