### PR TITLE
DROOLS-4440 Resolve dependency version in build

### DIFF
--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -152,6 +152,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -130,7 +130,7 @@ public abstract class AbstractKieModule
         }
         Collection<ReleaseId> deps = null;
         if( pomModel != null ) {
-            deps = adaptAll( pomModel.getDependencies(filter) );
+            deps = adaptAll( pomModel.getDependencies(filter), pomModel );
         }
         return deps == null ? Collections.<ReleaseId> emptyList() : deps;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -163,7 +163,7 @@ public class KieBuilderImpl
             // add all the pom dependencies to this builder ... not sure this is a good idea (?)
             KieRepositoryImpl repository = (KieRepositoryImpl) ks.getRepository();
             for ( AFReleaseId dep : pomModel.getDependencies( DependencyFilter.COMPILE_FILTER ) ) {
-                KieModule depModule = repository.getKieModule( adapt( dep ), pomModel );
+                KieModule depModule = repository.getKieModule( adapt( dep, pomModel ), pomModel );
                 if ( depModule != null ) {
                     addKieDependency( depModule );
                 }

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
@@ -18,11 +18,15 @@ package org.drools.compiler.kproject;
 import java.io.InputStream;
 import java.util.Collection;
 
+import org.appformer.maven.support.PomModel;
 import org.kie.api.builder.ReleaseId;
 
 import static java.util.stream.Collectors.toList;
 
 public class ReleaseIdImpl extends org.appformer.maven.support.AFReleaseIdImpl implements ReleaseId {
+
+    private static final String PROJECT_VERSION_MAVEN_PROPERTY = "${project.version}";
+    private static final String PARENT_VERSION_MAVEN_PROPERTY = "${project.parent.version}";
 
     public ReleaseIdImpl() {
     }
@@ -39,19 +43,27 @@ public class ReleaseIdImpl extends org.appformer.maven.support.AFReleaseIdImpl i
         super(groupId, artifactId, version, type);
     }
 
-    public static ReleaseId adapt(org.appformer.maven.support.AFReleaseId r ) {
+    public static ReleaseId adapt(org.appformer.maven.support.AFReleaseId r) {
+        return adapt(r, null);
+    }
+
+    public static ReleaseId adapt(org.appformer.maven.support.AFReleaseId r, PomModel pomModel) {
         if (r instanceof ReleaseId) {
             return ( ReleaseId ) r;
         }
-        final ReleaseIdImpl newReleaseIdImpl = new ReleaseIdImpl(r.getGroupId(), r.getArtifactId(), r.getVersion(), ((org.appformer.maven.support.AFReleaseIdImpl) r).getType());
+
+        final ReleaseIdImpl newReleaseIdImpl = new ReleaseIdImpl(r.getGroupId(),
+                                                                 r.getArtifactId(),
+                                                                 resolveVersion(r.getVersion(), pomModel),
+                                                                 ((org.appformer.maven.support.AFReleaseIdImpl) r).getType());
         if (r.isSnapshot()) {
             newReleaseIdImpl.setSnapshotVersion(r.getVersion());
         }
         return newReleaseIdImpl;
     }
 
-    public static Collection<ReleaseId> adaptAll( Collection<org.appformer.maven.support.AFReleaseId> rs ) {
-        return rs.stream().map(ReleaseIdImpl::adapt).collect(toList());
+    public static Collection<ReleaseId> adaptAll( Collection<org.appformer.maven.support.AFReleaseId> rs, PomModel pomModel ) {
+        return rs.stream().map(releaseId -> ReleaseIdImpl.adapt(releaseId, pomModel)).collect(toList());
     }
 
     public static ReleaseId fromPropertiesString( String path ) {
@@ -61,4 +73,20 @@ public class ReleaseIdImpl extends org.appformer.maven.support.AFReleaseIdImpl i
     public static ReleaseId fromPropertiesStream( InputStream stream, String path ) {
         return adapt( org.appformer.maven.support.AFReleaseIdImpl.fromPropertiesStream(stream, path) );
     }
+
+    private static String resolveVersion(String versionString, PomModel projectPomModel) {
+        if (projectPomModel != null) {
+            if (PROJECT_VERSION_MAVEN_PROPERTY.equals(versionString)) {
+                return projectPomModel.getReleaseId().getVersion();
+            } else if (PARENT_VERSION_MAVEN_PROPERTY.equals(versionString)
+                    && (projectPomModel.getParentReleaseId() != null)) {
+                return projectPomModel.getParentReleaseId().getVersion();
+            } else {
+                return versionString;
+            }
+        } else {
+            return versionString;
+        }
+    }
+
 }

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/ReleaseIdImpl.java
@@ -74,7 +74,7 @@ public class ReleaseIdImpl extends org.appformer.maven.support.AFReleaseIdImpl i
         return adapt( org.appformer.maven.support.AFReleaseIdImpl.fromPropertiesStream(stream, path) );
     }
 
-    private static String resolveVersion(String versionString, PomModel projectPomModel) {
+    public static String resolveVersion(String versionString, PomModel projectPomModel) {
         if (projectPomModel != null) {
             if (PROJECT_VERSION_MAVEN_PROPERTY.equals(versionString)) {
                 return projectPomModel.getReleaseId().getVersion();


### PR DESCRIPTION
This solves version resolution when a version of a dependency is defined in pom.xml as either "${project.version}" or "${project.parent.version}". Without this, the build fails because it cannot resolve the dependencies of a KJar. 

Example:
KJar1 has dependency on KJar2. KieBase from KJar1 includes KieBase from KJar2. KJar 1 defines the dependency version of KJar2 as "${project.version}". 

@etirelli could you please review as Mario and Luca have PTO?