### PR TITLE
DROOLS-4650: Fix missing equals implementations

### DIFF
--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ActionRetractFact.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/ActionRetractFact.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.models.datamodel.rule;
 
+import java.util.Objects;
+
 /**
  * This is used to specify that the bound fact should be retracted
  * when the rule fires.
@@ -23,6 +25,8 @@ package org.drools.workbench.models.datamodel.rule;
 public class ActionRetractFact
         implements
         IAction {
+
+    private static final long serialVersionUID = 729l;
 
     public ActionRetractFact() {
     }
@@ -43,14 +47,14 @@ public class ActionRetractFact
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ActionRetractFact)) {
+            return false;
+        }
         ActionRetractFact that = (ActionRetractFact) o;
-
-        if (variableName != null ? !variableName.equals(that.variableName) : that.variableName != null) return false;
-
-        return true;
+        return Objects.equals(variableName, that.variableName);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/CEPWindow.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/CEPWindow.java
@@ -17,6 +17,7 @@ package org.drools.workbench.models.datamodel.rule;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Definition of a CEP Window
@@ -87,23 +88,20 @@ public class CEPWindow
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CEPWindow)) {
+            return false;
+        }
         CEPWindow cepWindow = (CEPWindow) o;
-
-        if (operator != null ? !operator.equals(cepWindow.operator) : cepWindow.operator != null) return false;
-        if (parameters != null ? !parameters.equals(cepWindow.parameters) : cepWindow.parameters != null) return false;
-
-        return true;
+        return Objects.equals(operator, cepWindow.operator) &&
+                Objects.equals(parameters, cepWindow.parameters);
     }
 
     @Override
     public int hashCode() {
-        int result = operator != null ? operator.hashCode() : 0;
-        result = ~~result;
-        result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
-        result = ~~result;
-        return result;
+
+        return Objects.hash(operator, parameters);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/ActionRetractFactTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/ActionRetractFactTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.datamodel.rule;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ActionRetractFactTest {
+
+    @Test
+    public void testSameActions() {
+        final ActionRetractFact retractCar = new ActionRetractFact("car");
+        final ActionRetractFact retractSameCar = new ActionRetractFact("car");
+
+        assertEquals(retractCar, retractSameCar);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final ActionRetractFact retractCar = new ActionRetractFact("car");
+        final ActionRetractFact retractBike = new ActionRetractFact("bike");
+
+        assertNotEquals(retractCar, retractBike);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionCol52.java
@@ -17,6 +17,6 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 
 public class ActionCol52 extends DTColumnConfig52 {
 
-    private static final long serialVersionUID = 501l;
+    private static final long serialVersionUID = 729l;
 
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionCol52.java
@@ -31,4 +31,8 @@ public class ActionCol52 extends DTColumnConfig52 {
         return super.equals(o);
     }
 
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionCol52.java
@@ -19,4 +19,16 @@ public class ActionCol52 extends DTColumnConfig52 {
 
     private static final long serialVersionUID = 729l;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ActionCol52)) {
+            return false;
+        }
+
+        return super.equals(o);
+    }
+
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionInsertFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionInsertFactCol52.java
@@ -16,10 +16,11 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ActionInsertFactCol52 extends ActionCol52 {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -183,25 +184,13 @@ public class ActionInsertFactCol52 extends ActionCol52 {
         if (!super.equals(o)) {
             return false;
         }
-
         ActionInsertFactCol52 that = (ActionInsertFactCol52) o;
-
-        if (isInsertLogical != that.isInsertLogical) {
-            return false;
-        }
-        if (factType != null ? !factType.equals(that.factType) : that.factType != null) {
-            return false;
-        }
-        if (boundName != null ? !boundName.equals(that.boundName) : that.boundName != null) {
-            return false;
-        }
-        if (factField != null ? !factField.equals(that.factField) : that.factField != null) {
-            return false;
-        }
-        if (type != null ? !type.equals(that.type) : that.type != null) {
-            return false;
-        }
-        return valueList != null ? valueList.equals(that.valueList) : that.valueList == null;
+        return isInsertLogical == that.isInsertLogical &&
+                Objects.equals(factType, that.factType) &&
+                Objects.equals(boundName, that.boundName) &&
+                Objects.equals(factField, that.factField) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(valueList, that.valueList);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Red Hat, Inc. and/or its affiliates.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -20,11 +20,21 @@ package org.drools.workbench.models.guided.dtable.shared.model;
  */
 public class ActionRetractFactCol52 extends ActionCol52 {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     //Columns not implementing LimitedEntryCol are for Extended Entry Decision Tables 
     //for which the values are held in the table data. Consequentially the identifier 
     //for the Fact being retracted will be contained in the table data. This class
     //is therefore effectively a marker-interface for this type of action.
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ActionRetractFactCol52)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
@@ -35,6 +35,9 @@ public class ActionRetractFactCol52 extends ActionCol52 {
         if (!(o instanceof ActionRetractFactCol52)) {
             return false;
         }
+        if (!super.equals(o)) {
+            return false;
+        }
         return true;
     }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
@@ -35,9 +35,6 @@ public class ActionRetractFactCol52 extends ActionCol52 {
         if (!(o instanceof ActionRetractFactCol52)) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
-        return true;
+        return super.equals(o);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionRetractFactCol52.java
@@ -37,4 +37,9 @@ public class ActionRetractFactCol52 extends ActionCol52 {
         }
         return super.equals(o);
     }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionSetFieldCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionSetFieldCol52.java
@@ -16,10 +16,11 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ActionSetFieldCol52 extends ActionCol52 {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -165,22 +166,12 @@ public class ActionSetFieldCol52 extends ActionCol52 {
         if (!super.equals(o)) {
             return false;
         }
-
         ActionSetFieldCol52 that = (ActionSetFieldCol52) o;
-
-        if (update != that.update) {
-            return false;
-        }
-        if (boundName != null ? !boundName.equals(that.boundName) : that.boundName != null) {
-            return false;
-        }
-        if (factField != null ? !factField.equals(that.factField) : that.factField != null) {
-            return false;
-        }
-        if (type != null ? !type.equals(that.type) : that.type != null) {
-            return false;
-        }
-        return valueList != null ? valueList.equals(that.valueList) : that.valueList == null;
+        return update == that.update &&
+                Objects.equals(boundName, that.boundName) &&
+                Objects.equals(factField, that.factField) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(valueList, that.valueList);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemCol52.java
@@ -18,6 +18,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.drools.workbench.models.datamodel.workitems.PortableParameterDefinition;
 import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
@@ -27,7 +28,7 @@ import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
  */
 public class ActionWorkItemCol52 extends ActionCol52 {
 
-    private static final long serialVersionUID = 540l;
+    private static final long serialVersionUID = 729l;
 
     private PortableWorkDefinition workItemDefinition;
 
@@ -169,10 +170,8 @@ public class ActionWorkItemCol52 extends ActionCol52 {
         if (!super.equals(o)) {
             return false;
         }
-
         ActionWorkItemCol52 that = (ActionWorkItemCol52) o;
-
-        return workItemDefinition != null ? workItemDefinition.equals(that.workItemDefinition) : that.workItemDefinition == null;
+        return Objects.equals(workItemDefinition, that.workItemDefinition);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemInsertFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemInsertFactCol52.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An Action to insert and set a field value on a new Fact with the value of a
@@ -23,7 +24,7 @@ import java.util.List;
  */
 public class ActionWorkItemInsertFactCol52 extends ActionInsertFactCol52 {
 
-    private static final long serialVersionUID = 540L;
+    private static final long serialVersionUID = 729L;
 
     private String workItemName;
 
@@ -111,16 +112,10 @@ public class ActionWorkItemInsertFactCol52 extends ActionInsertFactCol52 {
         if (!super.equals(o)) {
             return false;
         }
-
         ActionWorkItemInsertFactCol52 that = (ActionWorkItemInsertFactCol52) o;
-
-        if (workItemName != null ? !workItemName.equals(that.workItemName) : that.workItemName != null) {
-            return false;
-        }
-        if (workItemResultParameterName != null ? !workItemResultParameterName.equals(that.workItemResultParameterName) : that.workItemResultParameterName != null) {
-            return false;
-        }
-        return parameterClassName != null ? parameterClassName.equals(that.parameterClassName) : that.parameterClassName == null;
+        return Objects.equals(workItemName, that.workItemName) &&
+                Objects.equals(workItemResultParameterName, that.workItemResultParameterName) &&
+                Objects.equals(parameterClassName, that.parameterClassName);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemSetFieldCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemSetFieldCol52.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An Action to set an existing Fact's field value with the value of a Work Item
@@ -23,7 +24,7 @@ import java.util.List;
  */
 public class ActionWorkItemSetFieldCol52 extends ActionSetFieldCol52 {
 
-    private static final long serialVersionUID = 540l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -105,16 +106,10 @@ public class ActionWorkItemSetFieldCol52 extends ActionSetFieldCol52 {
         if (!super.equals(o)) {
             return false;
         }
-
         ActionWorkItemSetFieldCol52 that = (ActionWorkItemSetFieldCol52) o;
-
-        if (workItemName != null ? !workItemName.equals(that.workItemName) : that.workItemName != null) {
-            return false;
-        }
-        if (workItemResultParameterName != null ? !workItemResultParameterName.equals(that.workItemResultParameterName) : that.workItemResultParameterName != null) {
-            return false;
-        }
-        return parameterClassName != null ? parameterClassName.equals(that.parameterClassName) : that.parameterClassName == null;
+        return Objects.equals(workItemName, that.workItemName) &&
+                Objects.equals(workItemResultParameterName, that.workItemResultParameterName) &&
+                Objects.equals(parameterClassName, that.parameterClassName);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/AttributeCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/AttributeCol52.java
@@ -16,11 +16,14 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This is a rule attribute - eg salience, no-loop etc.
  */
 public class AttributeCol52 extends DTColumnConfig52 {
+
+    private static final long serialVersionUID = 729l;
 
     //Attribute name
     private String attribute;
@@ -122,16 +125,10 @@ public class AttributeCol52 extends DTColumnConfig52 {
         if (!super.equals(o)) {
             return false;
         }
-
         AttributeCol52 that = (AttributeCol52) o;
-
-        if (reverseOrder != that.reverseOrder) {
-            return false;
-        }
-        if (useRowNumber != that.useRowNumber) {
-            return false;
-        }
-        return attribute != null ? attribute.equals(that.attribute) : that.attribute == null;
+        return reverseOrder == that.reverseOrder &&
+                useRowNumber == that.useRowNumber &&
+                Objects.equals(attribute, that.attribute);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumn.java
@@ -17,6 +17,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.drools.workbench.models.datamodel.rule.IAction;
 
@@ -29,7 +30,7 @@ public class BRLActionColumn extends ActionCol52
         implements
         BRLColumn<IAction, BRLActionVariableColumn> {
 
-    private static final long serialVersionUID = 540l;
+    private static final long serialVersionUID = 729l;
 
     private List<IAction> definition = new ArrayList<IAction>();
 
@@ -128,13 +129,9 @@ public class BRLActionColumn extends ActionCol52
         if (!super.equals(o)) {
             return false;
         }
-
         BRLActionColumn that = (BRLActionColumn) o;
-
-        if (definition != null ? !definition.equals(that.definition) : that.definition != null) {
-            return false;
-        }
-        return childColumns != null ? childColumns.equals(that.childColumns) : that.childColumns == null;
+        return Objects.equals(definition, that.definition) &&
+                Objects.equals(childColumns, that.childColumns);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionVariableColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionVariableColumn.java
@@ -17,6 +17,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A column representing a single BRL fragment variable
@@ -25,7 +26,7 @@ public class BRLActionVariableColumn extends ActionCol52
         implements
         BRLVariableColumn {
 
-    private static final long serialVersionUID = 540l;
+    private static final long serialVersionUID = 729l;
 
     private String varName;
     private String fieldType;
@@ -133,19 +134,11 @@ public class BRLActionVariableColumn extends ActionCol52
         if (!super.equals(o)) {
             return false;
         }
-
         BRLActionVariableColumn that = (BRLActionVariableColumn) o;
-
-        if (varName != null ? !varName.equals(that.varName) : that.varName != null) {
-            return false;
-        }
-        if (fieldType != null ? !fieldType.equals(that.fieldType) : that.fieldType != null) {
-            return false;
-        }
-        if (factType != null ? !factType.equals(that.factType) : that.factType != null) {
-            return false;
-        }
-        return factField != null ? factField.equals(that.factField) : that.factField == null;
+        return Objects.equals(varName, that.varName) &&
+                Objects.equals(fieldType, that.fieldType) &&
+                Objects.equals(factType, that.factType) &&
+                Objects.equals(factField, that.factField);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumn.java
@@ -17,6 +17,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.drools.workbench.models.datamodel.rule.IPattern;
 
@@ -29,7 +30,7 @@ public class BRLConditionColumn extends ConditionCol52
         implements
         BRLColumn<IPattern, BRLConditionVariableColumn> {
 
-    private static final long serialVersionUID = 540l;
+    private static final long serialVersionUID = 729l;
 
     private List<IPattern> definition = new ArrayList<IPattern>();
 
@@ -128,13 +129,9 @@ public class BRLConditionColumn extends ConditionCol52
         if (!super.equals(o)) {
             return false;
         }
-
         BRLConditionColumn that = (BRLConditionColumn) o;
-
-        if (definition != null ? !definition.equals(that.definition) : that.definition != null) {
-            return false;
-        }
-        return childColumns != null ? childColumns.equals(that.childColumns) : that.childColumns == null;
+        return Objects.equals(definition, that.definition) &&
+                Objects.equals(childColumns, that.childColumns);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionVariableColumn.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionVariableColumn.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A column representing a single BRL fragment variable
@@ -29,7 +30,7 @@ public class BRLConditionVariableColumn extends ConditionCol52
      */
     public static final String FIELD_VAR_NAME = "varName";
     public static final String FIELD_FACT_TYPE = "factType";
-    private static final long serialVersionUID = 540l;
+    private static final long serialVersionUID = 729l;
     private String varName;
     private String factType;
 
@@ -111,13 +112,9 @@ public class BRLConditionVariableColumn extends ConditionCol52
         if (!super.equals(o)) {
             return false;
         }
-
         BRLConditionVariableColumn that = (BRLConditionVariableColumn) o;
-
-        if (varName != null ? !varName.equals(that.varName) : that.varName != null) {
-            return false;
-        }
-        return factType != null ? factType.equals(that.factType) : that.factType == null;
+        return Objects.equals(varName, that.varName) &&
+                Objects.equals(factType, that.factType);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModel.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/BRLRuleModel.java
@@ -18,6 +18,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
@@ -276,7 +277,7 @@ public class BRLRuleModel extends RuleModel {
                     final int colIndex = dtable.getExpandedColumns().indexOf(col);
                     for (List<DTCellValue52> row : dtable.getData()) {
                         DTCellValue52 cell = row.get(colIndex);
-                        if (cell != null && cell.getStringValue().equals(binding)) {
+                        if (cell != null && Objects.equals(cell.getStringValue(), binding)) {
                             return true;
                         }
                     }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.HasParameterizedOperator;
@@ -33,7 +34,7 @@ public class ConditionCol52 extends DTColumnConfig52
         HasParameterizedOperator,
         HasBinding {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     // The type of the value that is in the cell, eg if it is a formula, or
     // literal value etc. The valid types are from ISingleFieldConstraint:
@@ -56,7 +57,7 @@ public class ConditionCol52 extends DTColumnConfig52
     private String valueList;
 
     //CEP operators' parameters
-    private Map<String, String> parameters;
+    private Map<String, String> parameters = new HashMap<>();
 
     //Binding for the field
     private String binding;
@@ -187,11 +188,11 @@ public class ConditionCol52 extends DTColumnConfig52
     }
 
     public void clearParameters() {
-        this.parameters = null;
+        this.parameters.clear();
     }
 
     public String getParameter( String key ) {
-        if ( parameters == null ) {
+        if ( parameters.isEmpty() ) {
             return null;
         }
         String parameter = parameters.get( key );
@@ -200,24 +201,15 @@ public class ConditionCol52 extends DTColumnConfig52
 
     public void setParameter( String key,
                               String parameter ) {
-        if ( parameters == null ) {
-            parameters = new HashMap<String, String>();
-        }
         parameters.put( key,
                         parameter );
     }
 
     public void deleteParameter( String key ) {
-        if ( this.parameters == null ) {
-            return;
-        }
         parameters.remove( key );
     }
 
     public Map<String, String> getParameters() {
-        if ( this.parameters == null ) {
-            this.parameters = new HashMap<String, String>();
-        }
         return this.parameters;
     }
 
@@ -248,28 +240,14 @@ public class ConditionCol52 extends DTColumnConfig52
         if (!super.equals(o)) {
             return false;
         }
-
         ConditionCol52 that = (ConditionCol52) o;
-
-        if (constraintValueType != that.constraintValueType) {
-            return false;
-        }
-        if (factField != null ? !factField.equals(that.factField) : that.factField != null) {
-            return false;
-        }
-        if (fieldType != null ? !fieldType.equals(that.fieldType) : that.fieldType != null) {
-            return false;
-        }
-        if (operator != null ? !operator.equals(that.operator) : that.operator != null) {
-            return false;
-        }
-        if (valueList != null ? !valueList.equals(that.valueList) : that.valueList != null) {
-            return false;
-        }
-        if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) {
-            return false;
-        }
-        return binding != null ? binding.equals(that.binding) : that.binding == null;
+        return constraintValueType == that.constraintValueType &&
+                Objects.equals(factField, that.factField) &&
+                Objects.equals(fieldType, that.fieldType) &&
+                Objects.equals(operator, that.operator) &&
+                Objects.equals(valueList, that.valueList) &&
+                Objects.equals(parameters, that.parameters) &&
+                Objects.equals(binding, that.binding);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52.java
@@ -17,12 +17,13 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class DTColumnConfig52
         implements BaseColumn,
                    DiffColumn {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -174,25 +175,12 @@ public class DTColumnConfig52
         if (!(o instanceof DTColumnConfig52)) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
-
         DTColumnConfig52 that = (DTColumnConfig52) o;
-
-        if (hideColumn != that.hideColumn) {
-            return false;
-        }
-        if (width != that.width) {
-            return false;
-        }
-        if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that.defaultValue != null) {
-            return false;
-        }
-        if (typedDefaultValue != null ? !typedDefaultValue.equals(that.typedDefaultValue) : that.typedDefaultValue != null) {
-            return false;
-        }
-        return header != null ? header.equals(that.header) : that.header == null;
+        return hideColumn == that.hideColumn &&
+                width == that.width &&
+                Objects.equals(defaultValue, that.defaultValue) &&
+                Objects.equals(typedDefaultValue, that.typedDefaultValue) &&
+                Objects.equals(header, that.header);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DescriptionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DescriptionCol52.java
@@ -43,4 +43,8 @@ public class DescriptionCol52 extends DTColumnConfig52 {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DescriptionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/DescriptionCol52.java
@@ -20,13 +20,27 @@ package org.drools.workbench.models.guided.dtable.shared.model;
  */
 public class DescriptionCol52 extends DTColumnConfig52 {
 
-    private static final long serialVersionUID = -306736594255777798L;
+    private static final long serialVersionUID = 729l;
 
     private static final DTCellValue52 DEFAULT_DESCRIPTION = new DTCellValue52( "" );
 
     @Override
     public DTCellValue52 getDefaultValue() {
         return DEFAULT_DESCRIPTION;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DescriptionCol52)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionInsertFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionInsertFactCol52.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A column that sets a field on a new fact.
@@ -24,7 +25,7 @@ public class LimitedEntryActionInsertFactCol52 extends ActionInsertFactCol52
         implements
         LimitedEntryCol {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -72,10 +73,8 @@ public class LimitedEntryActionInsertFactCol52 extends ActionInsertFactCol52
         if (!super.equals(o)) {
             return false;
         }
-
         LimitedEntryActionInsertFactCol52 that = (LimitedEntryActionInsertFactCol52) o;
-
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionRetractFactCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionRetractFactCol52.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A column representing the retraction of a Fact on a Limited Entry decision
@@ -26,7 +27,7 @@ public class LimitedEntryActionRetractFactCol52 extends ActionRetractFactCol52
         implements
         LimitedEntryCol {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -74,10 +75,8 @@ public class LimitedEntryActionRetractFactCol52 extends ActionRetractFactCol52
         if (!super.equals(o)) {
             return false;
         }
-
         LimitedEntryActionRetractFactCol52 that = (LimitedEntryActionRetractFactCol52) o;
-
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionSetFieldCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionSetFieldCol52.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A column that sets the value of an existing fact.
@@ -24,7 +25,7 @@ public class LimitedEntryActionSetFieldCol52 extends ActionSetFieldCol52
         implements
         LimitedEntryCol {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     /**
      * Available fields for this type of column.
@@ -72,10 +73,8 @@ public class LimitedEntryActionSetFieldCol52 extends ActionSetFieldCol52
         if (!super.equals(o)) {
             return false;
         }
-
         LimitedEntryActionSetFieldCol52 that = (LimitedEntryActionSetFieldCol52) o;
-
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryConditionCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryConditionCol52.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This is the config for a condition column that supports Limited Entry, hence
@@ -25,7 +26,7 @@ public class LimitedEntryConditionCol52 extends ConditionCol52
         implements
         LimitedEntryCol {
 
-    private static final long serialVersionUID = 510l;
+    private static final long serialVersionUID = 729l;
 
     private DTCellValue52 value;
 
@@ -67,16 +68,14 @@ public class LimitedEntryConditionCol52 extends ConditionCol52
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof LimitedEntryConditionCol52)) {
             return false;
         }
         if (!super.equals(o)) {
             return false;
         }
-
         LimitedEntryConditionCol52 that = (LimitedEntryConditionCol52) o;
-
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/MetadataCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/MetadataCol52.java
@@ -16,11 +16,14 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This is a rule metadata - eg @foo(bar) etc.
  */
 public class MetadataCol52 extends DTColumnConfig52 {
+
+    private static final long serialVersionUID = 729l;
 
     private String metadata;
 
@@ -79,10 +82,8 @@ public class MetadataCol52 extends DTColumnConfig52 {
         if (!super.equals(o)) {
             return false;
         }
-
         MetadataCol52 that = (MetadataCol52) o;
-
-        return metadata != null ? metadata.equals(that.metadata) : that.metadata == null;
+        return Objects.equals(metadata, that.metadata);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52.java
@@ -17,6 +17,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.drools.workbench.models.datamodel.rule.CEPWindow;
 import org.drools.workbench.models.datamodel.rule.HasCEPWindow;
@@ -242,25 +243,13 @@ public class Pattern52
         if (!super.equals(o)) {
             return false;
         }
-
         Pattern52 pattern52 = (Pattern52) o;
-
-        if (isNegated != pattern52.isNegated) {
-            return false;
-        }
-        if (factType != null ? !factType.equals(pattern52.factType) : pattern52.factType != null) {
-            return false;
-        }
-        if (boundName != null ? !boundName.equals(pattern52.boundName) : pattern52.boundName != null) {
-            return false;
-        }
-        if (conditions != null ? !conditions.equals(pattern52.conditions) : pattern52.conditions != null) {
-            return false;
-        }
-        if (window != null ? !window.equals(pattern52.window) : pattern52.window != null) {
-            return false;
-        }
-        return entryPointName != null ? entryPointName.equals(pattern52.entryPointName) : pattern52.entryPointName == null;
+        return isNegated == pattern52.isNegated &&
+                Objects.equals(factType, pattern52.factType) &&
+                Objects.equals(boundName, pattern52.boundName) &&
+                Objects.equals(conditions, pattern52.conditions) &&
+                Objects.equals(window, pattern52.window) &&
+                Objects.equals(entryPointName, pattern52.entryPointName);
     }
 
     @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52.java
@@ -240,9 +240,6 @@ public class Pattern52
         if (!(o instanceof Pattern52)) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
         Pattern52 pattern52 = (Pattern52) o;
         return isNegated == pattern52.isNegated &&
                 Objects.equals(factType, pattern52.factType) &&

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/RowNumberCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/RowNumberCol52.java
@@ -22,11 +22,21 @@ public class RowNumberCol52 extends DTColumnConfig52 {
 
     private static final long serialVersionUID = -2272148755430209968L;
 
-    private static final DTCellValue52 DEFAULT_ROW_NUMBER = new DTCellValue52( new Integer( 0 ) );
+    private static final DTCellValue52 DEFAULT_ROW_NUMBER = new DTCellValue52(new Integer(0));
 
     @Override
     public DTCellValue52 getDefaultValue() {
         return DEFAULT_ROW_NUMBER;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RowNumberCol52)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/RowNumberCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/RowNumberCol52.java
@@ -42,4 +42,9 @@ public class RowNumberCol52 extends DTColumnConfig52 {
         }
         return true;
     }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/RowNumberCol52.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/model/RowNumberCol52.java
@@ -20,7 +20,7 @@ package org.drools.workbench.models.guided.dtable.shared.model;
  */
 public class RowNumberCol52 extends DTColumnConfig52 {
 
-    private static final long serialVersionUID = -2272148755430209968L;
+    private static final long serialVersionUID = 729l;
 
     private static final DTCellValue52 DEFAULT_ROW_NUMBER = new DTCellValue52(new Integer(0));
 
@@ -35,6 +35,9 @@ public class RowNumberCol52 extends DTColumnConfig52 {
             return true;
         }
         if (!(o instanceof RowNumberCol52)) {
+            return false;
+        }
+        if (!super.equals(o)) {
             return false;
         }
         return true;

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionCol52Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.model;
+
+import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ActionCol52Test {
+
+    @Test
+    public void testSameActions() {
+        final ActionCol52 action = new ActionCol52();
+        final ActionCol52 sameAction = new ActionCol52();
+
+        assertEquals(action, sameAction);
+    }
+
+    @Test
+    public void testDifferentClasses() {
+        final ActionCol52 action = new ActionCol52();
+        final ConditionCol52 differentClass = new ConditionCol52();
+
+        assertNotEquals(action, differentClass);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionInsertFactCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionInsertFactCol52Test.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.model;
+
+import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ActionInsertFactCol52Test {
+
+    @Test
+    public void testSameActions() {
+        final ActionInsertFactCol52 insertPerson = new ActionInsertFactCol52();
+        insertPerson.setBoundName("$p");
+        insertPerson.setFactType("Person");
+        insertPerson.setFactField("age");
+        insertPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionInsertFactCol52 insertSamePerson = new ActionInsertFactCol52();
+        insertSamePerson.setBoundName("$p");
+        insertSamePerson.setFactType("Person");
+        insertSamePerson.setFactField("age");
+        insertSamePerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertEquals(insertPerson, insertSamePerson);
+    }
+
+    @Test
+    public void testDifferentBinding() {
+        final ActionInsertFactCol52 insertPerson = new ActionInsertFactCol52();
+        insertPerson.setBoundName("$p1");
+        insertPerson.setFactType("Person");
+        insertPerson.setFactField("age");
+        insertPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionInsertFactCol52 insertDifferentPerson = new ActionInsertFactCol52();
+        insertDifferentPerson.setBoundName("$p2");
+        insertDifferentPerson.setFactType("Person");
+        insertDifferentPerson.setFactField("age");
+        insertDifferentPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(insertPerson, insertDifferentPerson);
+    }
+
+    @Test
+    public void testDifferentFacts() {
+        final ActionInsertFactCol52 insertPerson = new ActionInsertFactCol52();
+        insertPerson.setBoundName("$p1");
+        insertPerson.setFactType("Person");
+        insertPerson.setFactField("age");
+        insertPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionInsertFactCol52 insertDifferentPerson = new ActionInsertFactCol52();
+        insertDifferentPerson.setBoundName("$p1");
+        insertDifferentPerson.setFactType("Human");
+        insertDifferentPerson.setFactField("age");
+        insertDifferentPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(insertPerson, insertDifferentPerson);
+    }
+
+    @Test
+    public void testDifferentFields() {
+        final ActionInsertFactCol52 insertPerson = new ActionInsertFactCol52();
+        insertPerson.setBoundName("$p1");
+        insertPerson.setFactType("Person");
+        insertPerson.setFactField("age");
+        insertPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionInsertFactCol52 insertDifferentPerson = new ActionInsertFactCol52();
+        insertDifferentPerson.setBoundName("$p1");
+        insertDifferentPerson.setFactType("Person");
+        insertDifferentPerson.setFactField("childrenCount");
+        insertDifferentPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(insertPerson, insertDifferentPerson);
+    }
+
+    @Test
+    public void testDifferentDataType() {
+        final ActionInsertFactCol52 insertPerson = new ActionInsertFactCol52();
+        insertPerson.setBoundName("$p1");
+        insertPerson.setFactType("Person");
+        insertPerson.setFactField("age");
+        insertPerson.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionInsertFactCol52 insertDifferentPerson = new ActionInsertFactCol52();
+        insertDifferentPerson.setBoundName("$p1");
+        insertDifferentPerson.setFactType("Person");
+        insertDifferentPerson.setFactField("age");
+        insertDifferentPerson.setType(DataType.TYPE_NUMERIC_BIGINTEGER);
+
+        assertNotEquals(insertPerson, insertDifferentPerson);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final ActionInsertFactCol52 insertAction = new ActionInsertFactCol52();
+        final ActionRetractFactCol52 retractAction = new ActionRetractFactCol52();
+
+        assertNotEquals(insertAction, retractAction);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionRetractFactCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionRetractFactCol52Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.model;
+
+import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ActionRetractFactCol52Test {
+
+    @Test
+    public void testSameActions() {
+        final ActionRetractFactCol52 retractAction = new ActionRetractFactCol52();
+        final ActionRetractFactCol52 sameRetractAction = new ActionRetractFactCol52();
+
+        assertEquals(retractAction, sameRetractAction);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final ActionInsertFactCol52 insertAction = new ActionInsertFactCol52();
+        final ActionRetractFactCol52 retractAction = new ActionRetractFactCol52();
+
+        assertNotEquals(insertAction, retractAction);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionSetFieldCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionSetFieldCol52Test.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.model;
+
+import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.junit.Test;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ActionSetFieldCol52Test {
+
+    @Test
+    public void testSameActions() {
+        final ActionSetFieldCol52 setAge = new ActionSetFieldCol52();
+        setAge.setBoundName("$p");
+        setAge.setFactField("age");
+        setAge.setUpdate(false);
+        setAge.setValueList("18,19,20");
+        setAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionSetFieldCol52 setSameAge = new ActionSetFieldCol52();
+        setSameAge.setBoundName("$p");
+        setSameAge.setFactField("age");
+        setSameAge.setUpdate(false);
+        setSameAge.setValueList("18,19,20");
+        setSameAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertEquals(setAge, setSameAge);
+    }
+
+    @Test
+    public void testDifferentBinding() {
+        final ActionSetFieldCol52 setAge = new ActionSetFieldCol52();
+        setAge.setBoundName("$p1");
+        setAge.setFactField("age");
+        setAge.setUpdate(false);
+        setAge.setValueList("18,19,20");
+        setAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionSetFieldCol52 setAgeOfSomeoneElse = new ActionSetFieldCol52();
+        setAgeOfSomeoneElse.setBoundName("$p2");
+        setAgeOfSomeoneElse.setFactField("age");
+        setAgeOfSomeoneElse.setUpdate(false);
+        setAgeOfSomeoneElse.setValueList("18,19,20");
+        setAgeOfSomeoneElse.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(setAge, setAgeOfSomeoneElse);
+    }
+
+    @Test
+    public void testDifferentFields() {
+        final ActionSetFieldCol52 setAge = new ActionSetFieldCol52();
+        setAge.setBoundName("$p");
+        setAge.setFactField("age");
+        setAge.setUpdate(false);
+        setAge.setValueList("18,19,20");
+        setAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionSetFieldCol52 setHeight = new ActionSetFieldCol52();
+        setHeight.setBoundName("$p");
+        setHeight.setFactField("height");
+        setHeight.setUpdate(false);
+        setHeight.setValueList("18,19,20");
+        setHeight.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(setAge, setHeight);
+    }
+
+    @Test
+    public void testDifferentPossibilities() {
+        final ActionSetFieldCol52 setAge = new ActionSetFieldCol52();
+        setAge.setBoundName("$p");
+        setAge.setFactField("age");
+        setAge.setUpdate(false);
+        setAge.setValueList("18,19,20");
+        setAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionSetFieldCol52 setHigherAge = new ActionSetFieldCol52();
+        setHigherAge.setBoundName("$p");
+        setHigherAge.setFactField("age");
+        setHigherAge.setUpdate(false);
+        setHigherAge.setValueList("19,20");
+        setHigherAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(setAge, setHigherAge);
+    }
+
+    @Test
+    public void testDifferentDataType() {
+        final ActionSetFieldCol52 setAge = new ActionSetFieldCol52();
+        setAge.setBoundName("$p1");
+        setAge.setUpdate(false);
+        setAge.setFactField("age");
+        setAge.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionSetFieldCol52 setAgeWithBiggerRange = new ActionSetFieldCol52();
+        setAgeWithBiggerRange.setBoundName("$p1");
+        setAgeWithBiggerRange.setUpdate(false);
+        setAgeWithBiggerRange.setFactField("age");
+        setAgeWithBiggerRange.setType(DataType.TYPE_NUMERIC_BIGINTEGER);
+
+        assertNotEquals(setAge, setAgeWithBiggerRange);
+    }
+
+    @Test
+    public void testDifferentHandling() {
+        final ActionSetFieldCol52 justSet = new ActionSetFieldCol52();
+        justSet.setBoundName("$p1");
+        justSet.setUpdate(false);
+        justSet.setFactField("age");
+        justSet.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        final ActionSetFieldCol52 setAndUpdate = new ActionSetFieldCol52();
+        setAndUpdate.setBoundName("$p1");
+        setAndUpdate.setUpdate(true);
+        setAndUpdate.setFactField("age");
+        setAndUpdate.setType(DataType.TYPE_NUMERIC_INTEGER);
+
+        assertNotEquals(justSet, setAndUpdate);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final ActionSetFieldCol52 insertAction = new ActionSetFieldCol52();
+        final ActionRetractFactCol52 retractAction = new ActionRetractFactCol52();
+
+        assertNotEquals(insertAction, retractAction);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionWorkItemCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/model/ActionWorkItemCol52Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.model;
+
+import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ActionWorkItemCol52Test {
+
+    @Test
+    public void testSameActions() {
+        final PortableWorkDefinition restWorkItemDefinition = new PortableWorkDefinition();
+        restWorkItemDefinition.setName("rest service");
+
+        final ActionWorkItemCol52 invokeRest = new ActionWorkItemCol52();
+        invokeRest.setWorkItemDefinition(restWorkItemDefinition);
+
+        final ActionWorkItemCol52 invokeSameRest = new ActionWorkItemCol52();
+        invokeSameRest.setWorkItemDefinition(restWorkItemDefinition);
+
+        assertEquals(invokeRest, invokeSameRest);
+    }
+
+    @Test
+    public void testDifferentWorkItemDefinitions() {
+        final PortableWorkDefinition restWorkItemDefinition = new PortableWorkDefinition();
+        restWorkItemDefinition.setName("rest service");
+
+        final ActionWorkItemCol52 invokeRestService = new ActionWorkItemCol52();
+        invokeRestService.setWorkItemDefinition(restWorkItemDefinition);
+
+        final PortableWorkDefinition logWorkItemDefinition = new PortableWorkDefinition();
+        logWorkItemDefinition.setName("log service");
+
+        final ActionWorkItemCol52 invokeLogService = new ActionWorkItemCol52();
+        invokeLogService.setWorkItemDefinition(logWorkItemDefinition);
+
+        assertNotEquals(invokeRestService, invokeLogService);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final ActionWorkItemCol52 workItemAction = new ActionWorkItemCol52();
+        final ActionRetractFactCol52 retractAction = new ActionRetractFactCol52();
+
+        assertNotEquals(workItemAction, retractAction);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemInsertFactCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemInsertFactCol52Test.java
@@ -29,6 +29,7 @@ import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnCon
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HEADER;
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HIDE_COLUMN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
@@ -75,6 +76,7 @@ public class ActionWorkItemInsertFactCol52Test extends ColumnTestBase {
     @Test
     public void testDiffEmpty() {
         checkDiffEmpty(column1, column2);
+        assertEquals(column1, column2);
     }
 
     @Test
@@ -83,6 +85,7 @@ public class ActionWorkItemInsertFactCol52Test extends ColumnTestBase {
         column2.setWorkItemName("WID2");
 
         checkSingleDiff(FIELD_WORK_ITEM_NAME, "WID1", "WID2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -91,6 +94,7 @@ public class ActionWorkItemInsertFactCol52Test extends ColumnTestBase {
         column2.setWorkItemResultParameterName("param2");
 
         checkSingleDiff(FIELD_WORK_ITEM_RESULT_PARAM_NAME, "param1", "param2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -99,6 +103,7 @@ public class ActionWorkItemInsertFactCol52Test extends ColumnTestBase {
         column2.setParameterClassName("Type2");
 
         checkSingleDiff(FIELD_PARAMETER_CLASSNAME, "Type1", "Type2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -168,5 +173,6 @@ public class ActionWorkItemInsertFactCol52Test extends ColumnTestBase {
         assertEquals(FIELD_PARAMETER_CLASSNAME, diff.get(11).getFieldName());
         assertEquals("Type1", diff.get(11).getOldValue());
         assertEquals("Type2", diff.get(11).getValue());
+        assertNotEquals(column1, column2);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemSetFieldCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ActionWorkItemSetFieldCol52Test.java
@@ -28,6 +28,7 @@ import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnCon
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HEADER;
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HIDE_COLUMN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
@@ -72,6 +73,7 @@ public class ActionWorkItemSetFieldCol52Test extends ColumnTestBase {
     @Test
     public void testDiffEmpty() {
         checkDiffEmpty(column1, column2);
+        assertEquals(column1, column2);
     }
 
     @Test
@@ -80,6 +82,7 @@ public class ActionWorkItemSetFieldCol52Test extends ColumnTestBase {
         column2.setWorkItemName("WID2");
 
         checkSingleDiff(FIELD_WORK_ITEM_NAME, "WID1", "WID2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -88,6 +91,7 @@ public class ActionWorkItemSetFieldCol52Test extends ColumnTestBase {
         column2.setWorkItemResultParameterName("param2");
 
         checkSingleDiff(FIELD_WORK_ITEM_RESULT_PARAM_NAME, "param1", "param2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -96,6 +100,7 @@ public class ActionWorkItemSetFieldCol52Test extends ColumnTestBase {
         column2.setParameterClassName("Type2");
 
         checkSingleDiff(FIELD_PARAMETER_CLASSNAME, "Type1", "Type2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -160,5 +165,6 @@ public class ActionWorkItemSetFieldCol52Test extends ColumnTestBase {
         assertEquals(FIELD_PARAMETER_CLASSNAME, diff.get(10).getFieldName());
         assertEquals("Type1", diff.get(10).getOldValue());
         assertEquals("Type2", diff.get(10).getValue());
+        assertNotEquals(column1, column2);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumnTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BRLActionColumnTest.java
@@ -22,6 +22,7 @@ import static org.drools.workbench.models.guided.dtable.shared.model.ConditionCo
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HEADER;
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HIDE_COLUMN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
@@ -59,6 +60,7 @@ public class BRLActionColumnTest extends ColumnTestBase {
     @Test
     public void testDiffEmpty() {
         checkDiffEmpty(column1, column2);
+        assertEquals(column1, column2);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class BRLActionColumnTest extends ColumnTestBase {
         column2.setDefinition(definition2);
 
         checkSingleDiff(FIELD_DEFINITION, definition1, definition2, column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -87,6 +90,7 @@ public class BRLActionColumnTest extends ColumnTestBase {
         assertEquals(FIELD_FIELD_TYPE, diff.get(1).getFieldName());
         assertEquals("FieldType1", diff.get(1).getOldValue());
         assertEquals("FieldType2", diff.get(1).getValue());
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -123,5 +127,6 @@ public class BRLActionColumnTest extends ColumnTestBase {
         assertEquals(FIELD_FIELD_TYPE, diff.get(4).getFieldName());
         assertEquals("FieldType1", diff.get(4).getOldValue());
         assertEquals("FieldType2", diff.get(4).getValue());
+        assertNotEquals(column1, column2);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumnTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/BRLConditionColumnTest.java
@@ -22,6 +22,7 @@ import static org.drools.workbench.models.guided.dtable.shared.model.ConditionCo
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HEADER;
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HIDE_COLUMN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
@@ -59,6 +60,7 @@ public class BRLConditionColumnTest extends ColumnTestBase {
     @Test
     public void testDiffEmpty() {
         checkDiffEmpty(column1, column2);
+        assertEquals(column1, column2);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class BRLConditionColumnTest extends ColumnTestBase {
         column2.setDefinition(definition2);
 
         checkSingleDiff(FIELD_DEFINITION, definition1, definition2, column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -87,6 +90,7 @@ public class BRLConditionColumnTest extends ColumnTestBase {
         assertEquals(FIELD_VAR_NAME, diff.get(1).getFieldName());
         assertEquals("var1", diff.get(1).getOldValue());
         assertEquals("var2", diff.get(1).getValue());
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -122,5 +126,6 @@ public class BRLConditionColumnTest extends ColumnTestBase {
         assertEquals(FIELD_VAR_NAME, diff.get(4).getFieldName());
         assertEquals("var1", diff.get(4).getOldValue());
         assertEquals("var2", diff.get(4).getValue());
+        assertNotEquals(column1, column2);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/ConditionCol52Test.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.models.guided.dtable.shared.model;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.junit.Before;
@@ -56,6 +57,18 @@ public class ConditionCol52Test extends ColumnTestBase {
         column2.setHeader( "header" );
         column2.setHideColumn( false );
         column2.setDefaultValue( new DTCellValue52( "default" ) );
+    }
+
+    @Test
+    public void testEquals() {
+        assertTrue(Objects.equals(column1, column2));
+    }
+
+    @Test
+    public void testEqualsWithParametersCall() {
+        column1.getParameters();
+
+        assertTrue(Objects.equals(column1, column2));
     }
 
     @Test

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/DTColumnConfig52Test.java
@@ -16,16 +16,18 @@
 
 package org.drools.workbench.models.guided.dtable.shared.model;
 
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_DEFAULT_VALUE;
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HEADER;
 import static org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52.FIELD_HIDE_COLUMN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 public class DTColumnConfig52Test extends ColumnTestBase {
 
@@ -43,6 +45,11 @@ public class DTColumnConfig52Test extends ColumnTestBase {
         column2.setHeader("header");
         column2.setHideColumn(false);
         column2.setDefaultValue(new DTCellValue52("default"));
+    }
+
+    @Test
+    public void testEquals() {
+        assertTrue(Objects.equals(column1, column2));
     }
 
     @Test

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/DescriptionCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/DescriptionCol52Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class DescriptionCol52Test {
+
+    @Test
+    public void testSameDescriptions() {
+        final DescriptionCol52 aDescription = new DescriptionCol52();
+        aDescription.setDefaultValue(new DTCellValue52("a description"));
+        final DescriptionCol52 sameDescription = new DescriptionCol52();
+        sameDescription.setDefaultValue(new DTCellValue52("a description"));
+
+        assertEquals(aDescription, sameDescription);
+    }
+
+    @Test
+    public void testDifferentDescriptions() {
+        final DescriptionCol52 aDescription = new DescriptionCol52();
+        aDescription.setDefaultValue(new DTCellValue52("a description"));
+        final DescriptionCol52 differentDescription = new DescriptionCol52();
+        differentDescription.setDefaultValue(new DTCellValue52("a different description"));
+
+        assertNotEquals(aDescription, differentDescription);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionInsertFactCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionInsertFactCol52Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class LimitedEntryActionInsertFactCol52Test {
+    @Test
+    public void testSameInsertActions() {
+        final LimitedEntryActionInsertFactCol52 insert = new LimitedEntryActionInsertFactCol52();
+        insert.setDefaultValue(new DTCellValue52(true));
+        final LimitedEntryActionInsertFactCol52 sameInsert = new LimitedEntryActionInsertFactCol52();
+        sameInsert.setDefaultValue(new DTCellValue52(true));
+
+        assertEquals(insert, sameInsert);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final LimitedEntryActionInsertFactCol52 insert = new LimitedEntryActionInsertFactCol52();
+        insert.setDefaultValue(new DTCellValue52(true));
+        final LimitedEntryActionInsertFactCol52 notInsert = new LimitedEntryActionInsertFactCol52();
+        notInsert.setDefaultValue(new DTCellValue52(false));
+
+        assertNotEquals(insert, notInsert);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionRetractFactCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionRetractFactCol52Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class LimitedEntryActionRetractFactCol52Test {
+
+    @Test
+    public void testSameRetractActions() {
+        final LimitedEntryActionRetractFactCol52 retract = new LimitedEntryActionRetractFactCol52();
+        retract.setDefaultValue(new DTCellValue52(true));
+        final LimitedEntryActionRetractFactCol52 sameRetract = new LimitedEntryActionRetractFactCol52();
+        sameRetract.setDefaultValue(new DTCellValue52(true));
+
+        assertEquals(retract, sameRetract);
+    }
+
+    @Test
+    public void testDifferentRetractActions() {
+        final LimitedEntryActionRetractFactCol52 retract = new LimitedEntryActionRetractFactCol52();
+        retract.setDefaultValue(new DTCellValue52(true));
+        final LimitedEntryActionRetractFactCol52 notRetract = new LimitedEntryActionRetractFactCol52();
+        notRetract.setDefaultValue(new DTCellValue52(false));
+
+        assertNotEquals(retract, notRetract);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionSetFieldCol52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/LimitedEntryActionSetFieldCol52Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.models.guided.dtable.shared.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class LimitedEntryActionSetFieldCol52Test {
+
+    @Test
+    public void testSameSetFieldActions() {
+        final LimitedEntryActionSetFieldCol52 set = new LimitedEntryActionSetFieldCol52();
+        set.setDefaultValue(new DTCellValue52(true));
+        final LimitedEntryActionSetFieldCol52 sameSet = new LimitedEntryActionSetFieldCol52();
+        sameSet.setDefaultValue(new DTCellValue52(true));
+
+        assertEquals(set, sameSet);
+    }
+
+    @Test
+    public void testDifferentActions() {
+        final LimitedEntryActionSetFieldCol52 set = new LimitedEntryActionSetFieldCol52();
+        set.setDefaultValue(new DTCellValue52(true));
+        final LimitedEntryActionSetFieldCol52 notSet = new LimitedEntryActionSetFieldCol52();
+        notSet.setDefaultValue(new DTCellValue52(false));
+
+        assertNotEquals(set, notSet);
+    }
+}

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52Test.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/shared/model/Pattern52Test.java
@@ -22,6 +22,7 @@ import static org.drools.workbench.models.guided.dtable.shared.model.Pattern52.F
 import static org.drools.workbench.models.guided.dtable.shared.model.Pattern52.FIELD_IS_NEGATED;
 import static org.drools.workbench.models.guided.dtable.shared.model.Pattern52.FIELD_WINDOW;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
@@ -54,6 +55,7 @@ public class Pattern52Test extends ColumnTestBase {
 
     @Test
     public void testDiffEmpty() {
+        assertEquals(column1, column2);
         checkDiffEmpty(column1, column2);
     }
 
@@ -63,6 +65,7 @@ public class Pattern52Test extends ColumnTestBase {
         column2.setFactType("Fact2");
 
         checkSingleDiff(FIELD_FACT_TYPE, "Fact1", "Fact2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -71,6 +74,7 @@ public class Pattern52Test extends ColumnTestBase {
         column2.setBoundName("$var2");
 
         checkSingleDiff(FIELD_BOUND_NAME, "$var1", "$var2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -79,6 +83,7 @@ public class Pattern52Test extends ColumnTestBase {
         column2.setNegated(true);
 
         checkSingleDiff(FIELD_IS_NEGATED, false, true, column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -92,6 +97,7 @@ public class Pattern52Test extends ColumnTestBase {
         column2.setWindow(window2);
 
         checkSingleDiff(FIELD_WINDOW, window1, window2, column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -100,6 +106,7 @@ public class Pattern52Test extends ColumnTestBase {
         column2.setEntryPointName("entryPoint2");
 
         checkSingleDiff(FIELD_ENTRY_POINT_NAME, "entryPoint1", "entryPoint2", column1, column2);
+        assertNotEquals(column1, column2);
     }
 
     @Test
@@ -149,5 +156,6 @@ public class Pattern52Test extends ColumnTestBase {
         assertEquals(column1.getWindow(), clone.getWindow());
         assertEquals(column1.getEntryPointName(), clone.getEntryPointName());
         assertEquals(column1.isNegated(), clone.isNegated());
+        assertEquals(column1, clone);
     }
 }


### PR DESCRIPTION
In original DROOLS-4650 PR we missed some equals implementations what caused to fail tests in drools-wb repository. This PR fixes it.

Ensemble together wit:
https://github.com/kiegroup/drools-wb/pull/1252