### PR TITLE
[7.26.x]  DROOLS-4545 : GDST V&V: Clean up situations where the webworker fails

### DIFF
--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/CheckType.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/CheckType.java
@@ -33,7 +33,8 @@ public enum CheckType {
     SUBSUMPTANT_ROWS,
     MISSING_RANGE,
     SINGLE_HIT_LOST,
-    EMPTY_RULE;
+    EMPTY_RULE,
+    ILLEGAL_VERIFIER_STATE;
 
     public static Set<CheckType> getRowLevelCheckTypes() {
         return EnumSet.of(

--- a/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssue.java
+++ b/drools-verifier/drools-verifier-api/src/main/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssue.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.api.reporting;
+
+import java.util.Collections;
+
+public class IllegalVerifierStateIssue
+        extends Issue {
+
+    public IllegalVerifierStateIssue() {
+        super(Severity.ERROR,
+              CheckType.ILLEGAL_VERIFIER_STATE,
+              Collections.EMPTY_SET
+        );
+    }
+}

--- a/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssueTest.java
+++ b/drools-verifier/drools-verifier-core/src/test/java/org/drools/verifier/api/reporting/IllegalVerifierStateIssueTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.verifier.api.reporting;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IllegalVerifierStateIssueTest {
+
+    @Test
+    public void defaults() {
+
+        final IllegalVerifierStateIssue issue = new IllegalVerifierStateIssue();
+
+        assertEquals(Severity.ERROR, issue.getSeverity());
+        assertEquals(CheckType.ILLEGAL_VERIFIER_STATE, issue.getCheckType());
+        assertTrue(issue.getRowNumbers().isEmpty());
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4545

https://github.com/kiegroup/drools/pull/2592
https://github.com/kiegroup/kie-wb-common/pull/2952
https://github.com/kiegroup/drools-wb/pull/1244

(cherry picked from commit ace16724dfccef8ed55d159a547596f24d40f17a)

