### PR TITLE
RHDM-1049 Wrong output variable values in PMML mining model

### DIFF
--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/summed.mvel
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/summed.mvel
@@ -96,6 +96,7 @@ then
    FactHandle fh = ((org.drools.core.datasources.InternalDataSource)results).getFactHandleForObject($reslt);
    $reslt.setResultCode("OK");
    $reslt.addResultVariable("Sum_@{miningModel.targetField}",target);
+   $reslt.addResultVariable("@{miningModel.targetField}",$svalue);
    results.update(fh,$reslt);
 end
 

--- a/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/summed.mvel
+++ b/kie-pmml/src/main/resources/org/kie/pmml/pmml_4_2/templates/mvel/mining/summed.mvel
@@ -25,6 +25,7 @@ import org.kie.pmml.pmml_4_2.model.datatypes.*;
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.pmml.ParameterInfo;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.api.pmml.PMML4OutputField;
 import org.kie.api.runtime.rule.FactHandle;
 
 
@@ -91,12 +92,18 @@ when
    accumulate( MiningSegmentWeight( $val: segmentValue != null ); $svalue: sum($val) )
    $reslt: PMML4Result( segmentId == null, resultVariables == null || "Sum_@{miningModel.targetField}" not memberOf resultVariables.keySet() ) from results
 then
+   @{packageName}.@{miningModel.targetField} modelTarget = new @{packageName}.@{miningModel.targetField}();
+   modelTarget.setName("@{miningModel.targetField}");
+   modelTarget.setTarget(true);
+   modelTarget.setValue($svalue);
+   modelTarget.setValid(true);
+   modelTarget.setContext("@{miningModel.modelId}");
    Summed_@{miningModel.targetField} target = new Summed_@{miningModel.targetField}();
    target.setValue($svalue);
    FactHandle fh = ((org.drools.core.datasources.InternalDataSource)results).getFactHandleForObject($reslt);
    $reslt.setResultCode("OK");
    $reslt.addResultVariable("Sum_@{miningModel.targetField}",target);
-   $reslt.addResultVariable("@{miningModel.targetField}",$svalue);
+   $reslt.addResultVariable("@{miningModel.targetField}",modelTarget);
    results.update(fh,$reslt);
 end
 

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelSumRegressionTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelSumRegressionTest.java
@@ -42,7 +42,8 @@ public class MiningModelSumRegressionTest {
     private static final String INPUT1_FIELD_NAME = "input1";
     private static final String INPUT2_FIELD_NAME = "input2";
     private static final String INPUT3_FIELD_NAME = "input3";
-    private static final String OUTPUT_FIELD_NAME = "Sum_Result";
+    private static final String SUM_OUTPUT_FIELD_NAME = "Sum_Result";
+    private static final String BASE_OUTPUT_FIELD_NAME = "Result";
 
     private static final double COMPARISON_DELTA = 0.001;
 
@@ -55,8 +56,8 @@ public class MiningModelSumRegressionTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
                 { Optional.of(10.0), Optional.of(10.0), Optional.of(10.0), 2070 },
-                { Optional.of(200.0), Optional.of(-1.0), Optional.of(2.0), -299 },
-                { Optional.of(90.0), Optional.of(2.0), Optional.of(4.0), 17040 },
+		{ Optional.of(200.0), Optional.of(-1.0), Optional.of(2.0), -299},
+		{ Optional.of(90.0), Optional.of(2.0), Optional.of(4.0), 17040},
         });
     }
 
@@ -83,7 +84,12 @@ public class MiningModelSumRegressionTest {
             assertEquals(request.getCorrelationId(), rd.getCorrelationId());
             if (rd.getSegmentationId() == null) {
                 assertEquals("OK",rd.getResultCode());
-                double value = rd.getResultValue(OUTPUT_FIELD_NAME, "value", Double.class).orElse(null);
+                double value = rd.getResultValue(SUM_OUTPUT_FIELD_NAME, "value", Double.class).orElse(null);
+                assertNotNull(value);
+                assertEquals(result, value, COMPARISON_DELTA);
+                // Note that the base output field is not a complex type and so
+                // does not require a field name to retrieve its value
+                value = rd.getResultValue(BASE_OUTPUT_FIELD_NAME, null, Double.class).orElse(null);
                 assertNotNull(value);
                 assertEquals(result, value, COMPARISON_DELTA);
             }

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelSumRegressionTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/mining/MiningModelSumRegressionTest.java
@@ -56,8 +56,8 @@ public class MiningModelSumRegressionTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
                 { Optional.of(10.0), Optional.of(10.0), Optional.of(10.0), 2070 },
-		{ Optional.of(200.0), Optional.of(-1.0), Optional.of(2.0), -299},
-		{ Optional.of(90.0), Optional.of(2.0), Optional.of(4.0), 17040},
+                { Optional.of(200.0), Optional.of(-1.0), Optional.of(2.0), -299 },
+                { Optional.of(90.0), Optional.of(2.0), Optional.of(4.0), 17040 },
         });
     }
 
@@ -87,9 +87,7 @@ public class MiningModelSumRegressionTest {
                 double value = rd.getResultValue(SUM_OUTPUT_FIELD_NAME, "value", Double.class).orElse(null);
                 assertNotNull(value);
                 assertEquals(result, value, COMPARISON_DELTA);
-                // Note that the base output field is not a complex type and so
-                // does not require a field name to retrieve its value
-                value = rd.getResultValue(BASE_OUTPUT_FIELD_NAME, null, Double.class).orElse(null);
+                value = rd.getResultValue(BASE_OUTPUT_FIELD_NAME, "value", Double.class).orElse(null);
                 assertNotNull(value);
                 assertEquals(result, value, COMPARISON_DELTA);
             }


### PR DESCRIPTION
* Changed output of the target field to be a simple value that is set at
the same time as the Sum_ version is created.
* Updated test to make sure change was effective in adding the output
value