### PR TITLE
[7.26.x] DROOLS-4539 : Legacy Test Scenario is failing when using java.time.LocalDate type field in expect part.

### DIFF
--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/populators/DateFieldPopulator.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/populators/DateFieldPopulator.java
@@ -23,7 +23,7 @@ import org.drools.workbench.models.testscenarios.backend.util.DateObjectFactory;
 
 public class DateFieldPopulator extends FieldPopulator {
 
-    private final Date value;
+    private final Object value;
 
     public DateFieldPopulator(Object factObject,
                               Class<?> fieldClass,

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/populators/DateFieldPopulator.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/populators/DateFieldPopulator.java
@@ -16,7 +16,6 @@
 package org.drools.workbench.models.testscenarios.backend.populators;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Date;
 import java.util.Map;
 
 import org.drools.workbench.models.testscenarios.backend.util.DateObjectFactory;
@@ -30,7 +29,7 @@ public class DateFieldPopulator extends FieldPopulator {
                               String fieldName,
                               String value) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         super(factObject, fieldName);
-        this.value = DateObjectFactory.createTimeObject(fieldClass, value);
+        this.value = DateObjectFactory.createDateObject(fieldClass, value);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactory.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactory.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,31 +11,37 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.drools.workbench.models.testscenarios.backend.util;
 
-import org.drools.core.util.DateUtils;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.drools.core.util.DateUtils;
 
 public class DateObjectFactory {
 
-    public static Date createTimeObject(Class<?> fieldClass,
-                                        String value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
-        Class<?> parameterTypes[] = new Class[1];
-        parameterTypes[0] = Long.TYPE;
-        Constructor<?> constructor
-                = fieldClass.getConstructor(parameterTypes);
-        Object args[] = new Object[1];
-        args[0] = getTimeAsLong(value);
-        return (Date) constructor.newInstance(args);
+    public static Object createTimeObject(final Class<?> fieldClass,
+                                          final String value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+
+        if (fieldClass.getName().equals("java.time.LocalDate")) {
+            return LocalDate.parse(value, DateTimeFormatter.ofPattern(DateUtils.getDateFormatMask()));
+        } else {
+
+            final Class<?> parameterTypes[] = new Class[1];
+            parameterTypes[0] = Long.TYPE;
+            final Constructor<?> constructor
+                    = fieldClass.getConstructor(parameterTypes);
+            final Object args[] = new Object[1];
+            args[0] = getTimeAsLong(value);
+            return constructor.newInstance(args);
+        }
     }
 
-    private static long getTimeAsLong(String value) {
+    private static long getTimeAsLong(final String value) {
         return DateUtils.parseDate(value).getTime();
     }
-
 }

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactory.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactory.java
@@ -24,21 +24,20 @@ import org.drools.core.util.DateUtils;
 
 public class DateObjectFactory {
 
-    public static Object createTimeObject(final Class<?> fieldClass,
+    public static LocalDate createLocalDateObject(final String value) {
+        return LocalDate.parse(value, DateTimeFormatter.ofPattern(DateUtils.getDateFormatMask()));
+    }
+
+    public static Object createDateObject(final Class<?> fieldClass,
                                           final String value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
 
-        if (fieldClass.getName().equals("java.time.LocalDate")) {
-            return LocalDate.parse(value, DateTimeFormatter.ofPattern(DateUtils.getDateFormatMask()));
-        } else {
-
-            final Class<?> parameterTypes[] = new Class[1];
-            parameterTypes[0] = Long.TYPE;
-            final Constructor<?> constructor
-                    = fieldClass.getConstructor(parameterTypes);
-            final Object args[] = new Object[1];
-            args[0] = getTimeAsLong(value);
-            return constructor.newInstance(args);
-        }
+        final Class<?> parameterTypes[] = new Class[1];
+        parameterTypes[0] = Long.TYPE;
+        final Constructor<?> constructor
+                = fieldClass.getConstructor(parameterTypes);
+        final Object args[] = new Object[1];
+        args[0] = getTimeAsLong(value);
+        return constructor.newInstance(args);
     }
 
     private static long getTimeAsLong(final String value) {

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolver.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolver.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.testscenarios.backend.util;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
 
 public class FieldTypeResolver {
 
@@ -31,7 +32,8 @@ public class FieldTypeResolver {
     public static boolean isDate(String fieldName, Object factObject) {
         for (Method method : factObject.getClass().getDeclaredMethods()) {
             if (hasMutator(fieldName, method)) {
-                if (java.util.Date.class.isAssignableFrom(method.getParameterTypes()[0])) {
+                if (java.util.Date.class.isAssignableFrom(method.getParameterTypes()[0])
+                        || LocalDate.class.isAssignableFrom(method.getParameterTypes()[0])) {
                     return true;
                 }
             }

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolver.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolver.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.drools.workbench.models.testscenarios.backend.util;
 
@@ -29,11 +29,23 @@ public class FieldTypeResolver {
         throw new IllegalArgumentException("No field named: " + fieldName);
     }
 
-    public static boolean isDate(String fieldName, Object factObject) {
+    public static boolean isLocalDate(final String fieldName,
+                                      final Object factObject) {
         for (Method method : factObject.getClass().getDeclaredMethods()) {
             if (hasMutator(fieldName, method)) {
-                if (java.util.Date.class.isAssignableFrom(method.getParameterTypes()[0])
-                        || LocalDate.class.isAssignableFrom(method.getParameterTypes()[0])) {
+                if (LocalDate.class.isAssignableFrom(method.getParameterTypes()[0])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean isDate(final String fieldName,
+                                 final Object factObject) {
+        for (Method method : factObject.getClass().getDeclaredMethods()) {
+            if (hasMutator(fieldName, method)) {
+                if (java.util.Date.class.isAssignableFrom(method.getParameterTypes()[0])) {
                     return true;
                 }
             }

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/verifiers/FactFieldValueVerifier.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/backend/verifiers/FactFieldValueVerifier.java
@@ -16,6 +16,13 @@
 
 package org.drools.workbench.models.testscenarios.backend.verifiers;
 
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import org.drools.core.util.MVELSafeHelper;
 import org.drools.workbench.models.testscenarios.backend.util.DateObjectFactory;
 import org.drools.workbench.models.testscenarios.backend.util.FieldTypeResolver;
@@ -26,13 +33,6 @@ import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
 import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.compiler.ExpressionCompiler;
-
-import java.io.Serializable;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 public class FactFieldValueVerifier {
 
@@ -108,13 +108,19 @@ public class FactFieldValueVerifier {
                 //Do nothing.
             }
         } else if (isFieldDate()) {
-            return DateObjectFactory.createTimeObject(FieldTypeResolver.getFieldType(currentField.getFieldName(), factObject), currentField.getExpected());
+            return DateObjectFactory.createDateObject(FieldTypeResolver.getFieldType(currentField.getFieldName(), factObject), currentField.getExpected());
+        } else if (isFieldLocalDate()) {
+            return DateObjectFactory.createLocalDateObject(currentField.getExpected());
         }
         return expectedResult;
     }
 
     private boolean isFieldDate() {
         return FieldTypeResolver.isDate(currentField.getFieldName(), factObject);
+    }
+
+    private boolean isFieldLocalDate() {
+        return FieldTypeResolver.isLocalDate(currentField.getFieldName(), factObject);
     }
 
     private String getSuccessfulExplanation() {

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactoryTest.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactoryTest.java
@@ -17,6 +17,7 @@ package org.drools.workbench.models.testscenarios.backend.util;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 import org.drools.core.util.DateUtils;
@@ -29,20 +30,35 @@ public class DateObjectFactoryTest {
 
     @Test
     public void date() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        final Object timeObject = DateObjectFactory.createTimeObject(Date.class, "12-Sep-2011");
+        final Object timeObject = DateObjectFactory.createDateObject(Date.class, "12-Sep-2011");
 
         assertTrue(timeObject instanceof Date);
         assertEquals("12-Sep-2011", DateUtils.format((Date) timeObject));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void dateInvalidValue() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        DateObjectFactory.createDateObject(Date.class, "12345");
+    }
+
+    @Test(expected = NoSuchMethodException.class)
+    public void dateInvalidClass() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        DateObjectFactory.createDateObject(String.class, "12-Sep-2011");
+    }
+
     @Test
-    public void localDate() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        final Object timeObject = DateObjectFactory.createTimeObject(LocalDate.class, "12-Sep-2011");
+    public void localDate() {
+        final Object timeObject = DateObjectFactory.createLocalDateObject("12-Sep-2011");
 
         assertTrue(timeObject instanceof LocalDate);
         final LocalDate localDate = (LocalDate) timeObject;
         assertEquals(2011, localDate.getYear());
         assertEquals(Month.SEPTEMBER, localDate.getMonth());
         assertEquals(12, localDate.getDayOfMonth());
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void localDateInvalidValue() {
+        DateObjectFactory.createLocalDateObject("1234");
     }
 }

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactoryTest.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/DateObjectFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.models.testscenarios.backend.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Date;
+
+import org.drools.core.util.DateUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DateObjectFactoryTest {
+
+    @Test
+    public void date() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        final Object timeObject = DateObjectFactory.createTimeObject(Date.class, "12-Sep-2011");
+
+        assertTrue(timeObject instanceof Date);
+        assertEquals("12-Sep-2011", DateUtils.format((Date) timeObject));
+    }
+
+    @Test
+    public void localDate() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        final Object timeObject = DateObjectFactory.createTimeObject(LocalDate.class, "12-Sep-2011");
+
+        assertTrue(timeObject instanceof LocalDate);
+        final LocalDate localDate = (LocalDate) timeObject;
+        assertEquals(2011, localDate.getYear());
+        assertEquals(Month.SEPTEMBER, localDate.getMonth());
+        assertEquals(12, localDate.getDayOfMonth());
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolverTest.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolverTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.models.testscenarios.backend.util;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FieldTypeResolverTest {
+
+    @Test
+    public void isDate() {
+        final Person person = new Person();
+        assertTrue(FieldTypeResolver.isDate("bday", person));
+        assertTrue(FieldTypeResolver.isDate("bdayLocalDate", person));
+        assertFalse(FieldTypeResolver.isDate("name", person));
+    }
+
+    class Person {
+
+        String name;
+        Date bday;
+        LocalDate bdayLocalDate;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Date getBday() {
+            return bday;
+        }
+
+        public void setBday(Date bday) {
+            this.bday = bday;
+        }
+
+        public LocalDate getBdayLocalDate() {
+            return bdayLocalDate;
+        }
+
+        public void setBdayLocalDate(LocalDate bdayLocalDate) {
+            this.bdayLocalDate = bdayLocalDate;
+        }
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolverTest.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/test/java/org/drools/workbench/models/testscenarios/backend/util/FieldTypeResolverTest.java
@@ -28,11 +28,19 @@ public class FieldTypeResolverTest {
     public void isDate() {
         final Person person = new Person();
         assertTrue(FieldTypeResolver.isDate("bday", person));
-        assertTrue(FieldTypeResolver.isDate("bdayLocalDate", person));
+        assertFalse(FieldTypeResolver.isDate("bdayLocalDate", person));
         assertFalse(FieldTypeResolver.isDate("name", person));
     }
 
-    class Person {
+    @Test
+    public void isLocalDate() {
+        final Person person = new Person();
+        assertFalse(FieldTypeResolver.isLocalDate("bday", person));
+        assertTrue(FieldTypeResolver.isLocalDate("bdayLocalDate", person));
+        assertFalse(FieldTypeResolver.isLocalDate("name", person));
+    }
+
+    static class Person {
 
         String name;
         Date bday;


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4539

@jomarko @danielezonca Same as master, the original is not yet merged, just needs to get the full build green. Opening this for 7.26.x to hopefully get a green build here before Friday. If you could please review. 

Keeping this as a draft so it does not get merged in before the one in master, but this is open for reviews.
Original: https://github.com/kiegroup/drools/pull/2544