### PR TITLE
RHPAM-2307 Guided Scorecard can not be tested according its name

### DIFF
--- a/drools-core/src/main/java/org/drools/core/command/runtime/pmml/ApplyPmmlModelCommand.java
+++ b/drools-core/src/main/java/org/drools/core/command/runtime/pmml/ApplyPmmlModelCommand.java
@@ -36,6 +36,7 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.ruleunit.RuleUnitDescription;
 import org.drools.core.ruleunit.RuleUnitDescriptionRegistry;
 import org.drools.core.runtime.impl.ExecutionResultImpl;
+import org.drools.core.util.StringUtils;
 import org.kie.api.KieBase;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.pmml.OutputFieldFactory;
@@ -158,13 +159,20 @@ public class ApplyPmmlModelCommand implements ExecutableCommand<PMML4Result>, Id
     private List<String> calculatePossiblePackageNames(String modelId, String...knownPackageNames) {
         List<String> packageNames = new ArrayList<>();
         String javaModelId = modelId.replaceAll("\\s","");
+        String capJavaModelId = StringUtils.ucFirst(javaModelId);
         if (knownPackageNames != null && knownPackageNames.length > 0) {
             for (String knownPkgName: knownPackageNames) {
                 packageNames.add(knownPkgName + "." + javaModelId);
+                if (!javaModelId.equals(capJavaModelId)) {
+                    packageNames.add(knownPkgName + "." + capJavaModelId);
+                }
             }
         }
         String basePkgName = PmmlConstants.DEFAULT_ROOT_PACKAGE+"."+javaModelId;
         packageNames.add(basePkgName);
+        if (!javaModelId.equals(capJavaModelId)) {
+            packageNames.add(PmmlConstants.DEFAULT_ROOT_PACKAGE + "." + capJavaModelId);
+        }
         return packageNames;
     }
 

--- a/drools-scorecards/src/test/java/org/drools/scorecards/TestUtil.java
+++ b/drools-scorecards/src/test/java/org/drools/scorecards/TestUtil.java
@@ -16,7 +16,6 @@
 
 package org.drools.scorecards;
 
-import static org.drools.core.command.runtime.pmml.PmmlConstants.DEFAULT_ROOT_PACKAGE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -25,8 +24,10 @@ import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.ruleunit.RuleUnitDescription;
+import org.drools.core.util.StringUtils;
 import org.kie.api.runtime.rule.RuleUnit;
-import org.kie.pmml.pmml_4_2.model.PMML4UnitImpl;
+
+import static org.drools.core.command.runtime.pmml.PmmlConstants.DEFAULT_ROOT_PACKAGE;
 
 public final class TestUtil {
 
@@ -51,13 +52,20 @@ public final class TestUtil {
     public static List<String> calculatePossiblePackageNames(String modelId, String... knownPackageNames) {
         List<String> packageNames = new ArrayList<>();
         String javaModelId = modelId.replaceAll("\\s", "");
+        String capJavaModelId = StringUtils.ucFirst(javaModelId);
         if (knownPackageNames != null && knownPackageNames.length > 0) {
             for (String knownPkgName : knownPackageNames) {
                 packageNames.add(knownPkgName + "." + javaModelId);
+                if (!javaModelId.equals(capJavaModelId)) {
+                    packageNames.add(knownPkgName + "." + capJavaModelId);
+                }
             }
         }
         String basePkgName = DEFAULT_ROOT_PACKAGE + "." + javaModelId;
         packageNames.add(basePkgName);
+        if (!javaModelId.equals(capJavaModelId)) {
+            packageNames.add(DEFAULT_ROOT_PACKAGE + "." + capJavaModelId);
+        }
         return packageNames;
     }
 

--- a/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/test2/GuidedScoreCardIntegrationJavaClassesAddedToKieFileSystemTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-scorecard/src/test/java/org/drools/workbench/models/guided/scorecard/backend/test2/GuidedScoreCardIntegrationJavaClassesAddedToKieFileSystemTest.java
@@ -28,6 +28,7 @@ import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.ruleunit.RuleUnitDescription;
+import org.drools.core.util.StringUtils;
 import org.drools.workbench.models.guided.scorecard.backend.base.Helper;
 import org.drools.workbench.models.guided.scorecard.backend.test1.ApplicantAttribute;
 import org.junit.Ignore;
@@ -239,13 +240,20 @@ public class GuidedScoreCardIntegrationJavaClassesAddedToKieFileSystemTest {
     protected List<String> calculatePossiblePackageNames(String modelId, String... knownPackageNames) {
         List<String> packageNames = new ArrayList<>();
         String javaModelId = modelId.replaceAll("\\s", "");
+        String capJavaModelId = StringUtils.ucFirst(javaModelId);
         if (knownPackageNames != null && knownPackageNames.length > 0) {
             for (String knownPkgName : knownPackageNames) {
                 packageNames.add(knownPkgName + "." + javaModelId);
+                if (!javaModelId.equals(capJavaModelId)) {
+                    packageNames.add(knownPkgName+"."+capJavaModelId);
+                }
             }
         }
         String basePkgName = DEFAULT_ROOT_PACKAGE + "." + javaModelId;
         packageNames.add(basePkgName);
+        if (!javaModelId.equals(capJavaModelId)) {
+            packageNames.add(DEFAULT_ROOT_PACKAGE + "." + capJavaModelId);
+        }
         return packageNames;
     }
 }

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4ExecutionHelper.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4ExecutionHelper.java
@@ -15,8 +15,6 @@
  */
 package org.kie.pmml.pmml_4_2;
 
-import static org.drools.core.command.runtime.pmml.PmmlConstants.DEFAULT_ROOT_PACKAGE;
-
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +26,7 @@ import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.InternalRuleUnitExecutor;
 import org.drools.core.ruleunit.RuleUnitDescription;
+import org.drools.core.util.StringUtils;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.io.Resource;
@@ -41,8 +40,9 @@ import org.kie.api.runtime.rule.RuleUnit;
 import org.kie.api.runtime.rule.RuleUnitExecutor;
 import org.kie.internal.utils.KieHelper;
 import org.kie.pmml.pmml_4_2.model.AbstractPMMLData;
-import org.kie.pmml.pmml_4_2.model.PMML4UnitImpl;
 import org.kie.pmml.pmml_4_2.model.mining.SegmentExecution;
+
+import static org.drools.core.command.runtime.pmml.PmmlConstants.DEFAULT_ROOT_PACKAGE;
 
 public class PMML4ExecutionHelper {
 
@@ -352,12 +352,19 @@ public class PMML4ExecutionHelper {
     protected List<String> calculatePossiblePackageNames(String modelId, String... knownPackageNames) {
         List<String> packageNames = new ArrayList<>();
         String javaModelId = modelId.replaceAll("\\s", "");
+        String capJavaModelId = StringUtils.ucFirst(javaModelId);
         if (knownPackageNames != null && knownPackageNames.length > 0) {
             for (String knownPkgName : knownPackageNames) {
                 packageNames.add(knownPkgName + "." + javaModelId);
+                if (!javaModelId.equals(capJavaModelId)) {
+                    packageNames.add(knownPkgName + "." + capJavaModelId);
+                }
             }
         }
         packageNames.add(DEFAULT_ROOT_PACKAGE + "." + javaModelId);
+        if (!javaModelId.equals(capJavaModelId)) {
+            packageNames.add(DEFAULT_ROOT_PACKAGE + "." + capJavaModelId);
+        }
         return packageNames;
     }
 

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/PMMLExecutor.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/PMMLExecutor.java
@@ -16,8 +16,6 @@
 
 package org.kie.pmml.pmml_4_2;
 
-import static org.drools.core.command.runtime.pmml.PmmlConstants.DEFAULT_ROOT_PACKAGE;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +26,7 @@ import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.InternalRuleUnitExecutor;
 import org.drools.core.ruleunit.RuleUnitDescription;
+import org.drools.core.util.StringUtils;
 import org.kie.api.KieBase;
 import org.kie.api.logger.KieRuntimeLogger;
 import org.kie.api.pmml.PMML4Data;
@@ -36,7 +35,8 @@ import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.runtime.rule.DataSource;
 import org.kie.api.runtime.rule.RuleUnit;
 import org.kie.api.runtime.rule.RuleUnitExecutor;
-import org.kie.pmml.pmml_4_2.model.PMML4UnitImpl;
+
+import static org.drools.core.command.runtime.pmml.PmmlConstants.DEFAULT_ROOT_PACKAGE;
 
 public class PMMLExecutor {
     private KieBase kieBase;
@@ -116,13 +116,20 @@ public class PMMLExecutor {
     private List<String> calculatePossiblePackageNames(String modelId, String...knownPackageNames) {
         List<String> packageNames = new ArrayList<>();
         String javaModelId = modelId.replaceAll("\\s","");
+        String capJavaModelId = StringUtils.ucFirst(javaModelId);
         if (knownPackageNames != null && knownPackageNames.length > 0) {
             for (String knownPkgName: knownPackageNames) {
                 packageNames.add(knownPkgName + "." + javaModelId);
+                if (!javaModelId.equals(capJavaModelId)) {
+                    packageNames.add(knownPkgName + "." + capJavaModelId);
+                }
             }
         }
         String basePkgName = DEFAULT_ROOT_PACKAGE+"."+javaModelId;
         packageNames.add(basePkgName);
+        if (!javaModelId.equals(capJavaModelId)) {
+            packageNames.add(DEFAULT_ROOT_PACKAGE+"."+capJavaModelId);
+        }
         return packageNames;
     }
 

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/ScorecardTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/ScorecardTest.java
@@ -18,24 +18,17 @@ package org.kie.pmml.pmml_4_2.predictive.models;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.drools.core.command.RequestContextImpl;
 import org.drools.core.command.runtime.pmml.ApplyPmmlModelCommand;
-import org.drools.core.impl.InternalKnowledgeBase;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.io.Resource;
-import org.kie.api.io.ResourceType;
-import org.kie.api.pmml.PMML4Data;
 import org.kie.api.pmml.PMML4Result;
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.runtime.KieContainer;
-import org.kie.api.runtime.rule.DataSource;
-import org.kie.api.runtime.rule.RuleUnit;
-import org.kie.api.runtime.rule.RuleUnitExecutor;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.utils.KieHelper;
 import org.kie.pmml.pmml_4_2.DroolsAbstractPMMLTest;
@@ -65,19 +58,14 @@ public class ScorecardTest extends DroolsAbstractPMMLTest {
 
     @Test
     public void testMultipleInputData() throws Exception {
-        RuleUnitExecutor executor[] = new RuleUnitExecutor[3];
+        PMML4ExecutionHelper helpers[] = new PMML4ExecutionHelper[3];
         PMMLRequestData requestData[] = new PMMLRequestData[3];
         PMML4Result resultHolder[] = new PMML4Result[3];
         Resource res = ResourceFactory.newClassPathResource(source1);
-        kbase = new KieHelper().addResource(res, ResourceType.PMML).build();
-
-        executor[0] = RuleUnitExecutor.create().bind(kbase);
-        executor[1] = RuleUnitExecutor.create().bind(kbase);
-        executor[2] = RuleUnitExecutor.create().bind(kbase);
-
-        DataSource<PMMLRequestData> requests[] = new DataSource[3];
-        DataSource<PMML4Result> results[] = new DataSource[3];
-        DataSource<PMML4Data> pmmlDatas[] = new DataSource[3];
+        for (int c = 0; c < helpers.length; c++) {
+            helpers[c] = PMML4ExecutionHelperFactory.getExecutionHelper("Sample Score", res, null);
+            helpers[c].addPossiblePackageName("org.drools.scorecards.example");
+        }
 
         Double expectedScores[] = new Double[3];
         expectedScores[0] = 41.345;
@@ -107,28 +95,8 @@ public class ScorecardTest extends DroolsAbstractPMMLTest {
         requestData[2] = createRequest("125","Sample Score", 10.0, "STUDENT", "TN", false);
 
         for (int x = 0; x < 3; x++) {
-            requests[x] = executor[x].newDataSource("request");
-            results[x] = executor[x].newDataSource("results");
-            pmmlDatas[x] = executor[x].newDataSource("pmmlData");
-            resultHolder[x] = new PMML4Result(requestData[x].getCorrelationId());
+            resultHolder[x] = helpers[x].submitRequest(requestData[x]);
         }
-        List<String> possiblePackages = calculatePossiblePackageNames("Sample Score", "org.drools.scorecards.example");
-        Class<? extends RuleUnit> unitClass = getStartingRuleUnit("RuleUnitIndicator",(InternalKnowledgeBase)kbase,possiblePackages);
-
-        assertNotNull(unitClass);
-        for (int x = 0; x < 3; x++) {
-            executor[x].run(unitClass);
-        }
-
-        for (int y = 0; y < 3; y++) {
-            requests[y].insert(requestData[y]);
-            results[y].insert(resultHolder[y]);
-        }
-
-        for (int z = 0; z < 3; z++) {
-            executor[z].run(unitClass);
-        }
-
         for (int p = 0; p < 3; p++) {
             checkResult(resultHolder[p],expectedScores[p],expectedResults[p]);
         }
@@ -239,7 +207,7 @@ public class ScorecardTest extends DroolsAbstractPMMLTest {
 
     @Test
     public void testSimpleScorecard() {
-        PMML4ExecutionHelper helper = PMML4ExecutionHelperFactory.getExecutionHelper("SimpleScorecard",
+        PMML4ExecutionHelper helper = PMML4ExecutionHelperFactory.getExecutionHelper("simpleScorecard",
                 ResourceFactory.newClassPathResource(SOURCE_SIMPLE_SCORECARD),
                 null);
         PMMLRequestDataBuilder rdb = new PMMLRequestDataBuilder("123", helper.getModelName())
@@ -253,7 +221,7 @@ public class ScorecardTest extends DroolsAbstractPMMLTest {
         Assertions.assertThat(rankingMap.get("reasonCh1")).isEqualTo(5);
         Assertions.assertThat(rankingMap.get("reasonCh2")).isEqualTo(-6);
 
-        PMMLRequestDataBuilder rdb2 = new PMMLRequestDataBuilder("123", "SimpleScorecard")
+        PMMLRequestDataBuilder rdb2 = new PMMLRequestDataBuilder("123", "simpleScorecard")
                 .addParameter("param1", 51.0, Double.class)
                 .addParameter("param2", 12.0, Double.class);
         resultHolder = helper.submitRequest(rdb2.build());

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/SimpleRegressionTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/predictive/models/SimpleRegressionTest.java
@@ -16,25 +16,24 @@
 
 package org.kie.pmml.pmml_4_2.predictive.models;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.drools.core.impl.InternalKnowledgeBase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.kie.api.runtime.rule.RuleUnit;
-import org.kie.api.runtime.rule.RuleUnitExecutor;
-import org.kie.pmml.pmml_4_2.DroolsAbstractPMMLTest;
 import org.kie.api.pmml.PMML4Result;
 import org.kie.api.pmml.PMMLRequestData;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.pmml.pmml_4_2.DroolsAbstractPMMLTest;
+import org.kie.pmml.pmml_4_2.PMML4ExecutionHelper;
+import org.kie.pmml.pmml_4_2.PMML4ExecutionHelper.PMML4ExecutionHelperFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
 public class SimpleRegressionTest extends DroolsAbstractPMMLTest {
@@ -67,26 +66,16 @@ public class SimpleRegressionTest extends DroolsAbstractPMMLTest {
 
     @Test
     public void testRegression() throws Exception {
-    	RuleUnitExecutor executor = createExecutor(source1);
+        PMML4ExecutionHelper helper = PMML4ExecutionHelperFactory.getExecutionHelper("LinReg",
+                                                                                     ResourceFactory.newClassPathResource(source1),
+                                                                                     null);
     	
         PMMLRequestData request = new PMMLRequestData("123","LinReg");
         request.addRequestParam("fld1",fld1);
         request.addRequestParam("fld2", fld2);
         request.addRequestParam("fld3", fld3);
         
-        PMML4Result resultHolder = new PMML4Result();
-        
-        List<String> possiblePackages = calculatePossiblePackageNames("LinReg");
-        Class<? extends RuleUnit> unitClass = getStartingRuleUnit("RuleUnitIndicator",(InternalKnowledgeBase)kbase,possiblePackages);
-        assertNotNull(unitClass);
-        
-        int x = executor.run(unitClass);
-        
-        data.insert(request);
-        resultData.insert(resultHolder);
-        
-        executor.run(unitClass);
-        
+        PMML4Result resultHolder = helper.submitRequest(request);
         assertEquals("OK",resultHolder.getResultCode());
         assertNotNull(resultHolder.getResultValue("Fld4", null));
         Double value = resultHolder.getResultValue("Fld4", "value", Double.class).orElse(null);
@@ -105,25 +94,16 @@ public class SimpleRegressionTest extends DroolsAbstractPMMLTest {
 
     @Test
     public void testClassification() throws Exception {
-    	RuleUnitExecutor executor = createExecutor(source2);
+        PMML4ExecutionHelper helper = PMML4ExecutionHelperFactory.getExecutionHelper("LinReg",
+                                                                                     ResourceFactory.newClassPathResource(source2),
+                                                                                     null);
 
         PMMLRequestData request = new PMMLRequestData("123","LinReg");
         request.addRequestParam("fld1", fld1);
         request.addRequestParam("fld2", fld2);
         request.addRequestParam("fld3", fld3);
 
-        PMML4Result resultHolder = new PMML4Result();
-        
-        List<String> possiblePackages = calculatePossiblePackageNames("LinReg");
-        Class<? extends RuleUnit> unitClass = getStartingRuleUnit("RuleUnitIndicator",(InternalKnowledgeBase)kbase,possiblePackages);
-        assertNotNull(unitClass);
-        
-        
-        data.insert(request);
-        resultData.insert(resultHolder);
-        
-        executor.run(unitClass);
-
+        PMML4Result resultHolder = helper.submitRequest(request);
         Map<String, Double> probabilities = categoryProbabilities(fld1, fld2, fld3);
         String maxCategory = null;
         double maxValue = Double.MIN_VALUE;

--- a/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_scorecard_simple.pmml
+++ b/kie-pmml/src/test/resources/org/kie/pmml/pmml_4_2/test_scorecard_simple.pmml
@@ -9,7 +9,7 @@
     <DataField name="overallScore" optype="continuous" dataType="double" />
   </DataDictionary>
 
-  <Scorecard modelName="SimpleScorecard" useReasonCodes="true" isScorable="true" functionName="regression" baselineScore="14" initialScore="0.8">
+  <Scorecard modelName="simpleScorecard" useReasonCodes="true" isScorable="true" functionName="regression" baselineScore="14" initialScore="0.8">
     <MiningSchema>
       <MiningField name="param1" usageType="active" invalidValueTreatment="asMissing"></MiningField>
       <MiningField name="param2" usageType="active" invalidValueTreatment="asMissing"></MiningField>


### PR DESCRIPTION
* Fixed methods that are used to find the package with a RuleUnit, so
that the model name can be in either upper or lower case.
* Updated the unit tests in kie-pmml so that they all use the
PMML4ExecutionHelper. This allowed refactoring of other classes, to
remove duplicated methods for determining the RuleUnit class to be used.
* Updated one of the test PMML resources (in kie-pmml) so that it has a
model name that starts with a lower case letter. This should make sure
that we are testing models with both upper and lower case letters at the
start of the model name.