### PR TITLE
[DROOLS-4522] Add an "expression" property for every complex type in Scenario Testing

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/ConstantsHolder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/ConstantsHolder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.scenariosimulation.api;
+
+/**
+ * Class which contains shared Constants in Scenario Simulation module
+ */
+public class ConstantsHolder {
+
+    /* Constants for manage expressions type column */
+    public static final String EXPRESSION_CLASSNAME = "expression";
+    public static final String EXPRESSION_SUFFIX = "Expression";
+
+    private ConstantsHolder() {
+        // Not instantiable
+    }
+}

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/ConstantsHolder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/ConstantsHolder.java
@@ -21,7 +21,7 @@ package org.drools.scenariosimulation.api;
 public class ConstantsHolder {
 
     /* Constants for manage expressions type column */
-    public static final String EXPRESSION_CLASSNAME = "expression";
+    public static final String EXPRESSION_CLASSNAME = "scesim-exp";
     public static final String EXPRESSION_SUFFIX = "Expression";
 
     private ConstantsHolder() {

--- a/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/ConstantsHolder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/src/main/java/org/drools/scenariosimulation/api/ConstantsHolder.java
@@ -22,7 +22,7 @@ public class ConstantsHolder {
 
     /* Constants for manage expressions type column */
     public static final String EXPRESSION_CLASSNAME = "scesim-exp";
-    public static final String EXPRESSION_SUFFIX = "Expression";
+    public static final String EXPRESSION_SUFFIX = "ScesimExpression";
 
     private ConstantsHolder() {
         // Not instantiable


### PR DESCRIPTION
@jomarko @gitgabrio @danielezonca can you please test and review it?

This represents the first step of development for https://issues.jboss.org/browse/BAPL-1402

Basically, with the changes introduced in this PR, every complex type object in Scenario has an additional property ("expression") where it will be possible to add expression logic to the referred object (fact). At the moment, the changes involve only front-end side.

https://issues.jboss.org/browse/DROOLS-4522

Related PR: https://github.com/kiegroup/drools-wb/pull/1232