### PR TITLE
Added null value checker in `flushRule()`

### DIFF
--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/DefaultRuleSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/DefaultRuleSheetListener.java
@@ -304,6 +304,9 @@ implements RuleSheetListener {
      * As when there are merged/spanned cells, they may be left out.
      */
     private void flushRule() {
+        if ( sourceBuilders == null ) {
+            return;
+        }
         for ( SourceBuilder src : sourceBuilders ) {
             if ( src.hasValues() ) {
                 switch ( src.getActionTypeCode() ) {


### PR DESCRIPTION
Adding such check should prevent the following issue:

At `KieBuilder::buildAll()`, a decision table file that contains no rule table triggers a `NullPointerException` in the edited method, instead of a parser exception, which makes it hard to find the cause.