### PR TITLE
DTAnalysis should skip gaps/overlaps for Collect decision tables

### DIFF
--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyser.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/dtanalysis/DMNDTAnalyser.java
@@ -50,6 +50,7 @@ import org.kie.dmn.feel.lang.impl.UnaryTestInterpretedExecutableExpression;
 import org.kie.dmn.feel.runtime.Range.RangeBoundary;
 import org.kie.dmn.model.api.DecisionRule;
 import org.kie.dmn.model.api.DecisionTable;
+import org.kie.dmn.model.api.HitPolicy;
 import org.kie.dmn.model.api.InputClause;
 import org.kie.dmn.model.api.ItemDefinition;
 import org.kie.dmn.model.api.LiteralExpression;
@@ -108,10 +109,12 @@ public class DMNDTAnalyser {
         compileTableRules(dt, ddtaTable);
         printDebugTableInfo(ddtaTable);
         DTAnalysis analysis = new DTAnalysis(dt, ddtaTable);
-        LOG.debug("findGaps");
-        findGaps(analysis, ddtaTable, 0, new Interval[ddtaTable.inputCols()], Collections.emptyList());
-        LOG.debug("findOverlaps");
-        findOverlaps(analysis, ddtaTable, 0, new Interval[ddtaTable.inputCols()], Collections.emptyList());
+        if (!dt.getHitPolicy().equals(HitPolicy.COLLECT)) {
+            LOG.debug("findGaps");
+            findGaps(analysis, ddtaTable, 0, new Interval[ddtaTable.inputCols()], Collections.emptyList());
+            LOG.debug("findOverlaps");
+            findOverlaps(analysis, ddtaTable, 0, new Interval[ddtaTable.inputCols()], Collections.emptyList());
+        }
         LOG.debug("computeMaskedRules");
         analysis.computeMaskedRules();
         LOG.debug("computeMisleadingRules");

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/dtanalysis/OverlapHitPolicyTest.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +53,8 @@ public class OverlapHitPolicyTest extends AbstractDTAnalysisTest {
 
     @Parameterized.Parameters(name = "using {0}")
     public static Collection<HitPolicy> data() {
-        return Arrays.asList(HitPolicy.values());
+        // Overlaps are not checked for COLLECT hit policy
+        return Arrays.asList(HitPolicy.values()).stream().filter(hp-> hp!= HitPolicy.COLLECT).collect(Collectors.toList());
     }
 
     @Test


### PR DESCRIPTION
@tarilabs  I believe that tables that output collections should not be checked by the DTAnalysis. Bruce original code did not check them as well.

Certainly collect tables should not be analyzed for gaps since its not a bad practice to have gaps in a collect table, it just yields an empty output and its fine. For example, a table that calculate all the rebates a customer can have access to could return no elements if the customer is not eligible to anything.