### PR TITLE
[7.26.x] DROOLS-4601 : Escape characters added to code after editing comma separated list in guided rule editor

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -4112,7 +4112,7 @@ public class RuleModelDRLPersistenceImpl
             } else if (value.startsWith("(")) {
                 if (operator != null && operator.contains("in")) {
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
-                    con.setValue(unwrapParenthesis(value));
+                    con.setValue(String.join(", ", ListSplitter.split("\"", true, unwrapParenthesis(value))));
                 } else {
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_RET_VALUE);
                     con.setValue(unwrapParenthesis(value));

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -9563,4 +9563,27 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
         assertEqualsIgnoreWhitespace(drl,
                                      RuleModelDRLPersistenceImpl.getInstance().marshal(model));
     }
+
+    @Test
+    public void unmarshalStringListsCorrectly() {
+        final String drl = "package org.mortgages;\n" +
+                "rule \"aaa\"\n" +
+                "\tdialect \"mvel\"\n" +
+                "\twhen\n" +
+                "\t\tApplicant( applicantName : name in ( \"a\", \"b\", \"c\" ) )\n" +
+                "\tthen\n" +
+                "end";
+
+        when(dmo.getPackageName()).thenReturn("org.mortgages");
+
+        final RuleModel model = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                                    Collections.emptyList(),
+                                                                                    dmo);
+
+        SingleFieldConstraint fieldConstraint = model.getLHSBoundField("applicantName");
+
+        assertEquals("a, b, c", fieldConstraint.getValue());
+        assertEqualsIgnoreWhitespace(drl,
+                                     RuleModelDRLPersistenceImpl.getInstance().marshal(model));
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4601

(cherry picked from commit d5fdb7024364eb18554a1c944e51a476d61bdf5b)