### PR TITLE
[DROOLS-4453] Proper handling of empty fields in collections + minor refactoring

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -34,7 +34,7 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
 
     protected boolean commonEvaluateUnaryExpression(Object rawExpression, Object resultValue, Class<?> resultClass) {
         if (resultClass != null && ScenarioSimulationSharedUtils.isCollection(resultClass.getCanonicalName())) {
-            return verifyResult(rawExpression, resultValue, resultClass);
+            return verifyResult(rawExpression, resultValue);
         } else {
             return internalUnaryEvaluation((String) rawExpression, resultValue, resultClass, false);
         }
@@ -107,7 +107,7 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
                 Object nestedObject = createObject(fieldDescriptor.getKey(), fieldDescriptor.getValue());
                 Object returnedObject = createAndFillObject((ObjectNode) jsonNode, nestedObject, fieldDescriptor.getKey(), fieldDescriptor.getValue());
                 setField(toReturn, key, returnedObject);
-            } else if (jsonNode.textValue() != null && !jsonNode.textValue().isEmpty()) {
+            } else if (!isEmptyText(jsonNode)) {
                 Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
                 setField(toReturn, key, internalLiteralEvaluation(jsonNode.textValue(), fieldDescriptor.getKey()));
             } else {
@@ -117,11 +117,8 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
         return toReturn;
     }
 
-    protected boolean verifyResult(Object rawExpression, Object resultRaw, Class<?> resultClass) {
-        if (resultRaw == null) {
-            return false;
-        }
-        if (!(resultRaw instanceof List) && !(resultRaw instanceof Map)) {
+    protected boolean verifyResult(Object rawExpression, Object resultRaw) {
+        if (resultRaw != null && !(resultRaw instanceof List) && !(resultRaw instanceof Map)) {
             throw new IllegalArgumentException("A list was expected");
         }
         if (!(rawExpression instanceof String)) {
@@ -133,9 +130,9 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
         try {
             JsonNode jsonNode = objectMapper.readTree(raw);
             if (jsonNode.isArray()) {
-                return verifyList((ArrayNode) jsonNode, (List) resultRaw, resultClass);
+                return verifyList((ArrayNode) jsonNode, (List) resultRaw);
             } else if (jsonNode.isObject()) {
-                return verifyObject((ObjectNode) jsonNode, resultRaw, resultClass);
+                return verifyObject((ObjectNode) jsonNode, resultRaw);
             }
             throw new IllegalArgumentException("Malformed raw data");
         } catch (IOException e) {
@@ -143,15 +140,17 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
         }
     }
 
-    protected boolean verifyList(ArrayNode json, List resultRaw, Class<?> resultClass) {
-
+    protected boolean verifyList(ArrayNode json, List resultRaw) {
+        if (resultRaw == null) {
+            return isListEmpty(json);
+        }
         for (JsonNode node : json) {
             boolean success = false;
             for (Object result : resultRaw) {
                 boolean simpleTypeNode = isSimpleTypeNode(node);
                 if (simpleTypeNode && internalUnaryEvaluation(getSimpleTypeNodeTextValue(node), result, result.getClass(), true)) {
                     success = true;
-                } else if (!simpleTypeNode && verifyObject((ObjectNode) node, result, resultClass)) {
+                } else if (!simpleTypeNode && verifyObject((ObjectNode) node, result)) {
                     success = true;
                 }
             }
@@ -162,36 +161,91 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
         return true;
     }
 
-    protected boolean verifyObject(ObjectNode json, Object result, Class<?> resultClass) {
+    protected boolean verifyObject(ObjectNode json, Object result) {
+        if (result == null) {
+            return isObjectEmpty(json);
+        }
         Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
         while (fields.hasNext()) {
             Map.Entry<String, JsonNode> element = fields.next();
             String key = element.getKey();
             JsonNode jsonNode = element.getValue();
             Object fieldValue = extractFieldValue(result, key);
-            if (fieldValue == null) {
-                return false;
-            }
-            // if is a simple value just return the parsed result
-            if (isSimpleTypeNode(jsonNode)) {
-                return internalUnaryEvaluation(getSimpleTypeNodeTextValue(jsonNode), fieldValue, fieldValue.getClass(), true);
-            }
+            Class<?> fieldClass = fieldValue != null ? fieldValue.getClass() : null;
 
-            if (jsonNode.isArray()) {
-                if (!verifyList((ArrayNode) jsonNode, (List) fieldValue, fieldValue.getClass())) {
+            if (isSimpleTypeNode(jsonNode)) {
+                if (!internalUnaryEvaluation(getSimpleTypeNodeTextValue(jsonNode), fieldValue, fieldClass, true)) {
+                    return false;
+                }
+            } else if (jsonNode.isArray()) {
+                if (!verifyList((ArrayNode) jsonNode, (List) fieldValue)) {
                     return false;
                 }
             } else if (jsonNode.isObject()) {
-                if (!verifyObject((ObjectNode) jsonNode, fieldValue, fieldValue.getClass())) {
+                if (!verifyObject((ObjectNode) jsonNode, fieldValue)) {
                     return false;
                 }
             } else {
-                if (!internalUnaryEvaluation(jsonNode.textValue(), fieldValue, fieldValue.getClass(), true)) {
+                if (!internalUnaryEvaluation(jsonNode.textValue(), fieldValue, fieldClass, true)) {
                     return false;
                 }
             }
         }
         return true;
+    }
+
+    /**
+     * Verify if given json node has all final values as empty strings
+     * @param json
+     * @return
+     */
+    protected boolean isNodeEmpty(JsonNode json) {
+        if (json.isArray()) {
+            return isListEmpty((ArrayNode) json);
+        } else if (json.isObject()) {
+            return isObjectEmpty((ObjectNode) json);
+        } else {
+            return isEmptyText(json);
+        }
+    }
+
+    /**
+     * Verify if all elements of given json array are empty
+     * @param json
+     * @return
+     */
+    protected boolean isListEmpty(ArrayNode json) {
+        for (JsonNode node : json) {
+            if (!isNodeEmpty(node)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Verify if all fields of given json object are empty
+     * @param json
+     * @return
+     */
+    protected boolean isObjectEmpty(ObjectNode json) {
+        Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
+        while (fields.hasNext()) {
+            JsonNode element = fields.next().getValue();
+            if (!isNodeEmpty(element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Verify if given json node text is empty
+     * @param jsonNode
+     * @return
+     */
+    protected boolean isEmptyText(JsonNode jsonNode) {
+        return jsonNode.textValue() == null || jsonNode.textValue().isEmpty();
     }
 
     /**

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -119,7 +119,7 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
 
     protected boolean verifyResult(Object rawExpression, Object resultRaw) {
         if (resultRaw != null && !(resultRaw instanceof List) && !(resultRaw instanceof Map)) {
-            throw new IllegalArgumentException("A list was expected");
+            throw new IllegalArgumentException("A list or map was expected");
         }
         if (!(rawExpression instanceof String)) {
             throw new IllegalArgumentException("Malformed raw data");
@@ -161,8 +161,8 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
         return true;
     }
 
-    protected boolean verifyObject(ObjectNode json, Object result) {
-        if (result == null) {
+    protected boolean verifyObject(ObjectNode json, Object resultRaw) {
+        if (resultRaw == null) {
             return isObjectEmpty(json);
         }
         Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
@@ -170,7 +170,7 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
             Map.Entry<String, JsonNode> element = fields.next();
             String key = element.getKey();
             JsonNode jsonNode = element.getValue();
-            Object fieldValue = extractFieldValue(result, key);
+            Object fieldValue = extractFieldValue(resultRaw, key);
             Class<?> fieldClass = fieldValue != null ? fieldValue.getClass() : null;
 
             if (isSimpleTypeNode(jsonNode)) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluator.java
@@ -67,6 +67,9 @@ public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
         if (rawExpression != null && skipEmptyString && rawExpression.isEmpty()) {
             return true;
         }
+        if (resultClass == null) {
+            return rawExpression == null || rawExpression.isEmpty();
+        }
         return BaseExpressionOperator.findOperator(rawExpression).eval(rawExpression, resultValue, resultClass, classLoader);
     }
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
@@ -143,6 +143,8 @@ public class AbstractExpressionEvaluatorTest {
     public void isNodeEmpty() {
         ObjectNode objectNode = new ObjectNode(factory);
         assertTrue(expressionEvaluatorMock.isNodeEmpty(objectNode));
+        objectNode.set("empty array", new ArrayNode(factory));
+        assertTrue(expressionEvaluatorMock.isNodeEmpty(objectNode));
         objectNode.set("key", new TextNode("value"));
         assertFalse(expressionEvaluatorMock.isNodeEmpty(objectNode));
 
@@ -162,6 +164,8 @@ public class AbstractExpressionEvaluatorTest {
         assertTrue(expressionEvaluatorMock.isListEmpty(json));
         ObjectNode nestedNode = new ObjectNode(factory);
         json.add(nestedNode);
+        assertTrue(expressionEvaluatorMock.isListEmpty(json));
+        nestedNode.set("emptyField", new TextNode(""));
         assertTrue(expressionEvaluatorMock.isListEmpty(json));
         nestedNode.set("notEmptyField", new TextNode("text"));
         assertFalse(expressionEvaluatorMock.isListEmpty(json));

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
@@ -139,6 +139,52 @@ public class AbstractExpressionEvaluatorTest {
         assertNull(expressionEvaluatorMock.getSimpleTypeNodeTextValue(jsonNode));
     }
 
+    @Test
+    public void isNodeEmpty() {
+        ObjectNode objectNode = new ObjectNode(factory);
+        assertTrue(expressionEvaluatorMock.isNodeEmpty(objectNode));
+        objectNode.set("key", new TextNode("value"));
+        assertFalse(expressionEvaluatorMock.isNodeEmpty(objectNode));
+
+        ArrayNode arrayNode = new ArrayNode(factory);
+        assertTrue(expressionEvaluatorMock.isNodeEmpty(arrayNode));
+        arrayNode.add(new TextNode("value"));
+        assertFalse(expressionEvaluatorMock.isNodeEmpty(arrayNode));
+
+        assertTrue(expressionEvaluatorMock.isNodeEmpty(new TextNode("")));
+        assertTrue(expressionEvaluatorMock.isNodeEmpty(new TextNode(null)));
+        assertFalse(expressionEvaluatorMock.isNodeEmpty(new TextNode("value")));
+    }
+
+    @Test
+    public void isListEmpty() {
+        ArrayNode json = new ArrayNode(factory);
+        assertTrue(expressionEvaluatorMock.isListEmpty(json));
+        ObjectNode nestedNode = new ObjectNode(factory);
+        json.add(nestedNode);
+        assertTrue(expressionEvaluatorMock.isListEmpty(json));
+        nestedNode.set("notEmptyField", new TextNode("text"));
+        assertFalse(expressionEvaluatorMock.isListEmpty(json));
+    }
+
+    @Test
+    public void isObjectEmpty() {
+        ObjectNode json = new ObjectNode(factory);
+        assertTrue(expressionEvaluatorMock.isObjectEmpty(json));
+        ObjectNode nestedNode = new ObjectNode(factory);
+        json.set("emptyField", nestedNode);
+        assertTrue(expressionEvaluatorMock.isObjectEmpty(json));
+        nestedNode.set("notEmptyField", new TextNode("text"));
+        assertFalse(expressionEvaluatorMock.isObjectEmpty(json));
+    }
+
+    @Test
+    public void isEmptyText() {
+        assertTrue(expressionEvaluatorMock.isEmptyText(new TextNode("")));
+        assertFalse(expressionEvaluatorMock.isEmptyText(new TextNode("value")));
+        assertTrue(expressionEvaluatorMock.isEmptyText(new ObjectNode(factory)));
+    }
+
     AbstractExpressionEvaluator expressionEvaluatorMock = new AbstractExpressionEvaluator() {
 
         @Override

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
@@ -121,6 +121,11 @@ public class BaseExpressionEvaluatorTest {
         assertFalse(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson, mapStringStringToCheck, Map.class));
         mapStringStringToCheck.put("key2", "value2");
         assertTrue(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson, mapStringStringToCheck, Map.class));
+
+        String mapOfStringJson1 = "{\"key1\" : {\"value\" : \"\"}}";
+        Map<String, String> mapStringStringToCheck1 = new HashMap<>();
+        mapStringStringToCheck1.put("key1", "value1");
+        assertTrue(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson1, mapStringStringToCheck1, Map.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -197,5 +202,8 @@ public class BaseExpressionEvaluatorTest {
 
         listJsonString = "[{\"value\" : \"> 100\"}]";
         assertFalse(expressionEvaluator.verifyResult(listJsonString, toCheck));
+
+        listJsonString = "[{\"value\" : \"\"}]";
+        assertTrue(expressionEvaluator.verifyResult(listJsonString, toCheck));
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
@@ -124,6 +124,7 @@ public class BaseExpressionEvaluatorTest {
 
         String mapOfStringJson1 = "{\"key1\" : {\"value\" : \"\"}}";
         Map<String, String> mapStringStringToCheck1 = new HashMap<>();
+        assertTrue(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson1, mapStringStringToCheck1, Map.class));
         mapStringStringToCheck1.put("key1", "value1");
         assertTrue(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson1, mapStringStringToCheck1, Map.class));
     }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/BaseExpressionEvaluatorTest.java
@@ -63,7 +63,22 @@ public class BaseExpressionEvaluatorTest {
 
     @Test
     public void verifyNullTest() {
-        assertFalse(expressionEvaluator.verifyResult("[]", null, List.class));
+        assertTrue(expressionEvaluator.verifyResult("[]", null));
+        assertFalse(expressionEvaluator.verifyResult("[{\"value\" : \"result\"}]", null));
+    }
+
+    @Test
+    public void nullResultTest() {
+        assertFalse(expressionEvaluator.evaluateUnaryExpression("> 1", null, null));
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("", null, null));
+        assertTrue(expressionEvaluator.evaluateUnaryExpression(null, null, null));
+
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("{}", null, Map.class));
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("[]", null, List.class));
+
+        String mapOfListJson = "{\"key1\" : [{\"value\" : \"value1\"}, {\"value\" : \"value2\"}]}";
+        Map<String, List<String>> mapOfListToCheck = new HashMap<>();
+        assertFalse(expressionEvaluator.evaluateUnaryExpression(mapOfListJson, mapOfListToCheck, Map.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -96,9 +111,16 @@ public class BaseExpressionEvaluatorTest {
         genericClasses.add(Integer.class.getCanonicalName());
         Map<String, Integer> resultToTest = new HashMap<>();
         resultToTest.put("Home", 120);
-        assertTrue(expressionEvaluator.verifyResult(expectWorkbenchMapInteger, resultToTest, Map.class));
+        assertTrue(expressionEvaluator.verifyResult(expectWorkbenchMapInteger, resultToTest));
         resultToTest.put("Home", 20);
-        assertFalse(expressionEvaluator.verifyResult(expectWorkbenchMapInteger, resultToTest, Map.class));
+        assertFalse(expressionEvaluator.verifyResult(expectWorkbenchMapInteger, resultToTest));
+
+        String mapOfStringJson = "{\"key1\" : {\"value\" : \"value1\"}, \"key2\" : {\"value\" : \"value2\"}}";
+        Map<String, String> mapStringStringToCheck = new HashMap<>();
+        mapStringStringToCheck.put("key1", "value1");
+        assertFalse(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson, mapStringStringToCheck, Map.class));
+        mapStringStringToCheck.put("key2", "value2");
+        assertTrue(expressionEvaluator.evaluateUnaryExpression(mapOfStringJson, mapStringStringToCheck, Map.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -133,9 +155,9 @@ public class BaseExpressionEvaluatorTest {
         element.setPhones(phones);
         toCheck.put("first", element);
 
-        assertTrue(expressionEvaluator.verifyResult(mapJsonString, toCheck, Map.class));
+        assertTrue(expressionEvaluator.verifyResult(mapJsonString, toCheck));
         phones.put("number", -1);
-        assertFalse(expressionEvaluator.verifyResult(mapJsonString, toCheck, Map.class));
+        assertFalse(expressionEvaluator.verifyResult(mapJsonString, toCheck));
     }
 
     @SuppressWarnings("unchecked")
@@ -152,10 +174,10 @@ public class BaseExpressionEvaluatorTest {
         assertEquals(2, parsedValue.get(1).getNames().size());
         assertTrue(parsedValue.get(1).getNames().contains("Anna"));
 
-        assertTrue(expressionEvaluator.verifyResult(listJsonString, parsedValue, List.class));
+        assertTrue(expressionEvaluator.verifyResult(listJsonString, parsedValue));
 
         parsedValue.get(1).setNames(new ArrayList<>());
-        assertFalse(expressionEvaluator.verifyResult(listJsonString, parsedValue, List.class));
+        assertFalse(expressionEvaluator.verifyResult(listJsonString, parsedValue));
     }
 
     @SuppressWarnings("unchecked")
@@ -171,9 +193,9 @@ public class BaseExpressionEvaluatorTest {
         listJsonString = "[{\"value\" : \"> 10\"}]";
         List<Integer> toCheck = Collections.singletonList(13);
 
-        assertTrue(expressionEvaluator.verifyResult(listJsonString, toCheck, List.class));
+        assertTrue(expressionEvaluator.verifyResult(listJsonString, toCheck));
 
         listJsonString = "[{\"value\" : \"> 100\"}]";
-        assertFalse(expressionEvaluator.verifyResult(listJsonString, toCheck, List.class));
+        assertFalse(expressionEvaluator.verifyResult(listJsonString, toCheck));
     }
 }


### PR DESCRIPTION
Management of empty values in collections was not correct on EXPECT side.
The correct logic is: if a value of a field in the collection has not been specified (= empty string in the json), it should be skipped.

Bug 1:
- Create a data object with a collection field (List or Map)
- Do not populate that field in GIVEN
- Add an empty check on that field in EXPECT (= add one or more elements to the collection but without specifying any value)
- It should not fail

Bug 2:
- Create a data object with a List of complex object (i.e. `Person(name, age)`) as field
- Populate that List with one or more elements without filling all the values (i.e. specify only `name` of `Person`)
- Add a valid check on the same field in EXPECT 
- It should not fail

https://issues.jboss.org/browse/DROOLS-4453

@jomarko @gitgabrio @Rikkola 