### PR TITLE
DROOLS-4539: Clean up drools-workbench-models-test-scenarios dependen…

### DIFF
--- a/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
@@ -21,11 +21,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-workbench-models-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/resources/org/drools/workbench/models/testscenarios/DroolsWorkbenchModelsTestScenarios.gwt.xml
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/resources/org/drools/workbench/models/testscenarios/DroolsWorkbenchModelsTestScenarios.gwt.xml
@@ -20,8 +20,6 @@
     "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
 <module>
 
-  <inherits name='org.drools.workbench.models.commons.DroolsWorkbenchModelsCommon'/>
-
   <source path="shared"/>
 
 </module>


### PR DESCRIPTION
…cies

During https://issues.jboss.org/browse/DROOLS-4539 an unused dependency was found. This PR removes it.