### PR TITLE
DROOLS-4629 DMN heuristic for invocation name

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -41,6 +41,7 @@ import org.kie.dmn.core.util.Msg;
 import org.kie.dmn.core.util.MsgUtil;
 import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.lang.CompiledExpression;
+import org.kie.dmn.feel.lang.impl.RootExecutionFrame;
 import org.kie.dmn.feel.runtime.FEELFunction;
 import org.kie.dmn.feel.runtime.UnaryTest;
 import org.kie.dmn.feel.runtime.decisiontables.DTDecisionRule;
@@ -187,6 +188,27 @@ public class DMNEvaluatorCompiler {
             return null;
         }
         String functionName = ((LiteralExpression) invocation.getExpression()).getText();
+        String[] fnameParts = functionName.split("\\.");
+        Optional<DMNNode> findAsDep = Optional.empty();
+        if (fnameParts.length == 2) {
+            QName importAlias = model.getImportNamespaceAndNameforAlias(fnameParts[0]);
+            findAsDep = node.getDependencies().values().stream().filter(d -> d.getModelNamespace().equals(importAlias.getNamespaceURI()) && d.getName().equals(fnameParts[1])).findAny();
+        } else {
+            findAsDep = node.getDependencies().values().stream().filter(d -> d.getName().equals(functionName)).findAny();
+        }
+        Object findAsBuiltin = RootExecutionFrame.INSTANCE.getValue(functionName);
+        if (!findAsDep.isPresent() && findAsBuiltin == null) {
+            MsgUtil.reportMessage(logger,
+                                  DMNMessage.Severity.WARN,
+                                  invocation,
+                                  model,
+                                  null,
+                                  null,
+                                  Msg.EXPRESSION_FOR_INVOCATION_NOT_RESOLVED,
+                                  functionName,
+                                  node.getIdentifierString(),
+                                  node.getDependencies().values().stream().map(DMNNode::getName).collect(Collectors.toList()));
+        }
         DMNInvocationEvaluator invEval = new DMNInvocationEvaluator(node.getName(), node.getSource(), functionName, invocation, null, ctx.getFeelHelper().newFEELInstance());
         for ( Binding binding : invocation.getBinding() ) {
             if( binding.getParameter() == null ) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/util/Msg.java
@@ -46,6 +46,7 @@ public final class Msg {
     public static final Message1 MISSING_EXPRESSION_FOR_DECISION                     = new Message1( DMNMessageType.MISSING_EXPRESSION, "Missing expression for Decision Node '%s'" );
     public static final Message1 MISSING_EXPRESSION_FOR_NODE                         = new Message1( DMNMessageType.MISSING_EXPRESSION, "Missing expression for Node '%s'" );
     public static final Message1 MISSING_EXPRESSION_FOR_INVOCATION                   = new Message1( DMNMessageType.MISSING_EXPRESSION, "Missing expression for invocation node '%s'" );
+    public static final Message3 EXPRESSION_FOR_INVOCATION_NOT_RESOLVED              = new Message3( DMNMessageType.REQ_NOT_FOUND, "The expression '%s' for invocation node '%s' did not resolve during compile time. In this DMN scope: %s" );
     public static final Message2 MISSING_EXPRESSION_FOR_PARAM_OF_INVOCATION          = new Message2( DMNMessageType.MISSING_EXPRESSION, "Missing expression for parameter %s on node '%s'");
     public static final Message1 MISSING_PARAMETER_FOR_INVOCATION                    = new Message1( DMNMessageType.MISSING_EXPRESSION, "Missing parameter for invocation node '%s'" );
     public static final Message2 MISSING_EXPRESSION_FOR_NAME                         = new Message2( DMNMessageType.MISSING_EXPRESSION, "No expression defined for name '%s' on node '%s'" );

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.kie.api.builder.Message.Level;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.api.core.DMNModel;
@@ -39,6 +40,7 @@ import org.kie.dmn.model.api.Definitions;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -114,7 +116,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testINVOCATION_MISSING_EXPR() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_MISSING_EXPR.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThan(0));
         assertThat( validate.get( 0 ).toString(), validate.get( 0 ).getMessageType(), is( DMNMessageType.MISSING_EXPRESSION ) );
     }
 
@@ -151,7 +153,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testINVOCATION_INCONSISTENT_PARAM_NAMES() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_INCONSISTENT_PARAM_NAMES.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThan(0));
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
     }
     
@@ -175,7 +177,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     @Test
     public void testINVOCATION_WRONG_PARAM_COUNT() {
         List<DMNMessage> validate = validator.validate( getReader( "INVOCATION_WRONG_PARAM_COUNT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), greaterThan(0));
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.PARAMETER_MISMATCH ) ) );
     }
     
@@ -367,5 +369,13 @@ public class ValidatorTest extends AbstractValidatorTest {
                                                      .theseModels(getReader("DSWithImport20181008-ModelA.dmn"),
                                                                   getReader("DSWithImport20181008-ModelB-missingDMNImport.dmn"));
         assertThat(missingDMNImport.stream().filter(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)).count(), is(2L)); // on Decision and Decision Service missing to locate the dependency given Import is omitted.
+    }
+
+    @Test
+    public void testInvalidFunctionNameInvocation() {
+        List<DMNMessage> validate = validator.validate(getReader("invalidFunctionNameInvocation.dmn"),
+                                                       VALIDATE_MODEL,
+                                                       VALIDATE_COMPILATION);
+        assertThat(validate.stream().filter(p -> p.getLevel() == Level.WARNING && p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)).count(), is(1L));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/invalidFunctionNameInvocation.dmn
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/invalidFunctionNameInvocation.dmn
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_C7686E06-29DE-407B-B83F-6F36FB3E8702" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_F74C92D9-78CE-4CED-99E8-A13777244959" name="a" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_C7686E06-29DE-407B-B83F-6F36FB3E8702">
+  <dmn:extensionElements/>
+  <dmn:businessKnowledgeModel id="_ADD5E543-4012-41F0-82AC-7178A3106EBC" name="Increaser">
+    <dmn:extensionElements/>
+    <dmn:variable id="_37DDDD42-67CB-473E-A83D-4854B309E687" name="Increaser" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_E050AEC7-49DD-4C9F-9410-9C9F323778A9" kind="FEEL">
+      <dmn:formalParameter id="_358944F6-F10E-40FA-B55A-59AD1F321302" name="num" typeRef="number"/>
+      <dmn:literalExpression id="_0857DA62-197C-4234-9DC8-B77E4C2B7EDC">
+        <dmn:text>num + 1</dmn:text>
+      </dmn:literalExpression>
+    </dmn:encapsulatedLogic>
+  </dmn:businessKnowledgeModel>
+  <dmn:decision id="_0F79585E-DD95-4129-BC92-7CB7F4476F93" name="Result">
+    <dmn:extensionElements/>
+    <dmn:variable id="_594F9C4F-B05C-46C8-B35B-BD83981B3924" name="Result" typeRef="number"/>
+    <dmn:informationRequirement id="_117DFF2E-C749-420B-91E4-3C48D48EA909">
+      <dmn:requiredInput href="#_9FDBA452-9CBF-4026-A0F4-D9AD959D93C4"/>
+    </dmn:informationRequirement>
+    <dmn:knowledgeRequirement id="_65C655EC-5E42-4F85-ADF2-C282DBDA450B">
+      <dmn:requiredKnowledge href="#_ADD5E543-4012-41F0-82AC-7178A3106EBC"/>
+    </dmn:knowledgeRequirement>
+    <dmn:invocation id="_8720AE7A-779E-4836-83A9-102F5F7E1DCF">
+      <dmn:literalExpression id="_8B4D0CBD-E79D-4B8C-9FE3-50B32C2BCDD7">
+        <dmn:text>Increase</dmn:text>
+      </dmn:literalExpression>
+      <dmn:binding>
+        <dmn:parameter id="_BC1B5AC8-D058-43C7-B4BA-FACF89852197" name="num" typeRef="number"/>
+        <dmn:literalExpression id="_F9AF49F5-7326-4B8E-B040-518E3361ACFD">
+          <dmn:text>NumInput</dmn:text>
+        </dmn:literalExpression>
+      </dmn:binding>
+    </dmn:invocation>
+  </dmn:decision>
+  <dmn:inputData id="_9FDBA452-9CBF-4026-A0F4-D9AD959D93C4" name="NumInput">
+    <dmn:extensionElements/>
+    <dmn:variable id="_29F4797A-ADA5-483B-BD66-9220FB5B7F50" name="NumInput" typeRef="number"/>
+  </dmn:inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_0857DA62-197C-4234-9DC8-B77E4C2B7EDC">
+            <kie:width>150.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_E050AEC7-49DD-4C9F-9410-9C9F323778A9">
+            <kie:width>50.0</kie:width>
+            <kie:width>150.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_8720AE7A-779E-4836-83A9-102F5F7E1DCF">
+            <kie:width>50.0</kie:width>
+            <kie:width>100.0</kie:width>
+            <kie:width>150.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_8B4D0CBD-E79D-4B8C-9FE3-50B32C2BCDD7"/>
+          <kie:ComponentWidths dmnElementRef="_F9AF49F5-7326-4B8E-B040-518E3361ACFD">
+            <kie:width>150.0</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_9FDBA452-9CBF-4026-A0F4-D9AD959D93C4" dmnElementRef="_9FDBA452-9CBF-4026-A0F4-D9AD959D93C4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="220" y="257" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_ADD5E543-4012-41F0-82AC-7178A3106EBC" dmnElementRef="_ADD5E543-4012-41F0-82AC-7178A3106EBC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="399" y="90" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_0F79585E-DD95-4129-BC92-7CB7F4476F93" dmnElementRef="_0F79585E-DD95-4129-BC92-7CB7F4476F93" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="257" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_117DFF2E-C749-420B-91E4-3C48D48EA909" dmnElementRef="_117DFF2E-C749-420B-91E4-3C48D48EA909">
+        <di:waypoint x="320" y="282"/>
+        <di:waypoint x="400" y="282"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_65C655EC-5E42-4F85-ADF2-C282DBDA450B" dmnElementRef="_65C655EC-5E42-4F85-ADF2-C282DBDA450B">
+        <di:waypoint x="449" y="140"/>
+        <di:waypoint x="450" y="257"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
Please note this is an heuristic, hence the `WARN` level, since the semantic for the function to be Invoked relies on LiteralExpression semantic, therefore it can only be fully determined in all cases at runtime. I took the point to improve anyway for the most cases, when some analysis can be done at compile time, indeed implementing this check as a warning.

@jomarko this will fix the problem you reported in https://issues.jboss.org/browse/RHDM-980?focusedCommentId=13796787&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13796787

@etirelli @baldimir @jiripetrlik 