### PR TITLE
DROOLS-4539: Prevent NPE in getting scenario result

### DIFF
--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/shared/VerifyFact.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/shared/VerifyFact.java
@@ -57,7 +57,7 @@ public class VerifyFact
 
     public boolean wasSuccessful() {
         for ( VerifyField verifyField : fieldValues ) {
-            if ( !verifyField.getSuccessResult().booleanValue() ) {
+            if ( verifyField.getSuccessResult() == null || !verifyField.getSuccessResult().booleanValue() ) {
                 return false;
             }
         }


### PR DESCRIPTION
During getting test scenario result we need to prevent NPE as we do not use `boolean` but `Boolean`

Dependent on:
- kiegroup/drools#2544

Ensemble together with:
- kiegroup/drools-wb#1243