### PR TITLE
[7.26.x] DROOLS-4539: Prevent NPE in getting scenario result (#2593)

### DIFF
--- a/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/shared/VerifyFact.java
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/src/main/java/org/drools/workbench/models/testscenarios/shared/VerifyFact.java
@@ -57,7 +57,7 @@ public class VerifyFact
 
     public boolean wasSuccessful() {
         for ( VerifyField verifyField : fieldValues ) {
-            if ( !verifyField.getSuccessResult().booleanValue() ) {
+            if ( verifyField.getSuccessResult() == null || !verifyField.getSuccessResult().booleanValue() ) {
                 return false;
             }
         }


### PR DESCRIPTION
During getting test scenario result we need to prevent NPE as we do not use `boolean` but `Boolean`

Cherry-pick of https://github.com/kiegroup/drools/commit/d1d891393afef5fae4f0506402326b724f3e6e33

Ensemble together with:
https://github.com/kiegroup/drools-wb/pull/1248