### PR TITLE
DROOLS-4745 DMN v1.3 support

### DIFF
--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_2/xstream/RuleAnnotationClauseConverter.java
@@ -55,7 +55,9 @@ public class RuleAnnotationClauseConverter extends DMNModelInstrumentedBaseConve
 
         RuleAnnotationClause e = (RuleAnnotationClause) parent;
 
-        writer.addAttribute(NAME, e.getName());
+        if (e.getName() != null) {
+            writer.addAttribute(NAME, e.getName());
+        }
     }
 
     @Override

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ArtifactConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ArtifactConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ArtifactConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+
+public abstract class ArtifactConverter extends DMNElementConverter {
+
+    public ArtifactConverter(XStream xstream) {
+        super(xstream);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AssociationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AssociationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AssociationConverter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.Association;
+import org.kie.dmn.model.api.AssociationDirection;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TAssociation;
+
+public class AssociationConverter extends ArtifactConverter {
+    public static final String TARGET_REF = "targetRef";
+    public static final String SOURCE_REF = "sourceRef";
+    public static final String ASSOCIATION_DIRECTION = "associationDirection";
+
+    public AssociationConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TAssociation();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TAssociation.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Association a = (Association) parent;
+        
+        if( SOURCE_REF.equals( nodeName ) ) {
+            a.setSourceRef( (DMNElementReference) child );
+        } else if( TARGET_REF.equals( nodeName ) ) {
+            a.setTargetRef( (DMNElementReference) child );
+        } else {
+            super.assignChildElement( parent, nodeName, child );
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Association a = (Association) parent;
+        
+        String associationDirectionValue = reader.getAttribute(ASSOCIATION_DIRECTION);
+        
+        if (associationDirectionValue != null) a.setAssociationDirection(AssociationDirection.fromValue(associationDirectionValue));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Association a = (Association) parent;
+        
+        writeChildrenNode(writer, context, a.getSourceRef(), SOURCE_REF);
+        writeChildrenNode(writer, context, a.getTargetRef(), TARGET_REF);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Association a = (Association) parent;
+        
+        if (a.getAssociationDirection() != null) writer.addAttribute(ASSOCIATION_DIRECTION, a.getAssociationDirection().value());
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AuthorityRequirementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AuthorityRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/AuthorityRequirementConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TAuthorityRequirement;
+
+public class AuthorityRequirementConverter extends DMNElementConverter {
+    public static final String REQUIRED_AUTHORITY = "requiredAuthority";
+    public static final String REQUIRED_INPUT = "requiredInput";
+    public static final String REQUIRED_DECISION = "requiredDecision";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        AuthorityRequirement ar = (AuthorityRequirement) parent;
+        
+        if (REQUIRED_DECISION.equals(nodeName)) {
+            ar.setRequiredDecision( (DMNElementReference) child );
+        } else if (REQUIRED_INPUT.equals(nodeName)) {
+            ar.setRequiredInput( (DMNElementReference) child );
+        } else if (REQUIRED_AUTHORITY.equals(nodeName)) {
+            ar.setRequiredAuthority( (DMNElementReference) child );
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        AuthorityRequirement ar = (AuthorityRequirement) parent;
+        
+        if (ar.getRequiredDecision() != null) writeChildrenNode(writer, context, ar.getRequiredDecision(), REQUIRED_DECISION); 
+        if (ar.getRequiredInput() != null) writeChildrenNode(writer, context, ar.getRequiredInput(), REQUIRED_INPUT);
+        if (ar.getRequiredAuthority() != null) writeChildrenNode(writer, context, ar.getRequiredAuthority(), REQUIRED_AUTHORITY);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+
+    public AuthorityRequirementConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TAuthorityRequirement();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TAuthorityRequirement.class);
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BindingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BindingConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BindingConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.Binding;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.v1_3.TBinding;
+
+public class BindingConverter extends DMNModelInstrumentedBaseConverter {
+    public static final String EXPRESSION = "expression";
+    public static final String PARAMETER = "parameter";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Binding b = (Binding) parent;
+        
+        if (PARAMETER.equals(nodeName)) {
+            b.setParameter((InformationItem) child);
+        } else if (child instanceof Expression) {
+            b.setExpression((Expression) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Binding b = (Binding) parent;
+        
+        writeChildrenNode(writer, context, b.getParameter(), PARAMETER);
+        if (b.getExpression() != null) writeChildrenNode(writer, context, b.getExpression(), MarshallingUtils.defineExpressionNodeName(b.getExpression()));
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public BindingConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TBinding();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TBinding.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BoundsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BoundsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BoundsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BoundsConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.Bounds;
+
+public class BoundsConverter extends DMNModelInstrumentedBaseConverter {
+
+
+    private static final String HEIGHT = "height";
+    private static final String WIDTH = "width";
+    private static final String Y = "y";
+    private static final String X = "x";
+
+    public BoundsConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Bounds abs = (Bounds) parent;
+
+        abs.setX(Double.valueOf(reader.getAttribute(X)));
+        abs.setY(Double.valueOf(reader.getAttribute(Y)));
+        abs.setWidth(Double.valueOf(reader.getAttribute(WIDTH)));
+        abs.setHeight(Double.valueOf(reader.getAttribute(HEIGHT)));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        Bounds abs = (Bounds) parent;
+
+        writer.addAttribute(X, FormatUtils.manageDouble(abs.getX()));
+        writer.addAttribute(Y, FormatUtils.manageDouble(abs.getY()));
+        writer.addAttribute(WIDTH, FormatUtils.manageDouble(abs.getWidth()));
+        writer.addAttribute(HEIGHT, FormatUtils.manageDouble(abs.getHeight()));
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.Bounds();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(org.kie.dmn.model.v1_3.dmndi.Bounds.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessContextElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessContextElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessContextElementConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.BusinessContextElement;
+
+public abstract class BusinessContextElementConverter extends NamedElementConverter {
+    public static final String URI = "URI";
+
+    public BusinessContextElementConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        BusinessContextElement bce = (BusinessContextElement) parent;
+        
+        String uri = reader.getAttribute(URI);
+        
+        bce.setURI(uri);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        BusinessContextElement bce = (BusinessContextElement) parent;
+        
+        if (bce.getURI() != null) writer.addAttribute(URI, bce.getURI());
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessKnowledgeModelConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessKnowledgeModelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/BusinessKnowledgeModelConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.BusinessKnowledgeModel;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.FunctionDefinition;
+import org.kie.dmn.model.api.KnowledgeRequirement;
+import org.kie.dmn.model.v1_3.TBusinessKnowledgeModel;
+
+public class BusinessKnowledgeModelConverter extends InvocableConverter {
+    public static final String ENCAPSULATED_LOGIC = "encapsulatedLogic";
+    public static final String VARIABLE = "variable";
+    public static final String KNOWLEDGE_REQUIREMENT = "knowledgeRequirement";
+    public static final String AUTHORITY_REQUIREMENT = "authorityRequirement";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        BusinessKnowledgeModel bkm = (BusinessKnowledgeModel) parent;
+        
+        if (ENCAPSULATED_LOGIC.equals(nodeName)) {
+            bkm.setEncapsulatedLogic((FunctionDefinition) child);
+        } else if (KNOWLEDGE_REQUIREMENT.equals(nodeName)) {
+            bkm.getKnowledgeRequirement().add((KnowledgeRequirement) child);
+        } else if (AUTHORITY_REQUIREMENT.equals(nodeName)) {
+            bkm.getAuthorityRequirement().add((AuthorityRequirement) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        BusinessKnowledgeModel bkm = (BusinessKnowledgeModel) parent;
+        
+        if (bkm.getEncapsulatedLogic() != null) writeChildrenNode(writer, context, bkm.getEncapsulatedLogic(), ENCAPSULATED_LOGIC);
+        // Now as Invocable: if (bkm.getVariable() != null) writeChildrenNode(writer, context, bkm.getVariable(), VARIABLE);
+        for (KnowledgeRequirement i : bkm.getKnowledgeRequirement()) {
+            writeChildrenNode(writer, context, i, KNOWLEDGE_REQUIREMENT);
+        }
+        for (AuthorityRequirement a : bkm.getAuthorityRequirement()) {
+            writeChildrenNode(writer, context, a, AUTHORITY_REQUIREMENT);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public BusinessKnowledgeModelConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TBusinessKnowledgeModel();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TBusinessKnowledgeModel.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ColorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ColorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ColorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ColorConverter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.Color;
+
+public class ColorConverter extends DMNModelInstrumentedBaseConverter {
+
+    private static final String RED = "red";
+    private static final String GREEN = "green";
+    private static final String BLUE = "blue";
+
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Color style = (Color) parent;
+
+        style.setRed(Integer.valueOf(reader.getAttribute(RED)));
+        style.setGreen(Integer.valueOf(reader.getAttribute(GREEN)));
+        style.setBlue(Integer.valueOf(reader.getAttribute(BLUE)));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Color style = (Color) parent;
+
+        writer.addAttribute(RED, Integer.valueOf(style.getRed()).toString());
+        writer.addAttribute(GREEN, Integer.valueOf(style.getGreen()).toString());
+        writer.addAttribute(BLUE, Integer.valueOf(style.getBlue()).toString());
+    }
+
+    public ColorConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.Color();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(org.kie.dmn.model.v1_3.dmndi.Color.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextConverter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.Context;
+import org.kie.dmn.model.api.ContextEntry;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TContext;
+
+public class ContextConverter extends ExpressionConverter {
+    public static final String CONTEXT_ENTRY = "contextEntry";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Context c = (Context) parent;
+        
+        if (CONTEXT_ENTRY.equals(nodeName)) {
+            c.getContextEntry().add((ContextEntry) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Context c = (Context) parent;
+        
+        for (ContextEntry ce : c.getContextEntry()) {
+            writeChildrenNode(writer, context, ce, CONTEXT_ENTRY);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public ContextConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TContext();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TContext.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextEntryConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextEntryConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ContextEntryConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.ContextEntry;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.v1_3.TContextEntry;
+
+public class ContextEntryConverter extends DMNElementConverter {
+    public static final String EXPRESSION = "expression";
+    public static final String VARIABLE = "variable";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        ContextEntry ce = (ContextEntry) parent;
+        
+        if (VARIABLE.equals(nodeName)) {
+            ce.setVariable((InformationItem) child);
+        } else if (child instanceof Expression) {
+            ce.setExpression((Expression) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        ContextEntry ce = (ContextEntry) parent;
+        
+        if (ce.getVariable() != null) writeChildrenNode(writer, context, ce.getVariable(), VARIABLE);
+        writeChildrenNode(writer, context, ce.getExpression(), MarshallingUtils.defineExpressionNodeName(ce.getExpression()));
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public ContextEntryConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TContextEntry();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TContextEntry.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNBaseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNBaseConverter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.Mapper;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+
+public abstract class DMNBaseConverter
+        extends AbstractCollectionConverter {
+
+    public DMNBaseConverter(Mapper mapper) {
+        super( mapper );
+    }
+
+    public void marshal(
+            Object object,
+            HierarchicalStreamWriter writer,
+            MarshallingContext context) {
+        writeAttributes(writer, object);
+        writeChildren(writer, context, object);
+    }
+    
+    protected void writeChildrenNode(HierarchicalStreamWriter writer, MarshallingContext context, Object node, String nodeAlias) {
+        writer.startNode(nodeAlias);
+        context.convertAnother(node);
+        writer.endNode();
+    }
+    
+    protected void writeChildrenNodeAsValue(HierarchicalStreamWriter writer, MarshallingContext context, String nodeValue, String nodeAlias) {
+        writer.startNode(nodeAlias);
+        writer.setValue(nodeValue);
+        writer.endNode();
+    }
+
+    protected abstract void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent);
+
+    protected abstract void writeAttributes(HierarchicalStreamWriter writer, Object parent);
+
+    public Object unmarshal(
+            HierarchicalStreamReader reader,
+            UnmarshallingContext context) {
+        DMNModelInstrumentedBase obj = createModelObject();
+        assignAttributes( reader, obj );
+        parseElements( reader, context, obj );
+        return obj;
+    }
+
+    protected void parseElements(HierarchicalStreamReader reader, UnmarshallingContext context, Object parent) {
+        while ( reader.hasMoreChildren() ) {
+            reader.moveDown();
+            String nodeName = reader.getNodeName();
+            Object object = readItem(
+                    reader,
+                    context,
+                    null );
+            if( object instanceof DMNModelInstrumentedBase ) {
+                ((KieDMNModelInstrumentedBase) object).setParent((KieDMNModelInstrumentedBase) parent);
+                ((KieDMNModelInstrumentedBase) parent).addChildren((KieDMNModelInstrumentedBase) object);
+            }
+            reader.moveUp();
+            assignChildElement( parent, nodeName, object );
+        }
+    }
+
+    protected abstract DMNModelInstrumentedBase createModelObject();
+
+    protected abstract void assignChildElement(Object parent, String nodeName, Object child);
+
+    protected abstract void assignAttributes(HierarchicalStreamReader reader, Object parent);
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDIConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDIConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDIConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDIConverter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.DMNDI;
+import org.kie.dmn.model.api.dmndi.DMNDiagram;
+import org.kie.dmn.model.api.dmndi.DMNStyle;
+
+public class DMNDIConverter extends DMNModelInstrumentedBaseConverter {
+
+    private static final String DMN_STYLE = "DMNStyle";
+    private static final String DMN_DIAGRAM = "DMNDiagram";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNDI list = (DMNDI) parent;
+        
+        if (child instanceof DMNDiagram) {
+            list.getDMNDiagram().add((DMNDiagram) child);
+        } else if (child instanceof DMNStyle) {
+            list.getDMNStyle().add((DMNStyle) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNDI list = (DMNDI) parent;
+        
+        for (DMNDiagram e : list.getDMNDiagram()) {
+            writeChildrenNode(writer, context, e, DMN_DIAGRAM);
+        }
+        for (DMNStyle e : list.getDMNStyle()) {
+            writeChildrenNode(writer, context, e, DMN_STYLE);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public DMNDIConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNDI();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(org.kie.dmn.model.v1_3.dmndi.DMNDI.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDecisionServiceDividerLineConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDecisionServiceDividerLineConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDecisionServiceDividerLineConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDecisionServiceDividerLineConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+
+public class DMNDecisionServiceDividerLineConverter extends EdgeConverter {
+
+    public DMNDecisionServiceDividerLineConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNDecisionServiceDividerLine();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(org.kie.dmn.model.v1_3.dmndi.DMNDecisionServiceDividerLine.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDiagramConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNDiagramConverter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.DMNDiagram;
+import org.kie.dmn.model.api.dmndi.DiagramElement;
+import org.kie.dmn.model.api.dmndi.Dimension;
+
+public class DMNDiagramConverter extends DiagramConverter {
+
+    private static final String SIZE = "Size";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNDiagram style = (DMNDiagram) parent;
+
+        if (child instanceof Dimension) {
+            style.setSize((Dimension) child);
+        } else if (child instanceof DiagramElement) {
+            style.getDMNDiagramElement().add((DiagramElement) child);
+        } else {
+            super.assignChildElement(style, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNDiagram style = (DMNDiagram) parent;
+        
+        if (style.getSize() != null) {
+            writeChildrenNode(writer, context, style.getSize(), SIZE);
+        }
+        for (DiagramElement de : style.getDMNDiagramElement()) {
+            writeChildrenNode(writer, context, de, de.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        // no attributes.
+    }
+
+    public DMNDiagramConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNDiagram();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(org.kie.dmn.model.v1_3.dmndi.DMNDiagram.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNEdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNEdgeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNEdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNEdgeConverter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.DMNEdge;
+import org.kie.dmn.model.api.dmndi.DMNLabel;
+
+public class DMNEdgeConverter extends EdgeConverter {
+
+    private static final String DMN_ELEMENT_REF = "dmnElementRef";
+    private static final String DMN_LABEL = "DMNLabel";
+
+    public DMNEdgeConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNEdge concrete = (DMNEdge) parent;
+
+        if (child instanceof DMNLabel) {
+            concrete.setDMNLabel((DMNLabel) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        DMNEdge concrete = (DMNEdge) parent;
+
+        String dmnElementRef = reader.getAttribute(DMN_ELEMENT_REF);
+
+        if (dmnElementRef != null) {
+            concrete.setDmnElementRef(new QName(dmnElementRef));
+        }
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNEdge concrete = (DMNEdge) parent;
+
+        if (concrete.getDMNLabel() != null) {
+            writeChildrenNode(writer, context, concrete.getDMNLabel(), DMN_LABEL);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        DMNEdge concrete = (DMNEdge) parent;
+        if (concrete.getDmnElementRef() != null) {
+            writer.addAttribute(DMN_ELEMENT_REF, concrete.getDmnElementRef().toString());
+        }
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNEdge();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(org.kie.dmn.model.v1_3.dmndi.DMNEdge.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import org.kie.dmn.model.api.*;
+import org.kie.dmn.model.v1_3.*;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+public abstract class DMNElementConverter
+        extends DMNModelInstrumentedBaseConverter {
+    public static final String ID          = "id";
+    public static final String LABEL       = "label";
+    public static final String DESCRIPTION = "description";
+    public static final String EXTENSION_ELEMENTS = "extensionElements";
+
+    public DMNElementConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        if ( DESCRIPTION.equals( nodeName ) && child instanceof String ) {
+            ((DMNElement) parent).setDescription( (String) child );
+        } else if(EXTENSION_ELEMENTS.equals(nodeName)
+                && child instanceof DMNElement.ExtensionElements) {
+            ((DMNElement)parent).setExtensionElements((DMNElement.ExtensionElements)child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        String id = reader.getAttribute( ID );
+        String label = reader.getAttribute( LABEL );
+
+        DMNElement dmne = (DMNElement) parent;
+
+        dmne.setId( id );
+        dmne.setLabel( label );
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNElement e = (DMNElement) parent;
+
+        if (e.getDescription() !=null) { writeChildrenNodeAsValue(writer, context, e.getDescription(), DESCRIPTION); }
+        if (e.getExtensionElements() != null ) { writeChildrenNode(writer, context, e.getExtensionElements(), EXTENSION_ELEMENTS); }
+    }
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        DMNElement e = (DMNElement) parent;
+        
+        if (e.getId() != null) writer.addAttribute( ID , e.getId() );
+        if (e.getLabel() != null) writer.addAttribute( LABEL , e.getLabel() );
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementReferenceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementReferenceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNElementReferenceConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TDMNElementReference;
+
+public class DMNElementReferenceConverter
+        extends DMNModelInstrumentedBaseConverter {
+
+    private static final String HREF = "href";
+
+    public DMNElementReferenceConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDMNElementReference.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement( parent, nodeName, child );
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        DMNElementReference er = (DMNElementReference) parent;
+
+        String href = reader.getAttribute( HREF );
+
+        er.setHref( href );
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDMNElementReference();
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        
+        // no children nodes.
+    }
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        DMNElementReference er = (DMNElementReference) parent;
+        
+        if ( er.getHref() != null ) writer.addAttribute(HREF, er.getHref()); 
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNLabelConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNLabelConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNLabelConverter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.DMNLabel;
+
+public class DMNLabelConverter extends ShapeConverter {
+
+    public static final String TEXT = "Text";
+
+    public DMNLabelConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNLabel concrete = (DMNLabel) parent;
+
+        if (nodeName.equals(TEXT)) {
+            concrete.setText((String) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNLabel concrete = (DMNLabel) parent;
+
+        if (concrete.getText() != null) {
+            writeChildrenNode(writer, context, concrete.getText(), TEXT);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNLabel();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(org.kie.dmn.model.v1_3.dmndi.DMNLabel.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNListConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNListConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNListConverter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.List;
+import org.kie.dmn.model.v1_3.TList;
+
+public class DMNListConverter extends ExpressionConverter {
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        List list = (List) parent;
+        
+        if (child instanceof Expression) {
+            list.getExpression().add((Expression) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        List list = (List) parent;
+        
+        for (Expression e : list.getExpression()) {
+            writeChildrenNode(writer, context, e, MarshallingUtils.defineExpressionNodeName(e));
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public DMNListConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TList();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TList.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNModelInstrumentedBaseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNModelInstrumentedBaseConverter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.backend.marshalling.CustomStaxReader;
+import org.kie.dmn.backend.marshalling.CustomStaxWriter;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TDefinitions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class DMNModelInstrumentedBaseConverter
+        extends DMNBaseConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DMNModelInstrumentedBaseConverter.class);
+
+    public DMNModelInstrumentedBaseConverter(XStream xstream) {
+        super( xstream.getMapper() );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        KieDMNModelInstrumentedBase mib = (KieDMNModelInstrumentedBase) parent;
+
+        CustomStaxReader customStaxReader = (CustomStaxReader) reader.underlyingReader();
+        
+        Map<String, String> currentNSCtx = customStaxReader.getNsContext();
+        mib.getNsContext().putAll(currentNSCtx);
+
+        mib.setLocation( customStaxReader.getLocation() );
+        
+        mib.setAdditionalAttributes( customStaxReader.getAdditionalAttributes() );
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        // no call to super as super is abstract method.
+    }
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        KieDMNModelInstrumentedBase mib = (KieDMNModelInstrumentedBase) parent;
+
+        CustomStaxWriter staxWriter = ((CustomStaxWriter) writer.underlyingWriter());
+        for (Entry<String, String> kv : mib.getNsContext().entrySet()) {
+            try {
+                if (KieDMNModelInstrumentedBase.URI_DMN.equals(kv.getValue())) {
+                    // skip as that is the default namespace xmlns<:prefix>=DMN is handled by the stax driver.
+                } else {
+                    staxWriter.writeNamespace(kv.getKey(), kv.getValue());
+                }
+            } catch (Exception e) {
+                LOG.warn("The XML driver writer failed to manage writing namespace, namespaces prefixes could be wrong in the resulting file.", e);
+            }
+        }
+        
+        for ( Entry<QName, String> kv : mib.getAdditionalAttributes().entrySet() ) {
+            staxWriter.addAttribute(kv.getKey().getPrefix() + ":" + kv.getKey().getLocalPart(), kv.getValue());
+        }
+
+        if (parent instanceof TDefinitions) {
+            TDefinitions tDefinitions = (TDefinitions) parent;
+            String dmndiPrefix = tDefinitions.getPrefixForNamespaceURI(KieDMNModelInstrumentedBase.URI_DMNDI).orElse("dmndi");
+            String diPrefix = tDefinitions.getPrefixForNamespaceURI(KieDMNModelInstrumentedBase.URI_DI).orElse("di");
+            String dcPrefix = tDefinitions.getPrefixForNamespaceURI(KieDMNModelInstrumentedBase.URI_DC).orElse("dc");
+
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNDI", dmndiPrefix), "DMNDI");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNDiagram", dmndiPrefix), "DMNDiagram");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNStyle", dmndiPrefix), "style");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNStyle", dmndiPrefix), "DMNStyle");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNShape", dmndiPrefix), "DMNShape");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNEdge", dmndiPrefix), "DMNEdge");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNDecisionServiceDividerLine", dmndiPrefix), "DMNDecisionServiceDividerLine");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "DMNLabel", dmndiPrefix), "DMNLabel");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, DMNLabelConverter.TEXT, dmndiPrefix), DMNLabelConverter.TEXT);
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "Size", dmndiPrefix), "Size");
+
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "FillColor", dmndiPrefix), "FillColor");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "StrokeColor", dmndiPrefix), "StrokeColor");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DMNDI, "FontColor", dmndiPrefix), "FontColor");
+
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DI, "waypoint", diPrefix), "waypoint");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DI, "extension", diPrefix), "extension");
+            staxWriter.getQNameMap().registerMapping(new QName(KieDMNModelInstrumentedBase.URI_DC, "Bounds", dcPrefix), "Bounds");
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNShapeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNShapeConverter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.DMNDecisionServiceDividerLine;
+import org.kie.dmn.model.api.dmndi.DMNLabel;
+import org.kie.dmn.model.v1_3.dmndi.DMNShape;
+
+public class DMNShapeConverter extends ShapeConverter {
+
+    private static final String FILL_COLOR = "FillColor";
+    private static final String STROKE_COLOR = "StrokeColor";
+    private static final String FONT_COLOR = "FontColor";
+    
+    private static final String FONT_FAMILY = "fontFamily";
+    private static final String FONT_SIZE = "fontSize";
+    private static final String FONT_ITALIC = "fontItalic";
+    private static final String FONT_BOLD = "fontBold";
+    private static final String FONT_UNDERLINE = "fontUnderline";
+    private static final String FONT_STRIKE_THROUGH = "fontStrikeThrough";
+    private static final String LABEL_HORIZONTAL_ALIGNMENT = "labelHorizontalAlignement";
+    private static final String LABEL_VERTICAL_ALIGNMENT = "labelVerticalAlignment";
+
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNShape style = (DMNShape) parent;
+        
+        if (child instanceof DMNLabel) {
+            style.setDMNLabel((DMNLabel) child);
+        } else if (child instanceof DMNDecisionServiceDividerLine) {
+            style.setDMNDecisionServiceDividerLine((DMNDecisionServiceDividerLine) child);
+        } else {
+            super.assignChildElement(style, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        DMNShape style = (DMNShape) parent;
+
+        style.setDmnElementRef(new QName(reader.getAttribute("dmnElementRef")));
+        
+        String isListedInputData = reader.getAttribute("isListedInputData");
+        String isCollapsed = reader.getAttribute("isCollapsed");
+         
+        if (isListedInputData != null) {
+            style.setIsListedInputData(Boolean.valueOf(isListedInputData));
+        }
+        if (isCollapsed != null) {
+            style.setIsCollapsed(Boolean.valueOf(isCollapsed));
+        }
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNShape style = (DMNShape) parent;
+        
+        if (style.getDMNLabel() != null) {
+            writeChildrenNode(writer, context, style.getDMNLabel(), "DMNLabel");
+        }
+        if (style.getDMNDecisionServiceDividerLine() != null) {
+            writeChildrenNode(writer, context, style.getDMNDecisionServiceDividerLine(), "DMNDecisionServiceDividerLine");
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        DMNShape style = (DMNShape) parent;
+
+        writer.addAttribute("dmnElementRef", style.getDmnElementRef().toString());
+
+        if (style.isIsListedInputData() != null) {
+            writer.addAttribute("isListedInputData", style.isIsListedInputData().toString());
+        }
+        writer.addAttribute("isCollapsed", Boolean.valueOf(style.isIsCollapsed()).toString());
+    }
+
+    public DMNShapeConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNShape();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(org.kie.dmn.model.v1_3.dmndi.DMNShape.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNStyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNStyleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNStyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DMNStyleConverter.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.AlignmentKind;
+import org.kie.dmn.model.api.dmndi.Color;
+import org.kie.dmn.model.api.dmndi.DMNStyle;
+
+public class DMNStyleConverter extends StyleConverter {
+
+    private static final String FILL_COLOR = "FillColor";
+    private static final String STROKE_COLOR = "StrokeColor";
+    private static final String FONT_COLOR = "FontColor";
+    
+    private static final String FONT_FAMILY = "fontFamily";
+    private static final String FONT_SIZE = "fontSize";
+    private static final String FONT_ITALIC = "fontItalic";
+    private static final String FONT_BOLD = "fontBold";
+    private static final String FONT_UNDERLINE = "fontUnderline";
+    private static final String FONT_STRIKE_THROUGH = "fontStrikeThrough";
+    private static final String LABEL_HORIZONTAL_ALIGNMENT = "labelHorizontalAlignement";
+    private static final String LABEL_VERTICAL_ALIGNMENT = "labelVerticalAlignment";
+
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DMNStyle style = (DMNStyle) parent;
+        
+        if (FILL_COLOR.equals(nodeName)) {
+            style.setFillColor((Color) child);
+        } else if (STROKE_COLOR.equals(nodeName)) {
+            style.setStrokeColor((Color) child);
+        } else if (FONT_COLOR.equals(nodeName)) {
+            style.setFontColor((Color) child);
+        } else {
+            super.assignChildElement(style, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        DMNStyle style = (DMNStyle) parent;
+
+        String fontFamily = reader.getAttribute(FONT_FAMILY );
+        String fontSize = reader.getAttribute(FONT_SIZE);
+        String fontItalic = reader.getAttribute(FONT_ITALIC);
+        String fontBold = reader.getAttribute(FONT_BOLD);
+        String fontUnderline = reader.getAttribute(FONT_UNDERLINE);
+        String fontStrikeThrough = reader.getAttribute(FONT_STRIKE_THROUGH);
+        String labelHorizontalAlignement = reader.getAttribute(LABEL_HORIZONTAL_ALIGNMENT);
+        String labelVerticalAlignment = reader.getAttribute(LABEL_VERTICAL_ALIGNMENT);
+         
+        if (fontFamily != null) {
+            style.setFontFamily(fontFamily);
+        }
+        if (fontSize != null) {
+            style.setFontSize(Double.valueOf(fontSize));
+        }
+        if (fontItalic != null) {
+            style.setFontItalic(Boolean.valueOf(fontItalic));
+        }
+        if (fontBold != null) {
+            style.setFontBold(Boolean.valueOf(fontBold));
+        }
+        if (fontUnderline != null) {
+            style.setFontUnderline(Boolean.valueOf(fontUnderline));
+        }
+        if (fontStrikeThrough != null) {
+            style.setFontStrikeThrough(Boolean.valueOf(fontStrikeThrough));
+        }
+        if (labelHorizontalAlignement != null) {
+            style.setLabelHorizontalAlignement(AlignmentKind.valueOf(labelHorizontalAlignement));
+        }
+        if (labelVerticalAlignment != null) {
+            style.setLabelVerticalAlignment(AlignmentKind.valueOf(labelVerticalAlignment));
+        }
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DMNStyle style = (DMNStyle) parent;
+        
+        if (style.getFillColor() != null) {
+            writeChildrenNode(writer, context, style.getFillColor(), FILL_COLOR);
+        }
+        if (style.getStrokeColor() != null) {
+            writeChildrenNode(writer, context, style.getStrokeColor(), STROKE_COLOR);
+        }
+        if (style.getFontColor() != null) {
+            writeChildrenNode(writer, context, style.getFontColor(), FONT_COLOR);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        DMNStyle style = (DMNStyle) parent;
+
+        if (style.getFontFamily() != null) {
+            writer.addAttribute(FONT_FAMILY, style.getFontFamily());
+        }
+        if (style.getFontSize() != null) {
+            writer.addAttribute(FONT_SIZE, FormatUtils.manageDouble(style.getFontSize()));
+        }
+        if (style.isFontItalic() != null) {
+            writer.addAttribute(FONT_ITALIC, style.isFontItalic().toString());
+        }
+        if (style.isFontBold() != null) {
+            writer.addAttribute(FONT_BOLD, style.isFontBold().toString());
+        }
+        if (style.isFontUnderline() != null) {
+            writer.addAttribute(FONT_UNDERLINE, style.isFontUnderline().toString());
+        }
+        if (style.isFontStrikeThrough() != null) {
+            writer.addAttribute(FONT_STRIKE_THROUGH, style.isFontStrikeThrough().toString());
+        }
+        if (style.getLabelHorizontalAlignement() != null) {
+            writer.addAttribute(LABEL_HORIZONTAL_ALIGNMENT, style.getLabelHorizontalAlignement().toString());
+        }
+        if (style.getLabelVerticalAlignment() != null) {
+            writer.addAttribute(LABEL_VERTICAL_ALIGNMENT, style.getLabelVerticalAlignment().toString());
+        }
+    }
+
+    public DMNStyleConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.DMNStyle();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(org.kie.dmn.model.v1_3.dmndi.DMNStyle.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DRGElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DRGElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DRGElementConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+public abstract class DRGElementConverter
+        extends NamedElementConverter {
+
+    public DRGElementConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement( parent, nodeName, child );
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionConverter.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Decision;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.InformationRequirement;
+import org.kie.dmn.model.api.KnowledgeRequirement;
+import org.kie.dmn.model.v1_3.TDecision;
+
+public class DecisionConverter extends DRGElementConverter {
+    public static final String QUESTION = "question";
+    public static final String ALLOWED_ANSWERS = "allowedAnswers";
+    public static final String VARIABLE = "variable";
+    public static final String INFORMATION_REQUIREMENT = "informationRequirement";
+    public static final String KNOWLEDGE_REQUIREMENT = "knowledgeRequirement";
+    public static final String AUTHORITY_REQUIREMENT = "authorityRequirement";
+    public static final String SUPPORTED_OBJECTIVE = "supportedObjective";
+    public static final String IMPACTED_PERFORMANCE_INDICATOR = "impactedPerformanceIndicator";
+    public static final String DECISION_MAKER = "decisionMaker";
+    public static final String DECISION_OWNER = "decisionOwner";
+    public static final String USING_PROCESS = "usingProcess";
+    public static final String USING_TASK = "usingTask";
+    public static final String EXPRESSION = "expression";
+
+    public DecisionConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDecision.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Decision dec = (Decision) parent;
+        
+        if (QUESTION.equals(nodeName)) {
+            dec.setQuestion((String) child);
+        } else if (ALLOWED_ANSWERS.equals(nodeName)) {
+            dec.setAllowedAnswers((String) child);
+        } else if (VARIABLE.equals(nodeName) ) {
+            dec.setVariable( (InformationItem) child );
+        } else if (INFORMATION_REQUIREMENT.equals(nodeName) ) {
+            dec.getInformationRequirement().add( (InformationRequirement) child );
+        } else if (KNOWLEDGE_REQUIREMENT.equals(nodeName) ) {
+            dec.getKnowledgeRequirement().add((KnowledgeRequirement) child);
+        } else if (AUTHORITY_REQUIREMENT.equals(nodeName) ) {
+            dec.getAuthorityRequirement().add((AuthorityRequirement) child);
+        } else if (SUPPORTED_OBJECTIVE.equals(nodeName) ) {
+            dec.getSupportedObjective().add((DMNElementReference) child);
+        } else if (IMPACTED_PERFORMANCE_INDICATOR.equals(nodeName) ) {
+            dec.getImpactedPerformanceIndicator().add((DMNElementReference) child);
+        } else if (DECISION_MAKER.equals(nodeName) ) {
+            dec.getDecisionMaker().add((DMNElementReference) child);
+        } else if (DECISION_OWNER.equals(nodeName) ) {
+            dec.getDecisionOwner().add((DMNElementReference) child);
+        } else if (USING_PROCESS.equals(nodeName) ) {
+            dec.getUsingProcess().add((DMNElementReference) child);
+        } else if (USING_TASK.equals(nodeName) ) {
+            dec.getUsingTask().add((DMNElementReference) child);
+        } else if ( child instanceof Expression ) {
+            dec.setExpression( (Expression) child );
+        } else {
+            super.assignChildElement( dec, nodeName, child );
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        
+        // no attributes.
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDecision();
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Decision dec = (Decision) parent;
+        
+        if (dec.getQuestion() != null) writeChildrenNodeAsValue(writer, context, dec.getQuestion(), QUESTION);
+        if (dec.getAllowedAnswers() != null) writeChildrenNodeAsValue(writer, context, dec.getAllowedAnswers(), ALLOWED_ANSWERS);
+        if (dec.getVariable() != null) writeChildrenNode(writer, context, dec.getVariable(), VARIABLE);
+        for ( InformationRequirement ir : dec.getInformationRequirement() ) {
+            writeChildrenNode(writer, context, ir, INFORMATION_REQUIREMENT);
+        }
+        for ( KnowledgeRequirement kr : dec.getKnowledgeRequirement() ) {
+            writeChildrenNode(writer, context, kr, KNOWLEDGE_REQUIREMENT);
+        }
+        for ( AuthorityRequirement ar : dec.getAuthorityRequirement() ) {
+            writeChildrenNode(writer, context, ar, AUTHORITY_REQUIREMENT);
+        }
+        for ( DMNElementReference so : dec.getSupportedObjective() ) {
+            writeChildrenNode(writer, context, so, SUPPORTED_OBJECTIVE);
+        }
+        for ( DMNElementReference ipi : dec.getImpactedPerformanceIndicator() ) {
+            writeChildrenNode(writer, context, ipi, IMPACTED_PERFORMANCE_INDICATOR);
+        }
+        for ( DMNElementReference dm : dec.getDecisionMaker() ) {
+            writeChildrenNode(writer, context, dm, DECISION_MAKER);
+        }
+        for ( DMNElementReference downer : dec.getDecisionOwner() ) {
+            writeChildrenNode(writer, context, downer, DECISION_OWNER);
+        }
+        for ( DMNElementReference up : dec.getUsingProcess() ) {
+            writeChildrenNode(writer, context, up, USING_PROCESS);
+        }
+        for ( DMNElementReference ut : dec.getUsingTask() ) {
+            writeChildrenNode(writer, context, ut, USING_TASK);
+        }
+        if (dec.getExpression() != null) {
+            Expression e = dec.getExpression();
+            String nodeName = MarshallingUtils.defineExpressionNodeName(e);
+            writeChildrenNode(writer, context, e, nodeName);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes 
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionRuleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionRuleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionRuleConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.DecisionRule;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.RuleAnnotation;
+import org.kie.dmn.model.api.UnaryTests;
+import org.kie.dmn.model.v1_3.TDecisionRule;
+
+public class DecisionRuleConverter extends DMNElementConverter {
+    public static final String OUTPUT_ENTRY = "outputEntry";
+    public static final String INPUT_ENTRY = "inputEntry";
+    public static final String ANNOTATION_ENTRY = "annotationEntry";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DecisionRule dr = (DecisionRule) parent;
+
+        if (INPUT_ENTRY.equals(nodeName)) {
+            dr.getInputEntry().add((UnaryTests) child);
+        } else if (OUTPUT_ENTRY.equals(nodeName)) {
+            dr.getOutputEntry().add((LiteralExpression) child);
+        } else if (ANNOTATION_ENTRY.equals(nodeName)) {
+            dr.getAnnotationEntry().add((RuleAnnotation) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DecisionRule dr = (DecisionRule) parent;
+        
+        for (UnaryTests ie : dr.getInputEntry()) {
+            writeChildrenNode(writer, context, ie, INPUT_ENTRY);
+        }
+        for (LiteralExpression oe : dr.getOutputEntry()) {
+            writeChildrenNode(writer, context, oe, OUTPUT_ENTRY);
+        }
+        for (RuleAnnotation a : dr.getAnnotationEntry()) {
+            writeChildrenNode(writer, context, a, ANNOTATION_ENTRY);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public DecisionRuleConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDecisionRule();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDecisionRule.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionServiceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionServiceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionServiceConverter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.DecisionService;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TDMNElementReference;
+import org.kie.dmn.model.v1_3.TDecisionService;
+
+public class DecisionServiceConverter extends InvocableConverter {
+
+    public static final String OUTPUT_DECISION = "outputDecision";
+
+    public static final String ENCAPSULATED_DECISION = "encapsulatedDecision";
+
+    public static final String INPUT_DECISION = "inputDecision";
+
+    public static final String INPUT_DATA = "inputData";
+
+    public DecisionServiceConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDecisionService();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDecisionService.class);
+    }
+
+    @Override
+    protected void parseElements(HierarchicalStreamReader reader, UnmarshallingContext context, Object parent) {
+        while (reader.hasMoreChildren()) {
+            reader.moveDown();
+            Object object = null;
+            String nodeName = reader.getNodeName();
+            if (nodeName.equals(INPUT_DATA)) {
+                // Patch because the tag name inputData is used in both decision services and as a DRG Element
+                DMNElementReference ref = new TDMNElementReference();
+                ref.setHref(reader.getAttribute("href"));
+                object = ref;
+            } else {
+                // Default behaviour
+                object = readItem(reader, context, null);
+            }
+            if (object instanceof DMNModelInstrumentedBase) {
+                ((KieDMNModelInstrumentedBase) object).setParent((KieDMNModelInstrumentedBase) parent);
+                ((KieDMNModelInstrumentedBase) parent).addChildren((KieDMNModelInstrumentedBase) object);
+            }
+            reader.moveUp();
+            assignChildElement(parent, nodeName, object);
+        }
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DecisionService decisionService = (DecisionService) parent;
+        switch (nodeName) {
+        case OUTPUT_DECISION:
+            decisionService.getOutputDecision().add((DMNElementReference) child);
+            break;
+        case ENCAPSULATED_DECISION:
+            decisionService.getEncapsulatedDecision().add((DMNElementReference) child);
+            break;
+        case INPUT_DECISION:
+            decisionService.getInputDecision().add((DMNElementReference) child);
+            break;
+        case INPUT_DATA:
+            decisionService.getInputData().add((DMNElementReference) child);
+            break;
+        default:
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DecisionService decisionService = (DecisionService) parent;
+
+        for (DMNElementReference ref : decisionService.getOutputDecision()) {
+            writeChildrenNode(writer, context, ref, OUTPUT_DECISION);
+        }
+        for (DMNElementReference ref : decisionService.getEncapsulatedDecision()) {
+            writeChildrenNode(writer, context, ref, ENCAPSULATED_DECISION);
+        }
+        for (DMNElementReference ref : decisionService.getInputDecision()) {
+            writeChildrenNode(writer, context, ref, INPUT_DECISION);
+        }
+        for (DMNElementReference ref : decisionService.getInputData()) {
+            writeChildrenNode(writer, context, ref, INPUT_DATA);
+        }
+
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionTableConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionTableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DecisionTableConverter.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.BuiltinAggregator;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.DecisionRule;
+import org.kie.dmn.model.api.DecisionTable;
+import org.kie.dmn.model.api.DecisionTableOrientation;
+import org.kie.dmn.model.api.HitPolicy;
+import org.kie.dmn.model.api.InputClause;
+import org.kie.dmn.model.api.OutputClause;
+import org.kie.dmn.model.api.RuleAnnotationClause;
+import org.kie.dmn.model.v1_3.TDecisionTable;
+
+public class DecisionTableConverter extends ExpressionConverter {
+    public static final String RULE = "rule";
+    public static final String OUTPUT = "output";
+    public static final String INPUT = "input";
+    public static final String HIT_POLICY = "hitPolicy";
+    public static final String AGGREGATION = "aggregation";
+    public static final String PREFERRED_ORIENTATION = "preferredOrientation";
+    public static final String OUTPUT_LABEL = "outputLabel";
+    
+    public static final String ANNOTATION = "annotation";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DecisionTable dt = (DecisionTable) parent;
+        
+        if (INPUT.equals(nodeName)) {
+            dt.getInput().add((InputClause) child);
+        } else if (OUTPUT.equals(nodeName)) {
+            dt.getOutput().add((OutputClause) child);
+        } else if (ANNOTATION.equals(nodeName)) {
+            dt.getAnnotation().add((RuleAnnotationClause) child);
+        } else if (RULE.equals(nodeName)) {
+            dt.getRule().add((DecisionRule) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        DecisionTable dt = (DecisionTable) parent;
+        
+        String hitPolicyValue = reader.getAttribute(HIT_POLICY);
+        String aggregationValue = reader.getAttribute(AGGREGATION);
+        String preferredOrientationValue = reader.getAttribute(PREFERRED_ORIENTATION);
+        String outputLabel = reader.getAttribute(OUTPUT_LABEL);
+        
+        if (hitPolicyValue != null) dt.setHitPolicy(HitPolicy.fromValue(hitPolicyValue));
+        if (aggregationValue != null) dt.setAggregation(BuiltinAggregator.fromValue(aggregationValue));
+        if (preferredOrientationValue != null) dt.setPreferredOrientation(DecisionTableOrientation.fromValue(preferredOrientationValue));
+        dt.setOutputLabel(outputLabel);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DecisionTable dt = (DecisionTable) parent;
+        
+        for (InputClause i : dt.getInput()) {
+            writeChildrenNode(writer, context, i, INPUT);
+        }
+        for (OutputClause o : dt.getOutput()) {
+            writeChildrenNode(writer, context, o, OUTPUT);
+        }
+        for (RuleAnnotationClause a : dt.getAnnotation()) {
+            writeChildrenNode(writer, context, a, ANNOTATION);
+        }
+        for (DecisionRule r : dt.getRule()) {
+            writeChildrenNode(writer, context, r, RULE);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        DecisionTable dt = (DecisionTable) parent;
+        
+        if (dt.getHitPolicy() != null) writer.addAttribute(HIT_POLICY, dt.getHitPolicy().value());
+        if (dt.getAggregation()!= null) writer.addAttribute(AGGREGATION, dt.getAggregation().value());
+        if (dt.getPreferredOrientation() != null) writer.addAttribute(PREFERRED_ORIENTATION, dt.getPreferredOrientation().value());
+        if (dt.getOutputLabel() != null) writer.addAttribute(OUTPUT_LABEL, dt.getOutputLabel());
+    }
+
+    public DecisionTableConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDecisionTable();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDecisionTable.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.Artifact;
+import org.kie.dmn.model.api.Association;
+import org.kie.dmn.model.api.BusinessContextElement;
+import org.kie.dmn.model.api.BusinessKnowledgeModel;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.DRGElement;
+import org.kie.dmn.model.api.Decision;
+import org.kie.dmn.model.api.DecisionService;
+import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.model.api.ElementCollection;
+import org.kie.dmn.model.api.Import;
+import org.kie.dmn.model.api.InputData;
+import org.kie.dmn.model.api.ItemDefinition;
+import org.kie.dmn.model.api.KnowledgeSource;
+import org.kie.dmn.model.api.OrganizationUnit;
+import org.kie.dmn.model.api.PerformanceIndicator;
+import org.kie.dmn.model.api.TextAnnotation;
+import org.kie.dmn.model.api.dmndi.DMNDI;
+import org.kie.dmn.model.v1_3.TDefinitions;
+
+public class DefinitionsConverter
+        extends NamedElementConverter {
+    private static final String EXPRESSION_LANGUAGE = "expressionLanguage";
+    private static final String TYPE_LANGUAGE       = "typeLanguage";
+    private static final String NAMESPACE           = "namespace";
+    private static final String EXPORTER            = "exporter";
+    private static final String EXPORTER_VERSION    = "exporterVersion";
+    
+    public static final String IMPORT = "import";
+    public static final String ITEM_DEFINITION = "itemDefinition";
+    public static final String DRG_ELEMENT = "drgElement";
+    public static final String ARTIFACT = "artifact";
+    public static final String ELEMENT_COLLECTION = "elementCollection";
+    public static final String BUSINESS_CONTEXT_ELEMENT = "businessContextElement";
+
+    public DefinitionsConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDefinitions.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Definitions def = (Definitions) parent;
+        if ( IMPORT.equals(nodeName) ) {
+            def.getImport().add((Import) child);
+        } else if (ITEM_DEFINITION.equals(nodeName)) {
+            def.getItemDefinition().add((ItemDefinition) child);
+        } else if (child instanceof DRGElement) {
+            def.getDrgElement().add( (DRGElement) child );
+        } else if (child instanceof Artifact) {
+            def.getArtifact().add((Artifact) child);
+        } else if (ELEMENT_COLLECTION.equals(nodeName)) {
+            def.getElementCollection().add((ElementCollection) child);
+        } else if (child instanceof BusinessContextElement ) {
+            def.getBusinessContextElement().add((BusinessContextElement) child);
+        } else if (child instanceof DMNDI) {
+            DMNDI dmndi = (DMNDI) child;
+            dmndi.normalize();
+            def.setDMNDI(dmndi);
+        } else {
+            super.assignChildElement( def, nodeName, child );
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        Definitions def = (Definitions) parent;
+
+        String exprLang = reader.getAttribute( EXPRESSION_LANGUAGE );
+        String typeLang = reader.getAttribute( TYPE_LANGUAGE ); 
+        String namespace = reader.getAttribute( NAMESPACE );
+        String exporter = reader.getAttribute( EXPORTER );
+        String exporterVersion = reader.getAttribute( EXPORTER_VERSION );
+
+        def.setExpressionLanguage( exprLang );
+        def.setTypeLanguage( typeLang );
+        def.setNamespace( namespace );
+        def.setExporter( exporter );
+        def.setExporterVersion( exporterVersion );
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDefinitions();
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Definitions def = (Definitions) parent;
+        
+        for ( Import i : def.getImport() ) {
+            writeChildrenNode(writer, context, i, IMPORT);
+        }
+        for ( ItemDefinition id : def.getItemDefinition() ) {
+            writeChildrenNode(writer, context, id, ITEM_DEFINITION);
+        }
+        for ( DRGElement e : def.getDrgElement() ) {
+            String nodeName = DRG_ELEMENT;
+            if (e instanceof BusinessKnowledgeModel) {
+                nodeName = "businessKnowledgeModel";
+            } else if (e instanceof Decision) {
+                nodeName = "decision";
+            } else if (e instanceof InputData) {
+                nodeName = "inputData";
+            } else if (e instanceof KnowledgeSource) {
+                nodeName = "knowledgeSource";
+            } else if (e instanceof DecisionService) {
+                nodeName = "decisionService";
+            }
+            writeChildrenNode(writer, context, e, nodeName);
+        }
+        for ( Artifact a : def.getArtifact() ) {
+            String nodeName = ARTIFACT;
+            if (a instanceof Association) {
+                nodeName = "association";
+            } else if (a instanceof TextAnnotation) {
+                nodeName = "textAnnotation";
+            }
+            writeChildrenNode(writer, context, a, nodeName);
+        }
+        for ( ElementCollection ec : def.getElementCollection() ) {
+            writeChildrenNode(writer, context, ec, ELEMENT_COLLECTION);
+        }
+        for ( BusinessContextElement bce : def.getBusinessContextElement() ) {
+            String nodeName = BUSINESS_CONTEXT_ELEMENT;
+            if (bce instanceof OrganizationUnit) {
+                nodeName = "organizationUnit";
+            } else if (bce instanceof PerformanceIndicator) {
+                nodeName = "performanceIndicator";
+            }
+            writeChildrenNode(writer, context, bce, nodeName);
+        }
+
+        if (def.getDMNDI() != null) {
+            writeChildrenNode(writer, context, def.getDMNDI(), "DMNDI");
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Definitions def = (Definitions) parent;
+        
+        if (def.getExpressionLanguage() != null) writer.addAttribute( EXPRESSION_LANGUAGE , def.getExpressionLanguage() );
+        if (def.getTypeLanguage() != null) writer.addAttribute( TYPE_LANGUAGE, def.getTypeLanguage() );
+        if (def.getNamespace() != null) writer.addAttribute( NAMESPACE, def.getNamespace());
+        if (def.getExporter() != null) writer.addAttribute( EXPORTER, def.getExporter() );
+        if (def.getExporterVersion() != null) writer.addAttribute( EXPORTER_VERSION, def.getExporterVersion());
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DefinitionsConverter.java
@@ -16,6 +16,8 @@
 
 package org.kie.dmn.backend.marshalling.v1_3.xstream;
 
+import javax.xml.XMLConstants;
+
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
@@ -39,9 +41,14 @@ import org.kie.dmn.model.api.PerformanceIndicator;
 import org.kie.dmn.model.api.TextAnnotation;
 import org.kie.dmn.model.api.dmndi.DMNDI;
 import org.kie.dmn.model.v1_3.TDefinitions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefinitionsConverter
         extends NamedElementConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefinitionsConverter.class);
+
     private static final String EXPRESSION_LANGUAGE = "expressionLanguage";
     private static final String TYPE_LANGUAGE       = "typeLanguage";
     private static final String NAMESPACE           = "namespace";
@@ -103,6 +110,10 @@ public class DefinitionsConverter
         def.setNamespace( namespace );
         def.setExporter( exporter );
         def.setExporterVersion( exporterVersion );
+
+        if (!def.getNsContext().containsKey(XMLConstants.DEFAULT_NS_PREFIX)) {
+            LOG.warn("This DMN file does not define a default namespace");
+        }
     }
 
     @Override

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramConverter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.dmndi.Diagram;
+
+public abstract class DiagramConverter extends DiagramElementConverter {
+
+    private static final String RESOLUTION = "resolution";
+    private static final String DOCUMENTATION = "documentation";
+    private static final String NAME = "name";
+
+    public DiagramConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Diagram abs = (Diagram) parent;
+
+        String name = reader.getAttribute(NAME);
+        String documentation = reader.getAttribute(DOCUMENTATION);
+        String resolution = reader.getAttribute(RESOLUTION);
+
+        if (name != null) {
+            abs.setName(name);
+        }
+        if (documentation != null) {
+            abs.setDocumentation(documentation);
+        }
+        if (resolution != null) {
+            abs.setResolution(Double.valueOf(resolution));
+        }
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Diagram abs = (Diagram) parent;
+
+        if (abs.getName() != null) {
+            writer.addAttribute(NAME, abs.getName());
+        }
+        if (abs.getDocumentation() != null) {
+            writer.addAttribute(DOCUMENTATION, abs.getDocumentation());
+        }
+        if (abs.getResolution() != null) {
+            writer.addAttribute(RESOLUTION, abs.getResolution().toString());
+        }
+    }
+
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementConverter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.dmndi.DiagramElement;
+import org.kie.dmn.model.api.dmndi.Style;
+
+public abstract class DiagramElementConverter extends DMNModelInstrumentedBaseConverter {
+
+    private static final String STYLE = "style";
+    private static final String SHARED_STYLE = "sharedStyle";
+    private static final String EXTENSION = "extension";
+    private static final String ID = "id";
+
+    public DiagramElementConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        DiagramElement abs = (DiagramElement) parent;
+        
+        if (child instanceof DiagramElement.Extension) {
+            abs.setExtension((DiagramElement.Extension) child);
+        } else if (child instanceof Style) {
+            abs.setStyle((Style) child);
+        } else {
+            super.assignChildElement(abs, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        DiagramElement abs = (DiagramElement) parent;
+        String id = reader.getAttribute(ID);
+        if (id != null) {
+            abs.setId(id);
+        }
+
+        String sharedStyleXmlSerialization = reader.getAttribute(SHARED_STYLE);
+        if (sharedStyleXmlSerialization != null) {
+            abs.setSharedStyle(new org.kie.dmn.model.v1_3.dmndi.Style.IDREFStubStyle(sharedStyleXmlSerialization));
+        }
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        DiagramElement abs = (DiagramElement) parent;
+        
+        if (abs.getExtension() != null) {
+            writeChildrenNode(writer, context, abs.getExtension(), EXTENSION);
+        }
+        if (abs.getStyle() != null) {
+            writeChildrenNode(writer, context, abs.getStyle(), STYLE);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        DiagramElement abs = (DiagramElement) parent;
+
+        if (abs.getId() != null) {
+            writer.addAttribute(ID, abs.getId());
+        }
+
+        if (abs.getSharedStyle() != null) {
+            writer.addAttribute(SHARED_STYLE, abs.getSharedStyle().getId());
+        }
+    }
+
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementExtensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DiagramElementExtensionConverter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.CannotResolveClassException;
+import org.kie.dmn.api.marshalling.DMNExtensionRegister;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.dmndi.DiagramElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DiagramElementExtensionConverter extends DMNModelInstrumentedBaseConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DiagramElementExtensionConverter.class);
+
+    private List<DMNExtensionRegister> extensionRegisters = new ArrayList<>();
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        // no attributes.
+    }
+
+    public DiagramElementExtensionConverter(XStream xStream, List<DMNExtensionRegister> extensionRegisters) {
+        super(xStream);
+        if (!extensionRegisters.isEmpty()) {
+            this.extensionRegisters.addAll(extensionRegisters);
+        }
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        DMNModelInstrumentedBase obj = createModelObject();
+        assignAttributes(reader, obj);
+        if (extensionRegisters.size() == 0) {
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+                String nodeName = reader.getNodeName();
+                // skipping nodeName
+                reader.moveUp();
+            }
+        } else {
+            // do as default behavior, but in case cannot unmarshall an extension element child, just skip it.
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+                String nodeName = reader.getNodeName();
+                try {
+                    Object object = readItem(reader, context, null);
+                    if (object instanceof DMNModelInstrumentedBase) {
+                        ((KieDMNModelInstrumentedBase) object).setParent(obj);
+                        ((KieDMNModelInstrumentedBase) obj).addChildren((KieDMNModelInstrumentedBase) object);
+                    }
+                    assignChildElement(obj, nodeName, object);
+                } catch (CannotResolveClassException e) {
+                    // do nothing; I tried to convert the extension element child with the converters, but no converter is registered for this child.
+                    LOG.debug("Tried to convert the extension element child {}, but no converter is registered for this child.", nodeName);
+                }
+                reader.moveUp();
+            }
+        }
+        return obj;
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+
+        if (extensionRegisters.size() == 0) {
+            return;
+        }
+
+        org.kie.dmn.model.api.dmndi.DiagramElement.Extension ee = (org.kie.dmn.model.api.dmndi.DiagramElement.Extension) parent;
+        if (ee.getAny() != null) {
+            for (Object a : ee.getAny()) {
+                writeItem(a, context, writer);
+            }
+        }
+    }
+
+    public DiagramElementExtensionConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new DiagramElement.Extension();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(DiagramElement.Extension.class);
+    }
+
+    @Override
+    public void assignChildElement(Object parent, String nodeName, Object child) {
+        org.kie.dmn.model.api.dmndi.DiagramElement.Extension id = (org.kie.dmn.model.api.dmndi.DiagramElement.Extension) parent;
+        id.getAny().add(child);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DimensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DimensionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DimensionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/DimensionConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.Dimension;
+
+public class DimensionConverter extends DMNModelInstrumentedBaseConverter {
+
+
+    private static final String HEIGHT = "height";
+    private static final String WIDTH = "width";
+
+    public DimensionConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Dimension abs = (Dimension) parent;
+
+        abs.setWidth(Double.valueOf(reader.getAttribute(WIDTH)));
+        abs.setHeight(Double.valueOf(reader.getAttribute(HEIGHT)));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Dimension abs = (Dimension) parent;
+
+        writer.addAttribute(WIDTH, FormatUtils.manageDouble(abs.getWidth()));
+        writer.addAttribute(HEIGHT, FormatUtils.manageDouble(abs.getHeight()));
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.Dimension();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(org.kie.dmn.model.v1_3.dmndi.Dimension.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/EdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/EdgeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/EdgeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/EdgeConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.dmndi.Edge;
+import org.kie.dmn.model.api.dmndi.Point;
+
+public abstract class EdgeConverter extends DiagramElementConverter {
+
+    private static final String WAYPOINT = "waypoint";
+
+    public EdgeConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Edge abs = (Edge) parent;
+
+        if (child instanceof Point) {
+            abs.getWaypoint().add((Point) child);
+        } else {
+            super.assignChildElement(abs, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Edge abs = (Edge) parent;
+
+        for (Point pt : abs.getWaypoint()) {
+            writeChildrenNode(writer, context, pt, WAYPOINT);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ElementCollectionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ElementCollectionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ElementCollectionConverter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.ElementCollection;
+import org.kie.dmn.model.v1_3.TElementCollection;
+
+public class ElementCollectionConverter extends NamedElementConverter {
+
+    public static final String DRG_ELEMENT = "drgElement";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        ElementCollection ec = (ElementCollection) parent;    
+        
+        if (DRG_ELEMENT.equals( nodeName )) {
+            ec.getDrgElement().add((DMNElementReference) child);
+        }
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        ElementCollection ec = (ElementCollection) parent;    
+        
+        for (DMNElementReference e : ec.getDrgElement()) {
+            writeChildrenNode(writer, context, e, DRG_ELEMENT);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public ElementCollectionConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TElementCollection();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TElementCollection.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExpressionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExpressionConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.Expression;
+
+public abstract class ExpressionConverter
+        extends DMNElementConverter {
+
+    public static final String TYPE_REF = "typeRef";
+
+    public ExpressionConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement( parent, nodeName, child );
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        String typeRef = reader.getAttribute( TYPE_REF );
+        ((Expression) parent).setTypeRef( MarshallingUtils.parseQNameString( typeRef ) );
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Expression e = (Expression) parent;
+        
+        if (e.getTypeRef() != null) {
+            writer.addAttribute(TYPE_REF, MarshallingUtils.formatQName(e.getTypeRef(), e));
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExtensionElementsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExtensionElementsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ExtensionElementsConverter.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.CannotResolveClassException;
+import org.kie.dmn.api.marshalling.DMNExtensionRegister;
+import org.kie.dmn.model.api.DMNElement.ExtensionElements;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TDMNElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExtensionElementsConverter extends DMNModelInstrumentedBaseConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExtensionElementsConverter.class);
+
+    private List<DMNExtensionRegister> extensionRegisters = new ArrayList<>();
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        // no attributes.
+    }
+
+    public ExtensionElementsConverter(XStream xStream, List<DMNExtensionRegister> extensionRegisters) {
+        super(xStream);
+        if ( !extensionRegisters.isEmpty() ) {
+            this.extensionRegisters.addAll(extensionRegisters);
+        }
+    }
+
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        DMNModelInstrumentedBase obj = createModelObject();
+        assignAttributes( reader, obj );
+        if(extensionRegisters.size() == 0) {
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+                String nodeName = reader.getNodeName();
+                // skipping nodeName
+                reader.moveUp();
+            }
+        } else {
+            // do as default behavior, but in case cannot unmarshall an extension element child, just skip it.
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+                String nodeName = reader.getNodeName();
+                try {
+                    Object object = readItem(reader, context, null);
+                    if (object instanceof DMNModelInstrumentedBase) {
+                        ((KieDMNModelInstrumentedBase) object).setParent(obj);
+                        ((KieDMNModelInstrumentedBase) obj).addChildren((KieDMNModelInstrumentedBase) object);
+                    }
+                    assignChildElement(obj, nodeName, object);
+                } catch (CannotResolveClassException e) {
+                    // do nothing; I tried to convert the extension element child with the converters, but no converter is registered for this child.
+                    LOG.debug("Tried to convert the extension element child {}, but no converter is registered for this child.", nodeName);
+                }
+                reader.moveUp();
+            }
+        }
+        return obj;
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        // no attributes.
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        
+        if(extensionRegisters.size() == 0) {
+            return;
+        }
+
+        ExtensionElements ee = (ExtensionElements) parent;
+        if ( ee.getAny() != null ) {
+            for ( Object a : ee.getAny() ) {
+                writeItem(a, context, writer);
+            }
+        }
+    }
+
+    public ExtensionElementsConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TDMNElement.TExtensionElements();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TDMNElement.TExtensionElements.class);
+    }
+
+    @Override
+    public void assignChildElement(Object parent, String nodeName, Object child) {
+        ExtensionElements id = (ExtensionElements)parent;
+        id.getAny().add(child);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FormatUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FormatUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FormatUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FormatUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import java.util.Objects;
+
+public class FormatUtils {
+
+    public static String manageDouble(Double d) {
+        Objects.requireNonNull(d);
+        long longValue = d.longValue();
+        if (d == longValue) {
+            return String.format("%d", longValue);
+        } else {
+            return String.format("%s", d);
+        }
+    }
+
+    private FormatUtils() {
+        // no constructor for utils class.
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionDefinitionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/FunctionDefinitionConverter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.FunctionDefinition;
+import org.kie.dmn.model.api.FunctionKind;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.v1_3.TFunctionDefinition;
+
+public class FunctionDefinitionConverter extends ExpressionConverter {
+
+    private static final String KIND = "kind";
+    public static final String EXPRESSION = "expression";
+    public static final String FORMAL_PARAMETER = "formalParameter";
+
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        FunctionDefinition fd = (FunctionDefinition) parent;
+        
+        if (FORMAL_PARAMETER.equals(nodeName)) {
+            fd.getFormalParameter().add((InformationItem) child);
+        } else if (child instanceof Expression) {
+            fd.setExpression((Expression) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+
+        FunctionDefinition i = (FunctionDefinition) parent;
+
+        String kind = reader.getAttribute(KIND);
+        if (kind != null) {
+            i.setKind(FunctionKind.fromValue(kind));
+        }
+
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        FunctionDefinition fd = (FunctionDefinition) parent;
+        
+        for (InformationItem fparam : fd.getFormalParameter()) {
+            writeChildrenNode(writer, context, fparam, FORMAL_PARAMETER);
+        }
+        if (fd.getExpression() != null) writeChildrenNode(writer, context, fd.getExpression(), MarshallingUtils.defineExpressionNodeName(fd.getExpression()));
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        FunctionDefinition fd = (FunctionDefinition) parent;
+        writer.addAttribute(KIND, fd.getKind().value());
+    }
+
+    public FunctionDefinitionConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TFunctionDefinition();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TFunctionDefinition.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportConverter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Import;
+import org.kie.dmn.model.v1_3.TImport;
+
+public class ImportConverter extends NamedElementConverter {
+    public static final String NAMESPACE = "namespace";
+    public static final String LOCATION_URI = "locationURI"; 
+    public static final String IMPORT_TYPE = "importType";  
+    
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Import i = (Import) parent;
+        
+        String namespace = reader.getAttribute(NAMESPACE);
+        String locationUri = reader.getAttribute(LOCATION_URI);
+        String importType = reader.getAttribute(IMPORT_TYPE);
+        
+        i.setNamespace(namespace);
+        i.setLocationURI(locationUri);
+        i.setImportType(importType);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Import i = (Import) parent;
+        
+        if (i.getNamespace() != null) writer.addAttribute(NAMESPACE, i.getNamespace());
+        if (i.getLocationURI() != null) writer.addAttribute(LOCATION_URI, i.getLocationURI());
+        if (i.getImportType() != null) writer.addAttribute(IMPORT_TYPE, i.getImportType());
+    }
+
+    public ImportConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TImport();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TImport.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportedValuesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportedValuesConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ImportedValuesConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.ImportedValues;
+import org.kie.dmn.model.v1_3.TImportedValues;
+
+public class ImportedValuesConverter extends ImportConverter {
+    public static final String IMPORTED_ELEMENT = "importedElement";
+    public static final String EXPRESSION_LANGUAGE = "expressionLanguage";
+
+    public ImportedValuesConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        ImportedValues iv = (ImportedValues) parent;
+        
+        if (IMPORTED_ELEMENT.equals(nodeName)) {
+            iv.setImportedElement((String) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        ImportedValues iv = (ImportedValues) parent;
+        
+        String expressionLanguage = reader.getAttribute(EXPRESSION_LANGUAGE);
+        
+        iv.setExpressionLanguage(expressionLanguage);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        ImportedValues iv = (ImportedValues) parent;
+        
+        writeChildrenNode(writer, context, iv.getImportedElement(), IMPORTED_ELEMENT);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        ImportedValues iv = (ImportedValues) parent;
+        
+        if (iv.getExpressionLanguage() != null) writer.addAttribute(EXPRESSION_LANGUAGE, iv.getExpressionLanguage());
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TImportedValues();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TImportedValues.class);
+    }
+    
+    
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationItemConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationItemConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationItemConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.v1_3.TInformationItem;
+
+public class InformationItemConverter
+        extends NamedElementConverter {
+    private static final String TYPE_REF = "typeRef";
+
+    public InformationItemConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TInformationItem.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement( parent, nodeName, child );
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        InformationItem ii = (InformationItem) parent;
+
+        String typeRef = reader.getAttribute( TYPE_REF );
+        ii.setTypeRef( MarshallingUtils.parseQNameString( typeRef ) );
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TInformationItem();
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        InformationItem ii = (InformationItem) parent;
+        
+        if (ii.getTypeRef() != null) {
+            writer.addAttribute(TYPE_REF, MarshallingUtils.formatQName(ii.getTypeRef(), ii));
+        }
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationRequirementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InformationRequirementConverter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.InformationRequirement;
+import org.kie.dmn.model.v1_3.TInformationRequirement;
+
+public class InformationRequirementConverter extends DMNElementConverter {
+
+    private static final String REQUIRED_INPUT    = "requiredInput";
+    private static final String REQUIRED_DECISION = "requiredDecision";
+
+    public InformationRequirementConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TInformationRequirement.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        InformationRequirement ir = (InformationRequirement) parent;
+        
+        if ( REQUIRED_INPUT.equals( nodeName ) ) {
+            ir.setRequiredInput( (DMNElementReference) child );
+        } else if ( REQUIRED_DECISION.equals( nodeName ) ) {
+            ir.setRequiredDecision( (DMNElementReference) child );
+        } else {
+            super.assignChildElement( parent, nodeName, child );
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TInformationRequirement();
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        InformationRequirement ir = (InformationRequirement) parent;
+        
+        if ( ir.getRequiredDecision() != null ) {
+            writeChildrenNode(writer, context, ir.getRequiredDecision(), REQUIRED_DECISION);
+        }
+        if ( ir.getRequiredInput() != null ) {
+            writeChildrenNode(writer, context, ir.getRequiredInput(), REQUIRED_INPUT);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputClauseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputClauseConverter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.InputClause;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.UnaryTests;
+import org.kie.dmn.model.v1_3.TInputClause;
+
+public class InputClauseConverter extends DMNElementConverter {
+    public static final String INPUT_VALUES = "inputValues";
+    public static final String INPUT_EXPRESSION = "inputExpression";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        InputClause ic = (InputClause) parent;
+        
+        if (INPUT_EXPRESSION.equals(nodeName)) {
+            ic.setInputExpression((LiteralExpression) child);
+        } else if (INPUT_VALUES.equals(nodeName)) {
+            ic.setInputValues((UnaryTests) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        InputClause ic = (InputClause) parent;
+        
+        writeChildrenNode(writer, context, ic.getInputExpression(), INPUT_EXPRESSION);
+        if (ic.getInputValues() != null) writeChildrenNode(writer, context, ic.getInputValues(), INPUT_VALUES); 
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+    }
+
+    public InputClauseConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TInputClause();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TInputClause.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputDataConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InputDataConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.InputData;
+import org.kie.dmn.model.v1_3.TInputData;
+
+public class InputDataConverter
+        extends DRGElementConverter {
+
+    private static final String VARIABLE = "variable";
+
+    public InputDataConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TInputData.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+        InputData id = (InputData) parent;
+        
+        if ( VARIABLE.equals( nodeName ) ) {
+            id.setVariable( (InformationItem) child );
+        } else {
+            super.assignChildElement( parent, nodeName, child );
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TInputData();
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        InputData id = (InputData) parent;
+        
+        if ( id.getVariable() != null ) {
+            writeChildrenNode(writer, context, id.getVariable(), VARIABLE);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+
+    
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocableConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocableConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocableConverter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.Invocable;
+
+public abstract class InvocableConverter extends DRGElementConverter {
+
+    public static final String VARIABLE = "variable";
+
+    public InvocableConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Invocable bkm = (Invocable) parent;
+
+        if (VARIABLE.equals(nodeName)) {
+            bkm.setVariable((InformationItem) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+
+        Invocable bkm = (Invocable) parent;
+
+        if (bkm.getVariable() != null) {
+            writeChildrenNode(writer, context, bkm.getVariable(), VARIABLE);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/InvocationConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.Binding;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.Invocation;
+import org.kie.dmn.model.v1_3.TInvocation;
+
+public class InvocationConverter extends ExpressionConverter {
+    public static final String BINDING = "binding";
+    public static final String EXPRESSION = "expression";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Invocation i = (Invocation) parent;
+        
+        if (child instanceof Expression) {
+            i.setExpression((Expression) child);
+        } else if (BINDING.equals(nodeName)) {
+            i.getBinding().add((Binding) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Invocation i = (Invocation) parent;
+        
+        if (i.getExpression() != null) writeChildrenNode(writer, context, i.getExpression(), MarshallingUtils.defineExpressionNodeName(i.getExpression()));
+        for (Binding b : i.getBinding()) {
+            writeChildrenNode(writer, context, b, BINDING);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+    }
+
+    public InvocationConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TInvocation();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TInvocation.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ItemDefinitionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ItemDefinitionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ItemDefinitionConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.ItemDefinition;
+import org.kie.dmn.model.api.UnaryTests;
+import org.kie.dmn.model.v1_3.TItemDefinition;
+
+public class ItemDefinitionConverter extends NamedElementConverter {
+    public static final String ITEM_COMPONENT = "itemComponent";
+    public static final String ALLOWED_VALUES = "allowedValues";
+    public static final String TYPE_REF = "typeRef";
+    public static final String TYPE_LANGUAGE = "typeLanguage";
+    public static final String IS_COLLECTION = "isCollection";
+    
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        ItemDefinition id = (ItemDefinition) parent;
+        
+        if (TYPE_REF.equals(nodeName)) {
+            id.setTypeRef((QName) child);
+        } else if (ALLOWED_VALUES.equals(nodeName)) {
+            id.setAllowedValues((UnaryTests) child);
+        } else if (ITEM_COMPONENT.equals(nodeName)) {
+            id.getItemComponent().add((ItemDefinition) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        ItemDefinition id = (ItemDefinition) parent;
+        
+        String typeLanguage = reader.getAttribute(TYPE_LANGUAGE);
+        String isCollectionValue = reader.getAttribute(IS_COLLECTION);
+        
+        id.setTypeLanguage(typeLanguage);
+        id.setIsCollection(Boolean.valueOf(isCollectionValue));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        ItemDefinition id = (ItemDefinition) parent;
+        
+        if (id.getTypeRef() != null) writeChildrenNode(writer, context, id.getTypeRef(), TYPE_REF);
+        if (id.getAllowedValues() != null) writeChildrenNode(writer, context, id.getAllowedValues(), ALLOWED_VALUES);
+        for ( ItemDefinition ic : id.getItemComponent() ) {
+            writeChildrenNode(writer, context, ic, ITEM_COMPONENT);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        ItemDefinition id = (ItemDefinition) parent;
+        
+        if (id.getTypeLanguage() != null) writer.addAttribute(TYPE_LANGUAGE, id.getTypeLanguage());
+        writer.addAttribute(IS_COLLECTION, Boolean.valueOf(id.isIsCollection()).toString());
+    }
+
+    public ItemDefinitionConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TItemDefinition();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TItemDefinition.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeRequirementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeRequirementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeRequirementConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.KnowledgeRequirement;
+import org.kie.dmn.model.v1_3.TKnowledgeRequirement;
+
+public class KnowledgeRequirementConverter extends DMNElementConverter {
+    public static final String REQUIRED_KNOWLEDGE = "requiredKnowledge";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        KnowledgeRequirement kr = (KnowledgeRequirement) parent;
+        
+        if (REQUIRED_KNOWLEDGE.equals(nodeName)) {
+            kr.setRequiredKnowledge((DMNElementReference) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        KnowledgeRequirement kr = (KnowledgeRequirement) parent;
+        
+        writeChildrenNode(writer, context, kr.getRequiredKnowledge(), REQUIRED_KNOWLEDGE);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public KnowledgeRequirementConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TKnowledgeRequirement();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TKnowledgeRequirement.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeSourceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeSourceConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/KnowledgeSourceConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.KnowledgeSource;
+import org.kie.dmn.model.v1_3.TKnowledgeSource;
+
+public class KnowledgeSourceConverter extends DRGElementConverter {
+    public static final String OWNER = "owner";
+    public static final String TYPE = "type";
+    public static final String AUTHORITY_REQUIREMENT = "authorityRequirement";
+    public static final String LOCATION_URI = "locationURI";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        KnowledgeSource ks = (KnowledgeSource) parent;
+        
+        if (AUTHORITY_REQUIREMENT.equals(nodeName)) {
+            ks.getAuthorityRequirement().add((AuthorityRequirement) child);
+        } else if (TYPE.equals(nodeName)) {
+            ks.setType((String) child);
+        } else if (OWNER.equals(nodeName)) {
+            ks.setOwner((DMNElementReference) child);
+        } else { 
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        KnowledgeSource ks = (KnowledgeSource) parent;
+        
+        String locationUri = reader.getAttribute(LOCATION_URI);
+        
+        ks.setLocationURI(locationUri);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        KnowledgeSource ks = (KnowledgeSource) parent;
+        
+        for ( AuthorityRequirement ar : ks.getAuthorityRequirement() ) {
+            writeChildrenNode(writer, context, ar, AUTHORITY_REQUIREMENT);
+        }
+        if (ks.getType() != null) writeChildrenNode(writer, context, ks.getType(), TYPE);
+        if (ks.getOwner() != null) writeChildrenNode(writer, context, ks.getOwner(), OWNER);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        KnowledgeSource ks = (KnowledgeSource) parent;
+        
+        if (ks.getLocationURI() != null) writer.addAttribute(LOCATION_URI, ks.getLocationURI());
+    }
+
+    public KnowledgeSourceConverter(XStream xstream) {
+        super(xstream);
+    }
+    
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TKnowledgeSource();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TKnowledgeSource.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/LiteralExpressionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/LiteralExpressionConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/LiteralExpressionConverter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.ImportedValues;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.v1_3.TLiteralExpression;
+
+public class LiteralExpressionConverter
+        extends ExpressionConverter {
+
+    public static final String IMPORTED_VALUES = "importedValues";
+    public static final String TEXT = "text";
+    public static final String EXPR_LANGUAGE = "expressionLanguage";
+
+    public LiteralExpressionConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TLiteralExpression.class);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        LiteralExpression le = (LiteralExpression)parent;
+        
+        if( TEXT.equals( nodeName ) ) {
+            le.setText( (String) child );
+        } else if( IMPORTED_VALUES.equals( nodeName ) ) {
+            le.setImportedValues( (ImportedValues) child );
+        } else {
+            super.assignChildElement( parent, nodeName, child );
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        LiteralExpression le = (LiteralExpression) parent;
+        
+        String exprLanguage = reader.getAttribute( EXPR_LANGUAGE );
+
+        le.setExpressionLanguage( exprLanguage );
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TLiteralExpression();
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        LiteralExpression le = (LiteralExpression) parent;
+        
+        if ( le.getText() != null ) writeChildrenNodeAsValue(writer, context, le.getText(), TEXT);
+        if ( le.getImportedValues() != null ) writeChildrenNode(writer, context, le.getImportedValues(), IMPORTED_VALUES);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        LiteralExpression le = (LiteralExpression) parent;
+        
+        if ( le.getExpressionLanguage() != null ) writer.addAttribute(EXPR_LANGUAGE, le.getExpressionLanguage());
+    }
+
+    
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/MarshallingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/MarshallingUtils.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/MarshallingUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+
+import org.kie.dmn.model.api.Context;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.DecisionTable;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.FunctionDefinition;
+import org.kie.dmn.model.api.Invocation;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.Relation;
+
+public final class MarshallingUtils {
+
+    private final static Pattern QNAME_PAT = Pattern.compile("(\\{([^\\}]*)\\})?(([^:]*):)?(.*)");
+
+    public static QName parseQNameString(String qns) {
+        if ( qns != null ) {
+            Matcher m = QNAME_PAT.matcher( qns );
+            if (m.matches()) {
+                if (m.group(4) != null) {
+                    return new QName(m.group(2), m.group(5), m.group(4));
+                } else {
+                    return new QName(m.group(2), m.group(5));
+                }
+            } else {
+                return new QName( qns );
+            }
+        } else {
+            return null;
+        }
+    }
+    
+    public static String formatQName(QName qname, DMNModelInstrumentedBase parent) {
+        if (!XMLConstants.DEFAULT_NS_PREFIX.equals(qname.getPrefix())) {
+            String nsForPrefix = parent.getNamespaceURI(qname.getPrefix());
+            if (parent.getURIFEEL().equals(nsForPrefix)) {
+                return qname.getLocalPart(); // DMN v1.2 feel comes without a prefix.
+            } else {
+                return qname.getPrefix() + "." + qname.getLocalPart(); // DMN v1.2 namespace typeRef lookup is done with dot.
+            }
+        } else {
+            return qname.toString();
+        }
+    }
+
+    /**
+     * TODO missing what-if in the case of List..
+     */
+    public static String defineExpressionNodeName(Expression e) {
+        String nodeName = "expression";
+        if (e instanceof Context) {
+            nodeName = "context";
+        } else if (e instanceof DecisionTable) {
+            nodeName = "decisionTable";
+        } else if (e instanceof FunctionDefinition) {
+            nodeName = "functionDefinition";
+        } else if (e instanceof Invocation) {
+            nodeName = "invocation";
+        } else if (e instanceof LiteralExpression) {
+            nodeName = "literalExpression";
+        } else if (e instanceof Relation) {
+            nodeName = "relation";
+        }
+        return nodeName;
+    }
+
+    private MarshallingUtils() {
+        // Constructing instances is not allowed for this class
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/NamedElementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/NamedElementConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/NamedElementConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import org.kie.dmn.model.api.*;
+import org.kie.dmn.model.v1_3.*;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+public abstract class NamedElementConverter
+        extends DMNElementConverter {
+    private static final String NAME = "name";
+
+    public NamedElementConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement( parent, nodeName, child );
+    }
+
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+        String name = reader.getAttribute( NAME );
+        ((NamedElement) parent).setName( name );
+    }
+    
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        
+        // no children.
+    }
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        NamedElement ne = (NamedElement) parent;
+        
+        writer.addAttribute( NAME , ne.getName() );
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OrganizationUnitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OrganizationUnitConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OrganizationUnitConverter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.OrganizationUnit;
+import org.kie.dmn.model.v1_3.TOrganizationUnit;
+
+public class OrganizationUnitConverter extends BusinessContextElementConverter {
+    public static final String DECISION_OWNED = "decisionOwned";
+    public static final String DECISION_MADE = "decisionMade";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        OrganizationUnit ou = (OrganizationUnit) parent;
+        
+        if (DECISION_MADE.equals(nodeName)) {
+            ou.getDecisionMade().add((DMNElementReference) child);
+        } else if (DECISION_OWNED.equals(nodeName)) {
+            ou.getDecisionOwned().add((DMNElementReference) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        OrganizationUnit ou = (OrganizationUnit) parent;
+        
+        for (DMNElementReference dm : ou.getDecisionMade()) {
+            writeChildrenNode(writer, context, dm, DECISION_MADE);
+        }
+        for (DMNElementReference downed : ou.getDecisionOwned()) {
+            writeChildrenNode(writer, context, downed, DECISION_OWNED);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public OrganizationUnitConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TOrganizationUnit();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TOrganizationUnit.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OutputClauseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OutputClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/OutputClauseConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.OutputClause;
+import org.kie.dmn.model.api.UnaryTests;
+import org.kie.dmn.model.v1_3.TOutputClause;
+
+public class OutputClauseConverter extends DMNElementConverter {
+    public static final String DEFAULT_OUTPUT_ENTRY = "defaultOutputEntry";
+    public static final String OUTPUT_VALUES = "outputValues";
+    public static final String NAME = "name";
+    public static final String TYPE_REF ="typeRef";
+    
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        OutputClause oc = (OutputClause) parent;
+        
+        if (OUTPUT_VALUES.equals(nodeName)) {
+            oc.setOutputValues((UnaryTests) child);
+        } else if (DEFAULT_OUTPUT_ENTRY.equals(nodeName)) {
+            oc.setDefaultOutputEntry((LiteralExpression) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        OutputClause oc = (OutputClause) parent;
+        
+        String name = reader.getAttribute(NAME);
+        String typeRefValue = reader.getAttribute(TYPE_REF);
+        
+        oc.setName(name);
+        if (typeRefValue != null) oc.setTypeRef(MarshallingUtils.parseQNameString(typeRefValue));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        OutputClause oc = (OutputClause) parent;
+        
+        if (oc.getOutputValues() != null) writeChildrenNode(writer, context, oc.getOutputValues(), OUTPUT_VALUES);
+        if (oc.getDefaultOutputEntry() != null) writeChildrenNode(writer, context, oc.getDefaultOutputEntry(), DEFAULT_OUTPUT_ENTRY);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        OutputClause oc = (OutputClause) parent;
+        
+        if (oc.getName() != null) writer.addAttribute(NAME, oc.getName());
+        if (oc.getTypeRef() != null) {
+            writer.addAttribute(TYPE_REF, MarshallingUtils.formatQName(oc.getTypeRef(), oc));
+        }
+    }
+
+    public OutputClauseConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TOutputClause();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TOutputClause.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PerformanceIndicatorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PerformanceIndicatorConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PerformanceIndicatorConverter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.PerformanceIndicator;
+import org.kie.dmn.model.v1_3.TPerformanceIndicator;
+
+public class PerformanceIndicatorConverter extends BusinessContextElementConverter {
+    public static final String IMPACTING_DECISION = "impactingDecision";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        PerformanceIndicator pi = (PerformanceIndicator) parent;
+        
+        if (IMPACTING_DECISION.equals(nodeName)) {
+            pi.getImpactingDecision().add((DMNElementReference) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        PerformanceIndicator pi = (PerformanceIndicator) parent;
+        
+        for ( DMNElementReference id : pi.getImpactingDecision() ) {
+            writeChildrenNode(writer, context, id, IMPACTING_DECISION);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public PerformanceIndicatorConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TPerformanceIndicator();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TPerformanceIndicator.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PointConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PointConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PointConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/PointConverter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.dmndi.Point;
+
+public class PointConverter extends DMNModelInstrumentedBaseConverter {
+
+
+    private static final String Y = "y";
+    private static final String X = "x";
+
+    public PointConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Point abs = (Point) parent;
+
+        abs.setX(Double.valueOf(reader.getAttribute(X)));
+        abs.setY(Double.valueOf(reader.getAttribute(Y)));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        Point abs = (Point) parent;
+
+        writer.addAttribute(X, FormatUtils.manageDouble(abs.getX()));
+        writer.addAttribute(Y, FormatUtils.manageDouble(abs.getY()));
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new org.kie.dmn.model.v1_3.dmndi.Point();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(org.kie.dmn.model.v1_3.dmndi.Point.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/QNameConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/QNameConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/QNameConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * Please note this does not extend the DMNBaseConverter as it just need access to the node value itself.
+ */
+public class QNameConverter implements Converter {
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals( QName.class );
+    }
+
+    @Override
+    public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+        // DMN v1.2 semantic always local part.
+        QName qname = (QName) object;
+        writer.setValue(qname.getLocalPart());
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        // DMN v1.2 semantic always local part.
+        QName qname = new QName(reader.getValue());
+        return qname;
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RelationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RelationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RelationConverter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.Relation;
+import org.kie.dmn.model.v1_3.TRelation;
+
+public class RelationConverter extends ExpressionConverter {
+    public static final String EXPRESSION = "expression";
+    public static final String ROW = "row";
+    public static final String COLUMN = "column";
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Relation r = (Relation) parent;
+        
+        if (COLUMN.equals(nodeName)) {
+            r.getColumn().add((InformationItem) child);
+        } else if (ROW.equals(nodeName)) {
+            r.getRow().add((org.kie.dmn.model.api.List) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Relation r = (Relation) parent;
+        
+        for (InformationItem c : r.getColumn()) {
+            writeChildrenNode(writer, context, c, COLUMN);
+        }
+        for (org.kie.dmn.model.api.List row : r.getRow()) {
+            writeChildrenNode(writer, context, row, ROW);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        
+        // no attributes.
+    }
+
+    public RelationConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TRelation();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TRelation.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationClauseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationClauseConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationClauseConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.RuleAnnotationClause;
+import org.kie.dmn.model.v1_3.TRuleAnnotationClause;
+
+public class RuleAnnotationClauseConverter extends DMNModelInstrumentedBaseConverter {
+
+    public static final String NAME = "name";
+
+    public RuleAnnotationClauseConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+
+        ((RuleAnnotationClause) parent).setName(reader.getAttribute(NAME));
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        RuleAnnotationClause e = (RuleAnnotationClause) parent;
+
+        if (e.getName() != null) {
+            writer.addAttribute(NAME, e.getName());
+        }
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TRuleAnnotationClause();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(TRuleAnnotationClause.class);
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/RuleAnnotationConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.RuleAnnotation;
+import org.kie.dmn.model.v1_3.TRuleAnnotation;
+
+public class RuleAnnotationConverter extends DMNModelInstrumentedBaseConverter {
+
+    public static final String TEXT = "text";
+
+    public RuleAnnotationConverter(XStream xstream) {
+        super( xstream );
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        super.assignChildElement(parent, nodeName, child);
+        RuleAnnotation e = (RuleAnnotation) parent;
+
+        if (TEXT.equals(nodeName)) {
+            e.setText((String) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes( reader, parent );
+
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        RuleAnnotation r = (RuleAnnotation) parent;
+
+        writeChildrenNode(writer, context, r.getText(), TEXT);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TRuleAnnotation();
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return type.equals(TRuleAnnotation.class);
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ShapeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ShapeConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/ShapeConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.dmndi.Bounds;
+import org.kie.dmn.model.api.dmndi.Shape;
+
+public abstract class ShapeConverter extends DiagramElementConverter {
+
+    private static final String BOUNDS = "Bounds";
+
+    public ShapeConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Shape abs = (Shape) parent;
+
+        if (child instanceof Bounds) {
+            abs.setBounds((Bounds) child);
+        } else {
+            super.assignChildElement(abs, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+
+        // no attributes.
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Shape abs = (Shape) parent;
+
+        if (abs.getBounds() != null) {
+            writeChildrenNode(writer, context, abs.getBounds(), BOUNDS);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+
+        // no attributes.
+    }
+
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/StyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/StyleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/StyleConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/StyleConverter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.dmndi.Style;
+import org.kie.dmn.model.api.dmndi.Style.Extension;
+
+public abstract class StyleConverter extends DMNModelInstrumentedBaseConverter {
+
+    private static final String EXTENSION = "extension";
+    private static final String ID = "id";
+
+    public StyleConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        Style style = (Style) parent;
+        
+        if (child instanceof Style.Extension) {
+            style.setExtension((Extension) child);
+        } else {
+            super.assignChildElement(style, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        Style style = (Style) parent;
+        String id = reader.getAttribute(ID);
+        if (id != null) {
+            style.setId(id);
+        }
+
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        Style style = (Style) parent;
+        
+        if (style.getExtension() != null) {
+            writeChildrenNode(writer, context, style.getExtension(), EXTENSION);
+        }
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        Style style = (Style) parent;
+
+        if (style.getId() != null) {
+            writer.addAttribute(ID, style.getId());
+        }
+
+    }
+
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/TextAnnotationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/TextAnnotationConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/TextAnnotationConverter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.TextAnnotation;
+import org.kie.dmn.model.v1_3.TTextAnnotation;
+
+public class TextAnnotationConverter extends ArtifactConverter {
+    public static final String TEXT = "text";
+    public static final String TEXT_FORMAT = "textFormat";
+    
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        TextAnnotation ta = (TextAnnotation) parent;
+        
+        if (TEXT.equals(nodeName)) {
+            ta.setText((String) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        TextAnnotation ta = (TextAnnotation) parent;
+        
+        String textFormat = reader.getAttribute(TEXT_FORMAT);
+        
+        ta.setTextFormat(textFormat);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        TextAnnotation ta = (TextAnnotation) parent;
+        
+        if (ta.getText() != null) writeChildrenNode(writer, context, ta.getText(), TEXT);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        TextAnnotation ta = (TextAnnotation) parent;
+        
+        if (ta.getTextFormat() != null) writer.addAttribute(TEXT_FORMAT, ta.getTextFormat()); 
+    }
+
+    public TextAnnotationConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TTextAnnotation();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TTextAnnotation.class);
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/UnaryTestsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/UnaryTestsConverter.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/UnaryTestsConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.UnaryTests;
+import org.kie.dmn.model.v1_3.TUnaryTests;
+
+public class UnaryTestsConverter extends DMNElementConverter {
+    public static final String TEXT = "text";
+    public static final String EXPRESSION_LANGUAGE = "expressionLanguage";
+    
+    @Override
+    protected void assignChildElement(Object parent, String nodeName, Object child) {
+        UnaryTests ut = (UnaryTests) parent;
+        
+        if (TEXT.equals(nodeName)) {
+            ut.setText((String) child);
+        } else {
+            super.assignChildElement(parent, nodeName, child);
+        }
+    }
+
+    @Override
+    protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
+        UnaryTests ut = (UnaryTests) parent;
+
+        String expressionLanguage = reader.getAttribute(EXPRESSION_LANGUAGE);
+        
+        ut.setExpressionLanguage(expressionLanguage);
+    }
+
+    @Override
+    protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
+        super.writeChildren(writer, context, parent);
+        UnaryTests ut = (UnaryTests) parent;
+
+        writeChildrenNode(writer, context, ut.getText(), TEXT);
+    }
+
+    @Override
+    protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
+        super.writeAttributes(writer, parent);
+        UnaryTests ut = (UnaryTests) parent;
+
+        if (ut.getExpressionLanguage() != null) writer.addAttribute(EXPRESSION_LANGUAGE, ut.getExpressionLanguage());
+    }
+
+    public UnaryTestsConverter(XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new TUnaryTests();
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return clazz.equals(TUnaryTests.class);
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/XStreamMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/XStreamMarshaller.java
+++ b/kie-dmn/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_3/xstream/XStreamMarshaller.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.xstream;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.AbstractPullReader;
+import com.thoughtworks.xstream.io.xml.QNameMap;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+import com.thoughtworks.xstream.io.xml.StaxWriter;
+import org.kie.dmn.api.marshalling.DMNExtensionRegister;
+import org.kie.dmn.api.marshalling.DMNMarshaller;
+import org.kie.dmn.backend.marshalling.CustomStaxReader;
+import org.kie.dmn.backend.marshalling.CustomStaxWriter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.TArtifact;
+import org.kie.dmn.model.v1_3.TAssociation;
+import org.kie.dmn.model.v1_3.TAuthorityRequirement;
+import org.kie.dmn.model.v1_3.TBinding;
+import org.kie.dmn.model.v1_3.TBusinessContextElement;
+import org.kie.dmn.model.v1_3.TBusinessKnowledgeModel;
+import org.kie.dmn.model.v1_3.TContext;
+import org.kie.dmn.model.v1_3.TContextEntry;
+import org.kie.dmn.model.v1_3.TDMNElement;
+import org.kie.dmn.model.v1_3.TDMNElementReference;
+import org.kie.dmn.model.v1_3.TDecision;
+import org.kie.dmn.model.v1_3.TDecisionRule;
+import org.kie.dmn.model.v1_3.TDecisionService;
+import org.kie.dmn.model.v1_3.TDecisionTable;
+import org.kie.dmn.model.v1_3.TDefinitions;
+import org.kie.dmn.model.v1_3.TElementCollection;
+import org.kie.dmn.model.v1_3.TExpression;
+import org.kie.dmn.model.v1_3.TFunctionDefinition;
+import org.kie.dmn.model.v1_3.TImport;
+import org.kie.dmn.model.v1_3.TImportedValues;
+import org.kie.dmn.model.v1_3.TInformationItem;
+import org.kie.dmn.model.v1_3.TInformationRequirement;
+import org.kie.dmn.model.v1_3.TInputClause;
+import org.kie.dmn.model.v1_3.TInputData;
+import org.kie.dmn.model.v1_3.TInvocation;
+import org.kie.dmn.model.v1_3.TItemDefinition;
+import org.kie.dmn.model.v1_3.TKnowledgeRequirement;
+import org.kie.dmn.model.v1_3.TKnowledgeSource;
+import org.kie.dmn.model.v1_3.TLiteralExpression;
+import org.kie.dmn.model.v1_3.TNamedElement;
+import org.kie.dmn.model.v1_3.TOrganizationUnit;
+import org.kie.dmn.model.v1_3.TOutputClause;
+import org.kie.dmn.model.v1_3.TPerformanceIndicator;
+import org.kie.dmn.model.v1_3.TRelation;
+import org.kie.dmn.model.v1_3.TRuleAnnotation;
+import org.kie.dmn.model.v1_3.TRuleAnnotationClause;
+import org.kie.dmn.model.v1_3.TTextAnnotation;
+import org.kie.dmn.model.v1_3.TUnaryTests;
+import org.kie.dmn.model.v1_3.dmndi.Bounds;
+import org.kie.dmn.model.v1_3.dmndi.Color;
+import org.kie.dmn.model.v1_3.dmndi.DMNDI;
+import org.kie.dmn.model.v1_3.dmndi.DMNDecisionServiceDividerLine;
+import org.kie.dmn.model.v1_3.dmndi.DMNDiagram;
+import org.kie.dmn.model.v1_3.dmndi.DMNEdge;
+import org.kie.dmn.model.v1_3.dmndi.DMNLabel;
+import org.kie.dmn.model.v1_3.dmndi.DMNShape;
+import org.kie.dmn.model.v1_3.dmndi.DMNStyle;
+import org.kie.dmn.model.v1_3.dmndi.DiagramElement;
+import org.kie.dmn.model.v1_3.dmndi.Dimension;
+import org.kie.dmn.model.v1_3.dmndi.Point;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.kie.soup.commons.xstream.XStreamUtils.createTrustingXStream;
+
+public class XStreamMarshaller
+        implements DMNMarshaller {
+
+    private static Logger logger = LoggerFactory.getLogger( XStreamMarshaller.class );
+    private List<DMNExtensionRegister> extensionRegisters = new ArrayList<>();
+
+
+    private static StaxDriver staxDriver;
+    static {
+        staxDriver = new StaxDriver() {
+            public AbstractPullReader createStaxReader(XMLStreamReader in) {
+                return new CustomStaxReader(getQnameMap(), in);
+            }
+            
+            public StaxWriter createStaxWriter(XMLStreamWriter out, boolean writeStartEndDocument) throws XMLStreamException {
+                return new CustomStaxWriter(newQNameMap(), out, writeStartEndDocument, isRepairingNamespace(), getNameCoder());
+            }
+
+            public QNameMap newQNameMap() {
+                QNameMap qmap = new QNameMap();
+                configureQNameMap( qmap );
+                return qmap;
+            }
+        };
+        QNameMap qmap = new QNameMap();
+        configureQNameMap( qmap );
+        staxDriver.setQnameMap(qmap);
+        staxDriver.setRepairingNamespace(false);
+    }
+    
+    public static void configureQNameMap( QNameMap qmap ) {
+        qmap.setDefaultNamespace(KieDMNModelInstrumentedBase.URI_DMN);
+    }
+
+    public XStreamMarshaller() {
+
+    }
+
+    public XStreamMarshaller (List<DMNExtensionRegister> extensionRegisters) {
+        this.extensionRegisters.addAll(extensionRegisters);
+    }
+
+
+    @Override
+    public Definitions unmarshal(String xml) {
+        return unmarshal( new StringReader( xml ) );
+    }
+
+    @Override
+    public Definitions unmarshal(Reader isr) {
+        try {
+            XStream xStream = newXStream();
+
+            Definitions def = (Definitions) xStream.fromXML( isr );
+
+            return def;
+        } catch ( Exception e ) {
+            logger.error( "Error unmarshalling DMN model from reader.", e );
+        }
+        return null;
+    }
+
+    @Override
+    public String marshal(Object o) {
+        try ( Writer writer = new StringWriter();
+              CustomStaxWriter hsWriter = (CustomStaxWriter) staxDriver.createWriter(writer); ) {
+            XStream xStream = newXStream();
+            if ( o instanceof DMNModelInstrumentedBase ) {
+                KieDMNModelInstrumentedBase base = (KieDMNModelInstrumentedBase) o;
+                String dmnPrefix = base.getNsContext().entrySet().stream().filter(kv -> KieDMNModelInstrumentedBase.URI_DMN.equals(kv.getValue())).findFirst().map(Map.Entry::getKey).orElse("");
+                hsWriter.getQNameMap().setDefaultPrefix( dmnPrefix );
+            }
+            extensionRegisters.forEach( r -> r.beforeMarshal(o, hsWriter.getQNameMap()) );
+            xStream.marshal(o, hsWriter);
+            hsWriter.flush();
+            return writer.toString();
+        } catch ( Exception e ) {
+            logger.error( "Error marshalling DMN model to XML.", e );
+        }
+        return null;
+    }
+
+    @Override
+    public void marshal(Object o, Writer out) {
+        try {
+            out.write( marshal( o ) );
+        } catch ( Exception e ) {
+            logger.error( "Error marshalling DMN model to XML.", e );
+        }
+    }
+
+    private XStream newXStream() {
+        XStream xStream = createTrustingXStream( staxDriver, Definitions.class.getClassLoader() );
+        
+        xStream.alias("artifact", TArtifact.class);
+        xStream.alias("definitions", TDefinitions.class);
+        xStream.alias("inputData", TInputData.class);
+        xStream.alias("decision", TDecision.class);
+        xStream.alias("variable", TInformationItem.class);
+        xStream.alias("informationRequirement", TInformationRequirement.class);
+        xStream.alias("requiredInput", TDMNElementReference.class);
+        xStream.alias("literalExpression", TLiteralExpression.class);
+        
+        xStream.alias("DMNElement", TDMNElement.class);
+        xStream.alias("allowedValues", TUnaryTests.class);
+        xStream.alias("artifact", TArtifact.class);
+        xStream.alias("association", TAssociation.class);
+        xStream.alias("authorityRequirement", TAuthorityRequirement.class);
+        xStream.alias("binding", TBinding.class);
+        xStream.alias("businessContextElement", TBusinessContextElement.class);
+        xStream.alias("businessKnowledgeModel", TBusinessKnowledgeModel.class);
+        xStream.alias("column", TInformationItem.class);
+        xStream.alias("context", TContext.class);
+        xStream.alias("contextEntry", TContextEntry.class);
+        xStream.alias("decision", TDecision.class);
+        xStream.alias("decisionMade", TDMNElementReference.class);
+        xStream.alias("decisionMaker", TDMNElementReference.class);
+        xStream.alias("decisionOwned", TDMNElementReference.class);
+        xStream.alias("decisionOwner", TDMNElementReference.class);
+        xStream.alias("decisionService", TDecisionService.class);
+        xStream.alias("decisionTable", TDecisionTable.class);
+        xStream.alias("defaultOutputEntry", TLiteralExpression.class);
+        xStream.alias("definitions", TDefinitions.class);
+        xStream.alias("drgElement", TDMNElementReference.class);
+        xStream.alias("elementCollection", TElementCollection.class);
+        xStream.alias("encapsulatedDecision", TDMNElementReference.class);
+        xStream.alias("encapsulatedLogic", TFunctionDefinition.class);
+        xStream.alias("expression", TExpression.class);
+        xStream.alias("formalParameter", TInformationItem.class);
+        xStream.alias("functionDefinition", TFunctionDefinition.class);
+        xStream.alias("impactedPerformanceIndicator", TDMNElementReference.class);
+        xStream.alias("impactingDecision", TDMNElementReference.class);
+        xStream.alias("import", TImport.class);
+        xStream.alias("import", TImport.class);
+        xStream.alias("importedElement", String.class ); // TODO where?
+        xStream.alias("importedValues", TImportedValues.class);
+        xStream.alias("informationItem", TInformationItem.class);
+        xStream.alias("informationRequirement", TInformationRequirement.class);
+        xStream.alias("input", TInputClause.class);
+        xStream.alias("inputData", TInputData.class);
+        xStream.alias("inputDecision", TDMNElementReference.class);
+        xStream.alias("inputEntry", TUnaryTests.class);
+        xStream.alias("inputExpression", TLiteralExpression.class);
+        xStream.alias("inputValues", TUnaryTests.class);
+        xStream.alias("invocation", TInvocation.class);
+        xStream.alias("itemComponent", TItemDefinition.class);
+        xStream.alias("itemDefinition", TItemDefinition.class);
+        xStream.alias("knowledgeRequirement", TKnowledgeRequirement.class);
+        xStream.alias("knowledgeSource", TKnowledgeSource.class);
+        xStream.alias("literalExpression", TLiteralExpression.class);
+        xStream.alias("namedElement", TNamedElement.class);
+        xStream.alias("organizationUnit", TOrganizationUnit.class);
+        xStream.alias("output", TOutputClause.class);
+        xStream.alias("outputDecision", TDMNElementReference.class);
+        xStream.alias("outputEntry", TLiteralExpression.class);
+        xStream.alias("outputValues", TUnaryTests.class);
+        xStream.alias("owner", TDMNElementReference.class);
+        xStream.alias("parameter", TInformationItem.class);
+        xStream.alias("performanceIndicator", TPerformanceIndicator.class);
+        xStream.alias("relation", TRelation.class);
+        xStream.alias("requiredAuthority", TDMNElementReference.class);
+        xStream.alias("requiredDecision", TDMNElementReference.class);
+        xStream.alias("requiredInput", TDMNElementReference.class);
+        xStream.alias("requiredKnowledge", TDMNElementReference.class);
+        xStream.alias("rule", TDecisionRule.class);
+        xStream.alias("sourceRef", TDMNElementReference.class);
+        xStream.alias("supportedObjective", TDMNElementReference.class);
+        xStream.alias("targetRef", TDMNElementReference.class);
+        xStream.alias("textAnnotation", TTextAnnotation.class);
+        xStream.alias("type", String.class ); // TODO where?
+        xStream.alias("typeRef", QName.class );
+        xStream.alias("usingProcess", TDMNElementReference.class);
+        xStream.alias("usingTask", TDMNElementReference.class);
+        xStream.alias("variable", TInformationItem.class);
+        xStream.alias("row", org.kie.dmn.model.v1_3.TList.class);
+        xStream.alias("list", org.kie.dmn.model.v1_3.TList.class);
+        xStream.alias("extensionElements", TDMNElement.TExtensionElements.class);
+
+        // Manually imported TEXT = String
+        xStream.alias( LiteralExpressionConverter.TEXT, String.class );
+        // unnecessary 'text' key repetition:        xStream.alias( TextAnnotationConverter.TEXT, String.class );
+        // unnecessary 'text' key repetition:        xStream.alias( UnaryTestsConverter.TEXT, String.class );
+        xStream.alias( DecisionConverter.QUESTION, String.class );
+        xStream.alias( DecisionConverter.ALLOWED_ANSWERS, String.class );
+        xStream.alias( DMNElementConverter.DESCRIPTION, String.class );
+        // unnecessary 'text' key repetition:      xStream.alias("text", xsd:string.class );
+        // unnecessary 'text' key repetition:      xStream.alias("text", xsd:string.class );
+        // unnecessary 'text' key repetition:      xStream.alias("text", xsd:string.class );
+        //      xStream.alias("question", xsd:string.class );
+        //      xStream.alias("allowedAnswers", xsd:string.class );
+        //      xStream.alias("description", xsd:string.class );
+
+        // DMN v1.2:
+        // Note, to comply with NS for XStream need also to adjust entries inside DMNModelInstrumentedBaseConverter
+        xStream.alias("annotation", TRuleAnnotationClause.class);
+        xStream.alias("annotationEntry", TRuleAnnotation.class);
+        xStream.registerConverter(new RuleAnnotationClauseConverter(xStream));
+        xStream.registerConverter(new RuleAnnotationConverter(xStream));
+        xStream.alias("DMNDI", DMNDI.class);
+        xStream.registerConverter(new DMNDIConverter(xStream));
+        xStream.alias("DMNDiagram", DMNDiagram.class);
+        xStream.registerConverter(new DMNDiagramConverter(xStream));
+        xStream.alias("DMNStyle", DMNStyle.class);
+        xStream.registerConverter(new DMNStyleConverter(xStream));
+        xStream.alias("Size", Dimension.class);
+        xStream.registerConverter(new DimensionConverter(xStream));
+        xStream.alias("DMNShape", DMNShape.class);
+        xStream.registerConverter(new DMNShapeConverter(xStream));
+        xStream.alias("FillColor", Color.class);
+        xStream.alias("StrokeColor", Color.class);
+        xStream.alias("FontColor", Color.class);
+        xStream.registerConverter(new ColorConverter(xStream));
+        xStream.alias("Bounds", Bounds.class);
+        xStream.registerConverter(new BoundsConverter(xStream));
+        xStream.alias("DMNLabel", DMNLabel.class);
+        xStream.registerConverter(new DMNLabelConverter(xStream));
+        xStream.alias("DMNEdge", DMNEdge.class);
+        xStream.registerConverter(new DMNEdgeConverter(xStream));
+        xStream.alias("DMNDecisionServiceDividerLine", DMNDecisionServiceDividerLine.class);
+        xStream.registerConverter(new DMNDecisionServiceDividerLineConverter(xStream));
+        xStream.alias("waypoint", Point.class);
+        xStream.registerConverter(new PointConverter(xStream));
+        xStream.alias("extension", DiagramElement.Extension.class);
+        xStream.alias(DMNLabelConverter.TEXT, String.class);
+
+        xStream.registerConverter(new AssociationConverter( xStream ) );
+        xStream.registerConverter(new AuthorityRequirementConverter( xStream ) );
+        xStream.registerConverter(new BindingConverter( xStream ) );
+        xStream.registerConverter(new BusinessKnowledgeModelConverter( xStream ) );
+        xStream.registerConverter(new ContextConverter( xStream ) );
+        xStream.registerConverter(new ContextEntryConverter( xStream ) );
+        xStream.registerConverter(new DecisionConverter( xStream ) );
+        xStream.registerConverter(new DecisionRuleConverter( xStream ) );
+        xStream.registerConverter(new DecisionServiceConverter(xStream));
+        xStream.registerConverter(new DecisionTableConverter( xStream ) );
+        xStream.registerConverter(new DefinitionsConverter( xStream ) );
+        xStream.registerConverter(new DMNElementReferenceConverter( xStream ) );
+        xStream.registerConverter(new FunctionDefinitionConverter( xStream ) );
+        xStream.registerConverter(new ImportConverter( xStream ) );
+        xStream.registerConverter(new ImportedValuesConverter( xStream ) );
+        xStream.registerConverter(new InformationItemConverter( xStream ) );
+        xStream.registerConverter(new InformationRequirementConverter( xStream ) );
+        xStream.registerConverter(new InputClauseConverter( xStream ) );
+        xStream.registerConverter(new InputDataConverter( xStream ) );
+        xStream.registerConverter(new InvocationConverter( xStream ) );
+        xStream.registerConverter(new ItemDefinitionConverter( xStream ) );
+        xStream.registerConverter(new KnowledgeRequirementConverter( xStream ) );
+        xStream.registerConverter(new KnowledgeSourceConverter( xStream ) );
+        xStream.registerConverter(new LiteralExpressionConverter( xStream ) );
+        xStream.registerConverter(new OrganizationUnitConverter( xStream ) );
+        xStream.registerConverter(new OutputClauseConverter( xStream ) );
+        xStream.registerConverter(new PerformanceIndicatorConverter( xStream ) );
+        xStream.registerConverter(new RelationConverter( xStream ) );
+        xStream.registerConverter(new TextAnnotationConverter( xStream ) );
+        xStream.registerConverter(new UnaryTestsConverter( xStream ) );
+        
+        xStream.registerConverter(new QNameConverter());
+        xStream.registerConverter(new DMNListConverter( xStream ) );
+        xStream.registerConverter(new ElementCollectionConverter( xStream ) );
+        xStream.registerConverter(new ExtensionElementsConverter( xStream, extensionRegisters ) );
+        xStream.registerConverter(new DiagramElementExtensionConverter(xStream, extensionRegisters));
+        
+        xStream.ignoreUnknownElements();
+
+        for(DMNExtensionRegister extensionRegister : extensionRegisters) {
+            extensionRegister.registerExtensionConverters(xStream);
+        }
+
+        return xStream;
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_2/UnmarshalMarshalTest.java
@@ -64,6 +64,11 @@ public class UnmarshalMarshalTest {
     protected static final Logger logger = LoggerFactory.getLogger(UnmarshalMarshalTest.class);
 
     @Test
+    public void testV12_simple() throws Exception {
+        testRoundTripV12("org/kie/dmn/backend/marshalling/v1_2/", "simple.dmn");
+    }
+
+    @Test
     public void testV12_ch11example() throws Exception {
         testRoundTripV12("org/kie/dmn/backend/marshalling/v1_2/", "ch11example.dmn");
     }

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/UnmarshalMarshalTest.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/UnmarshalMarshalTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.Test;
+import org.kie.dmn.api.marshalling.DMNMarshaller;
+import org.kie.dmn.backend.marshalling.v1_3.extensions.TrisoExtensionRegister;
+import org.kie.dmn.backend.marshalling.v1x.DMNMarshallerFactory;
+import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.validation.Languages;
+import org.xmlunit.validation.ValidationProblem;
+import org.xmlunit.validation.ValidationResult;
+import org.xmlunit.validation.Validator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class UnmarshalMarshalTest {
+
+    private static final StreamSource DMN13_SCHEMA_SOURCE = new StreamSource(UnmarshalMarshalTest.class.getResource("/DMN13.xsd").getFile());
+    private static final DMNMarshaller MARSHALLER = new org.kie.dmn.backend.marshalling.v1x.XStreamMarshaller();
+    protected static final Logger logger = LoggerFactory.getLogger(UnmarshalMarshalTest.class);
+
+    @Test
+    public void testV13_simple() throws Exception {
+        testRoundTripV13("org/kie/dmn/backend/marshalling/v1_3/", "simple.dmn");
+    }
+
+    @Test
+    public void testV13_ch11example_asFromOMG() throws Exception {
+        DMNMarshaller marshaller = DMNMarshallerFactory.newMarshallerWithExtensions(Arrays.asList(new TrisoExtensionRegister())); // as the example from OMG contains example of extension element, preserving.
+        testRoundTrip("org/kie/dmn/backend/marshalling/v1_3/", "Chapter 11 Example.dmn", marshaller, DMN13_SCHEMA_SOURCE);
+    }
+
+    @Test
+    public void testV13_financial() throws Exception {
+        testRoundTripV13("org/kie/dmn/backend/marshalling/v1_3/", "Financial.dmn");
+    }
+
+    @Test
+    public void testV13_loan_info() throws Exception {
+        testRoundTripV13("org/kie/dmn/backend/marshalling/v1_3/", "Loan info.dmn");
+    }
+
+    @Test
+    public void testV13_recommended_loan_product() throws Exception {
+        testRoundTripV13("org/kie/dmn/backend/marshalling/v1_3/", "Recommended Loan Products.dmn");
+    }
+
+    public void testRoundTripV13(String subdir, String xmlfile) throws Exception {
+        testRoundTrip(subdir, xmlfile, MARSHALLER, DMN13_SCHEMA_SOURCE);
+    }
+
+    public void testRoundTrip(String subdir, String xmlfile, DMNMarshaller marshaller, Source schemaSource) throws Exception {
+
+        File baseOutputDir = new File("target/test-xmlunit/");
+        File testClassesBaseDir = new File("target/test-classes/");
+
+
+        File inputXMLFile = new File(testClassesBaseDir, subdir + xmlfile);
+
+        FileInputStream fis = new FileInputStream( inputXMLFile );
+
+        Definitions unmarshal = marshaller.unmarshal( new InputStreamReader( fis ) );
+
+        Validator v = Validator.forLanguage(Languages.W3C_XML_SCHEMA_NS_URI);
+        v.setSchemaSource(schemaSource);
+        ValidationResult validateInputResult = v.validateInstance(new StreamSource( inputXMLFile ));
+        if (!validateInputResult.isValid()) {
+            for ( ValidationProblem p : validateInputResult.getProblems()) {
+                System.err.println(p);
+            }
+        }
+        assertTrue(validateInputResult.isValid());
+
+        final File subdirFile = new File(baseOutputDir, subdir);
+        if (!subdirFile.mkdirs()) {
+            logger.warn("mkdirs() failed for File: " + subdirFile.getAbsolutePath() + "!");
+        }
+        FileOutputStream sourceFos = new FileOutputStream( new File(baseOutputDir, subdir + "a." + xmlfile) );
+        Files.copy(
+                new File(testClassesBaseDir, subdir + xmlfile).toPath(),
+                sourceFos
+                );
+        sourceFos.flush();
+        sourceFos.close();
+
+        System.out.println( marshaller.marshal(unmarshal) );
+        File outputXMLFile = new File(baseOutputDir, subdir + "b." + xmlfile);
+        try (FileWriter targetFos = new FileWriter( outputXMLFile )) {
+            marshaller.marshal(unmarshal, targetFos);
+        }
+
+        // Should also validate output XML:
+        ValidationResult validateOutputResult = v.validateInstance(new StreamSource( outputXMLFile ));
+        if (!validateOutputResult.isValid()) {
+            for ( ValidationProblem p : validateOutputResult.getProblems()) {
+                System.err.println(p);
+            }
+        }
+        assertTrue(validateOutputResult.isValid());
+
+        System.out.println("\n---\nDefault XMLUnit comparison:");
+        Source control = Input.fromFile( inputXMLFile ).build();
+        Source test = Input.fromFile( outputXMLFile ).build();
+        Diff allDiffsSimilarAndDifferent = DiffBuilder
+                .compare( control )
+                .withTest( test )
+                .build();
+        allDiffsSimilarAndDifferent.getDifferences().forEach(System.out::println);
+
+        System.out.println("XMLUnit comparison with customized similarity for defaults:");
+        // in the following a manual DifferenceEvaluator is needed until XMLUnit is configured for properly parsing the XSD linked inside the XML,
+        // in order to detect the optional+defaultvalue attributes of xml element which might be implicit in source-test, and explicit in test-serialized.
+        /*
+         * $ grep -Eo "<xsd:attribute name=\\\"([^\\\"]*)\\\" type=\\\"([^\\\"]*)\\\" use=\\\"optional\\\" default=\\\"([^\\\"])*\\\"" dmn.xsd 
+<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/FEEL/20140401"
+<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="http://www.omg.org/spec/FEEL/20140401"
+<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"
+<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"
+<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"
+DMNv1.2:
+<xsd:attribute name="kind" type="tFunctionKind" default="FEEL"/>
+<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+DMNDIv1.2:
+<xsd:attribute name="isCollapsed" type="xsd:boolean" use="optional" default="false"/>
+         */
+        Set<QName> attrWhichCanDefault = new HashSet<QName>();
+        attrWhichCanDefault.addAll(Arrays.asList(new QName[]{
+                new QName("expressionLanguage"),
+                new QName("typeLanguage"),
+                new QName("isCollection"),
+                new QName("hitPolicy"),
+                new QName("preferredOrientation"),
+                new QName("kind"),
+                new QName("textFormat"),
+                new QName("associationDirection"),
+                new QName("isCollapsed")
+                }));
+        Set<String> nodeHavingDefaultableAttr = new HashSet<>();
+        nodeHavingDefaultableAttr.addAll(Arrays.asList(new String[]{"definitions", "decisionTable", "itemDefinition", "itemComponent", "encapsulatedLogic", "textAnnotation", "association", "DMNShape"}));
+        Diff checkSimilar = DiffBuilder
+                .compare( control )
+                .withTest( test )
+                .withDifferenceEvaluator(
+                        DifferenceEvaluators.chain(DifferenceEvaluators.Default,
+                        ((comparison, outcome) -> {
+                            if (outcome == ComparisonResult.DIFFERENT && comparison.getType() == ComparisonType.ELEMENT_NUM_ATTRIBUTES) {
+                                if (comparison.getControlDetails().getTarget().getNodeName().equals( comparison.getTestDetails().getTarget().getNodeName() )
+                                        && nodeHavingDefaultableAttr.contains( safeStripDMNPRefix( comparison.getControlDetails().getTarget() ) )) {
+                                    return ComparisonResult.SIMILAR;
+                                }
+                            }
+                            // DMNDI/DMNDiagram#documentation is actually deserialized escaped with newlines as &#10; by the XML JDK infra.
+                            if (outcome == ComparisonResult.DIFFERENT && comparison.getType() == ComparisonType.ATTR_VALUE) {
+                                if (comparison.getControlDetails().getTarget().getNodeName().equals( comparison.getTestDetails().getTarget().getNodeName() )
+                                        && comparison.getControlDetails().getTarget().getNodeType() == Node.ATTRIBUTE_NODE
+                                        && comparison.getControlDetails().getTarget().getLocalName().equals("documentation")) {
+                                    return ComparisonResult.SIMILAR;
+                                }
+                            }
+                            if (outcome == ComparisonResult.DIFFERENT && comparison.getType() == ComparisonType.ATTR_NAME_LOOKUP) {
+                                boolean testIsDefaulableAttribute = false;
+                                QName whichDefaultableAttr = null;
+                                if (comparison.getControlDetails().getValue() == null && attrWhichCanDefault.contains(comparison.getTestDetails().getValue())) {
+                                    for (QName a : attrWhichCanDefault) {
+                                        boolean check = comparison.getTestDetails().getXPath().endsWith("@"+a);
+                                        if (check) {
+                                            testIsDefaulableAttribute = true;
+                                            whichDefaultableAttr = a;
+                                            continue;
+                                        }
+                                    }
+                                }
+                                if ( testIsDefaulableAttribute ) {
+                                    if (comparison.getTestDetails().getXPath().equals(comparison.getControlDetails().getXPath() + "/@" + whichDefaultableAttr )) {
+                                        // TODO missing to check the explicited option attribute has value set to the actual default value.
+                                        return ComparisonResult.SIMILAR;
+                                    }
+                                }
+                            }
+                        return outcome;
+                    })))
+                .ignoreWhitespace()
+                .checkForSimilar()
+                .build();
+        checkSimilar.getDifferences().forEach(System.err::println);
+        if (!checkSimilar.getDifferences().iterator().hasNext()) {
+            System.out.println("[ EMPTY - no diffs using customized similarity ]");
+        }
+        assertFalse("XML are NOT similar: " + checkSimilar.toString(), checkSimilar.hasDifferences());
+    }
+
+    private String safeStripDMNPRefix(Node target) {
+        if (KieDMNModelInstrumentedBase.URI_DMN.equals(target.getNamespaceURI()) ||
+            KieDMNModelInstrumentedBase.URI_DMNDI.equals(target.getNamespaceURI())) {
+            return target.getLocalName();
+        }
+        return null;
+    }
+}

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/ProjectCharter.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/ProjectCharter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.extensions;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+@XStreamAlias("ProjectCharter")
+public class ProjectCharter {
+
+    @XStreamAlias("projectGoals")
+    private String projectGoals;
+
+    @XStreamAlias("projectChallenges")
+    private String projectChallenges;
+
+    @XStreamAlias("projectStakeholders")
+    private String projectStakeholders;
+
+    public String getProjectGoals() {
+        return projectGoals;
+    }
+
+    public void setProjectGoals(String content) {
+        this.projectGoals = content;
+    }
+
+    public String getProjectChallenges() {
+        return projectChallenges;
+    }
+
+    public void setProjectChallenges(String projectChallenges) {
+        this.projectChallenges = projectChallenges;
+    }
+
+    public String getProjectStakeholders() {
+        return projectStakeholders;
+    }
+
+    public void setProjectStakeholders(String projectStakeholders) {
+        this.projectStakeholders = projectStakeholders;
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/TrisoExtensionRegister.java
+++ b/kie-dmn/kie-dmn-backend/src/test/java/org/kie/dmn/backend/marshalling/v1_3/extensions/TrisoExtensionRegister.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.backend.marshalling.v1_3.extensions;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.QNameMap;
+import org.kie.dmn.api.marshalling.DMNExtensionRegister;
+
+public class TrisoExtensionRegister implements DMNExtensionRegister {
+
+    @Override
+    public void registerExtensionConverters(XStream xStream) {
+        xStream.processAnnotations(ProjectCharter.class);
+    }
+
+    @Override
+    public void beforeMarshal(Object o, QNameMap qmap) {
+        qmap.registerMapping(new QName("http://www.trisotech.com/2015/triso/modeling", "ProjectCharter", "triso"), "ProjectCharter");
+        qmap.registerMapping(new QName("http://www.trisotech.com/2015/triso/modeling", "projectGoals", "triso"), "projectGoals");
+        qmap.registerMapping(new QName("http://www.trisotech.com/2015/triso/modeling", "projectChallenges", "triso"), "projectChallenges");
+        qmap.registerMapping(new QName("http://www.trisotech.com/2015/triso/modeling", "projectStakeholders", "triso"), "projectStakeholders");
+    }
+
+}

--- a/kie-dmn/kie-dmn-backend/src/test/resources/DMN13.xsd
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/DMN13.xsd
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified"
+	xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+	targetNamespace="https://www.omg.org/spec/DMN/20191111/MODEL/">
+
+	<xsd:import namespace="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+	            schemaLocation="DMNDI13.xsd">
+		<xsd:annotation>
+			<xsd:documentation>
+				Include the DMN Diagram Interchange (DI) schema
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:import>
+
+	<xsd:element name="DMNElement" type="tDMNElement" abstract="true"/>
+	<xsd:complexType name="tDMNElement">
+		<xsd:sequence>
+			<xsd:element name="description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="extensionElements" minOccurs="0" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="label" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:element name="namedElement" type="tNamedElement" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tNamedElement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tDMNElementReference">
+		<xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="definitions" type="tDefinitions" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="itemDefinition" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="drgElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="elementCollection" type="tElementCollection" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="businessContextElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dmndi:DMNDI" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20191111/FEEL/"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20191111/FEEL/"/>
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="exporter" type="xsd:string" use="optional"/>
+				<xsd:attribute name="exporterVersion" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="import" type="tImport" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tImport">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="elementCollection" type="tElementCollection" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tElementCollection">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="drgElement" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="drgElement" type="tDRGElement" abstract="true" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDRGElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decision" type="tDecision" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tDecision">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="question" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="allowedAnswers" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="informationRequirement" type="tInformationRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supportedObjective" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="impactedPerformanceIndicator" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionMaker" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwner" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingProcess" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingTask" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- decisionLogic -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessContextElement" type="tBusinessContextElement" abstract="true"/>
+	<xsd:complexType name="tBusinessContextElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="performanceIndicator" type="tPerformanceIndicator" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tPerformanceIndicator">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="impactingDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="organizationUnit" type="tOrganizationUnit" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tOrganizationUnit">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="decisionMade" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwned" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocable" type="tInvocable" abstract="true" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInvocable">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessKnowledgeModel" type="tBusinessKnowledgeModel" substitutionGroup="invocable"/>
+	<xsd:complexType name="tBusinessKnowledgeModel">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="encapsulatedLogic" type="tFunctionDefinition" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="inputData" type="tInputData" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInputData">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeSource" type="tKnowledgeSource" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tKnowledgeSource">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="owner" type="tDMNElementReference" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="informationRequirement" type="tInformationRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tInformationRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:choice minOccurs="1" maxOccurs="1">
+						<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+						<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					</xsd:choice>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tKnowledgeRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="requiredKnowledge" type="tDMNElementReference" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="authorityRequirement" type="tAuthorityRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tAuthorityRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:choice minOccurs="1" maxOccurs="1">
+					<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+					<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					<xsd:element name="requiredAuthority" type="tDMNElementReference"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="expression" type="tExpression" abstract="true"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element name="typeRef" type="xsd:string"/>
+						<xsd:element name="allowedValues" type="tUnaryTests" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:element name="itemComponent" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="functionItem" type="tFunctionItem" minOccurs="0" maxOccurs="1"/>
+				</xsd:choice>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionItem" type="tFunctionItem" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tFunctionItem">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="parameters" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="outputTypeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="literalExpression" type="tLiteralExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tLiteralExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:element name="text" type="xsd:string"/>
+					<xsd:element name="importedValues" type="tImportedValues"/>
+				</xsd:choice>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocation" type="tInvocation" substitutionGroup="expression"/>
+	<xsd:complexType name="tInvocation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- calledFunction -->
+					<xsd:element ref="expression" minOccurs="0"/>
+					<xsd:element name="binding" type="tBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tBinding">
+		<xsd:sequence>
+			<xsd:element name="parameter" type="tInformationItem" minOccurs="1" maxOccurs="1"/>
+			<!-- bindingFormula -->
+			<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="informationItem" type="tInformationItem" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tInformationItem">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionTable" type="tDecisionTable" substitutionGroup="expression"/>
+	<xsd:complexType name="tDecisionTable">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="input" type="tInputClause" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="output" type="tOutputClause" maxOccurs="unbounded"/>
+					<xsd:element name="annotation" type="tRuleAnnotationClause"  minOccurs="0" maxOccurs="unbounded"/>
+					<!-- NB: when the hit policy is FIRST or RULE ORDER, the ordering of the rules is significant and MUST be preserved -->
+					<xsd:element name="rule" type="tDecisionRule" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"/>
+				<xsd:attribute name="aggregation" type="tBuiltinAggregator" use="optional"/>
+				<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"/>
+				<xsd:attribute name="outputLabel" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputExpression" type="tLiteralExpression"/>
+					<xsd:element name="inputValues" type="tUnaryTests" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tOutputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="outputValues" type="tUnaryTests" minOccurs="0"/>
+					<xsd:element name="defaultOutputEntry" type="tLiteralExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotationClause">
+		<xsd:attribute name="name" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:complexType name="tDecisionRule">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputEntry" type="tUnaryTests" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputEntry" type="tLiteralExpression" maxOccurs="unbounded"/>
+					<xsd:element name="annotationEntry" type="tRuleAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotation">
+		<xsd:sequence>
+			<xsd:element name="text" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:simpleType name="tHitPolicy">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNIQUE"/>
+			<xsd:enumeration value="FIRST"/>
+			<xsd:enumeration value="PRIORITY"/>
+			<xsd:enumeration value="ANY"/>
+			<xsd:enumeration value="COLLECT"/>
+			<xsd:enumeration value="RULE ORDER"/>
+			<xsd:enumeration value="OUTPUT ORDER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tBuiltinAggregator">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SUM"/>
+			<xsd:enumeration value="COUNT"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tDecisionTableOrientation">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rule-as-Row"/>
+			<xsd:enumeration value="Rule-as-Column"/>
+			<xsd:enumeration value="CrossTable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="tImportedValues">
+		<xsd:complexContent>
+			<xsd:extension base="tImport">
+				<xsd:sequence>
+					<xsd:element name="importedElement" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="artifact" type="tArtifact" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tArtifact">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="group" type="tGroup" substitutionGroup="artifact"/>
+	<xsd:complexType name="tGroup">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="tDMNElementReference"/>
+					<xsd:element name="targetRef" type="tDMNElementReference"/>
+				</xsd:sequence>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="context" type="tContext" substitutionGroup="expression"/>
+	<xsd:complexType name="tContext">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element ref="contextEntry" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="contextEntry" type="tContextEntry" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tContextEntry">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0" maxOccurs="1"/>
+					<!-- value -->
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionDefinition" type="tFunctionDefinition" substitutionGroup="expression"/>
+	<xsd:complexType name="tFunctionDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="formalParameter" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- body -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="kind" type="tFunctionKind" default="FEEL"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tFunctionKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="FEEL"/>
+			<xsd:enumeration value="Java"/>
+			<xsd:enumeration value="PMML"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="relation" type="tRelation" substitutionGroup="expression"/>
+	<xsd:complexType name="tRelation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="column" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="row" type="tList" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="list" type="tList" substitutionGroup="expression"/>
+	<xsd:complexType name="tList">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- element -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tUnaryTests">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionService" type="tDecisionService" substitutionGroup="invocable"/>
+	<xsd:complexType name="tDecisionService">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="outputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="encapsulatedDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputData" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/DMNDI13.xsd
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/DMNDI13.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+            elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DI/"
+	            schemaLocation="DI.xsd"/>
+
+	<xsd:element name="DMNDI" type="dmndi:DMNDI"/>
+	<xsd:element name="DMNDiagram" type="dmndi:DMNDiagram"/>
+	<xsd:element name="DMNDiagramElement" type="di:DiagramElement">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="DMNShape" type="dmndi:DMNShape" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNEdge" type="dmndi:DMNEdge" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNStyle" type="dmndi:DMNStyle" substitutionGroup="di:Style"/>
+	<xsd:element name="DMNLabel" type="dmndi:DMNLabel"/>
+	<xsd:element name="DMNDecisionServiceDividerLine" type="dmndi:DMNDecisionServiceDividerLine"/>
+
+	<xsd:complexType name="DMNDI">
+		<xsd:sequence>
+			<xsd:element ref="dmndi:DMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="dmndi:DMNStyle" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDiagramElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDecisionServiceDividerLine" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="isListedInputData" type="xsd:boolean" use="optional"/>
+				<xsd:attribute name="isCollapsed" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+		<xsd:complexType name="DMNDecisionServiceDividerLine">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="sourceElement" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="targetElement" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element name="FillColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="StrokeColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="FontColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="fontFamily" type="xsd:string"/>
+				<xsd:attribute name="fontSize" type="xsd:double"/>
+				<xsd:attribute name="fontItalic" type="xsd:boolean"/>
+				<xsd:attribute name="fontBold" type="xsd:boolean"/>
+				<xsd:attribute name="fontUnderline" type="xsd:boolean"/>
+				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean"/>
+				<xsd:attribute name="labelHorizontalAlignement" type="dc:AlignmentKind"/>
+				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_2/simple.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_2/simple.dmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"
+xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"
+xmlns:trisofeed="http://trisotech.com/feed"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+xmlns="http://www.trisotech.com/definitions/_3068644b-d2c7-4b81-ab9d-64f011f81f47"
+id="_3068644b-d2c7-4b81-ab9d-64f011f81f47"
+namespace="http://www.trisotech.com/definitions/_3068644b-d2c7-4b81-ab9d-64f011f81f47"         
+exporter="DMN Modeler" 
+exporterVersion="6.1.5" 
+name="DMN Specification Chapter 11 Example" 
+triso:logoChoice="Default">
+<semantic:extensionElements/>
+<semantic:decisionService id="_61a137fa-eedd-4cf0-8969-827591267b4b_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+    <semantic:variable name="Whole Model Decision Service" id="_61a137fa-eedd-4cf0-8969-827591267b4b_DS_VAR" typeRef="Any"/>
+    <semantic:outputDecision href="#_938e8026-7825-47c1-8890-a0bed982db6f"/>
+    <semantic:inputData href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+</semantic:decisionService>
+<semantic:decisionService id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3_DS" name="Diagram Page 1" triso:dynamicDecisionService="true">
+    <semantic:variable name="Diagram Page 1" id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3_DS_VAR" typeRef="Any"/>
+    <semantic:outputDecision href="#_938e8026-7825-47c1-8890-a0bed982db6f"/>
+    <semantic:inputData href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+</semantic:decisionService>
+<semantic:inputData id="_e4e47ee0-ff98-41fd-922a-f80bac93bcc3" name="name">
+    <semantic:variable name="name" id="_7a9307f0-fa0d-4e15-9a3a-b8009558c758" typeRef="string"/>
+</semantic:inputData>
+<semantic:decision id="_938e8026-7825-47c1-8890-a0bed982db6f" name="salutation">
+    <semantic:variable name="salutation" id="_4c00fc87-5c90-4cf7-96ba-49a5b3c05807" typeRef="string"/>
+    <semantic:informationRequirement id="_db797801-9e06-49ba-8384-6f7c6a15019b">
+        <semantic:requiredInput href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression id="_6bae1586-dff3-442c-99c4-57cb2ca8813f" typeRef="string" triso:expressionId="_875337f7-4847-4d98-926c-957c71626d79">
+        <semantic:text>"Hello, "+name</semantic:text>
+    </semantic:literalExpression>
+</semantic:decision>
+<dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3" triso:modelElementRef="_7dc00112-0d6b-4d89-a677-9c99cbf29bcf" name="Page 1">
+        <di:extension/>
+        <dmndi:Size height="1050" width="1485"/>
+        <dmndi:DMNShape id="_3ed3ded2-30be-46b8-872f-0d9db4b572d2" dmnElementRef="_e4e47ee0-ff98-41fd-922a-f80bac93bcc3">
+            <dc:Bounds x="295.7588291168213" y="223" width="135.48234176635742" height="60"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" />
+        </dmndi:DMNShape>
+        <dmndi:DMNShape id="_cd689688-c21d-4d97-8e84-147eb7ef12e2" dmnElementRef="_938e8026-7825-47c1-8890-a0bed982db6f">
+            <dc:Bounds x="486.2411708831787" y="223" width="153" height="60"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" />
+        </dmndi:DMNShape>
+        <dmndi:DMNEdge id="_f6ec1781-c8d6-4abc-9290-d682e3d2c6ef" dmnElementRef="_db797801-9e06-49ba-8384-6f7c6a15019b">
+            <di:waypoint x="431.9968013763428" y="253"/>
+            <di:waypoint x="486.2411708831787" y="253"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0"/>
+        </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+    <dmndi:DMNStyle id="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Chapter 11 Example.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Chapter 11 Example.dmn
@@ -1,0 +1,2995 @@
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:include1="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" xmlns:drools="http://www.drools.org/kie/dmn/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:feel="https://www.omg.org/spec/DMN/20191111/FEEL/"              xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" name="Chapter 11 Example" namespace="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" exporter="DMN Modeler" exporterVersion="6.2.2.1" triso:logoChoice="None">
+    <semantic:description/>
+    <semantic:extensionElements>
+        <triso:ProjectCharter>
+            <triso:projectGoals/>
+            <triso:projectChallenges/>
+            <triso:projectStakeholders/>
+        </triso:ProjectCharter>
+    </semantic:extensionElements>
+    <semantic:import namespace="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" name="Financial" triso:fileId="eyJmIjp7InNrdSI6IjU1ZTFkZDA5LTdjYTUtNGUyMC04NzI1LWVlOTI5NzI2OTZkYiIsIm5hbWUiOiJGaW5hbmNpYWwifSwiciI6eyJhcGlrZXkiOiIyOTIwMDNmNjk4NDBlNzEyIn19" triso:fileName="Chapter 11 Example/Financial" importType="https://www.omg.org/spec/DMN/20191111/MODEL/" drools:modelName="Financial"/>
+    <semantic:itemDefinition isCollection="false" name="tStrategy" label="tStrategy">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE","BUREAU","THROUGH"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tEligibility" label="tEligibility">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tBureauCallType" label="tBureauCallType">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"FULL","MINI","NONE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tRiskCategory" label="tRiskCategory">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tApplicantData" label="tApplicantData">
+        <semantic:itemComponent isCollection="false" name="Age" id="_df3aab6f-1610-41fa-a407-09678a89d6da">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="MartitalStatus" id="_d39ad810-7781-4ffb-9644-de51d1ca7f7a">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"S","M"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="EmploymentStatus" id="_9242f7aa-a9fc-451e-a8ee-60f1ff992664">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"EMPLOYED","SELF-EMPLOYED","STUDENT","UNEMPLOYED"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="ExistingCustomer" id="_5b4cce4a-bb99-41d5-99f2-0b2d7deeea8e">
+            <semantic:typeRef>boolean</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Monthly" id="_c3ad187d-246f-4707-aa05-b9d5d8da1f58">
+            <semantic:itemComponent isCollection="false" name="Income" id="_0ff9ec7c-ef0f-425a-af5c-d251135e3631">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+            <semantic:itemComponent isCollection="false" name="Repayments" id="_d4389c69-0a87-4db9-96fa-99674bff6b97">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+            <semantic:itemComponent isCollection="false" name="Expenses" id="_c0bd1a20-826f-4fe4-86bc-b6cca2af06a1">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tBureauData" label="tBureauData">
+        <semantic:itemComponent isCollection="false" name="Bankrupt" id="_4b58e0c0-649b-472a-8a28-f8dde1e40068">
+            <semantic:typeRef>boolean</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="CreditScore" id="_42350ffd-8f82-4500-b9cb-696758cc287e">
+            <semantic:typeRef>number</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>[0..999], null</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tRouting" label="tRouting">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE","REFER","ACCEPT"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tRequestedProduct" label="tRequestedProduct">
+        <semantic:itemComponent isCollection="false" name="ProductType" id="_c993adad-698b-477d-a395-f4021d38ef8b">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"STANDARD LOAN","SPECIAL LOAN"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Rate" id="_5ddc6d4c-67d2-4a00-a9c0-3614d228964b">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Term" id="_4e47a0e8-ab4a-46a2-ae8c-209401ebdd8f">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Amount" id="_24103ee1-2867-4e01-abfc-d40b3aed0ce5">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:decisionService id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Whole Model Decision Service" id="_650ef4de-168c-4d69-80aa-f697971e49a2" typeRef="Any"/>
+        <semantic:outputDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:encapsulatedDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:encapsulatedDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_ce4a4c00-c3a3-46a6-8938-055239f6b326_DS" name="Diagram DRD of all automated decisionmaking" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD of all automated decisionmaking" id="_0a28bdea-cbbd-4454-9cc8-c91a76322790" typeRef="Any"/>
+        <semantic:outputDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:encapsulatedDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:encapsulatedDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262_DS" name="Diagram DRD for Decide bureau strategy decision point" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Decide bureau strategy decision point" id="_8848054f-a6dc-4c89-b419-470ad7bf3c56" typeRef="Any"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:encapsulatedDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_3275163a-921d-48f8-967a-21c4373b1197_DS" name="Diagram DRD for Decide routing decision point" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Decide routing decision point" id="_9dfc2eb7-fbb2-485f-9591-5a26a242339d" typeRef="Any"/>
+        <semantic:outputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b_DS" name="Diagram DRD for Review application decision point" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Review application decision point" id="_42af205f-c1cb-4bb6-b48a-40b4944359c7" typeRef="Any"/>
+        <semantic:outputDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:inputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_5c111794-4c6b-4747-8dfc-99d2ad0b6313_DS" name="Diagram Bureau Strategy Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram Bureau Strategy Decision Service" id="_e69084e3-2a45-49f1-9bd0-7da468de75f8" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_69750f88-f46f-4b47-bb3c-fb77f574f2b3_DS" name="Diagram Routing Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram Routing Decision Service" id="_5bb6af75-1df6-4f84-a2c7-1e106a313c94" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_95e871bf-e58f-4976-b1bf-d9b220fdb2cb_DS" name="Diagram DRD for Credit Risk Analytics" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Credit Risk Analytics" id="_b6a75564-fdf6-44ec-a1cf-2141befbc189" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decision id="_4bd33d4a-741b-444a-968b-64e1841211e7" name="Adjudication" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span lang="JA"&gt;Determine if&amp;nbsp;an application requiring adjudication should be accepted or declined given the available application data and supporting documents.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Should this application that has been referred for adjudication be accepted?</semantic:question>
+        <semantic:allowedAnswers>Yes/No</semantic:allowedAnswers>
+        <semantic:variable name="Adjudication" id="_12f285f8-ae4e-4421-98bd-d9b1fd236e10" typeRef="Any"/>
+        <semantic:informationRequirement id="_290b4df4-ffe6-4106-9e22-07a339146161">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+            <semantic:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+            <semantic:requiredDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+            <semantic:requiredInput href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+        </semantic:informationRequirement>
+        <semantic:authorityRequirement id="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+            <semantic:requiredAuthority href="#_989d137f-86ff-4249-813f-af67c08a2762"/>
+        </semantic:authorityRequirement>
+        <semantic:impactedPerformanceIndicator href="#_4d7ae526-d994-4ea2-9f26-81b9c693a45a"/>
+        <semantic:impactedPerformanceIndicator href="#_18c16494-3da7-42d8-8a7d-599b158dd840"/>
+        <semantic:decisionMaker href="#_036e1231-d563-4c1c-8a68-6b89df81d7c0"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+    </semantic:decision>
+    <semantic:knowledgeSource id="_989d137f-86ff-4249-813f-af67c08a2762" name="Credit officer experience">
+        <semantic:description>&lt;p&gt;The collected wisdom of the credit officers as collected in their best practice wiki.&lt;/p&gt;</semantic:description>
+        <semantic:type>Expertise</semantic:type>
+        <semantic:owner href="#_036e1231-d563-4c1c-8a68-6b89df81d7c0"/>
+    </semantic:knowledgeSource>
+    <semantic:inputData id="_34cd3187-8764-4249-959d-2664bf9f1847" name="Supporting documents">
+        <semantic:description>&lt;p&gt;Documents associated with a loan that are not processed electronically but are available for manual adjudication.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Supporting documents" id="_d996b907-be17-4ff1-a54e-6fe7d62f55b1" typeRef="Any"/>
+    </semantic:inputData>
+    <semantic:decision id="_5b8356f3-2cf2-40e8-8f80-324937e8b276" name="Bureau call type" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Bureau call type&amp;nbsp;&lt;/span&gt;table, passing the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>How much data should be requested from the credit bureau for this application?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Full", "Mini", "None"</semantic:allowedAnswers>
+        <semantic:variable name="Bureau call type" id="_207da57c-29a0-487b-b591-751807636337" typeRef="tBureauCallType"/>
+        <semantic:informationRequirement id="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+            <semantic:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+            <semantic:requiredKnowledge href="#_a654be71-b54d-4d6e-90f0-ae505125e9a6"/>
+        </semantic:knowledgeRequirement>
+        <semantic:impactedPerformanceIndicator href="#_0519e753-66a5-43cd-ad04-caf4de93b7f0"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" typeRef="tBureauCallType" triso:expressionId="_6ed18a0f-24e0-46ab-a13d-67c8090ef4dc">
+            <semantic:literalExpression id="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd">
+                <semantic:text>Bureau call type table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_8f5b7ce8-b4f9-4af4-8aa5-5580682382c6" name="Pre-Bureau Risk Category"/>
+                <semantic:literalExpression id="_40020f96-0afd-405c-828a-0aa6684d150d">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="_8b838f06-968a-4c66-875e-f5412fd692cf" name="Strategy" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Strategy&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, unique-hit decision table deriving Strategy from&amp;nbsp;&lt;/span&gt;Eligibility and Bureau call type.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>What is the appropriate handling strategy for this application?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Decline", "Bureau", "Through"</semantic:allowedAnswers>
+        <semantic:variable name="Strategy" id="_80c9b3dd-f6c3-412b-9ee9-48e3e0812746" typeRef="tStrategy"/>
+        <semantic:informationRequirement id="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+            <semantic:requiredDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+            <semantic:requiredDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        </semantic:informationRequirement>
+        <semantic:impactedPerformanceIndicator href="#_4d7ae526-d994-4ea2-9f26-81b9c693a45a"/>
+        <semantic:impactedPerformanceIndicator href="#_3a51a3c5-06f5-471f-88ef-8a3ea99b0d49"/>
+        <semantic:impactedPerformanceIndicator href="#_18c16494-3da7-42d8-8a7d-599b158dd840"/>
+        <semantic:impactedPerformanceIndicator href="#_96b30012-a6e7-4545-89d3-068ec722469c"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:decisionTable id="_0991d970-7c58-4669-89ec-a5e3e9d264df" hitPolicy="UNIQUE" outputLabel="Strategy" typeRef="tStrategy" triso:expressionId="_1e25316a-8ac8-47b6-b423-0e24cbb03d30">
+            <semantic:input id="_661471d5-5028-4910-b070-1e3bad0125c7">
+                <semantic:inputExpression typeRef="tEligibility">
+                    <semantic:text>Eligibility</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="enumeration">
+                    <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:input id="_b48e30f7-0a90-42d0-ba06-ad931fdfe5da">
+                <semantic:inputExpression typeRef="tBureauCallType">
+                    <semantic:text>Bureau call type</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="enumeration">
+                    <semantic:text>"FULL","MINI","NONE"</semantic:text>
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:output id="_f722c4f0-299d-4492-9b0c-fa0177239d08">
+                <semantic:outputValues triso:constraintsType="enumeration">
+                    <semantic:text>"DECLINE","BUREAU","THROUGH"</semantic:text>
+                </semantic:outputValues>
+            </semantic:output>
+            <semantic:annotation/>
+            <semantic:rule id="_799a874e-d695-4683-9774-a4a911bbda7c">
+                <semantic:inputEntry id="_a1e93932-14d9-41aa-b408-418df532584e">
+                    <semantic:text>"INELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_46a2c9c2-10ba-4ebd-b596-d8d50ef4e27d">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_ddad297d-4a7e-45b4-bfc5-78cfc1504f8e">
+                    <semantic:text>"DECLINE"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_8e10bf87-3308-4cb5-84fd-231656eb15f3">
+                <semantic:inputEntry id="_27b85f52-29db-4114-8393-4c307fda69de">
+                    <semantic:text>"ELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_658b9e6d-4039-4a30-a14f-b9af59e9ff3e">
+                    <semantic:text>"FULL", "MINI"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_4099772e-6ec4-48e2-a4ac-daa6d7aa1148">
+                    <semantic:text>"BUREAU"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_cec87cd2-9715-47b2-97df-087698d8fc70">
+                <semantic:inputEntry id="_617a19de-dd6d-4448-be7b-dc5c0f57de9c">
+                    <semantic:text>"ELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_0600d1e9-3293-4c91-b0f1-f1fecb10f422">
+                    <semantic:text>"NONE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_f17c18da-fb15-401b-88a5-550d1918583b">
+                    <semantic:text>"THROUGH"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" name="Eligibility" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Eligibility rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Applicant data.Age as the Age parameter, the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter, and the output of the Pre-bureau affordability decision as the Pre-Bureau Affordability parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Does this applicant appear eligible for the loan they applied for given only their application data?</semantic:question>
+        <semantic:allowedAnswers>Value from the explicit list "Eligible", "Not Eligible"</semantic:allowedAnswers>
+        <semantic:variable name="Eligibility" id="_a160fe23-8110-4242-9944-86278d32000e" typeRef="tEligibility"/>
+        <semantic:informationRequirement id="_94475973-9022-46d7-a520-756538ba9c00">
+            <semantic:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+            <semantic:requiredDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+            <semantic:requiredKnowledge href="#_dc2ca64d-2044-4806-9d0e-e705b3b14447"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" typeRef="tEligibility" triso:expressionId="_4063907e-d25c-4857-887c-edb2f73682c7">
+            <semantic:literalExpression id="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979">
+                <semantic:text>Eligibility rules</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_07fdfb40-acac-4098-8a66-f09f216cd9ec" name="Age"/>
+                <semantic:literalExpression id="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca">
+                    <semantic:text>Applicant data.Age</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_a2bc5321-7041-40c0-be9d-4e53c22442d1" name="Pre-Bureau Risk Category"/>
+                <semantic:literalExpression id="_91986b6f-d45e-4aa7-926d-00b35a47686f">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_c3432a72-40b0-4213-9f94-7f5e8e15ee85" name="Pre-Bureau Affordability"/>
+                <semantic:literalExpression id="_719504be-6121-4c16-9c00-1480b58f2ecb">
+                    <semantic:text>Pre-bureau affordability</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="_dc2ca64d-2044-4806-9d0e-e705b3b14447" name="Eligibility rules">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Eligibility rules" id="_fe2d2049-704b-4a88-88be-3d1a56c3d376" typeRef="tEligibility"/>
+        <semantic:encapsulatedLogic typeRef="tEligibility" triso:expressionId="_e89d2f82-6356-4541-9a92-4d9829ecdf40">
+            <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:formalParameter name="Pre-Bureau Affordability" typeRef="boolean"/>
+            <semantic:formalParameter name="Age" typeRef="number"/>
+            <semantic:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" outputLabel="Eligibility rules">
+                <semantic:input id="_2bab5dc0-be18-4098-b9b4-6b3486955d1b">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Pre-Bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_836645fe-83ba-4f36-9b6d-279b017c59ea">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Pre-Bureau Affordability</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_4946be73-cb1e-43b4-ac03-b01e378c298a">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Age</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_81aab6dd-d832-4c9e-8a3c-55f5f4a89cc7">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_3352c79c-5aa5-4f2a-bf7e-c1e24f72a7ed">
+                    <semantic:inputEntry id="_51fa1535-776a-411f-ba5d-4915f04adf46">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_209c0b4c-7e1f-4758-bb2d-ff56116ebf70">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e5e44a50-b664-4ce1-8b48-a7c5b73bec50">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f506afa7-a3fe-48d5-8ec6-4bf2cc2dd28b">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_1e4a3e10-0d85-4160-85eb-6d3ad7adee82">
+                    <semantic:inputEntry id="_0366fd41-b16b-4848-8759-1c1b2f5defc9">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4c4d51a8-0927-47d1-bf5d-732eeaf9af50">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_bc0c7201-97b5-41ea-8427-31a3923d674c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3611f774-9b66-468d-be7f-06bf14407161">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_c871d706-98a2-4d65-903c-7cbd1571f17c">
+                    <semantic:inputEntry id="_4e174888-d7ca-4561-aba8-5fd8dfb3b35b">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6e1f9fc4-69b2-4e8c-bcf9-8878ec8bd455">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a120264e-f028-4b2b-8b94-b29b68aa5499">
+                        <semantic:text>&lt; 18</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_504ac7aa-2538-48d1-b518-f10a5ff1d87c">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_11673d64-2390-42c1-bc6f-43074ee90097">
+                    <semantic:inputEntry id="_d1ca6c94-6088-43be-bcfe-83b9de492d8a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_c19d2814-6733-46dc-92cc-48c7b0e59fa8">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_bac13f3d-00eb-49f7-b715-0d379562c1c3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_0d0dd4a4-0468-44cc-97fc-6cf243ee28b9">
+                        <semantic:text>"ELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+            <semantic:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:knowledgeSource id="_a5f9b126-7853-4037-9e23-3dd7e93c4032" name="Product specification">
+        <semantic:description>&lt;p&gt;Definitions of the products, their cost structure and eligibility criteria.&lt;/p&gt;</semantic:description>
+        <semantic:type>Policy</semantic:type>
+        <semantic:owner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_536d7a39-87a6-4651-b743-6ee03e16e535" name="Routing rules">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Routing rules" id="_08f4f63e-54e4-4b19-b0d2-08aeed21605c" typeRef="tRouting"/>
+        <semantic:encapsulatedLogic typeRef="tRouting" triso:expressionId="_9f0b535e-87b4-43e3-a818-8d47d1b109bd">
+            <semantic:formalParameter name="Post-bureau risk category" typeRef="tRiskCategory"/>
+            <semantic:formalParameter name="Post-bureau affordability" typeRef="boolean"/>
+            <semantic:formalParameter name="Bankrupt" typeRef="boolean"/>
+            <semantic:formalParameter name="Credit score" typeRef="number"/>
+            <semantic:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" outputLabel="Routing rules">
+                <semantic:input id="_b3bde44f-2274-41d5-8e04-5cb2f7529e6c">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Post-bureau risk category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_edb3efb0-2fea-4d55-9b5f-ae279ad5ecaa">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Post-bureau affordability</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_1fbd45e7-99d5-497d-beb0-a643dd558b63">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Bankrupt</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_83878ad8-a1fc-43b0-b601-f1b093e39b48">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Credit score</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>null, [0..999]</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_109021ab-349a-47f0-9c9e-564a9fbc20e8">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","REFER","ACCEPT"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_b9e04531-35ba-4562-9c9e-2a6900315e1c">
+                    <semantic:inputEntry id="_2844a3b1-bdcf-49f0-9c5c-f80990077a43">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7ac71a80-a65f-4b42-b125-682fec1c0cda">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e3ef460f-b05e-4d54-af1e-355c2d6d191e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ec772f81-1eee-475c-872a-596fb40c650c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_27239ae2-8529-4afd-8981-043bb51d2fb2">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_3ed8ac44-80a1-4e64-b610-f84d79c5b875">
+                    <semantic:inputEntry id="_64077b12-6193-4842-86e2-896290756562">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_07978900-95e3-4102-8916-eb439316c4e1">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2e822dc4-cba8-4594-82bd-b48b4be2180d">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b3856c1d-2067-483a-b6ca-ba3c8080f12c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_684c798b-7ade-4155-ad42-cc111cf920a9">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_0e511735-f478-4041-97f8-158ea173668b">
+                    <semantic:inputEntry id="_9ee5cc2a-42ce-4fc6-b4a2-b6ae3c6590c4">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_be5739cd-c1c9-47ca-af91-47109d2c288a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f4f9d322-ca0a-4a24-a967-916aa32f5136">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_fda948c5-43a7-4023-9c52-4020007ca482">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_000ea279-76af-4c1a-a2d6-b8eda969df7a">
+                        <semantic:text>"REFER"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_06c90e6c-99d1-4c99-a443-374ab1288c1b">
+                    <semantic:inputEntry id="_c87517c4-b47d-4653-a884-3a265dba1ec7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_0fc27099-c992-4041-b164-9c4d1dddb462">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_527df004-e723-46de-9475-aa2db4e0f4f7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_dbc688c4-064b-4fe1-ab7e-6992d6cbaf61">
+                        <semantic:text>&lt; 580</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_20941825-2c8b-4d94-9fde-0b3039b12a3c">
+                        <semantic:text>"REFER"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_3a1673bb-17ae-4b62-b686-d8ecc0f4657b">
+                    <semantic:inputEntry id="_7e258e45-824d-402b-b6e5-a46088e90e1e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2f51bdea-d5bc-4b8e-ac34-ae093f1ae170">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_913c21a5-d028-4c3b-8482-83d2a5eae2c6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4665c331-032d-4489-97bf-4e19eead103e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f77e29ae-79a3-4f1d-9eed-7b3795031861">
+                        <semantic:text>"ACCEPT"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+            <semantic:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_ca1e6032-12eb-428a-a80b-49028a88c0b5" name="Routing" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Routing rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Bureau data . Bankrupt as the Bankrupt parameter, Bureau data . CreditScore as the Credit Score parameter, the output of the Post-bureau risk category decision as the Post-Bureau Risk Category parameter, and the output of the Post-bureau affordability decision as the Post-Bureau Affordability parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Bankrupt and Credit Score parameters will be null.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>How this should this applicant be routed given all available data?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Decline", "Refer for Adjudication", "Accept without Review"</semantic:allowedAnswers>
+        <semantic:variable name="Routing" id="_da1b4341-41b8-4b67-b33a-f54d2782cf4e" typeRef="tRouting"/>
+        <semantic:informationRequirement id="_132debf9-e318-4710-a226-982da98dd278">
+            <semantic:requiredDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+            <semantic:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+            <semantic:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_839ccfec-8902-40ca-8767-df9073f797e5">
+            <semantic:requiredKnowledge href="#_536d7a39-87a6-4651-b743-6ee03e16e535"/>
+        </semantic:knowledgeRequirement>
+        <semantic:impactedPerformanceIndicator href="#_3a51a3c5-06f5-471f-88ef-8a3ea99b0d49"/>
+        <semantic:impactedPerformanceIndicator href="#_4d7ae526-d994-4ea2-9f26-81b9c693a45a"/>
+        <semantic:impactedPerformanceIndicator href="#_96b30012-a6e7-4545-89d3-068ec722469c"/>
+        <semantic:impactedPerformanceIndicator href="#_18c16494-3da7-42d8-8a7d-599b158dd840"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_78ce14d2-2c68-454a-b772-075b3f1395c3" typeRef="tRouting" triso:expressionId="_57b4d31c-ab28-4fee-8fdb-312ad13b3230">
+            <semantic:literalExpression id="literal__78ce14d2-2c68-454a-b772-075b3f1395c3">
+                <semantic:text>Routing rules</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_8a009394-dc06-4ee6-b039-dde94390bf6b" name="Bankrupt"/>
+                <semantic:literalExpression id="_32742ced-8b58-4be0-a6be-d48ab1126f69">
+                    <semantic:text>Bureau data.Bankrupt</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_5b79a0ff-62ed-4d3d-b512-ea706cc06f62" name="Credit score"/>
+                <semantic:literalExpression id="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a">
+                    <semantic:text>Bureau data.CreditScore</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_79216390-7bf1-4b14-9b3e-91ee83a5cd4a" name="Post-bureau risk category"/>
+                <semantic:literalExpression id="_30a91838-0f0a-4843-a6d0-6b5a655f36b2">
+                    <semantic:text>Post-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_6edce48a-be0d-4896-af06-f5c05980970b" name="Post-bureau affordability"/>
+                <semantic:literalExpression id="_7a672677-fd20-4174-87f9-ba5e9146ddba">
+                    <semantic:text>Post-bureau affordability</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="_a654be71-b54d-4d6e-90f0-ae505125e9a6" name="Bureau call type table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving&amp;nbsp;&lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Bureau call type table" id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3" typeRef="tBureauCallType"/>
+        <semantic:encapsulatedLogic typeRef="tBureauCallType" triso:expressionId="_309a5634-43bc-49cb-a5d1-b0b2a573404c">
+            <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" outputLabel="Bureau call type table">
+                <semantic:input id="_92e35546-27e5-43a5-b8e6-85a692f42eb8">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Pre-Bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_6254d113-6c92-400f-88d5-fdb340519336">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"FULL","MINI","NONE"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_49d3d12b-8572-4341-9102-6f68667bf81a">
+                    <semantic:inputEntry id="_7abba955-f604-4995-aea5-842f7eefa839">
+                        <semantic:text>"HIGH", "MEDIUM"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_573aec0a-0759-435a-ba0c-5f27498897a0">
+                        <semantic:text>"FULL"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_db49e5ea-da50-4b07-ae82-9db29f3730b9">
+                    <semantic:inputEntry id="_1f21c493-c6f2-4b81-92f0-59b6511f9ddd">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_9aa8475c-4b5e-4da3-8f3e-aae70f694f83">
+                        <semantic:text>"MINI"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_304ebea6-617f-4f47-949d-aa9ac1dd1227">
+                    <semantic:inputEntry id="_d3f0c96c-521d-4228-b073-c945aca7483d">
+                        <semantic:text>"VERY LOW", "DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_2174bcfa-2d27-44ad-8525-56fce28fb75e">
+                        <semantic:text>"NONE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:knowledgeSource id="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" name="Risk management strategy">
+        <semantic:description>&lt;p&gt;Overall risk management approach for the financial institution including its approach to&amp;nbsp;application risk, credit contingencies and credit risk scoring.&lt;/p&gt;</semantic:description>
+        <semantic:type>Policy</semantic:type>
+        <semantic:owner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_b982a42a-0b62-47fa-8911-6c9d1145d982" name="Credit contingency factor table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;/span&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;decision&lt;/span&gt; logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/p&gt;
+&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Credit contingency factor table" id="_40c0f987-7b90-4c3e-9dcd-411e56f66c92" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number" triso:expressionId="_2e0e5afc-8e62-46e4-9989-2f9d47015e53">
+            <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory"/>
+            <semantic:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table">
+                <semantic:input id="_2b8fecfd-e00f-4d4b-acf3-660ca3560ca0">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_8d0d6fe3-a352-48a7-a35e-1fc1dd192039"/>
+                <semantic:annotation/>
+                <semantic:rule id="_21ec60ae-6137-41e2-b8b5-37447708c47b">
+                    <semantic:inputEntry id="_8c7e14f8-23db-4645-8b2a-2c69aada207d">
+                        <semantic:text>"HIGH", "DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_6052bbc0-6f0e-45db-bdd3-3c0ac4c45793">
+                        <semantic:text>0.6</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_8c5eb4e3-1902-4bf5-8257-1e21636fc978">
+                    <semantic:inputEntry id="_fe0190b4-e2f3-441f-a989-f22e1d425fd8">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_6320ae5d-459e-4775-b492-f9c0d0d492bb">
+                        <semantic:text>0.7</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_93e2a1a2-b281-42a4-8e34-865c28557929">
+                    <semantic:inputEntry id="_cd63cc67-53a5-480f-abcd-f394e606a7bd">
+                        <semantic:text>"LOW", "VERY LOW"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_fdcb46a5-a23c-4e29-93f1-66ce4e3c25da">
+                        <semantic:text>0.8</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:knowledgeSource id="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" name="Affordability spreadsheet">
+        <semantic:description>&lt;p&gt;Internal spreadsheet showing the relationship of income, payments, expenses, risk and affordability.&lt;/p&gt;</semantic:description>
+        <semantic:type>Policy</semantic:type>
+        <semantic:owner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" name="Affordability calculation">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from&amp;nbsp;&lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Affordability calculation" id="_80af1aa7-e29c-47fc-9cce-1959a3e1e717" typeRef="boolean"/>
+        <semantic:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL" typeRef="boolean" triso:expressionId="_5087c77a-913c-4ab4-b600-0c5c182c2e6d">
+            <semantic:formalParameter name="Monthly Income" typeRef="number" id="_f916b091-cd6d-44cb-b32b-cc83cc27e333"/>
+            <semantic:formalParameter name="Monthly Repayments" typeRef="number" id="_d68b6438-cba5-4c02-a708-bce0d2762d35"/>
+            <semantic:formalParameter name="Monthly Expenses" typeRef="number" id="_5fd5609d-89ce-463e-a882-6827921edf54"/>
+            <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory" id="_2acfe2aa-892f-4a5c-b9ab-111c7a8bbd40"/>
+            <semantic:formalParameter name="Required Monthly Installment" typeRef="number" id="_3a423c76-11c7-4b66-b86a-07928181a631"/>
+            <semantic:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256">
+                <semantic:contextEntry id="_ec37158d-b49b-4ffd-88e0-1e2f05c9a023">
+                    <semantic:variable name="Disposable Income" id="_3cc56162-97c1-416e-acb9-3ae81d692e58" typeRef="number"/>
+                    <semantic:literalExpression id="_2fcda742-6d7b-49c5-afe6-6b334c8f049b">
+                        <semantic:text>Monthly Income - (Monthly Repayments + Monthly Expenses)</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_fccafa17-121e-436a-bbed-1927f01a898d">
+                    <semantic:variable name="Credit Contingency Factor" id="_0f406bed-56f5-422e-b6c3-ad4892a38291" typeRef="number"/>
+                    <semantic:invocation id="_78bc74d6-25a4-4639-8509-186534b3c67a">
+                        <semantic:literalExpression id="literal__78bc74d6-25a4-4639-8509-186534b3c67a">
+                            <semantic:text>Credit contingency factor table</semantic:text>
+                        </semantic:literalExpression>
+                        <semantic:binding>
+                            <semantic:parameter id="_7fed77e8-7d20-4f3f-9504-2c0c0706bd39" name="Risk Category"/>
+                            <semantic:literalExpression id="_a02265a9-3dd1-48cd-a254-84531f28a058">
+                                <semantic:text>Risk Category</semantic:text>
+                            </semantic:literalExpression>
+                        </semantic:binding>
+                    </semantic:invocation>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_7ef4d2b6-c294-4f9c-a483-99d1923daa31">
+                    <semantic:variable name="Affordability" id="_efb9411e-34c6-4e72-a664-85a30197f5d0" typeRef="boolean"/>
+                    <semantic:literalExpression id="_3051a016-282e-4f83-8cfa-4c57084e559f">
+                        <semantic:text>if Disposable Income * Credit Contingency Factor &gt; Required Monthly Installment
+then true
+else false</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_56470ec7-03b0-4ce2-bf7f-32c2ad584d37">
+                    <semantic:literalExpression id="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55">
+                        <semantic:text>Affordability</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+            </semantic:context>
+        </semantic:encapsulatedLogic>
+        <semantic:knowledgeRequirement id="_7f7c177a-5acb-4941-9654-23f9408200b3">
+            <semantic:requiredKnowledge href="#_b982a42a-0b62-47fa-8911-6c9d1145d982"/>
+        </semantic:knowledgeRequirement>
+        <semantic:authorityRequirement id="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+            <semantic:requiredAuthority href="#_18d836e7-6d61-490c-b9a8-be3ce0c60c1e"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_ed60265c-25e2-400f-a99f-fafd3b489838" name="Pre-bureau affordability" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Pre-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Can the applicant afford the loan they applied for given only their application data?</semantic:question>
+        <semantic:allowedAnswers>Yes/No</semantic:allowedAnswers>
+        <semantic:variable name="Pre-bureau affordability" id="_bd744aca-06aa-4438-81de-0754fc15a44e" typeRef="boolean"/>
+        <semantic:informationRequirement id="_00c137a3-a81c-42ff-af6d-5c3247151273">
+            <semantic:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+            <semantic:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+            <semantic:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+        <semantic:invocation id="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" typeRef="boolean" triso:expressionId="_5a9f0da6-f281-4d47-9bb2-76c2f107e3ce">
+            <semantic:literalExpression id="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86">
+                <semantic:text>Affordability calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_ea45f34e-c7f7-41fe-a2fa-c9329dc03ead" name="Monthly Income"/>
+                <semantic:literalExpression id="_63cbd20f-fab4-480e-9471-1367b2e1fc6c">
+                    <semantic:text>Applicant data.Monthly.Income</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_28b8d43b-e005-42f0-a432-5ea3c6547247" name="Monthly Repayments"/>
+                <semantic:literalExpression id="_c35a57bf-208c-4333-973f-c8a9e9ce85f4">
+                    <semantic:text>Applicant data.Monthly.Repayments</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_650b93d6-d6cd-46dc-8ebc-d1d80c5c4fa7" name="Monthly Expenses"/>
+                <semantic:literalExpression id="_174c9fb3-c940-455f-ab97-035989e83446">
+                    <semantic:text>Applicant data.Monthly.Expenses</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_70836844-402b-49b0-b07a-347c81e0f345" name="Risk Category"/>
+                <semantic:literalExpression id="_34d3db82-c899-45f6-b46c-ef7cb2f550c3">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_b94f43b0-69d0-4f20-9698-5f91b85f026a" name="Required Monthly Installment"/>
+                <semantic:literalExpression id="_47e0147f-030a-4020-a5d3-728c563c0bd2">
+                    <semantic:text>Required monthly installment</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" name="Post-bureau affordability" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Post-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Can the applicant afford the loan they applied for given all available data?</semantic:question>
+        <semantic:allowedAnswers>Yes/No</semantic:allowedAnswers>
+        <semantic:variable name="Post-bureau affordability" id="_b6f25146-5302-470e-a242-3d71c4311add" typeRef="boolean"/>
+        <semantic:informationRequirement id="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+            <semantic:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_9eeef063-346f-44d4-b722-2d8071d3d994">
+            <semantic:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_466b70d3-035a-413d-93bd-ae28c778d02d">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+            <semantic:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+        <semantic:invocation id="_3e5d9f10-9433-4853-b084-33790988de2a" typeRef="boolean" triso:expressionId="_fdcaffc9-aa3d-4c33-bc0c-09634cc64f05">
+            <semantic:literalExpression id="literal__3e5d9f10-9433-4853-b084-33790988de2a">
+                <semantic:text>Affordability calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_ecb484a1-1ca6-40d8-863f-ba95fea13779" name="Monthly Income"/>
+                <semantic:literalExpression id="_610d5776-9163-4707-85c4-c4f0ff35db0a">
+                    <semantic:text>Applicant data.Monthly.Income</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_b5f0835b-4dba-418b-a11c-3a23a76f3ae6" name="Monthly Repayments"/>
+                <semantic:literalExpression id="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36">
+                    <semantic:text>Applicant data.Monthly.Repayments</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_f8edc4a3-5000-4558-80f0-45efaee7e339" name="Monthly Expenses"/>
+                <semantic:literalExpression id="_3d3c099c-c287-45ff-82de-ca3079da67b0">
+                    <semantic:text>Applicant data.Monthly.Expenses</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_a8c6984b-8bca-41cc-b284-d056a18b43af" name="Risk Category"/>
+                <semantic:literalExpression id="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113">
+                    <semantic:text>Post-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_cac9db30-48f9-4b43-b9fa-699171ac858b" name="Required Monthly Installment"/>
+                <semantic:literalExpression id="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227">
+                    <semantic:text>Required monthly installment</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="_40b45659-9299-43a6-af30-04c948c5c0ec" name="Post-bureau risk category" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Post-bureau&amp;nbsp;&lt;/span&gt;risk category business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter, Bureau data.CreditScore as the Credit Score parameter, and the output of the Application risk score decision as the Application Risk Score parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Credit Score parameter will be null.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Which risk category is most appropriate for this applicant given all available data?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Decline", "High Risk", "Medium Risk", "Low Risk", "Very Low Risk"</semantic:allowedAnswers>
+        <semantic:variable name="Post-bureau risk category" id="_34b85411-de9d-4d9a-8b03-ad1b1cec8777" typeRef="tRiskCategory"/>
+        <semantic:informationRequirement id="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+            <semantic:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_668fa95d-373d-4430-b833-7c27308d2a80">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_655fba60-b529-4c21-bd96-9c778998d3fb">
+            <semantic:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+            <semantic:requiredKnowledge href="#_1c72ed95-ec72-47b4-8639-5ed14ccb77df"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" typeRef="tRiskCategory" triso:expressionId="_dc37ff04-62ca-4b96-940c-dc7e63f3da80">
+            <semantic:literalExpression id="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b">
+                <semantic:text>Post-bureau risk category table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_a7faf416-0247-43c1-8827-9346540d13c3" name="Existing Customer"/>
+                <semantic:literalExpression id="_9eb92498-0de3-44b1-a8e2-301a2bc091d4">
+                    <semantic:text>Applicant data.ExistingCustomer</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_b0bb0d61-0ea4-4c10-8a97-94be610bee0b" name="Credit Score"/>
+                <semantic:literalExpression id="_ad652244-9438-4a76-9637-2ca8dde2cee4">
+                    <semantic:text>Bureau data.CreditScore</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_4bb7604e-18d8-4d57-8097-cd2585c59266" name="Application Risk Score"/>
+                <semantic:literalExpression id="_9ead8557-599e-4900-80b8-7157c0653d82">
+                    <semantic:text>Application risk score</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:inputData id="_e91de815-22ba-431c-8b46-55891f2a1ef6" name="Bureau data">
+        <semantic:description>&lt;p&gt;External credit score and bankruptcy information provided by a bureau.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Bureau data" id="_aa8440f8-8f48-4e37-b775-ab8d771d24eb" typeRef="tBureauData"/>
+    </semantic:inputData>
+    <semantic:businessKnowledgeModel id="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" name="Post-bureau risk category table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Post-bureau risk category table" id="_689c96f3-6dd3-4c74-9a8f-721a966eb1af" typeRef="tRiskCategory"/>
+        <semantic:encapsulatedLogic typeRef="tRiskCategory" triso:expressionId="_4c7a54ab-487d-44aa-94cd-6f8164f0857b">
+            <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
+            <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
+            <semantic:formalParameter name="Credit Score" typeRef="number"/>
+            <semantic:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" outputLabel="Post-bureau risk category table">
+                <semantic:input id="_fc4cfa6b-926b-4751-81d9-d363b6f19299">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Existing Customer</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_77a90f33-64d6-4050-a932-a9c8454b10ab">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Application Risk Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_129a63ca-ea08-460a-98f3-bbb9b9a11121">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Credit Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_44033e77-5b86-4040-83a3-63629ae25983">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_22d41220-e512-4248-bed3-935266abfac6">
+                    <semantic:inputEntry id="_2c44dae4-55da-4aad-8dca-6db78b1463ff">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f75f53c2-d798-4b12-bfbb-f3c2dcbb7d13">
+                        <semantic:text>&lt; 120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_19694f9e-0022-42bd-a10c-8ec5855d2608">
+                        <semantic:text>&lt; 590</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_04e9777f-143b-44f5-be3e-a17710658417">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ca0d34ce-5f88-489f-b07d-c153cfcc9a9f">
+                    <semantic:inputEntry id="_1a227ae6-84eb-46b5-a355-e9414e2b4c68">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d571de40-d13c-40d1-b4d8-7c9ef4f3d405">
+                        <semantic:text>&lt; 120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_eaad5ff9-9a13-4321-b1ed-b9b81a6bc7c3">
+                        <semantic:text>[590..610]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_e47b1857-760e-4a6a-ab76-575d57ed3d75">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_731cfff1-8846-4204-b2d8-d4273e7caf6d">
+                    <semantic:inputEntry id="_9398558c-7346-41e6-b466-6db6a65a6886">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_69198768-fbd1-48f4-a233-6a237f8759d3">
+                        <semantic:text>&lt; 120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_9853a883-301b-4134-8411-11fcc78cca01">
+                        <semantic:text>&gt; 610</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_e56ad1e0-521d-4648-9209-81909e453bec">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_7124ae55-0a5c-40a5-858a-2e97d3fcee2b">
+                    <semantic:inputEntry id="_d66444ed-d5af-47e9-9425-d41c72eab9d8">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a24e787d-5735-4086-b27e-b536108f0cab">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_801d5239-537e-4147-80ce-2226cf9bb6dd">
+                        <semantic:text>&lt; 600</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_27df9777-129b-4e9a-8e01-1c016b90f049">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_6849c070-ffaf-4afd-b739-c9516e093a2d">
+                    <semantic:inputEntry id="_d7cdde1c-c04e-4cf6-9c6e-58e73ceb48e4">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_79cd3d7c-5e16-48c1-bb40-b5f30dec9830">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1c63b959-c10b-4c66-b024-684fb3773c13">
+                        <semantic:text>[600..625]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ad886bab-7ca9-466a-873e-a7fdc7dc0e29">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_abe53d6c-0c5e-4de6-8835-452442e07761">
+                    <semantic:inputEntry id="_8a73641d-2a45-423e-ba92-cc6463dcdefe">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a4131075-a73f-46cf-9e6b-4cf014f95567">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d81f0359-dab6-4813-a818-62bebe59d2c6">
+                        <semantic:text>&gt; 625</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_28527dae-a87d-4cd3-9f2e-7d244c617b17">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_1a267a70-0937-42cd-a778-9ef369309660">
+                    <semantic:inputEntry id="_6d4e7030-c29d-4f31-b1a5-8e57323425fd">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d0be0dbe-0ef4-4198-b612-7a415e569e73">
+                        <semantic:text>&gt; 130</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ffb1d0e3-4ecb-4497-8df0-6262f0e56ff2">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3de03ecf-f018-4135-add5-fd54737cee48">
+                        <semantic:text>"VERY LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4ec01cc3-2dce-453f-a195-e8a598be44ab">
+                    <semantic:inputEntry id="_69c5f5cb-c384-4596-8fd7-615cdcc4abf4">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_86661a8a-4179-4df7-9556-5e5937b676b9">
+                        <semantic:text>&lt;= 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7580e93d-f53b-405c-b6ab-87d9cb1f5fa1">
+                        <semantic:text>&lt; 580</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_00ef5d95-f613-41c8-8bf5-35aeee1e55e8">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_2ca1a47c-33b0-426d-87b4-d1dd23de3e30">
+                    <semantic:inputEntry id="_d9bafc07-3e85-442e-bb8a-99f7f2b7488a">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_005e60af-83b1-471c-aa1c-1a1bc9e8f197">
+                        <semantic:text>&lt;= 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_0a6e9560-ff9a-4b30-b5e4-1f218b8ea6c2">
+                        <semantic:text>[580..600]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_2bd1761e-b0f6-4eed-8df0-0f3bedf84817">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4ad8a80e-0e44-4512-8925-6f3ef0bcf67e">
+                    <semantic:inputEntry id="_25c987a9-40dd-4f40-a7b2-7b6b7020f729">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a8c73104-1d46-4c4d-ba3b-25ac8b812a4b">
+                        <semantic:text>&lt;= 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_295d25f5-f29a-456e-a000-7b26c3a3ba1d">
+                        <semantic:text>&gt; 600</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ae145544-b4e9-4c07-95d4-9e77237813f6">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_a14b851e-8b11-416e-806b-59222b4b0cc9">
+                    <semantic:inputEntry id="_77185ff7-c946-46cc-b93a-dabdc111f5dd">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_be1969ad-6a34-4e7f-8e14-cfabf84c9d33">
+                        <semantic:text>&gt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b93f37d5-afe8-40e1-aa4f-272d19da02d9">
+                        <semantic:text>&lt; 590</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_d7479784-014d-497f-9d06-1b111fa9c29f">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4377ced8-b8d9-4069-9dcf-098007969563">
+                    <semantic:inputEntry id="_28eee2fe-8a48-4a73-8488-10c506a7add5">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7c50c99a-c045-42c5-a647-22a4eae50036">
+                        <semantic:text>&gt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a71f7fc4-f200-4694-9738-23b01485ba78">
+                        <semantic:text>[590..615]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_02efcf34-86b8-411c-81bc-98668fe07bb3">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_20a9e6e8-bab5-4d49-803c-12d3b574fdd3">
+                    <semantic:inputEntry id="_2ba73fd9-c951-45dc-ac77-f6904c26e37c">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_cf3a2739-9a36-4702-b0f3-e8b0a0338db1">
+                        <semantic:text>&gt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_56cc9c15-43a9-4d81-975a-ab69f53a528b">
+                        <semantic:text>&gt; 615</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_13bc4965-9c91-44bd-973c-25dd9c1bebab">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_9997fcfd-0f50-4933-939e-88a235b5e2a0" name="Pre-bureau risk category" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-Bureau Risk Category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Pre-bureau&amp;nbsp;&lt;/span&gt;risk category table business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter and the output of the Application risk score decision as the Application Risk Score parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Which risk category is most appropriate for this applicant given only their application data?</semantic:question>
+        <semantic:allowedAnswers>Value from explicit list "Decline", "High Risk", "Medium Risk", "Low Risk", "Very Low Risk"</semantic:allowedAnswers>
+        <semantic:variable name="Pre-bureau risk category" id="_a739014d-8c5e-438b-b76a-805e3689c977" typeRef="tRiskCategory"/>
+        <semantic:informationRequirement id="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+            <semantic:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+            <semantic:requiredKnowledge href="#_51cc9510-3bfa-4e5a-a119-9bf83efdd266"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_04337ddb-db98-40e9-81cd-12802e74401e" typeRef="tRiskCategory" triso:expressionId="_7084eef5-12a7-40e1-9774-ccf6170679c2">
+            <semantic:literalExpression id="literal__04337ddb-db98-40e9-81cd-12802e74401e">
+                <semantic:text>Pre-bureau risk category table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_74d8aa6b-838e-4d87-8d64-8b734146aac6" name="Existing Customer"/>
+                <semantic:literalExpression id="_4b5e5cfb-d6fa-4d41-a13a-783170887126">
+                    <semantic:text>Applicant data.ExistingCustomer</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_929d5796-6174-41eb-b27c-52f956fd44dd" name="Application Risk Score"/>
+                <semantic:literalExpression id="_b93f253e-7f93-4356-a98b-3fae510485e3">
+                    <semantic:text>Application risk score</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" name="Pre-bureau risk category table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Pre-bureau risk category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Pre-bureau risk category table" id="_cfb1bb8c-ad27-42e2-b52a-50eadea198a6" typeRef="tRiskCategory"/>
+        <semantic:encapsulatedLogic typeRef="tRiskCategory" triso:expressionId="_b1819f1c-d9c9-4c39-91e2-9d87640b7422">
+            <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
+            <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
+            <semantic:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table">
+                <semantic:input id="_1ee6291f-423f-47d9-8774-858b392d4762">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Existing Customer</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_22607edc-31dd-4d18-982f-b3d4b4606804">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Application Risk Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_f482a2b4-eed1-4dfc-84b6-4860edec088d">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_05c9836c-6f21-49e9-8e4b-0ad029d1a38c">
+                    <semantic:inputEntry id="_5dc5082d-6dc3-46ce-821f-3fe0981a0407">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f9c9f1c0-dba5-4adc-8764-c740d55abc5e">
+                        <semantic:text>&lt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_520b6480-8c90-4ab0-bfd2-2e6107c9c2aa">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_7d1fbf47-e150-44d1-aa1c-b6c15ccc92c3">
+                    <semantic:inputEntry id="_2c0451d5-f065-41a4-ada7-4a3fb29a668d">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e7f1fb9b-32d4-4a45-95f3-8390801435a8">
+                        <semantic:text>[100..120)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_699696bd-226d-4dca-bba3-1a5b7ad0a8f0">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_da654f4f-3a18-44ec-8087-f27715c1e12b">
+                    <semantic:inputEntry id="_5df3c3df-0bed-4171-b915-e084fce11e51">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_dd71d0af-cfb7-4472-a745-28a36251b945">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_331e4bd4-397e-44dd-a403-44b3cf4ad15d">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_524a197c-3981-41ee-baed-1de02c55fac3">
+                    <semantic:inputEntry id="_a76ff1d9-f651-4833-8773-7d75925b5fe4">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_123b03ad-4815-4f98-8870-9c25e06fac6b">
+                        <semantic:text>&gt; 130</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f33f040b-a116-43c1-9791-bef711299be6">
+                        <semantic:text>"VERY LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ab1dfe10-5fbc-47fc-8ade-fd56c0a334c5">
+                    <semantic:inputEntry id="_acf40b4c-d68c-49d6-a2a4-2a88ace33016">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ce80bf8c-6cad-400b-8b18-23c920d6f594">
+                        <semantic:text>&lt; 80</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_44ea4ff9-e85c-40b6-b1a8-c9a76b1ae13e">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_a297a507-5206-4903-94f6-9b6fd6619195">
+                    <semantic:inputEntry id="_9a3f8732-e85f-4111-a3f1-2284065f64fe">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7d398c94-e4c1-4d9c-bf06-cf40f2c04d64">
+                        <semantic:text>[80..90)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f54b6b94-ec25-451d-8d7d-1049155b3e2b">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_740e7ddb-0834-4705-bbb3-7b092e9570dc">
+                    <semantic:inputEntry id="_7fe40ffd-bd8e-4405-8719-0bd706933fd5">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4b77407a-565f-40ad-b324-6e3940134518">
+                        <semantic:text>[90..110]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_894b1284-9923-4727-bbc4-fc621b47a28b">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_95fb462f-6435-44b7-8c21-84427ce71bc9">
+                    <semantic:inputEntry id="_3e033f1d-a632-41d4-9eb9-63d66e5e4380">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_753f756e-cdee-49d2-8953-dfad7aa9b092">
+                        <semantic:text>&gt; 110</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_2fb8f713-e746-4a65-aff0-fa1de216f57a">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" name="Application risk score" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application Risk Score&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Application&amp;nbsp;&lt;/span&gt;risk score model business knowledge model, passing Applicant data.Age as the Age parameter, Applicant data.MaritalStatus as the Marital Status parameter and Applicant data.EmploymentStatus as the Employment Status parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>What is the risk score for this applicant?</semantic:question>
+        <semantic:allowedAnswers>A number greater than 70 and less than 150</semantic:allowedAnswers>
+        <semantic:variable name="Application risk score" id="_f2abe78f-d5d0-4b9e-8d05-f1ea2bd7fc9b" typeRef="number"/>
+        <semantic:informationRequirement id="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_c94de723-def1-49e4-9aae-5270fe39630f">
+            <semantic:requiredKnowledge href="#_e9e07f04-0ff2-40c4-bd14-e5f06a91f942"/>
+        </semantic:knowledgeRequirement>
+        <semantic:impactedPerformanceIndicator href="#_0519e753-66a5-43cd-ad04-caf4de93b7f0"/>
+        <semantic:decisionOwner href="#_b6554413-30ba-4320-be7f-98efdf73ea08"/>
+        <semantic:invocation id="_348139f6-7fd0-40be-952d-66a8bb83d59c" typeRef="number" triso:expressionId="_954ca6de-2248-404d-8c85-7d620a39330b">
+            <semantic:literalExpression id="literal__348139f6-7fd0-40be-952d-66a8bb83d59c">
+                <semantic:text>Application risk score model</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_aba556aa-0e5b-4d01-bd6e-d25b780bbf28" name="Age"/>
+                <semantic:literalExpression id="_9c3009af-9a1b-4821-8901-7edf800ac60b">
+                    <semantic:text>Applicant data.Age</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_259966f2-bf40-4139-b587-6c9b989f1aa0" name="Marital Status"/>
+                <semantic:literalExpression id="_610941db-8c4e-483c-9d75-789b3d5c2333">
+                    <semantic:text>Applicant data.MartitalStatus</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_dc6d2bc7-3bde-4994-838d-b3fa1fe1ab2c" name="Employment Status"/>
+                <semantic:literalExpression id="_c08280b8-beb0-4eb1-a0d0-f022de521d25">
+                    <semantic:text>Applicant data.EmploymentStatus</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:knowledgeSource id="_821a6840-e910-418f-809e-4c7d60b0b21a" name="Credit risk analytics">
+        <semantic:description>&lt;p&gt;Credit risk scorecard analysis to determine the relevant factors for application risk scoring&lt;/p&gt;</semantic:description>
+        <semantic:authorityRequirement id="_7891c386-9a9f-43e8-92e2-a41c8500ff12">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:authorityRequirement>
+        <semantic:authorityRequirement id="_dc1087cb-ba0c-4c8a-9a3a-a318d966ab58">
+            <semantic:requiredInput href="#_2240bb79-1848-4b49-ac1b-8cf7db432770"/>
+        </semantic:authorityRequirement>
+        <semantic:authorityRequirement id="_e154a8ca-866b-42d2-aae0-226fc994789f">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+        <semantic:type>Analytic Insight</semantic:type>
+        <semantic:owner href="#_b6554413-30ba-4320-be7f-98efdf73ea08"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" name="Application risk score model">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table&amp;nbsp;&lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Application risk score model" id="_645f4911-6a95-4dbd-8efb-13fac8154fa2" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number" triso:expressionId="_2385cee1-8ce7-4ccb-b75d-b233362e2054">
+            <semantic:formalParameter name="Age" typeRef="number"/>
+            <semantic:formalParameter name="Marital Status" typeRef="string"/>
+            <semantic:formalParameter name="Employment Status" typeRef="string"/>
+            <semantic:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM">
+                <semantic:input id="_09b90043-cccb-4cf7-b8bc-44e97787443f">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Age</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="simple">
+                        <semantic:text>[18..120]</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_803f1aa0-731a-4541-bfba-6211a564af69">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Marital Status</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"S","M"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_e32f7b2c-5837-4e18-acea-a100115f412d">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Employment Status</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"UNEMPLOYED","STUDENT","EMPLOYED","SELF-EMPLOYED"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_e7b50872-4ad3-496a-ac06-15dc98c9d526"/>
+                <semantic:annotation/>
+                <semantic:rule id="_cd986c20-a58b-413e-96c3-37d2f48fe361">
+                    <semantic:inputEntry id="_b5fa1bbc-0cc3-462c-b978-429e932a83ab">
+                        <semantic:text>[18..22)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_43189918-aecd-4713-8e23-231b35b299d7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f8be0751-2823-46d8-8007-c4fb601fcba8">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_dab1ccbe-edc2-4cc2-9167-1d452b4ad0c2">
+                        <semantic:text>32</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_271d1521-3fb9-4b1d-a74d-0abf1c131186">
+                    <semantic:inputEntry id="_57a0f913-e95b-4941-b868-e306d484f045">
+                        <semantic:text>[22..26)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_23b572c3-9c6f-4e17-8bdb-95fd58f404d5">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_85a87989-40c4-4027-b674-6d21b6d5bb64">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_8f6c2458-a000-4d1f-b6a1-a553f8b3c4db">
+                        <semantic:text>35</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_558f8923-cd42-484a-b6b0-7cb28bfa7480">
+                    <semantic:inputEntry id="_795dc738-ca79-4c60-9746-e44bc1b34663">
+                        <semantic:text>[26..36)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_8492546f-c66a-46e5-9e86-9b0a79ec99d6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2efe9985-1475-426d-abb3-760fed744a14">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_7146afbc-d68f-415d-9abf-da3ad5a87527">
+                        <semantic:text>40</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_389ee4a2-47d3-42fc-ad04-e8798d638d33">
+                    <semantic:inputEntry id="_cf08fa6c-084d-4f2c-ae60-aa0abb5d7b2a">
+                        <semantic:text>[36..50)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7b81f517-a79a-4213-b74b-4cf01ee9a7c3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1101bb57-178a-4c25-9d79-7759553e9d7d">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_10c870e9-f72d-45f0-bcfd-bc6bcc0d2315">
+                        <semantic:text>43</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_8c355a92-0f8b-4d41-ada2-b98b05237249">
+                    <semantic:inputEntry id="_c28cca26-4eda-4d37-a056-15b23eec9690">
+                        <semantic:text>&gt;=50</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_29ab6240-13dd-478f-ac73-0805778efe30">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_3ddc0313-cd5b-40f3-8858-87a384ee1f23">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_c2fe72a6-2591-413b-b4e8-a73a3fca33bc">
+                        <semantic:text>48</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ffdf62cd-9909-4dd0-a15e-19fcb5a5ce6f">
+                    <semantic:inputEntry id="_90065ca5-703d-4b29-9924-c949f210683e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_5167d8a0-f82c-4f9b-b948-94ee8ef9b753">
+                        <semantic:text>"S"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d9f2e10b-80c2-4f8e-af9b-83d3317e14b9">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f1dd8303-3db4-4fe2-879c-fd5b0ecd970d">
+                        <semantic:text>25</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_cf192d51-2d52-4280-a41f-4941f1611b60">
+                    <semantic:inputEntry id="_b1e8abb2-ecee-4fdf-8d75-a292d8bf8b0f">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_35f4590a-63a0-4a46-a875-9b37b6e8ada2">
+                        <semantic:text>"M"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e50ee6a1-78bc-4ee0-8030-6f9654057e9a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f36c68f8-b188-4675-bb7b-ea5347a08fff">
+                        <semantic:text>45</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_90b8f62c-6ca6-4234-97c4-4de2011374b9">
+                    <semantic:inputEntry id="_a1de40fe-8951-4ecb-bfc7-516a2d77bf55">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_63f774ad-98ab-44e6-8ebf-83a00437e7d6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_9e4a3948-ec86-4987-a80d-2f0bc9c63530">
+                        <semantic:text>"UNEMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3f14a6c0-3829-41c2-a57c-154574752788">
+                        <semantic:text>15</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_bc447e0a-a445-4029-804b-138b76a766ef">
+                    <semantic:inputEntry id="_9196a27c-a829-43d7-b973-73bf13915ec3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1d672363-4080-4dd8-82cd-d30ff16d4383">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_28ca5667-24ac-4c8c-8557-ede60e51b461">
+                        <semantic:text>"STUDENT"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_90a363e8-d80d-4d78-9e33-2be7cbb9fd05">
+                        <semantic:text>18</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_5651d55b-18a5-4ff4-bc28-30ce10385a2d">
+                    <semantic:inputEntry id="_93400b3b-bdda-4370-878b-e221bf8521c6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_df5d20cf-6971-4911-832f-683d2a790c11">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a0b06347-1422-4b9d-bdd0-ede06b7e5d0b">
+                        <semantic:text>"EMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_78582066-9c90-4b16-88a3-1709b784a4ff">
+                        <semantic:text>45</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_07c9f995-1814-4a77-9ab1-f03c21337165">
+                    <semantic:inputEntry id="_b377eba2-90f6-4913-8a84-e0e358cb4ae5">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_c515456a-3519-4446-aeaa-6f3f613a8812">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6d9fc071-2870-4397-83de-802aa5f398a5">
+                        <semantic:text>"SELF-EMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_233be7af-2d3f-4b9c-bb69-561f8378e870">
+                        <semantic:text>36</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+            <semantic:requiredAuthority href="#_821a6840-e910-418f-809e-4c7d60b0b21a"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:inputData id="_d14df033-f4a2-47e3-9590-84e9ff04db4e" name="Applicant data">
+        <semantic:description>&lt;p&gt;Information about the applicant including personal information, marital status and household income/expenses.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Applicant data" id="_76597f43-a435-4d85-bc82-98007b9e0d1d" typeRef="tApplicantData"/>
+    </semantic:inputData>
+    <semantic:decision id="_3c8cee68-99dd-418c-847d-0b54697354f2" name="Required monthly installment" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Required monthly installment&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Installment calculation business knowledge model, passing Requested product.ProductType as the Product Type parameter, Requested product.Rate as the Rate parameter, Requested product.Term as the Term parameter, and Requested product.Amount as the Amount parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>What is the minimum monthly installment payment required for this loan product?</semantic:question>
+        <semantic:allowedAnswers>A dollar amount greater than zero</semantic:allowedAnswers>
+        <semantic:variable name="Required monthly installment" id="_f581169e-828d-45cd-9af5-e401eebc8f27" typeRef="number"/>
+        <semantic:informationRequirement id="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <semantic:requiredInput href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+            <semantic:requiredKnowledge href="#_7235d875-2426-4869-b6df-92ca06ae80c5"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+        <semantic:invocation id="_2cc659df-0249-417c-8074-d3a375c6b5f5" typeRef="number" triso:expressionId="_9530fe45-acf2-49a5-8232-b9613375ed18">
+            <semantic:literalExpression id="literal__2cc659df-0249-417c-8074-d3a375c6b5f5">
+                <semantic:text>Installment calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_fa5953c6-c8f2-449e-ac2b-4bc04cb000c2" name="Product Type"/>
+                <semantic:literalExpression id="_87dccb4c-d416-42ca-9c72-a0b591b4ba88">
+                    <semantic:text>Requested product.ProductType</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_78623557-831b-47e4-81fe-349a0743fc5a" name="Rate"/>
+                <semantic:literalExpression id="_3ba44309-b466-42d8-8126-bb2ef2d0544e">
+                    <semantic:text>Requested product.Rate</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_48ac3dfb-dc98-420f-b051-2a9a3035e5f3" name="Term"/>
+                <semantic:literalExpression id="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce">
+                    <semantic:text>Requested product.Term</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_a8c6ca38-2e6c-42cb-8d5d-2e40469a4e4a" name="Amount"/>
+                <semantic:literalExpression id="_df160506-5551-4fe3-bf04-1fcb462bcaec">
+                    <semantic:text>Requested product.Amount</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:inputData id="_fe938494-ee59-425e-8728-2347ea703563" name="Requested product">
+        <semantic:description>&lt;p&gt;Details of the loan the applicant has applied for.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Requested product" id="_480bcfd2-2643-4d1c-852b-3034dfa62790" typeRef="tRequestedProduct"/>
+    </semantic:inputData>
+    <semantic:businessKnowledgeModel id="_7235d875-2426-4869-b6df-92ca06ae80c5" name="Installment calculation">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment&amp;nbsp;&lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Installment calculation" id="_c02274e9-a6c8-4498-9d43-eaa33be7a0d9" typeRef="number"/>
+        <semantic:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL" typeRef="number" triso:expressionId="_d246e55f-0397-487d-925a-853e41d17f07">
+            <semantic:formalParameter name="Product Type" typeRef="string" id="_f6831cd9-3eab-4399-8d29-42b141fd9968"/>
+            <semantic:formalParameter name="Rate" typeRef="number" id="_c6f48aeb-b65d-4307-8722-dd44f7335566"/>
+            <semantic:formalParameter name="Term" typeRef="number" id="_708eb9af-fe19-418c-8547-1647cb50f596"/>
+            <semantic:formalParameter name="Amount" typeRef="number" id="_fddc99bb-3be6-45b0-bf8c-d8d4c016a90b"/>
+            <semantic:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4">
+                <semantic:contextEntry id="_d773da17-a45c-4a3b-8b70-565058cb6e1d">
+                    <semantic:variable name="Monthly Fee" id="_2db6ada1-2a67-4c84-bb31-e78178cf6b32" typeRef="number"/>
+                    <semantic:literalExpression id="_ad1e4499-e806-42f1-8069-254e98f5d498">
+                        <semantic:text>if Product Type = "STANDARD LOAN"
+then 20.00
+else if Product Type = "SPECIAL LOAN"
+then 25.00
+else null</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_f4156a0c-ea28-475d-8025-9e209280bd2c">
+                    <semantic:variable name="Monthly Repayment" id="_594996b3-1aea-4557-bf8e-f3bc91470fee" typeRef="number"/>
+                    <semantic:literalExpression id="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3">
+                        <semantic:text>Financial.PMT(Rate, Term, Amount)</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_cebe4ac7-7aa7-4ef9-ae70-b6caf6cbb593">
+                    <semantic:literalExpression id="_f6293695-dc2e-4e16-9dc7-1595423f0f91">
+                        <semantic:text>Monthly Repayment + Monthly Fee</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+            </semantic:context>
+        </semantic:encapsulatedLogic>
+        <semantic:knowledgeRequirement id="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+            <semantic:requiredKnowledge href="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514#_a30c75ec-7d81-4606-802c-b31ea308392d"/>
+        </semantic:knowledgeRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decisionService id="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" name="Bureau Strategy Decision Service">
+        <semantic:variable name="Bureau Strategy Decision Service" id="_81ad8660-56e2-40b3-be19-1c9349367081" typeRef="Any"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:outputDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_4d91e3a5-acec-4254-81e4-8535a1d336ee" name="Routing Decision Service">
+        <semantic:variable name="Routing Decision Service" id="_23c674f4-a331-472c-b32d-246ad6d5f51d" typeRef="Any"/>
+        <semantic:outputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:inputData id="_2240bb79-1848-4b49-ac1b-8cf7db432770" name="Loan default data">
+        <semantic:description>&lt;p&gt;Information about historical loan defaults.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Loan default data" id="_4b912c7d-9f4c-4475-a2e1-1a090f9a1abf" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:textAnnotation id="_f319ab16-ff1a-4629-93b3-c48a7613d874">
+        <semantic:text>The credit risk scorecard is built from past applicants' data and information about those loans that defaulted. It must conform to the overall risk management strategy.</semantic:text>
+    </semantic:textAnnotation>
+    <semantic:organizationUnit id="_036e1231-d563-4c1c-8a68-6b89df81d7c0" name="Credit officers">
+        <semantic:description>&lt;p&gt;Individuals in the Retail Banking organization responsible for manual adjudication of loans.&lt;/p&gt;</semantic:description>
+        <semantic:decisionMade href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+    </semantic:organizationUnit>
+    <semantic:organizationUnit id="_2fb957d8-e426-49a0-a6d2-67c26a40560b" name="Product management">
+        <semantic:description>&lt;p&gt;Organization responsible for defining loan and other banking products, how those products are priced, sold and tracked for profitability.&lt;/p&gt;</semantic:description>
+        <semantic:decisionOwned href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:decisionOwned href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:decisionOwned href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+    </semantic:organizationUnit>
+    <semantic:organizationUnit id="_6a80329f-9577-4497-aca3-67bf5aa41a7a" name="Credit risk">
+        <semantic:description>&lt;p&gt;Organization within the bank responsible for defining credit risk strategies and policies and providing tools for managing against these.&lt;/p&gt;</semantic:description>
+        <semantic:decisionOwned href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:decisionOwned href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:decisionOwned href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:decisionOwned href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:decisionOwned href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:decisionOwned href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:decisionOwned href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+    </semantic:organizationUnit>
+    <semantic:organizationUnit id="_b6554413-30ba-4320-be7f-98efdf73ea08" name="Credit risk analytics group">
+        <semantic:description>&lt;p&gt;Organization responsible for credit risk models and the use of data to predict credit risk for customers and loan applicants.&lt;/p&gt;</semantic:description>
+        <semantic:decisionOwned href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+    </semantic:organizationUnit>
+    <semantic:performanceIndicator id="_4d7ae526-d994-4ea2-9f26-81b9c693a45a" name="Monthly loan accept rate">
+        <semantic:description>&lt;p&gt;The percentage of loans accepted in a calendar month.&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_3a51a3c5-06f5-471f-88ef-8a3ea99b0d49" name="Monthly auto-adjudication rate">
+        <semantic:description>&lt;p&gt;The percentage of loans that did not require a credit officer to review the case in a calendar month.&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_18c16494-3da7-42d8-8a7d-599b158dd840" name="Monthly value of loans written">
+        <semantic:description>&lt;p&gt;The total value of Loans written in a calendar month&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_96b30012-a6e7-4545-89d3-068ec722469c" name="Auto-adjudication rate 90%">
+        <semantic:description>&lt;p&gt;By end of the current year, have an auto-adjudication rate of at least 90 percent&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_0519e753-66a5-43cd-ad04-caf4de93b7f0" name="Monthly bureau costs">
+        <semantic:description>&lt;p&gt;The total cost charged by the bureau for all Bureau Data requested while originating Loans in a calendar month.&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:impactingDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+    </semantic:performanceIndicator>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_ce4a4c00-c3a3-46a6-8938-055239f6b326" triso:modelElementRef="_ce4a4c00-c3a3-46a6-8938-055239f6b326" name="DRD of all automated decision-making">
+            <di:extension/>
+            <dmndi:Size height="1050.9786834716797" width="1411.2411708831787"/>
+            <dmndi:DMNShape id="_71b16a12-bf83-47a5-ad8b-68c0d302beec" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7">
+                <dc:Bounds x="1069" y="54.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_679112c3-6972-441f-b33c-04fac539b373" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762">
+                <dc:Bounds x="893.5" y="50" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="899" y="58.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_05c030a4-e19b-45d0-991a-864c3590cb59" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847">
+                <dc:Bounds x="1225.7588291168213" y="262.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_446c9f43-6c05-4bb6-b256-9f9a7c15bddb" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276">
+                <dc:Bounds x="177" y="262.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d29344c2-6e50-4b8c-a5b3-a40ffea37690" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf">
+                <dc:Bounds x="277" y="142.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_11d165e6-b609-483c-a6c8-3b29d0f57007" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3">
+                <dc:Bounds x="374" y="262.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d9aca572-c374-446b-858b-cb4ab805e3e8" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447">
+                <dc:Bounds x="591.5" y="263.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_5d3ed3ec-3569-4871-80a0-ca6463ff4822" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032">
+                <dc:Bounds x="721.5" y="150" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a1b2549e-ebfd-48f9-9eb9-26cf2a633197" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535">
+                <dc:Bounds x="810.5" y="263.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c52f4be2-14a9-492d-b43c-414509221ef1" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="1024" y="262.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ce794d2d-6915-4449-94f3-6c696f13735f" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6">
+                <dc:Bounds x="88.5" y="370.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_740df4b9-aae6-48c2-a043-2afd5c49f652" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="50" y="476.4786796569824" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1a770b99-fccb-4815-89f9-81f5e095745e" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982">
+                <dc:Bounds x="567" y="365" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3c91f051-3f67-4cc8-b264-1a2cc439a21f" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e">
+                <dc:Bounds x="789" y="365" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b1693c26-379c-4de0-b67e-bea8432e6952" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5">
+                <dc:Bounds x="695.5" y="476.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4f00c139-48a7-4bb4-8e10-972ce790bbd9" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838">
+                <dc:Bounds x="494.5" y="475.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_22d6f112-9f15-4326-8412-6db0a794275e" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474">
+                <dc:Bounds x="918.5" y="475.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_e1b06a01-5f9e-4212-8814-019fbcf06122" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec">
+                <dc:Bounds x="1024" y="587.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_68899272-8eb1-48e2-815e-707a9ecd8083" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="1225.7588291168213" y="715.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a82d0133-35e7-43d1-a642-60caa2d04b90" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df">
+                <dc:Bounds x="1024.5" y="716.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_662479c8-e054-4e52-9db4-6ef922c56c39" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0">
+                <dc:Bounds x="277" y="587.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3fd27363-f5e5-4374-93c8-7067576ed30b" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266">
+                <dc:Bounds x="138" y="716.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_343c2b83-2e04-4f08-8dfa-dac81d2b0331" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="277" y="822.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9152652c-9f2a-4b64-9ff3-f136cb69dbe7" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="50" y="818" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c98a40a9-1e93-4fe0-96db-719739d88bbe" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="138" y="941.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_99a17d09-ffa6-4b9f-be2b-4506aaf73b34" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="503.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_317dd163-3d23-4ea3-b027-8ce87da1cad1" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="840.5" y="822.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_96ac6a43-4e04-4ceb-be85-89ffd1dc3006" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="736.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_254ffe68-6cd4-432e-bc44-2de5252d947f" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5">
+                <dc:Bounds x="945" y="941.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_43001462-46a2-4d67-9f54-eb8381decbf6" dmnElementRef="include1:_a30c75ec-7d81-4606-802c-b31ea308392d">
+                <dc:Bounds x="1173" y="941.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_1" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16" width="94" x="1201" y="962.4786796569824"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_ff5e52a4-5bea-448c-bd90-bda28eec9323" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+                <di:waypoint x="993.5" y="84.5"/>
+                <di:waypoint x="1069" y="84.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_92d9b87b-d396-448f-a004-349cf0ca6f45" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+                <di:waypoint x="1293.4968013763428" y="262.97867584228516"/>
+                <di:waypoint x="1195.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_8ddc01e9-ef2c-4f20-a070-e0a9b45c47b9" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+                <di:waypoint x="962.5" y="292.4786796569824"/>
+                <di:waypoint x="1024" y="292.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_06486f6d-6994-41ef-a8db-81770fc7e9b7" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+                <di:waypoint x="1100.5" y="262.9786796569824"/>
+                <di:waypoint x="1135.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_21562fd6-873a-4e83-b8cc-a16df4057da6" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+                <di:waypoint x="784" y="203"/>
+                <di:waypoint x="885.5" y="263.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_c4a7713d-e0d0-4764-bae8-e63f3537b42a" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+                <di:waypoint x="734" y="217"/>
+                <di:waypoint x="666.5" y="263.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_79cc7227-2172-46cd-8376-e6db749153ef" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+                <di:waypoint x="253.5" y="262.9786796569824"/>
+                <di:waypoint x="323.5" y="202.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f7b69077-9a1f-439b-ba5c-c5ddd7e9dea9" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+                <di:waypoint x="440.5" y="262.9786796569824"/>
+                <di:waypoint x="373.5" y="202.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_90f39c58-82a0-405e-ad2f-9c6f8ffa5bdd" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+                <di:waypoint x="591.5" y="292.4786796569824"/>
+                <di:waypoint x="527" y="292.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7987705d-5788-4ff1-9497-819e523b8ac1" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+                <di:waypoint x="692" y="424"/>
+                <di:waypoint x="740.5" y="476.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_57295a64-8277-4df4-9054-5c99cbd13b9c" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+                <di:waypoint x="826.5" y="432"/>
+                <di:waypoint x="800.5" y="476.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1a9b2354-b389-47d9-8d38-a81e2da67f46" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+                <di:waypoint x="173.5" y="370.4786796569824"/>
+                <di:waypoint x="223.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_810cbec7-bd9e-4d9b-898c-47161d5162cf" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+                <di:waypoint x="333.5" y="587.9786796569824"/>
+                <di:waypoint x="253.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_97a3b1e2-1eba-4a28-9812-358358f94d0b" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+                <di:waypoint x="100" y="476.4786796569824"/>
+                <di:waypoint x="153.5" y="429.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_788d6f7c-bbfa-4040-bd8d-e401f65f3fe0" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+                <di:waypoint x="353.5" y="587.9786796569824"/>
+                <di:waypoint x="440.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3b1a8ae8-d120-454c-8607-e0893ef2d352" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+                <di:waypoint x="383.5" y="587.9786796569824"/>
+                <di:waypoint x="531" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b9c4734a-bf1e-4873-91fb-17603b453dda" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+                <di:waypoint x="150" y="490.9786796569824"/>
+                <di:waypoint x="567" y="394"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_19f3493f-378f-4b01-9e8f-6c947e2a1c92" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+                <di:waypoint x="847.5" y="505.4786796569824"/>
+                <di:waypoint x="918.5" y="505.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_79b6d42a-a88d-4bbe-af92-7eb43530f212" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+                <di:waypoint x="695.5" y="505.4786796569824"/>
+                <di:waypoint x="647.5" y="505.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7d9886a9-b720-449b-a9ee-b9ff19214215" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+                <di:waypoint x="995" y="475.9786796569824"/>
+                <di:waypoint x="1080.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7a184012-35d0-4ccd-bab4-75b682532e75" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+                <di:waypoint x="1100.5" y="587.9786796569824"/>
+                <di:waypoint x="1100.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_28f25ecb-1438-4c3f-b479-409dc62e8ea3" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+                <di:waypoint x="1293.4968013763428" y="715.9786758422852"/>
+                <di:waypoint x="1155.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0592b263-628a-4188-84fa-ebcb5db3f7ae" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+                <di:waypoint x="590.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="1105.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_dd46ade9-b5f3-4c69-be62-2fba4d2ccad3" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+                <di:waypoint x="1099.5" y="716.4786796569824"/>
+                <di:waypoint x="1100.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1e2df774-a85d-47d3-9b69-e9b658a5c7de" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+                <di:waypoint x="1263.4968013763428" y="715.9786758422852"/>
+                <di:waypoint x="1140.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_98bf15a8-c171-408c-8640-7ef2614ff482" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+                <di:waypoint x="1283.4968013763428" y="715.9786758422852"/>
+                <di:waypoint x="1120.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_10c5c589-256f-4a8b-a30d-94d4f77112a6" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+                <di:waypoint x="570.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="571" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b02f656c-ac89-403c-940b-5e737be2b638" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="813.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="887" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d5609aac-93d8-466d-955a-9c322f903260" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+                <di:waypoint x="1010" y="941.4786796569824"/>
+                <di:waypoint x="937" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b8b060fc-0deb-4079-8d6b-b93daf1133bc" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+                <di:waypoint x="1090.5" y="587.9786796569824"/>
+                <di:waypoint x="995" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0e6ee14b-6806-4593-b398-efc4da3e1feb" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+                <di:waypoint x="927" y="822.9786796569824"/>
+                <di:waypoint x="985" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_fc769965-b6c4-4f77-9d11-33ff625cf58a" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+                <di:waypoint x="610.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="965" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_44deed7d-0ca8-4e9c-a972-7f4e8397e064" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+                <di:waypoint x="632.4968013763428" y="950.9786758422852"/>
+                <di:waypoint x="1060.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2465cbb3-0279-4117-9a10-27172b9c3a28" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+                <di:waypoint x="87.5" y="543.4786796569824"/>
+                <di:waypoint x="146.5" y="724.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_54e9b93b-7633-4983-9150-232a3565b0a3" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+                <di:waypoint x="213" y="716.4786796569824"/>
+                <di:waypoint x="313.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e0f5f874-01e6-4730-8f0b-61376728eb86" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="87.5" y="885"/>
+                <di:waypoint x="138" y="980.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b14c232b-e4ea-41aa-9f67-6413c8423675" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+                <di:waypoint x="223" y="941.4786796569824"/>
+                <di:waypoint x="323.5" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2cafac50-1bf7-4841-bb88-7eb1400af07a" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="510.4968013763428" y="950.9786758422852"/>
+                <di:waypoint x="403.5" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d8760f3a-1108-4efd-ba5f-2bdf21f90a81" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+                <di:waypoint x="530.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="373.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_097af913-509c-4cd8-bdd6-45fce884bbab" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+                <di:waypoint x="353.5" y="822.9786796569824"/>
+                <di:waypoint x="353.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2819cfea-477d-4652-8ebf-4c90456ccef1" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+                <di:waypoint x="150" y="510.9786796569824"/>
+                <di:waypoint x="1024.5" y="735.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0093086e-95dc-4ba9-9edb-2e249d1cf967" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+                <di:waypoint x="907" y="822.9786796569824"/>
+                <di:waypoint x="601" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_972a19bf-350a-47be-8afe-74540f14a4d0" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+                <di:waypoint x="550.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="450.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_71fe7cd9-0e0d-4a6a-989f-3842a965bb64" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+                <di:waypoint x="571" y="475.9786796569824"/>
+                <di:waypoint x="460.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a770742b-4ff3-40a5-95be-92d8d9e470f0" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+                <di:waypoint x="430" y="842.9786796569824"/>
+                <di:waypoint x="1024" y="617.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2de39711-33bb-4aad-94be-036606811a00" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+                <di:waypoint x="1173" y="970.4786796569824"/>
+                <di:waypoint x="1097" y="970.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262" triso:modelElementRef="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262" name="DRD for Decide bureau strategy decision point">
+            <di:extension/>
+            <dmndi:Size height="978.5" width="979.8080854415894"/>
+            <dmndi:DMNShape id="_80a2a8fd-9bc7-49cb-8b91-bea566d2324b" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="594" y="740.9999923706055" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_119017a3-7e0d-4324-800f-3e088e498c75" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="698.2411708831787" y="622.9999961853027" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3b1d8f15-d493-4fa9-bcfb-42fcbd6a7287" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="513.7588291168213" y="856.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_68dc56c3-7930-4816-b843-089a9de5c1a6" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="148.5" y="857.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9f98c1ca-1354-49dc-95a7-c5dd85cac42d" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="29.5" y="736.0213203430176" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="35" y="744.3681896596715"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_0f1008a0-ae96-4e27-aa5d-b3bc11c05fac" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="275.5" y="741" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_191faa22-22f9-4c0e-a7d7-b16b8a44d560" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266">
+                <dc:Bounds x="148.5" y="623.4999961853027" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3ee31f31-9681-4389-8bfa-4a3643ee85db" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0">
+                <dc:Bounds x="287.5" y="532" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6943ac13-5ec7-47f5-a93e-00df738f8362" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838">
+                <dc:Bounds x="505" y="383" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_cec4eba7-8505-4ef2-ab1f-a6b997f4d43e" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5">
+                <dc:Bounds x="706" y="383.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_65f0b61c-ece5-4d43-9fb0-57288f3900c3" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e">
+                <dc:Bounds x="799.5" y="272.0213203430176" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="805" y="280.3681896596715"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_0cc08173-136b-42d3-9fa1-09c690920b37" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982">
+                <dc:Bounds x="572.5" y="290.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c1903235-a689-4c6c-9dcc-479e982b57d8" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="29.5" y="417.0213203430176" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="89" x="35" y="416.3681896596715"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6d63627c-90c4-49fd-9230-c3eb47926594" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6">
+                <dc:Bounds x="89" y="290.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4a8fd722-4d10-4234-b2d2-e8408a4e65fa" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032">
+                <dc:Bounds x="732" y="57.02132034301758" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="737.5" y="65.36818965967151"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_641f3b03-7f81-468a-b326-e89b881e9c9b" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447">
+                <dc:Bounds x="602" y="170.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7076cd45-5bf9-47a2-9fed-6df474257bfb" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3">
+                <dc:Bounds x="384.5" y="170" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_fe28b5fd-85bb-4254-a3a3-22f5feff055e" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf">
+                <dc:Bounds x="287.5" y="50" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d3099e88-e780-4a4f-affc-c8169158a5e8" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276">
+                <dc:Bounds x="187.5" y="170" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_326709ad-71e2-4e73-ace4-0cc197b3f536" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5">
+                <dc:Bounds x="777.8080854415894" y="741.4999961853027" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_bd1b4da0-c300-467c-bc4d-f3876dac57b9" dmnElementRef="include1:_a30c75ec-7d81-4606-802c-b31ea308392d">
+                <dc:Bounds x="777.8080854415894" y="856.4999961853027" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_1" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16" width="94" x="805.8080854415894" y="877.4999961853027"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_9af973d8-43d2-4c7e-a1b8-073379713699" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+                <di:waypoint x="581.5" y="383"/>
+                <di:waypoint x="471" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_df0420fd-e9e5-4e41-935a-16ef8dc7e88c" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+                <di:waypoint x="551.4968013763428" y="856.9999961853027"/>
+                <di:waypoint x="461" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_91bbd80d-6ea4-41e2-883f-2e8acf5ba7a5" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+                <di:waypoint x="764.7411708831787" y="622.9999961853027"/>
+                <di:waypoint x="611.5" y="443"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3d004781-db04-4465-8cfb-302ea51eb8d1" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+                <di:waypoint x="352" y="741"/>
+                <di:waypoint x="354" y="592"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a2dad098-4b9a-4131-8a0c-1be284eb0539" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+                <di:waypoint x="541.4968013763428" y="856.9999961853027"/>
+                <di:waypoint x="384" y="592"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2880c9ff-4f28-421e-8fae-34b89b06c204" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="520.9968013763428" y="866.9999961853027"/>
+                <di:waypoint x="402" y="801"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_024c0689-9ed4-491b-a2e1-2d02b7d42383" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+                <di:waypoint x="233.5" y="857.5"/>
+                <di:waypoint x="322" y="801"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_39fbc611-0e1b-4af1-883b-aa77e1e2061f" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="67" y="803.0213203430176"/>
+                <di:waypoint x="148.5" y="886.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_8f610d6c-98f2-45b3-85f6-312ff212bc7b" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+                <di:waypoint x="223.5" y="623.4999961853027"/>
+                <di:waypoint x="324" y="592"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_bd8e70ee-0662-4e8a-8f9a-a7ebf404a46b" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+                <di:waypoint x="67" y="484.0213203430176"/>
+                <di:waypoint x="148.5" y="662.4999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_cb7eaa51-8619-48c6-a0d6-3b10f40a1eac" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+                <di:waypoint x="852.8080854415894" y="741.4999961853027"/>
+                <di:waypoint x="794.7411708831787" y="682.9999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2533deda-855f-48ba-8fdc-3675fb2df3ce" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="671.7379722595215" y="740.9999923706055"/>
+                <di:waypoint x="744.7411708831787" y="682.9999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e786b1f0-c3ef-4060-a3b7-eb16e0edf2ea" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+                <di:waypoint x="581.4968013763428" y="856.9999961853027"/>
+                <di:waypoint x="581.5" y="443"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_effc3ae5-2fca-402b-aece-4e9fa58f9812" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+                <di:waypoint x="706" y="412.5"/>
+                <di:waypoint x="658" y="413"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2d19fb5f-d272-4cd3-8297-6fb9740f4342" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+                <di:waypoint x="129.5" y="431.5213203430176"/>
+                <di:waypoint x="572.5" y="319.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ad0db5e4-a620-4a97-872f-a8c9289a538c" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+                <di:waypoint x="394" y="532"/>
+                <di:waypoint x="541.5" y="443"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_64bf8314-a651-4f52-a99e-e6457550ad59" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+                <di:waypoint x="364" y="532"/>
+                <di:waypoint x="451" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_20e13ac5-c830-4bd4-bce5-2ce61c3963a9" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+                <di:waypoint x="79.5" y="417.0213203430176"/>
+                <di:waypoint x="154" y="349.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_89190762-0fd1-4cf5-a43b-1b072a8640a0" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+                <di:waypoint x="344" y="532"/>
+                <di:waypoint x="264" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9b46cfcc-256b-4660-8763-36e297fb8800" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+                <di:waypoint x="174" y="290.5"/>
+                <di:waypoint x="234" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3cdffa98-f7e4-4ea3-a65f-2cfb83d58f2c" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+                <di:waypoint x="837" y="339.0213203430176"/>
+                <di:waypoint x="811" y="383.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b7a08e14-77cf-489c-bd66-df8e548beacf" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+                <di:waypoint x="697.5" y="349.5"/>
+                <di:waypoint x="751" y="383.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_93a83c4a-576a-47ec-bc9d-d8b0c1a95b97" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+                <di:waypoint x="602" y="199.5"/>
+                <di:waypoint x="537.5" y="200"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_16370eb0-b28e-481e-bb2b-ae0466659220" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+                <di:waypoint x="451" y="170"/>
+                <di:waypoint x="384" y="110"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9f4799aa-52da-4bc5-a5e3-8bd8e6ae0d78" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+                <di:waypoint x="264" y="170"/>
+                <di:waypoint x="334" y="110"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0cfb20a2-fd2a-4911-b754-bab4f138c1d6" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+                <di:waypoint x="744.5" y="124.02132034301758"/>
+                <di:waypoint x="677" y="170.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_94766029-ffee-43b9-a472-2a47cabd92d5" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+                <di:waypoint x="853.8080854415894" y="857.4999961853027"/>
+                <di:waypoint x="853.8080854415894" y="800.4999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_3275163a-921d-48f8-967a-21c4373b1197" triso:modelElementRef="_3275163a-921d-48f8-967a-21c4373b1197" name="DRD for Decide routing decision point">
+            <di:extension/>
+            <dmndi:Size height="768.4786834716797" width="1140.5"/>
+            <dmndi:DMNShape id="_7b4cf31d-6e5e-4654-9dc6-44fbaa21b105" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5">
+                <dc:Bounds x="338.2411708831787" y="658.9786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_8841d4b9-1fe6-4238-b473-9500efb152c9" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="129.5" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_e25734f2-0621-4de4-a551-7a2e3ff4b4e3" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="233.7411708831787" y="528.4786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7106a296-cf23-402e-ba5a-da68d3b2cbf6" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="542.7588291168213" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_85ca2722-c63d-4bee-b4a2-20865788790b" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="938.5" y="528.9786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c5b281c8-65f9-4170-8d91-bc4356eb0199" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="990.5" y="393" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="996" y="401.3468693166539"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_12e52af3-c2f4-4838-9312-77ae9d9367e2" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="716" y="528.4786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_cdf6ea09-1597-4ce6-baad-32bd9bfab22a" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df">
+                <dc:Bounds x="233.87058544158936" y="398.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3668effc-4c16-48eb-af14-8807dcae39ef" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="815.7588291168213" y="397.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_8bc5b940-7c9b-4ad4-ba19-3c8ca4fbfd15" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec">
+                <dc:Bounds x="598" y="397.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_644f0ba0-4030-4fe1-8719-e2a96687da4b" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474">
+                <dc:Bounds x="482.5" y="248.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b9c5cd5a-548c-4616-9969-1a9612959967" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5">
+                <dc:Bounds x="259.5" y="249.47867965698242" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c9bf39d1-bbb8-4229-a138-bf899e6c35ba" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e">
+                <dc:Bounds x="363.87058544158936" y="142" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="369.37058544158936" y="150.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2dd25d60-5458-4699-91d3-61afb5bdc9f4" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982">
+                <dc:Bounds x="50" y="249.47867965698242" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7a72af18-3e24-42c0-9e88-782c7d298182" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="76" y="393" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="89" x="81.5" y="392.3468693166539"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_18491c1e-7e4f-4930-8e41-96fea4126b9f" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="598" y="54.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16.000000000000004" width="146" x="600.5064935064935" y="76.4868763782939"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_85bcfbfb-3697-42f8-86d5-e09f06265ceb" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535">
+                <dc:Bounds x="374.5" y="55.47867965698242" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_86c8b375-241a-422b-b7ee-0aa92acdf4f3" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032">
+                <dc:Bounds x="192.5" y="50" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="198" y="58.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_e70a052a-708c-4039-af18-6c7cc2c5cc0d" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+                <di:waypoint x="792.5" y="528.4786796569824"/>
+                <di:waypoint x="714.5" y="457.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9df5af62-acc5-4bd6-8bde-1844b9898b1a" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+                <di:waypoint x="176" y="427.5"/>
+                <di:waypoint x="233.87058544158936" y="427.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_bcc15c66-942e-444f-9622-0b46e4bb9452" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="620.4968013763428" y="658.4786758422852"/>
+                <di:waypoint x="792.5" y="588.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_75625c72-7057-4063-aad5-51c1b2fba93b" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+                <di:waypoint x="938.5" y="557.9786796569824"/>
+                <di:waypoint x="869" y="558.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0f4486ba-53a9-44b1-bfca-1c5ffb4cb6b3" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="1028" y="460"/>
+                <di:waypoint x="1023.5" y="528.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2c2611a4-223c-4066-a90a-e676fd9bcac8" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+                <di:waypoint x="610.4968013763428" y="658.4786758422852"/>
+                <di:waypoint x="664.5" y="457.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0a1d74e7-65e1-4e55-977a-cf3c6d3259fe" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+                <di:waypoint x="600.4968013763428" y="658.4786758422852"/>
+                <di:waypoint x="549" y="308.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_110dc4e7-e6f6-4ed3-a99f-5360386496e6" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+                <di:waypoint x="320.2411708831787" y="528.4786796569824"/>
+                <di:waypoint x="509" y="308.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2d5b24a8-4a8b-4e16-8b84-c0d4a8345335" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+                <di:waypoint x="664.5" y="397.9786796569824"/>
+                <di:waypoint x="609" y="308.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a5d92ccd-57bd-4b21-a415-caf534fe7e73" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+                <di:waypoint x="403.2411708831787" y="658.9786796569824"/>
+                <di:waypoint x="330.2411708831787" y="588.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7d743acb-874e-4b70-a1ed-fedf58bb3362" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="207.23797225952148" y="658.4786758422852"/>
+                <di:waypoint x="280.2411708831787" y="588.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_cd1178b0-dbee-4718-8393-227565d10f7d" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+                <di:waypoint x="873.4968013763428" y="397.97867584228516"/>
+                <di:waypoint x="694.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ca2d3a25-e73e-4416-9f52-cc2505773bf2" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+                <di:waypoint x="815.9968013763428" y="427.97867584228516"/>
+                <di:waypoint x="751" y="427.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ca70ee2f-e133-4214-b0ff-955d68df06f1" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+                <di:waypoint x="385.87058544158936" y="427.4786796569824"/>
+                <di:waypoint x="598" y="427.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f0f2802e-aea3-48ce-bec1-82ed35845063" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+                <di:waypoint x="674.5" y="397.9786796569824"/>
+                <di:waypoint x="674.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e817868c-79fa-4b31-8903-10b612c6470c" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+                <di:waypoint x="559" y="248.97867965698242"/>
+                <di:waypoint x="654.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1b100239-3889-4410-b03f-85577ad57026" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+                <di:waypoint x="411.5" y="278.4786796569824"/>
+                <di:waypoint x="482.5" y="278.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f83178d6-4e9d-4751-ad72-78932a93e2f7" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+                <di:waypoint x="126" y="393"/>
+                <di:waypoint x="126" y="308.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_91491d86-be6e-4b14-8795-dff66e50c320" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+                <di:waypoint x="401.37058544158936" y="209"/>
+                <di:waypoint x="364.5" y="249.47867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f3bd7301-1563-482b-89d7-8fdd2354f121" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+                <di:waypoint x="202" y="278.4786796569824"/>
+                <di:waypoint x="259.5" y="278.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_afc6bacd-7d75-4c22-9379-87dae05a7ec3" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+                <di:waypoint x="292.5" y="84.5"/>
+                <di:waypoint x="374.5" y="84.47867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_919da30d-975c-4b80-b974-5ce79d1f8c0a" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+                <di:waypoint x="526.5" y="84.47867965698242"/>
+                <di:waypoint x="598" y="84.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b" triso:modelElementRef="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b" name="DRD for Review application decision point">
+            <di:extension/>
+            <dmndi:Size height="430.9786834716797" width="665.7411708831787"/>
+            <dmndi:DMNShape id="_8753a9cc-cdac-4090-93e3-27e9b1080619" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="57.75882911682129" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b2b2db6e-d9b3-4fa5-bb7d-42ecf849a6a6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="382.2588291168213" y="320.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_031ba6ca-c73e-42ae-917b-70726dab086c" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="179.5" y="320.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6dc46488-4b09-4ca2-a116-31b1dd57ec22" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847">
+                <dc:Bounds x="480.2588291168213" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1ee7ca06-5141-461b-8df0-6396c924f424" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762">
+                <dc:Bounds x="50" y="50" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="55.5" y="58.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_fa882c2e-c721-42e2-927b-629c58481dc9" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7">
+                <dc:Bounds x="225.5" y="54.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_997dab16-04be-4787-ae98-b893a7731df9" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+                <di:waypoint x="135.49680137634277" y="222.97867584228516"/>
+                <di:waypoint x="272" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_87998c24-d099-4504-8f7d-d85d0d25aa87" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+                <di:waypoint x="449.9968013763428" y="320.97867584228516"/>
+                <di:waypoint x="302" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_45119ce3-3629-49af-8b1a-735ab94ec94c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+                <di:waypoint x="256" y="320.9786796569824"/>
+                <di:waypoint x="292" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9aad460e-772e-44b4-a8b0-956fc8a63bdf" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+                <di:waypoint x="547.9968013763428" y="222.97867584228516"/>
+                <di:waypoint x="322" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_137fbdfd-56c6-4c13-8ee1-b9fd8f6438d3" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+                <di:waypoint x="150" y="84.5"/>
+                <di:waypoint x="225.5" y="84.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_5c111794-4c6b-4747-8dfc-99d2ad0b6313" triso:modelElementRef="_5c111794-4c6b-4747-8dfc-99d2ad0b6313" name="Bureau Strategy Decision Service" documentation="&lt;p&gt;Stateless, side-effect free service to determine the appropriate bureau strategy for a specific applicant and product&lt;/p&gt;">
+            <di:extension/>
+            <dmndi:Size height="893.0000038146973" width="743.8705854415894"/>
+            <dmndi:DMNShape id="_58aa9ca2-9b70-489b-a992-ab9a11c7cbc9" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="308.1470727920532" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_58f9e0e3-cfcc-4f08-aef4-e192d06975f4" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="524.6294145584106" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_392bc431-eb67-4350-9671-2a0677db09f4" dmnElementRef="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" isCollapsed="false">
+                <dc:Bounds x="50" y="50" width="643.8705854415894" height="670"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+                <dmndi:DMNDecisionServiceDividerLine>
+                    <di:waypoint x="50" y="275"/>
+                    <di:waypoint x="693.8705854415894" y="275"/>
+                </dmndi:DMNDecisionServiceDividerLine>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9e34a4d1-45da-4831-badc-73d8677348c0" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf">
+                <dc:Bounds x="299.38824367523193" y="88" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_eca64fdc-9a9b-4437-a09c-985f20e5aa97" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276">
+                <dc:Bounds x="136" y="197" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_5f9bf062-d0e9-447f-89c9-77e4c469182e" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3">
+                <dc:Bounds x="299.38824367523193" y="307" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6afc8123-61b9-4532-beeb-47ef0a188d18" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838">
+                <dc:Bounds x="479.5" y="461.5" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_502c37dd-dea7-4fde-b8df-8837fba3d41b" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0">
+                <dc:Bounds x="136" y="461.5" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_587c02f7-6b33-4183-a2a7-7b66ea54c018" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="79" y="600" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4319ac14-8191-4f5b-90ed-143062b9b6b2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="515.8705854415894" y="583" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_949bf535-e11a-49e9-9ce8-e3ad4840ea27" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+                <di:waypoint x="212.5" y="197"/>
+                <di:waypoint x="345.88824367523193" y="148"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_648d510e-45f5-4f6b-85ce-f6c0d78bd2cf" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+                <di:waypoint x="375.88824367523193" y="307"/>
+                <di:waypoint x="375.88824367523193" y="148"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b10bc203-1c9c-40d0-bf3d-3c2bb420ca22" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+                <di:waypoint x="212.5" y="461.5"/>
+                <di:waypoint x="212.5" y="257"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d2e1b2a4-8675-4791-a021-b037a51db9cd" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+                <di:waypoint x="232.5" y="461.5"/>
+                <di:waypoint x="365.88824367523193" y="367"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_19ae4b52-8660-46d8-8c20-3321766662ee" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+                <di:waypoint x="289" y="491.5"/>
+                <di:waypoint x="479.5" y="491.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_6b91c9bc-cb17-4f49-824d-ed044d77345c" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+                <di:waypoint x="415.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="496" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_077dfe7c-521b-472e-b93e-9037c54103ea" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="592.3673868179321" y="782.9999961853027"/>
+                <di:waypoint x="592.3705854415894" y="643"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_56de7caf-fbd7-440c-ba61-82db11f56f89" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="335.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="155.5" y="660"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3478b12f-259d-4a1a-8a9e-63c6633d2d17" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+                <di:waypoint x="365.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="232.5" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4fd6e1df-93a4-422c-9cd5-816a0a9f54ae" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+                <di:waypoint x="155.5" y="600"/>
+                <di:waypoint x="212.5" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4dac9a2f-c185-429a-8a34-ed4df45333c2" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+                <di:waypoint x="592.3705854415894" y="583"/>
+                <di:waypoint x="556" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_86e67447-9abc-411f-9e0c-7f96590ae288" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+                <di:waypoint x="375.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="375.88824367523193" y="367"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_580f903e-7d68-42db-8a25-5349993b2c25" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+                <di:waypoint x="556" y="461.5"/>
+                <di:waypoint x="385.88824367523193" y="367"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_69750f88-f46f-4b47-bb3c-fb77f574f2b3" triso:modelElementRef="_69750f88-f46f-4b47-bb3c-fb77f574f2b3" name="Routing Decision Service" documentation="&lt;p&gt;Stateless, side-effect free service for determining the recommending handling approach for an applicant given their details, the loan applied for and any relevant bureau data.&lt;/p&gt;">
+            <di:extension/>
+            <dmndi:Size height="789.4573631286621" width="793"/>
+            <dmndi:DMNShape id="_9796f837-6893-4090-8b2e-2a7683cc76b5" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="607.5176582336426" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7544fd3e-8acb-4f69-8c9f-10f617ed28ac" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="269.7588291168213" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7a126b99-6aa3-4152-b7f5-c8a62b928c51" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="83.75882911682129" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_448a6614-664f-4aa1-b68f-b8e5286db1b3" dmnElementRef="_4d91e3a5-acec-4254-81e4-8535a1d336ee" isCollapsed="false">
+                <dc:Bounds x="50" y="50" width="693" height="562.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+                <dmndi:DMNDecisionServiceDividerLine>
+                    <di:waypoint x="50" y="190"/>
+                    <di:waypoint x="743" y="190"/>
+                </dmndi:DMNDecisionServiceDividerLine>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_0cc014c9-e77f-42b7-9db9-d191dc1282b3" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="400.62941455841064" y="82" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_06d6329b-0290-40a8-afa7-9c013a5c11ef" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474">
+                <dc:Bounds x="179.62941455841064" y="219.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_08ff0bda-72ca-4f4f-b97c-8086e256dc37" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec">
+                <dc:Bounds x="400.62941455841064" y="369.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_918c03e8-0a27-402a-bcb6-c73ce6bf7b68" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="400.62941455841064" y="496.4786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1736d75d-d232-49ef-b240-40f54606c120" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="75" y="369.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_10959e18-49b9-47f2-9857-616a5475f978" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+                <di:waypoint x="256.12941455841064" y="219.97867965698242"/>
+                <di:waypoint x="427.12941455841064" y="142"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4954a232-9bb2-4b69-aa27-980d05026a6a" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+                <di:waypoint x="477.12941455841064" y="369.9786796569824"/>
+                <di:waypoint x="477.12941455841064" y="142"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e943ad5c-b09f-497e-b27b-897baa3821cb" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+                <di:waypoint x="655.2556304931641" y="679.4573554992676"/>
+                <di:waypoint x="527.1294145584106" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_20993320-b2cc-4c5f-a70b-41c76e8fe5de" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+                <di:waypoint x="675.2556304931641" y="679.4573554992676"/>
+                <di:waypoint x="527.1294145584106" y="142"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4c9ff6d6-e7cd-4026-9613-fc79c17bf9f3" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="151.49680137634277" y="679.4573554992676"/>
+                <di:waypoint x="151.5" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7ca313c0-de73-455a-98ba-3bc5ff24ce8f" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+                <di:waypoint x="467.12941455841064" y="369.9786796569824"/>
+                <di:waypoint x="306.12941455841064" y="279.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f7a5e094-bbf5-492e-89a7-069a267f8a32" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+                <di:waypoint x="161.5" y="369.9786796569824"/>
+                <di:waypoint x="206.12941455841064" y="279.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ec68e6ae-4cbd-44b4-9102-7239b40c83d9" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+                <di:waypoint x="327.4968013763428" y="679.4573554992676"/>
+                <di:waypoint x="256.12941455841064" y="279.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1d2a10bb-7892-47b4-88cf-d8c3bccb62a4" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+                <di:waypoint x="337.4968013763428" y="679.4573554992676"/>
+                <di:waypoint x="407.12941455841064" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1cafa890-64c6-456f-b7e6-44f7779d6155" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="347.4968013763428" y="679.4573554992676"/>
+                <di:waypoint x="477.12941455841064" y="556.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_582cea04-bab2-44de-991d-b7f4335b0a1e" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+                <di:waypoint x="477.12941455841064" y="496.4786796569824"/>
+                <di:waypoint x="477.12941455841064" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_95e871bf-e58f-4976-b1bf-d9b220fdb2cb" triso:modelElementRef="_55b83dbb-d659-43c6-a102-0851a75d92e8" name="DRD for Credit Risk Analytics">
+            <di:extension/>
+            <dmndi:Size height="491.9786834716797" width="885"/>
+            <dmndi:DMNShape id="_9e8b811b-13d7-4805-a5f2-46b151a47adf" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="540.5" y="81" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="94.00000000000001" x="568.512987012987" y="84.01639344262296"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_da6554ff-51c3-496d-b930-df6df3cc9a2a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="340.5" y="81" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="346" y="89.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_13e7c4d4-5b40-463b-a8cd-88bee6c7a954" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="46.75882911682129" y="37.978675842285156" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16" width="93.99999999999999" x="66.17174174738867" y="58.978679529825854"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ca52df5c-3325-48b9-bd4b-81a570049173" dmnElementRef="_2240bb79-1848-4b49-ac1b-8cf7db432770">
+                <dc:Bounds x="46.75882911682129" y="119.99999618530273" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="66.17174174738867" y="142.99999987284343"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2060b4cc-ad14-44c3-89a7-5dfd1b485865" dmnElementRef="_f319ab16-ff1a-4629-93b3-c48a7613d874">
+                <dc:Bounds x="376.5" y="188" width="235" height="65"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="54" width="229" x="381.5" y="196"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_726b3d32-779b-4320-85bb-58f7b2786cc2" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="232" y="286" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="89" x="237.5" y="285.3468693166539"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_3070db6b-665c-4d35-8bf0-68acdf4a3c2e" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="440.5" y="105.4"/>
+                <di:waypoint x="540.5" y="110"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a4ccd46c-7516-488a-a436-835dd42b8b5e" dmnElementRef="_7891c386-9a9f-43e8-92e2-a41c8500ff12">
+                <di:waypoint x="182.99680137634277" y="67.97867584228516"/>
+                <di:waypoint x="340.5" y="105.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ddb69903-2486-420a-b2d5-7572b53f3858" dmnElementRef="_dc1087cb-ba0c-4c8a-9a3a-a318d966ab58">
+                <di:waypoint x="182.99680137634277" y="149.99999618530273"/>
+                <di:waypoint x="340.5" y="125.4"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0dec0070-d1e3-4ab1-b427-7e29abe158e7" dmnElementRef="_e154a8ca-866b-42d2-aae0-226fc994789f">
+                <di:waypoint x="282" y="286"/>
+                <di:waypoint x="353" y="148"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" fontFamily="arial,helvetica,sans-serif" fontSize="14" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+        <dmndi:DMNStyle id="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_1" fontFamily="arial,helvetica,sans-serif" fontSize="14" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+        <dmndi:DMNStyle id="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Financial.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Financial.dmn
@@ -1,0 +1,31 @@
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:rss="http://purl.org/rss/2.0/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:feel="https://www.omg.org/spec/DMN/20191111/FEEL/"           xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" id="_5e8e877a-af87-434b-9c36-ed51c8d6b514" name="Financial" namespace="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" exporter="DMN Modeler" exporterVersion="6.2.2.1" triso:logoChoice="None">
+    <semantic:decisionService id="_5e8e877a-af87-434b-9c36-ed51c8d6b514_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Whole Model Decision Service" id="_7510044d-9f94-4b5a-a172-bb5412031a86" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_78d4b1b3-d780-407d-b8ba-b7c28c334551_DS" name="Diagram Page 1" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram Page 1" id="_077c39ab-7b07-490e-bd40-bdc6d7bb0a48" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:businessKnowledgeModel id="_a30c75ec-7d81-4606-802c-b31ea308392d" name="PMT">
+        <semantic:description>&lt;p&gt;&lt;span lang="JA"&gt;Standard calculation of monthly installment&amp;nbsp;&lt;/span&gt;from Rate, Term and Amount.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="PMT" id="_702e93e8-7d03-4400-aae4-a21543a4d631" typeRef="Any"/>
+        <semantic:encapsulatedLogic id="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" kind="FEEL" typeRef="Any" triso:expressionId="_3e686571-acdc-46c2-8fe0-8e399ee6a570">
+            <semantic:formalParameter name="Rate" typeRef="number" id="_1787cf94-5e76-4926-ac24-5b4096b28dca"/>
+            <semantic:formalParameter name="Term" typeRef="number" id="_0d037df5-8942-473f-9feb-2e16d6d7d631"/>
+            <semantic:formalParameter name="Amount" typeRef="number" id="_deb10bf3-97f0-4f6b-8ae4-5cbfd44debac"/>
+            <semantic:literalExpression id="_4d149dbb-89da-498e-853f-2c33f4e9b834">
+                <semantic:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</semantic:text>
+            </semantic:literalExpression>
+        </semantic:encapsulatedLogic>
+    </semantic:businessKnowledgeModel>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_78d4b1b3-d780-407d-b8ba-b7c28c334551" triso:modelElementRef="_78d4b1b3-d780-407d-b8ba-b7c28c334551" name="Page 1">
+            <di:extension/>
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_f3441ebe-15cd-435b-9451-206c147a6985" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d">
+                <dc:Bounds x="274.5" y="213.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_5e8e877a-af87-434b-9c36-ed51c8d6b514_0"/>
+            </dmndi:DMNShape>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_5e8e877a-af87-434b-9c36-ed51c8d6b514_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Loan info.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Loan info.dmn
@@ -1,0 +1,758 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" id="_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Loan info" namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" exporter="DMN Modeler" exporterVersion="6.2.2.3">
+	<semantic:itemDefinition name="tBorrower" label="tBorrower">
+		<semantic:itemComponent id="_b7dcc14d-510d-4628-a510-ca774208e501" name="Full Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8cb2dd31-072e-48f0-8358-65cf75fcfda9" name="Tax ID">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_88b9503a-d677-4fd0-9f4c-3e16cb4f5ec0" name="Employment Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dc653a3f-5bc0-4aa3-ae82-d25db1e5abbc" name="Other Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1033e487-e687-48e2-b763-74cc29e2f242" name="Assets">
+			<semantic:typeRef>tAssets</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0ef27863-fb82-48f6-b7d9-dd006feaba60" name="Liabilities">
+			<semantic:typeRef>tLiabilities</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAsset" isCollection="false" label="tAsset">
+		<semantic:itemComponent id="_178a9712-768e-4150-860a-62fadcca989f" name="Type">
+			<semantic:typeRef>tAssetType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c977d77b-4c8a-486d-b177-0a5859662c97" name="Institution Account or Description">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_591c646d-eeb9-4011-bc7f-69b157a6f591" name="Value">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssets" isCollection="true" label="tAssets">
+		<semantic:typeRef>tAsset</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssetType" label="tAssetType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Checking Savings Brokerage account","Real Estate","Other Liquid","Other Non-Liquid"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiability" label="tLiability">
+		<semantic:itemComponent id="_57fce471-2342-4fc7-8116-405daa3ef433" name="Type">
+			<semantic:typeRef>tLiabilityType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dd30338f-9852-4149-8896-0efd298b4ac0" name="Payee">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_05fa38d8-21e6-4da2-a839-af266bb235f8" name="Monthly payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_81e5630b-f15a-4b4b-912e-6400bdb1cc36" name="Balance">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0b284d1f-d87a-4f80-846c-70f128074f49" name="To be paid off">
+			<semantic:typeRef>boolean</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilities" isCollection="true" label="tLiabilities">
+		<semantic:typeRef>tLiability</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilityType" label="tLiabilityType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Credit card","Auto loan","Student loan","Lease","Lien","Real estate loan","Alimony child support","Other"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAmortizationType" label="tAmortizationType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanProduct" label="tLoanProduct">
+		<semantic:itemComponent id="_1833883f-633d-4212-920d-1954b412bea6" name="Lender Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8d009922-d11e-4c23-8c14-f141f3ba94a8" name="Product Name">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1414b396-63f4-4f4b-825d-bce4ea87a07f" name="Type">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_27d5f2e4-a73a-464d-a80b-c05ed1a95471" name="Best Rate Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e44b0b2f-71a7-4233-9fd7-0cdcdb79f80b" name="Points Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f2d16774-2421-4e39-8412-512dadf40cd6" name="Fees Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0a6f5fef-4cb1-4d50-94a3-d22cf903a8c7" name="Term">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProperty" label="tProperty">
+		<semantic:itemComponent id="_5e820b14-1f14-44e2-bee1-a35fbedc477f" name="Address">
+			<semantic:itemComponent id="_d40919e3-168d-46dc-a7da-ccefeead8a49" name="Street">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_a03ae467-fb6a-46f0-ab1a-dc0992d81095" name="Unit">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_f902cd87-2c95-4b90-95cf-a2c6b1b87a1e" name="City">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_97f12b0d-be5c-4d42-abb5-d565599fee87" name="State">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_2fdc92bc-55da-4ff7-8a9d-c5213b69a0a8" name="ZIP">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cc0e8c3f-ae44-4080-88db-555d8a2f8560" name="Purchase Price">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3fb7e2b1-6ad9-4858-ae46-45e6b83e063d" name="Monthly Tax Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_aa55fa1a-3e82-4439-b422-21921c6a64b0" name="Monthly Insurance Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_77f3b202-47ba-432b-9ada-e81700db445f" name="Monthly HOA/Condo Fee">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercentList" isCollection="true" label="tPercentList">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercent" label="tPercent">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tCreditScore" label="tCreditScore">
+		<semantic:typeRef>number</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>[300..850]</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProductName" label="tProductName">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanData" isCollection="false" label="tLoanData">
+		<semantic:itemComponent id="_fd6a3e80-4ffe-438c-9e39-9f77a67c1f91" name="Points Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_6f71ccdc-b275-43c6-985a-31559b523c6c" name="Note Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_35c2796b-c800-4803-92e6-9cb5a96fcdc8" name="LTV" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_82b33b6f-e7c3-4016-a69d-f15d55a56d58" name="Closing Costs" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3a485bc8-8c27-4395-99ab-32c0d53616e2" name="Funds Toward Purchase" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_97e275f6-5776-4b55-86cb-f5e392c73307" name="Interest Rate Percent" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7a9b65fd-ca47-4788-bdde-246237480654" name="Qualifying Rate Percent" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f74f4b87-3684-4345-98b1-eaef7732385f" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_d6ba831e-226f-4284-9035-b1fcb7e40f21" name="Qualifying Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanInfo" isCollection="false" label="tLoanInfo">
+		<semantic:itemComponent id="_4307deb6-caba-4a7b-9075-820459281679" name="Product" isCollection="false">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_689ecdaf-4b3b-40ca-9eff-b7dff7e10bc3" name="Amortization Type" isCollection="false">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f96fc5bd-ecad-497f-931e-1d2ba0cc0ac7" name="LTV" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3445d602-de4b-44b6-afa2-a3c7d04368d7" name="Note Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_4ea4f624-c68b-47a0-9161-5244585e4898" name="Initial Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_81c9c31a-8d89-4d7f-856d-c6642499ed29" name="Qualifying Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cd96db58-d312-41dc-a3e4-6fa93766b49d" name="Initial Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c05792fd-417f-4662-b6b8-7cf708c26976" name="Quallifying Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_30babadc-60b5-4879-b233-410b43349ef4" name="Points Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_6c1aedf8-5d23-448d-acca-e91b5845a746" name="Fees Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_d7c3f0b8-f0d7-4bc9-95be-414530c2c23c" name="Funds Toward Purchase" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_37e9699c-e1bd-40b7-aafb-6e9b9e51e532" name="Down Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ec560b2b-0a1d-43fc-9a72-4ce30a92030e" name="Closing Costs" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7751d0b1-c992-4c52-a7c1-ea89b0226033" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:inputData id="_e0cfe605-3068-42a2-946f-c7db3774de1e" name="Property">
+		<semantic:variable name="Property" id="_35fe76b3-4304-4a45-bbc5-c3ac926fd494" typeRef="tProperty"/>
+	</semantic:inputData>
+	<semantic:inputData id="_d78ee6d5-96ed-43e6-89d2-123e0f388a67" name="Credit Score">
+		<semantic:variable name="Credit Score" id="_3bf8b83f-789a-4e98-bb0d-34ab6a6e01d9" typeRef="tCreditScore"/>
+	</semantic:inputData>
+	<semantic:inputData id="_29a44873-e886-42de-bc2f-6d5704b6b298" name="Loan Product">
+		<semantic:variable name="Loan Product" id="_45a92729-62fc-413d-a811-5aae30277a87" typeRef="tLoanProduct"/>
+	</semantic:inputData>
+	<semantic:decision id="_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5" name="Loan Data">
+		<semantic:variable name="Loan Data" id="_b864ab4b-b825-4740-b287-8f31eef41881" typeRef="tLoanData"/>
+		<semantic:informationRequirement id="_e47777c4-b10c-4aa8-8087-371824560192">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_ffe87244-b1ab-4075-a243-5f2a87f170d0">
+			<semantic:requiredInput href="#_29a44873-e886-42de-bc2f-6d5704b6b298"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_d9d4a780-7427-4000-b2c7-575717ebcae5">
+			<semantic:requiredInput href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_8304cbac-5619-459b-92a8-b389aaaf2aff">
+			<semantic:requiredInput href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_28360d50-9eee-4fa1-9f4d-a19c5bc9bbcb">
+			<semantic:requiredKnowledge href="#_aeaa30db-0f84-424a-b2f5-af9b2538a9ce"/>
+		</semantic:knowledgeRequirement>
+		<semantic:knowledgeRequirement id="_ff803e3f-9159-401f-b22c-edbb48cbf164">
+			<semantic:requiredKnowledge href="#_0d2a6f36-0403-41ad-a191-f793743649d4"/>
+		</semantic:knowledgeRequirement>
+		<semantic:context id="_99e0f553-477c-424f-ab66-017e789d2070" typeRef="tLoanData">
+			<semantic:contextEntry id="_e5e58153-cc87-4746-96f8-fa7926db2f8d">
+				<semantic:variable name="Points Amount" id="_ed35ac71-a2fa-48c6-9221-838374aebce4" typeRef="number"/>
+				<semantic:literalExpression id="_abf4629a-d2cb-4d54-b700-84820144b429">
+					<semantic:text>decimal((Property.Purchase Price - Down Payment)*Loan Product.Points Pct/100,2)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_f99be8be-baee-4480-a493-42355b9fcdaf">
+				<semantic:variable name="Note Amount" id="_73c0d2bc-6d72-41ac-a2cf-611eb0fd3bc8" typeRef="number"/>
+				<semantic:literalExpression id="_9a509356-5d67-44b1-a7b7-943af81a998a">
+					<semantic:text>Property.Purchase Price - Down Payment + Loan Product.Fees Amount + Points Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_c8f5c8ed-7b41-456c-89bb-0855e69c8c33">
+				<semantic:variable name="LTV" id="_d33843ed-4131-477e-9487-ce397ccdd90b" typeRef="tPercent"/>
+				<semantic:literalExpression id="_0a20e467-7ccf-43c8-a6c3-62790a118f04">
+					<semantic:text>decimal(100*Note Amount/Property.Purchase Price,2)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_139b25d4-2c14-46d8-8e30-f026113d2ccb">
+				<semantic:variable name="Closing Costs" id="_032891c4-ff8a-42cf-a7a3-78e7eb443996" typeRef="number"/>
+				<semantic:literalExpression id="_835a0c7a-e31c-464f-8b22-5fa51dab7a5d">
+					<semantic:text>decimal(0.02*Note Amount,2)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_5ee98bf7-7992-4f7d-8537-178747da47f0">
+				<semantic:variable name="Funds Toward Purchase" id="_cbb00b9e-859a-4370-994a-157c12110ab1" typeRef="number"/>
+				<semantic:literalExpression id="_f5715792-e937-48ad-b5f5-311c1d7c4006">
+					<semantic:text>Note Amount - Loan Product.Fees Amount - Points Amount - Closing Costs</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_9a74db9e-53c6-40ba-beb7-9bee87a08d46">
+				<semantic:variable name="Interest Rate Percent" id="_1c30ac25-201c-4935-85ed-2d3382f47e70" typeRef="tPercent"/>
+				<semantic:literalExpression id="_6c63b7c3-33ea-4c39-b672-dd20c99fd0ea">
+					<semantic:text>Loan Product.Best Rate Pct + Rate Adjustment(Credit Score, LTV)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_c33c71e3-dde8-40ec-a7c3-acba227fd1f6">
+				<semantic:variable name="Qualifying Rate Percent" id="_c3c44b72-ad66-4557-a2fa-c75d461b6b4d" typeRef="tPercent"/>
+				<semantic:literalExpression id="_67cb42ba-fbec-4f4a-88af-13a645097147">
+					<semantic:text>if Loan Product.Type="Variable rate" then Interest Rate Percent+2 else Interest Rate Percent</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_6285cef3-5c41-4a30-a5ff-a77ea05903cc">
+				<semantic:variable name="Monthly Payment" id="_293149c4-e398-4063-a199-872942d1ebd5" typeRef="number"/>
+				<semantic:invocation id="_b5712b08-217d-4a76-9312-63b8ff789307">
+					<semantic:literalExpression id="literal__b5712b08-217d-4a76-9312-63b8ff789307">
+						<semantic:text>payment</semantic:text>
+					</semantic:literalExpression>
+					<semantic:binding>
+						<semantic:parameter id="_95656f17-902e-44fe-8fb5-4cd509618f05" name="p"/>
+						<semantic:literalExpression id="_89014d7d-040f-40ba-b1cc-d4f38b3ae033">
+							<semantic:text>Note Amount</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_a15a5721-2b87-403c-9793-dca7092091cf" name="r"/>
+						<semantic:literalExpression id="_a228a99c-bbd3-4951-8a57-76cc2ac09079">
+							<semantic:text>Interest Rate Percent/100</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_ce45382c-f637-4fd6-9ac4-73266f044c4d" name="n"/>
+						<semantic:literalExpression id="_c0e4f3fc-b3fc-4920-94a7-b8dc8d97df9f">
+							<semantic:text>Loan Product.Term</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+				</semantic:invocation>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_0840a234-bfed-4f58-8ab9-309be8fbfb10">
+				<semantic:variable name="Qualifying Payment" id="_051a1c8b-dd3a-4162-bdcc-d599b2d9d464" typeRef="number"/>
+				<semantic:invocation id="_6ddbe47b-b38c-4a5e-89e9-a9bf40dbc7b9">
+					<semantic:literalExpression id="literal__6ddbe47b-b38c-4a5e-89e9-a9bf40dbc7b9">
+						<semantic:text>payment</semantic:text>
+					</semantic:literalExpression>
+					<semantic:binding>
+						<semantic:parameter id="_f911095f-98db-44e6-8f63-68009fb81074" name="p"/>
+						<semantic:literalExpression id="_8dd85c93-aac3-4d6e-b521-1c5eb251b7a6">
+							<semantic:text>Note Amount</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_092230d5-5427-4a63-b814-12378ee5faee" name="r"/>
+						<semantic:literalExpression id="_70d85747-3e76-4277-9889-53042cb495b9">
+							<semantic:text>Qualifying Rate Percent/100</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_91d4257c-3c3f-4159-8f76-157234246efe" name="n"/>
+						<semantic:literalExpression id="_8db10de0-2c74-4aa7-8753-76874706af14">
+							<semantic:text>Loan Product.Term</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+				</semantic:invocation>
+			</semantic:contextEntry>
+		</semantic:context>
+	</semantic:decision>
+	<semantic:inputData id="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c" name="Down Payment">
+		<semantic:variable name="Down Payment" id="_bbe3f7c0-d59c-472b-9266-73bcdcc0fbb6" typeRef="number"/>
+	</semantic:inputData>
+	<semantic:businessKnowledgeModel id="_aeaa30db-0f84-424a-b2f5-af9b2538a9ce" name="Rate Adjustment">
+		<semantic:variable name="Rate Adjustment" id="_3199df2d-5734-481f-a201-933b41d6196e" typeRef="tPercent"/>
+		<semantic:encapsulatedLogic typeRef="tPercent">
+			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore"/>
+			<semantic:formalParameter name="LTV" typeRef="tPercent"/>
+			<semantic:decisionTable id="_cd20f4b0-fbc2-4b9d-b31f-4a83d951e989" hitPolicy="UNIQUE" outputLabel="Rate Adjustment" typeRef="tPercent">
+				<semantic:input id="_b66906d2-f62e-47ba-856b-538a97bb3fa5">
+					<semantic:inputExpression typeRef="tCreditScore">
+						<semantic:text>Credit Score</semantic:text>
+					</semantic:inputExpression>
+					<semantic:inputValues>
+						<semantic:text>[300..850]</semantic:text>
+					</semantic:inputValues>
+				</semantic:input>
+				<semantic:input id="_b8ec7502-1b2a-409e-93c1-cb3771025154">
+					<semantic:inputExpression typeRef="tPercent">
+						<semantic:text>LTV</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:output id="_b7f72972-4ba1-4b2f-912e-349803135418"/>
+				<semantic:annotation name="Description"/>
+				<semantic:rule id="_3e460ca6-9b4f-42f3-b88c-4917970f788c">
+					<semantic:inputEntry id="_829ad9b0-0cf3-4d00-9200-8ec1758e0552">
+						<semantic:text>&gt;=660</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_30142347-09ce-4888-8efb-1c46b9f33ab9">
+						<semantic:text>&lt;=60</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_22bb07d5-518d-4a68-9133-afd49eecf707">
+						<semantic:text>0</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_b4193cc2-fa9d-4225-bd43-d01def7a7b99">
+					<semantic:inputEntry id="_51b2a53b-a6c2-482a-be44-5bcb429fe000">
+						<semantic:text>[620..660)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_f06826ef-835c-4f38-a54d-ae1c0a310146">
+						<semantic:text>&lt;=60</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_9def10dd-fefa-415d-af70-57e604100c35">
+						<semantic:text>0.125</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_aa33035d-70c3-46c7-8a03-091aa1cac209">
+					<semantic:inputEntry id="_b5d9d461-0c25-4696-a0f0-fef4db24e091">
+						<semantic:text>&gt;=700</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_c1af9407-d7da-4375-aa32-ae6718024876">
+						<semantic:text>&gt;60</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_02773f21-ff28-4953-871f-79e11247a4ea">
+						<semantic:text>0.125</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_ab605848-4621-46b1-b004-72e2cfb0790d">
+					<semantic:inputEntry id="_7989b770-8e8e-408d-b2f6-8645a9907948">
+						<semantic:text>[660..700)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_6d21df38-d485-444b-88ab-df7f96b2acf9">
+						<semantic:text>(60..70]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_2dc38af3-2e5e-4209-9b4c-efc01ea7bbf3">
+						<semantic:text>0.125</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_af2ccda3-bdbe-4765-b77b-5e3dbb511d67">
+					<semantic:inputEntry id="_79b63a75-ab77-4ab6-887a-ae469a742628">
+						<semantic:text>[620..660)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_7bed0211-a515-48a2-bd57-60f79342b1b5">
+						<semantic:text>(60..70]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_519343cd-1c7a-4bc0-af66-d70cac2ee465">
+						<semantic:text>0.25</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_496169e5-073b-4387-a929-05cbe62bc98b">
+					<semantic:inputEntry id="_45f13f95-6f0f-48bf-8f3c-ab7f9bd99fde">
+						<semantic:text>[680..700)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_62afa937-c3b1-46c9-9e93-88a9fa3e1149">
+						<semantic:text>&gt;70</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_19aa90b1-12a9-4e53-83dd-e4555b05b27c">
+						<semantic:text>0.25</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_62273267-d968-4124-8f47-17c93eb7b46e">
+					<semantic:inputEntry id="_388d54da-b672-4f0c-8b01-605cf210bd09">
+						<semantic:text>[640..680)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_dbc8b85c-222f-4503-b6c5-64a39e15cdae">
+						<semantic:text>&gt;70</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_4ffd9f8b-91e7-4e49-89b6-a58e3dd26ed7">
+						<semantic:text>0.375</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_8fc1174c-a757-4549-af9f-99700065c077">
+					<semantic:inputEntry id="_ea897caa-1470-4fab-af36-c97059f147fd">
+						<semantic:text>[620..640)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_3d5c2935-ffe9-415b-a3f1-97eb34d6df76">
+						<semantic:text>(70..80]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_8bb7e26c-c2d7-44c8-aea0-fa9a90e1427f">
+						<semantic:text>0.375</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_2e26421d-08e6-4a80-a661-5985b0a9b3ac">
+					<semantic:inputEntry id="_5af33bef-309c-4df0-a59c-646a33c54be5">
+						<semantic:text>[620..640)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_6e811648-5954-43d4-8e3e-6668ebf3cd16">
+						<semantic:text>&gt;80</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_a24d5aab-d03f-4fb1-988d-a7cf034975b8">
+						<semantic:text>0.5</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_e215d517-2d2a-4117-acfc-a982c8fb0353">
+					<semantic:inputEntry id="_9c12fc0d-2fa9-4a74-8b16-2ff02aebcaf6">
+						<semantic:text>&lt;620</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_c4dcb9aa-226a-43b8-badc-7f04f763d8b5">
+						<semantic:text>-</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_b47625d7-01f3-4284-98bf-ff9d3b86c81e">
+						<semantic:text>0.5</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+			</semantic:decisionTable>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:businessKnowledgeModel id="_0d2a6f36-0403-41ad-a191-f793743649d4" name="payment">
+		<semantic:variable name="payment" id="_8c231b6d-165f-4c36-bcd3-617498b36e0e" typeRef="number"/>
+		<semantic:encapsulatedLogic id="_97168569-14dd-4533-8d8c-497681134e3b" kind="FEEL" typeRef="number">
+			<semantic:formalParameter name="p" typeRef="number" id="_b65fd962-b719-4dca-b37b-4c4d2b7e9867"/>
+			<semantic:formalParameter name="r" typeRef="number" id="_22bb5be8-b3dd-4a05-8e0d-6458fe53aa4a"/>
+			<semantic:formalParameter name="n" typeRef="number" id="_6a169eec-28b4-4789-ac5e-141348bcc99a"/>
+			<semantic:literalExpression id="_0c92187a-2412-4f49-a635-3e8cdd6e58fe" typeRef="number">
+				<semantic:text>decimal(p*r/12/(1-(1+r/12)**-n),2)</semantic:text>
+			</semantic:literalExpression>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:decision id="_8a182857-b5a1-4389-9a76-01a316938cea" name="Loan Info">
+		<semantic:variable name="Loan Info" id="_edac09bb-d679-46a5-b363-ede359f2dfd9" typeRef="tLoanInfo"/>
+		<semantic:informationRequirement id="_1f641b45-5ad1-4dfa-bdc5-19d0f52b87b4">
+			<semantic:requiredDecision href="#_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_70f3db04-5830-45d2-ba12-7c355e571fcd">
+			<semantic:requiredInput href="#_29a44873-e886-42de-bc2f-6d5704b6b298"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_da7d6551-1fd0-49ea-9723-ec51d15005a8">
+			<semantic:requiredInput href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_8d9ec740-a917-4215-88ec-e531ee90a348">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:context id="_b61ecb51-0c30-4cb0-bc0b-db503e7e03cd" typeRef="tLoanInfo">
+			<semantic:contextEntry id="_305a8898-1350-49ed-b827-0a59a76f9216">
+				<semantic:variable name="Product" id="_07481b52-07d7-4257-a124-2bffd7a7e080" typeRef="tProductName"/>
+				<semantic:literalExpression id="_404ff614-bed5-44bc-a64d-abae8419e748">
+					<semantic:text>Loan Product.Product Name</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_b3a59630-4f96-4fab-9a75-eb50b5e745c0">
+				<semantic:variable name="Amortization Type" id="_1e05445b-6883-41d8-9ae5-cdfb5205bc19" typeRef="tAmortizationType"/>
+				<semantic:literalExpression id="_ce1727a9-2ae4-4646-93a4-7e02924e908a">
+					<semantic:text>Loan Product.Type</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_2cdc74c5-b2aa-48ca-8cf4-588db17d4f2f">
+				<semantic:variable name="LTV" id="_6cf1a718-ae6c-490b-acbd-5bec33561d2b" typeRef="tPercent"/>
+				<semantic:literalExpression id="_59388af1-8e25-4bc9-860a-a1b0c189f6cf">
+					<semantic:text>Loan Data.LTV</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_c8d181a9-e299-4779-a8db-e8233e6fb37d">
+				<semantic:variable name="Note Amount" id="_d999ea55-7695-43e0-9154-527ca2199e4b" typeRef="number"/>
+				<semantic:literalExpression id="_866f935f-7366-4cfa-92b3-d04801d2847e">
+					<semantic:text>Loan Data.Note Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_111bd935-e736-459d-85e9-e00c46941198">
+				<semantic:variable name="Initial Rate Pct" id="_32dae540-bdc9-457b-850c-ab5b377cae20" typeRef="tPercent"/>
+				<semantic:literalExpression id="_37bdb610-6e92-4586-a76c-41ed00bceba8">
+					<semantic:text>Loan Data.Interest Rate Percent</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_75c82e82-f510-4d03-9b64-6dee23866637">
+				<semantic:variable name="Qualifying Rate Pct" id="_d1c92a72-78f9-4dae-9d5a-0df028f75ca0" typeRef="tPercent"/>
+				<semantic:literalExpression id="_d57fa679-94ea-4b23-a148-79b5b7440384">
+					<semantic:text>Loan Data.Qualifying Rate Percent</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_7b3c0475-18f1-46ae-b14c-bd10f2e01a6d">
+				<semantic:variable name="Initial Monthly Payment" id="_948cfa68-d3eb-449b-b16e-323fd0b77ea7" typeRef="number"/>
+				<semantic:literalExpression id="_c2ebcf27-03cd-47ee-94e9-414f37db18bd">
+					<semantic:text>Loan Data.Monthly Payment</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_e1274c1b-069b-4010-8663-08f5e27382f7">
+				<semantic:variable name="Qualifying Monthly Payment" id="_b1ea078d-4dfa-442b-98d7-4cbccce12ea5" typeRef="number"/>
+				<semantic:literalExpression id="_57b45210-6690-4432-ba16-80418853025c">
+					<semantic:text>Loan Data.Qualifying Payment</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_d5306ff6-04a9-41cd-88c6-655edd2ff712">
+				<semantic:variable name="Points Amount" id="_fdc165a7-8b0f-4888-8ff3-ad7580d8fce3" typeRef="number"/>
+				<semantic:literalExpression id="_81052536-49c2-4590-850f-cef72e3df7e9">
+					<semantic:text>Loan Data.Points Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_ae4ba9f9-40a3-40e8-9b34-a331be00d6f9">
+				<semantic:variable name="Fees Amount" id="_a8834bb9-4be1-47af-a668-afc17efc6d54" typeRef="number"/>
+				<semantic:literalExpression id="_282885e1-a60f-48c2-90b2-dbe621f1317f">
+					<semantic:text>Loan Product.Fees Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_bfc9b305-8e2d-4a0a-98f7-602ebd533497">
+				<semantic:variable name="Funds Toward Purchase" id="_272c1b83-e45c-4066-8e38-4f476d7e948f" typeRef="number"/>
+				<semantic:literalExpression id="_b22eaafb-59c9-4db6-8824-c33b8c303ec8">
+					<semantic:text>Loan Data.Funds Toward Purchase</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_26d4d85d-1b77-4be3-9ec3-79c36296c8ce">
+				<semantic:variable name="Down Payment" id="_591ebd13-c2be-47c7-a3dd-fb5561131e02" typeRef="number"/>
+				<semantic:literalExpression id="_d95db62e-5b4c-4c91-95d8-55b0be6f3b09">
+					<semantic:text>Down Payment</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_26dd9af6-d1d9-4965-ac86-b9e68044b675">
+				<semantic:variable name="Closing Costs" id="_839e434c-41f0-45c3-9f43-605b865c2005" typeRef="number"/>
+				<semantic:literalExpression id="_8147cce9-e3b5-486f-ba40-77a6749a5063">
+					<semantic:text>Loan Data.Closing Costs</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_885eb1b1-58a1-43ba-85aa-5fe90fd9a2af">
+				<semantic:variable name="Cash to Close" id="_133b174b-6408-4546-84dd-66b0ef52bb7d" typeRef="number"/>
+				<semantic:literalExpression id="_d4a59c37-c285-4486-a1f4-7a70131171db">
+					<semantic:text>Property.Purchase Price - Funds Toward Purchase</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+		</semantic:context>
+	</semantic:decision>
+	<semantic:decisionService id="_f5761a7f-090d-4177-a06a-7f21f925c6ff" name="Loan Info Service">
+		<semantic:variable name="Loan Info Service" id="_f8f5ffe8-362f-4cdf-8c5e-d5c2e7bdadde" typeRef="Any"/>
+		<semantic:outputDecision href="#_8a182857-b5a1-4389-9a76-01a316938cea"/>
+		<semantic:encapsulatedDecision href="#_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5"/>
+		<semantic:inputData href="#_29a44873-e886-42de-bc2f-6d5704b6b298"/>
+		<semantic:inputData href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		<semantic:inputData href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		<semantic:inputData href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+	</semantic:decisionService>
+	<dmndi:DMNDI xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/">
+		<dmndi:DMNDiagram id="_0b101bf8-a9c5-4e7c-8763-c8fcb4263a32" name="Page 1">
+			<di:extension xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"/>
+			<dmndi:Size height="1054.996529420125" width="1803.949344176753"/>
+			<dmndi:DMNShape id="_a3898cf2-06c3-4ff6-aee8-ff1980e1df26" dmnElementRef="_e0cfe605-3068-42a2-946f-c7db3774de1e">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="1131.4602065272172" y="422.99652560542773" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94" x="1150.6981787867387" y="445.99652560542773"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_4b1fc771-634e-4074-b5fa-9fddc959704d" dmnElementRef="_d78ee6d5-96ed-43e6-89d2-123e0f388a67">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="923.7588291168213" y="403.9965256054276" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94" x="942.9968013763428" y="426.9965256054276"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_514ee41e-624f-49ab-bbd4-bc72290d220f" dmnElementRef="_29a44873-e886-42de-bc2f-6d5704b6b298">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="1215.460206527217" y="328.9965256054276" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="93.99999999999999" x="1234.8731191577845" y="351.9965292929683"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_9fdb64c0-601f-47bf-8592-01d5144ef096" dmnElementRef="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="1215.4602065272172" y="228.0034667651778" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="93.99999999999999" x="1234.8731191577847" y="251.0034704527185"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_6946a3af-1379-4948-831f-8b40c6fa8b52" dmnElementRef="_aeaa30db-0f84-424a-b2f5-af9b2538a9ce">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="671.734375" y="364.49652942012494" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94.00000000000001" x="699.747362012987" y="387.51292286274787"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_aa434c2c-6b3b-4799-b1e3-628a27162558" dmnElementRef="_0d2a6f36-0403-41ad-a191-f793743649d4">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="671.7343750000001" y="278.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94" x="699.7343750000001" y="301.5"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_9244509d-f461-4336-8b36-04a1a6954423" dmnElementRef="_f5761a7f-090d-4177-a06a-7f21f925c6ff" isCollapsed="false">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="878.7013774103955" y="156.00347057987508" width="260" height="219.99652942012492"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12.21875" width="254" x="894.7013774103955" y="172.00347057987508"/>
+				</dmndi:DMNLabel>
+				<dmndi:DMNDecisionServiceDividerLine>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="878.7013774103955" y="271.00347057987506"/>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1138.7013774103955" y="271.00347057987506"/>
+				</dmndi:DMNDecisionServiceDividerLine>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_e23c0c63-fda2-411e-9a7f-12226a908c91" dmnElementRef="_8a182857-b5a1-4389-9a76-01a316938cea">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="932.2013774103956" y="196.00347057987508" width="153.0000000000001" height="59.99999999999997"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="146" x="935.2013774103956" y="220.00347057987508"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_ec44949f-5a92-40a5-8165-5192c916e4ac" dmnElementRef="_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="932.2013774103958" y="291" width="152.9999999999999" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12.000000000000004" width="146" x="934.7078709168893" y="314.5081967213115"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="_76f6f123-fc4f-460b-8ea7-1aaab6959d9b" dmnElementRef="_e47777c4-b10c-4aa8-8087-371824560192">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1189.1981787867387" y="422.99652560542773"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1048.7013774103957" y="351"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_98386957-cfad-49d1-bce7-6259d54d5ba3" dmnElementRef="_ffe87244-b1ab-4075-a243-5f2a87f170d0">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1217.6981787867385" y="348.9965256054276"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="341"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_8d4993ba-08a6-4e98-96bd-dc339f359d2d" dmnElementRef="_d9d4a780-7427-4000-b2c7-575717ebcae5">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1263.1981787867387" y="228.0034667651778"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="301"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_2f96d770-5269-42e9-baed-ea78445b3e46" dmnElementRef="_8304cbac-5619-459b-92a8-b389aaaf2aff">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="971.4968013763428" y="403.9965256054276"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="968.7013774103958" y="351"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_382e7238-103d-4aa7-9438-7832b2ea88d2" dmnElementRef="_28360d50-9eee-4fa1-9f4d-a19c5bc9bbcb">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="823.734375" y="393.49652942012494"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="932.2013774103958" y="331"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_bf0dd31b-d9f6-4b3e-9546-f59a29795a16" dmnElementRef="_ff803e3f-9159-401f-b22c-edbb48cbf164">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="671.7343750000001" y="307.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="321"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_e20fb50a-b082-434d-892a-869950f1d79d" dmnElementRef="_1f641b45-5ad1-4dfa-bdc5-19d0f52b87b4">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="968.7013774103958" y="291"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="968.7013774103956" y="256.00347057987506"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_4515e28c-f7ea-40ff-859f-65fd5d310072" dmnElementRef="_70f3db04-5830-45d2-ba12-7c355e571fcd">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1273.1981787867385" y="328.9965256054276"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="236.00347057987508"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_3affdb18-a0c8-4e50-9e36-73c650b2467b" dmnElementRef="_da7d6551-1fd0-49ea-9723-ec51d15005a8">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1217.6981787867387" y="248.0034667651778"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="226.00347057987508"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_9b2c749a-da49-43cc-8688-e72f394f0b32" dmnElementRef="_8d9ec740-a917-4215-88ec-e531ee90a348">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1209.1981787867387" y="422.99652560542773"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1078.7013774103957" y="256.00347057987506"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+		<dmndi:DMNStyle id="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+	</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Recommended Loan Products.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/Recommended Loan Products.dmn
@@ -1,0 +1,1412 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   id="_736fa164-03d8-429f-8318-4913a548c3a6" name="Recommended Loan Products" namespace="http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6" exporter="DMN Modeler" exporterVersion="6.2.3" xmlns:include1="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed">
+	<semantic:import namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Services" importType="https://www.omg.org/spec/DMN/20191111/MODEL/"/>
+	<semantic:itemDefinition name="tBorrower" label="tBorrower">
+		<semantic:itemComponent id="_b7dcc14d-510d-4628-a510-ca774208e501" name="Full Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8cb2dd31-072e-48f0-8358-65cf75fcfda9" name="Tax ID">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_88b9503a-d677-4fd0-9f4c-3e16cb4f5ec0" name="Employment Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dc653a3f-5bc0-4aa3-ae82-d25db1e5abbc" name="Other Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1033e487-e687-48e2-b763-74cc29e2f242" name="Assets">
+			<semantic:typeRef>tAssets</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0ef27863-fb82-48f6-b7d9-dd006feaba60" name="Liabilities">
+			<semantic:typeRef>tLiabilities</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAsset" isCollection="false" label="tAsset">
+		<semantic:itemComponent id="_178a9712-768e-4150-860a-62fadcca989f" name="Type">
+			<semantic:typeRef>tAssetType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c977d77b-4c8a-486d-b177-0a5859662c97" name="Institution Account or Description">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_591c646d-eeb9-4011-bc7f-69b157a6f591" name="Value">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssets" isCollection="true" label="tAssets">
+		<semantic:typeRef>tAsset</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssetType" label="tAssetType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Checking Savings Brokerage account","Real Estate","Other Liquid","Other Non-Liquid"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiability" label="tLiability">
+		<semantic:itemComponent id="_57fce471-2342-4fc7-8116-405daa3ef433" name="Type">
+			<semantic:typeRef>tLiabilityType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dd30338f-9852-4149-8896-0efd298b4ac0" name="Payee">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_05fa38d8-21e6-4da2-a839-af266bb235f8" name="Monthly payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_81e5630b-f15a-4b4b-912e-6400bdb1cc36" name="Balance">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0b284d1f-d87a-4f80-846c-70f128074f49" name="To be paid off">
+			<semantic:typeRef>boolean</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilities" isCollection="true" label="tLiabilities">
+		<semantic:typeRef>tLiability</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilityType" label="tLiabilityType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Credit card","Auto loan","Student loan","Lease","Lien","Real estate loan","Alimony child support","Other"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAmortizationType" label="tAmortizationType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoan" label="tLoan">
+		<semantic:itemComponent id="_1414b396-63f4-4f4b-825d-bce4ea87a07f" name="Type">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_27d5f2e4-a73a-464d-a80b-c05ed1a95471" name="Best Rate Percent">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0a6f5fef-4cb1-4d50-94a3-d22cf903a8c7" name="Term Months">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e44b0b2f-71a7-4233-9fd7-0cdcdb79f80b" name="Points Percent">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f2d16774-2421-4e39-8412-512dadf40cd6" name="Fee Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProperty" label="tProperty">
+		<semantic:itemComponent id="_5e820b14-1f14-44e2-bee1-a35fbedc477f" name="Address">
+			<semantic:itemComponent id="_d40919e3-168d-46dc-a7da-ccefeead8a49" name="Street">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_a03ae467-fb6a-46f0-ab1a-dc0992d81095" name="Unit">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_f902cd87-2c95-4b90-95cf-a2c6b1b87a1e" name="City">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_97f12b0d-be5c-4d42-abb5-d565599fee87" name="State">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_2fdc92bc-55da-4ff7-8a9d-c5213b69a0a8" name="ZIP">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cc0e8c3f-ae44-4080-88db-555d8a2f8560" name="Purchase Price">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ce17ee0b-f1e1-43cf-8a5e-4a18390fc6d6" name="Monthly Tax Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_338c3f84-8ff7-404d-9b61-d211a5cebe4b" name="Monthly Insurance Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_fe427d63-1cf3-4d2d-b268-f7e01dccad59" name="Monthly HOA Condo Fee">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercentList" isCollection="true" label="tPercentList">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercent" label="tPercent">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tCreditScore" label="tCreditScore">
+		<semantic:typeRef>number</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>[300..850]</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAffordability" label="tAffordability">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Affordable","Marginal","Unaffordable"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProductName" label="tProductName">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanProduct" isCollection="false" label="tLoanProduct">
+		<semantic:itemComponent id="_c94dcf22-5cd0-4b41-9f1c-e39d3e1eecd7" name="Lender Name" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_68f6a641-5e2d-4b1b-9f2b-41f933976dee" name="Product Name" isCollection="false">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed30-NoPointsOrFees","Fixed30-Standard","Fixed30-LowestRate","Fixed15-NoPointsOrFees","Fixed15-Standard"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_39c5300a-339c-4bde-8dfc-17e5d3f6f535" name="Type" isCollection="false">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_5f8e2576-2c33-49b1-8fce-7bb5e5a253e7" name="Best Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_905aac44-b95e-4159-9b30-08326a07d633" name="Points Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_bcaa6e47-3a6b-443c-b99e-a363aff93346" name="Fees Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a540971e-df77-456a-8499-349cef053ca6" name="Term" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanProducts" isCollection="true" label="tLoanProducts">
+		<semantic:typeRef>tLoanProduct</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanInfoRow" label="tLoanInfoRow">
+		<semantic:itemComponent id="_7a448de3-c619-44d1-bc17-9a63ca82f05c" name="Product">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_16b32188-4c17-4990-801e-cbaa9b68e749" name="Amortization Type">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_4548db4e-81d2-41ed-b3ad-1ad35237826a" name="LTV">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_34bde427-441e-417f-9b24-a3d5b808bb38" name="Note Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_84a1e8ef-747e-4dbe-879a-56795b578faf" name="Initial Rate Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3ee1f841-148c-42f3-9242-1ef327a5d98f" name="Qualifying Rate Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ea618291-896a-4948-9922-0d3e46d6f724" name="Initial Monthly Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_bbecbf22-7afd-4284-af29-ba2ddcaeec40" name="Qualifying Monthly Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_30057076-38a0-4e11-b0fa-e327b56c37a6" name="Points Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_4b18ec63-ad34-4af8-bc92-bb10e0f5d5aa" name="Fees Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cecc7cc5-945b-4bd2-9dca-2134a14f80fa" name="Funds Toward Purchase">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_bfc26334-ceb5-4adb-9bf4-31202aac793c" name="Down Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c9f217e8-def9-4123-8fdc-fc1b092f433a" name="Closing Costs">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ae1f758c-5647-4c06-a982-c12c50f1e9c9" name="Cash to Close">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanInfoTable" isCollection="true" label="tLoanInfoTable">
+		<semantic:typeRef>tLoanInfoRow</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tEligibilityTable" isCollection="true" label="tEligibilityTable">
+		<semantic:typeRef>tTableRow</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLTVCategory" label="tLTVCategory">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Low","Medium","High"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tEligibilityParams" label="tEligibilityParams">
+		<semantic:itemComponent id="_d3a02da5-731e-4633-833a-cf999edc2136" name="DTI Category">
+			<semantic:typeRef>tAffordability</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_14f97cec-f1ff-44bb-916d-074aaf58380f" name="Reserves">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7e123ec1-4a76-4cd5-beb5-522dbac1b92b" name="LTV Category">
+			<semantic:typeRef>tLTVCategory</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tParams" isCollection="false" label="tParams">
+		<semantic:itemComponent id="_7af54197-7bf4-4a81-8036-dfdac7cdf990" name="DTI" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8c2c0b73-9319-4c06-ba25-14518ea1d470" name="DTI Category" isCollection="false">
+			<semantic:typeRef>tAffordability</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Affordable","Marginal","Unaffordable"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_23df4d83-c124-4dc7-a0bd-355d7312e43f" name="LTV Category" isCollection="false">
+			<semantic:typeRef>tLTVCategory</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Low","Medium","High"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c0943b8f-dd9b-426a-9f6c-2fd2c966f514" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7ed22b26-68a3-4974-8dcf-6da2b50479ce" name="Reserves" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tEligibilityParameters" isCollection="false" label="tEligibilityParameters">
+		<semantic:itemComponent id="_2422f664-556a-475e-af82-abb361de56a0" name="Housing Expense" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_971c1e75-1682-4d14-809c-04d72ed16a48" name="Non-Housing Debt Payments" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e12ae77f-3732-4867-a511-69717cc57cfc" name="Income" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a7888cf8-5b7e-42b6-8e4c-3ebb96c3c0a6" name="DTI Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_9ee8adf0-94a0-405e-ba57-a3cfb1fe86e3" name="Liquid Assets Before Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_05b991b0-dad0-486f-b933-8866a45a5b37" name="Debts Paid Off By Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_73a12edf-4608-4462-90d5-f8e2c37141a1" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e0556de3-256b-465e-bdd7-00b00e4d714a" name="Reserves" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLenderRating" label="tLenderRating">
+		<semantic:itemComponent id="_1e6fda10-128f-48e1-a8b8-cd34ce9381c3" name="Lender Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_339f91a8-da05-43cf-b6ea-2c5f1ea6180a" name="Customer Rating">
+			<semantic:typeRef>number</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>[1..5]</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLenderRatings" isCollection="true" label="tLenderRatings">
+		<semantic:typeRef>tLenderRating</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tRecommendation" label="tRecommendation">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Best","Good","Not Recommended","Ineligible"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tTableRow" isCollection="false" label="tTableRow">
+		<semantic:itemComponent id="_7688fc87-c042-438c-9490-acd8c35c6179" name="Product" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_d247bfbe-d417-4b7e-b902-b8d507c6084a" name="Note Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e6838dc2-2e38-4ba5-80b0-7c05b352fb5f" name="Interest Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_da010099-9782-43c6-8494-5894031e581f" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a1f11f10-52db-401c-b5db-57fa2f194672" name="LTV" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_20cc2106-8782-41c0-8aa0-86a77cc6a659" name="DTI" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_b8a09bf2-4dc5-48a6-9a98-8f2297f6f595" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e894eadb-85ef-417a-941e-02b1ab15f508" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_5e4f7ce5-1df8-4ae8-803e-ba90e8e6e17c" name="Reserves" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_014b70a0-68c5-472e-a177-9b85a4849115" name="Required Credit Score" isCollection="false">
+			<semantic:typeRef>tCreditScore</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>[300..850]</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_2a7e3a86-ab04-44e5-a811-819e8bee4969" name="Recommendation" isCollection="false">
+			<semantic:typeRef>tRecommendation</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Best","Good","Not Recommended","Ineligible"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tformattedrow" isCollection="false" label="tformattedrow">
+		<semantic:itemComponent id="_f068f917-e759-4337-8d1a-fdbb13e75b5d" name="Product" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a095eec9-ccfc-4354-8a1d-aba195858993" name="Note Amount" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_430c983c-3f73-4373-9c46-b2ac5f6ff249" name="Interest Rate Pct" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7801d6b3-4639-4246-8852-ed2e3d491a7a" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f68971e8-0a0a-41fa-aa6a-5c95385ddcbc" name="LTV" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_fd8fe4ba-45a9-4a7b-8de1-a63435fbeecb" name="DTI" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_9d8a1274-95c4-40c1-93a6-66e3fcfcc214" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_de9dad22-a6ea-4ddb-9632-252c11cb03b3" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1ccce7a0-26c7-48ea-bc7c-184d32880b5a" name="Reserves" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c2254b61-d9d1-4e99-afdd-585456b1ab4e" name="Required Credit Score">
+			<semantic:typeRef>tCreditScore</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_16338ccf-00da-4f59-9e3e-eaa3bd773d79" name="Recommendation" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tRecommendedTable" isCollection="true" label="tRecommendedTable">
+		<semantic:typeRef>tformattedrow_1</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tformattedrow_1" isCollection="false" label="tformattedrow_1">
+		<semantic:itemComponent id="_7364c8f4-075a-4537-8e71-37e9849ad953" name="Product" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a3bdaa50-87e1-44a7-8903-381b7cdfa3ba" name="Note Amount" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c1d3d41c-77a3-4e49-aab1-fe43ed490672" name="Interest Rate Pct" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f3b926fb-8b55-47bc-81ca-b007fff1edb4" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_215d51c3-eef2-434c-8c93-45d1fb95435e" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3cc6467e-8205-4cfa-88d3-fc41dfc19d20" name="Required Credit Score" isCollection="false">
+			<semantic:typeRef>tCreditScore</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>[300..850]</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1d1dd9c0-2610-4b26-93f6-ab946de39a49" name="Recommendation" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:inputData id="_a177b73e-7064-4140-8757-23bdf7a5d696" name="Borrower">
+		<semantic:variable name="Borrower" id="_90f520cc-f1a6-4e0e-b4d1-9bf07ada89d6" typeRef="tBorrower"/>
+	</semantic:inputData>
+	<semantic:inputData id="_e0cfe605-3068-42a2-946f-c7db3774de1e" name="Property">
+		<semantic:variable name="Property" id="_35fe76b3-4304-4a45-bbc5-c3ac926fd494" typeRef="tProperty"/>
+	</semantic:inputData>
+	<semantic:inputData id="_d78ee6d5-96ed-43e6-89d2-123e0f388a67" name="Credit Score">
+		<semantic:variable name="Credit Score" id="_3bf8b83f-789a-4e98-bb0d-34ab6a6e01d9" typeRef="tCreditScore"/>
+	</semantic:inputData>
+	<semantic:inputData id="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c" name="Down Payment">
+		<semantic:variable name="Down Payment" id="_bbe3f7c0-d59c-472b-9266-73bcdcc0fbb6" typeRef="number"/>
+	</semantic:inputData>
+	<semantic:businessKnowledgeModel id="_a6e2c692-4a0c-4385-bbc3-7280e94a8760" name="Min Credit Score">
+		<semantic:variable name="Min Credit Score" id="_bafc7628-ede7-40ed-8229-b79e1760b8ee" typeRef="tCreditScore"/>
+		<semantic:encapsulatedLogic typeRef="tCreditScore">
+			<semantic:formalParameter name="DTI" typeRef="tPercent"/>
+			<semantic:formalParameter name="LTV" typeRef="tPercent"/>
+			<semantic:formalParameter name="Reserves" typeRef="number"/>
+			<semantic:decisionTable id="_a99db8c3-9663-41dc-967e-b4f635506dcd" hitPolicy="COLLECT" outputLabel="Min Credit Score" typeRef="tCreditScore" aggregation="MIN" >
+				<semantic:input id="_5e4ee90f-583a-4a8f-bf42-2616c139ce31">
+					<semantic:inputExpression typeRef="tPercent">
+						<semantic:text>DTI</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:input id="_51e71746-911d-4256-b751-b711e2476c4f">
+					<semantic:inputExpression typeRef="tPercent">
+						<semantic:text>LTV</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:input id="_7ba31eb3-c907-4d20-a4c4-b41b0172112d">
+					<semantic:inputExpression typeRef="number">
+						<semantic:text>Reserves</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:output id="_f2d9e49b-793e-4a7e-8749-5e3ddcfd2a3a">
+					<semantic:outputValues>
+						<semantic:text>[300..850]</semantic:text>
+					</semantic:outputValues>
+				</semantic:output>
+				<semantic:annotation name="Description"/>
+				<semantic:rule id="_60fb255d-3cca-406e-96aa-145e5c3134e2">
+					<semantic:inputEntry id="_2dfcbc28-2f05-4c34-9360-ce1274be0344">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_48bdac5c-e2a4-4103-a3e8-adcfad17008b">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_82ef54c3-234c-4384-aca6-645eaa900410">
+						<semantic:text>&gt;2</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_aba459a7-a9bd-48ea-86d0-c964ebb54b4d">
+						<semantic:text>620</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_8fdabf93-b884-49a4-9768-ed496c1eca15">
+					<semantic:inputEntry id="_2e12a1da-8528-4941-a36f-05eae403e2ba">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_7940fa44-e304-45b9-9e33-a291f2d4701e">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_ede7214c-676e-46d0-bda7-8e70f7523a09">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_7e96c5da-327c-4055-9e1f-743e794fe3ed">
+						<semantic:text>640</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_ce04eb2e-2f8f-4bcb-bf21-b90bfc039de5">
+					<semantic:inputEntry id="_28251421-0039-4e33-81ca-5a69720605b1">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_da168d60-5fc2-45e4-ad80-49881e0dcec4">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_05b04b38-4ad5-481e-9f88-4532da0a65f5">
+						<semantic:text>&gt;6</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_f64cf229-d24f-4128-bd62-fc7560cb2017">
+						<semantic:text>660</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_ab97313e-cdac-4984-8888-28abbfd52e67">
+					<semantic:inputEntry id="_62505674-40e1-4691-956a-7050a140861a">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_50988719-00c1-4671-8edf-beef5a5ae529">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_ac71f56c-c4b5-4ada-8f4b-c012fb1bc170">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_fd8a25ff-8896-400b-b15d-bff667d11d5c">
+						<semantic:text>680</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_c6aef964-bebc-4372-a9e8-518bca51140d">
+					<semantic:inputEntry id="_38a12a6c-9644-4904-8f28-0939dc344636">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_6e913c66-7fe4-4597-a088-fc9bb1baf64a">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_e7a7856c-eb23-4b84-933a-33e54d5efbec">
+						<semantic:text>&gt;6</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_c3991353-5446-4083-be12-e10cd21dbfd1">
+						<semantic:text>660</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_4364e403-a2cf-411b-a91e-649ded6ebb53">
+					<semantic:inputEntry id="_2de00a53-a95a-4226-9bd3-bbd1fa466f32">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_2fc2a147-b745-499d-8183-9b73b39beb6e">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_f04775d9-a126-42e6-8123-e7e71e793092">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_5aca97fc-636c-48bf-8787-59ce61d8ee65">
+						<semantic:text>680</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_05db9a53-f530-4c35-bffd-4f8e07e35e12">
+					<semantic:inputEntry id="_38e6e020-7be4-4f0a-b93e-c46ab65bcd0f">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_086a842d-995a-43f9-8881-99560fc964ee">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_d2e65076-26a7-4735-9427-38e3fe02fc2f">
+						<semantic:text>&gt;6</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_2db22546-005a-4f3a-a76e-b8f11a777225">
+						<semantic:text>700</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_5c867367-a339-48df-8423-262f36bc2e48">
+					<semantic:inputEntry id="_ef6f0eeb-5f35-48b1-a662-52db20addb51">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_f3a182bb-5598-4a9c-9504-54d182068498">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_d074833b-4e28-413f-ab2d-212aae14448d">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_1b3be1eb-1387-439f-adb5-96837c31cdbd">
+						<semantic:text>720</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+			</semantic:decisionTable>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:decision id="_93f33bde-df66-4731-82ad-0cf0d86a3294" name="Loan Products">
+		<semantic:variable name="Loan Products" id="_8712a5d0-d218-473d-9c41-45d31851f560" typeRef="tLoanProducts"/>
+		<semantic:relation id="_93baa493-4725-4ebf-97f7-addb340f7a83" typeRef="tLoanProducts">
+			<semantic:column id="_9820a1a8-19e6-4f13-9fa3-70bab7ea306a" name="Lender Name" typeRef="string"/>
+			<semantic:column id="_6cd3cab8-c436-48e9-b80f-945543a6c93c" name="Product Name" typeRef="tProductName"/>
+			<semantic:column id="_4746448d-cdfa-43e5-9c5a-05ebbbbe6ca2" name="Type" typeRef="tAmortizationType"/>
+			<semantic:column id="_2ca00325-916f-434d-a831-0448c32e9250" name="Best Rate Pct" typeRef="tPercent"/>
+			<semantic:column id="_542134a3-08b6-42cd-ad09-9d86a29871bd" name="Points Pct" typeRef="tPercent"/>
+			<semantic:column id="_f549bb90-f2f0-489e-bfec-8e06da0151d3" name="Fees Amount" typeRef="number"/>
+			<semantic:column id="_366d18ad-119a-4284-a6e5-49b7ef89b160" name="Term" typeRef="number"/>
+			<semantic:row id="_cc6ef300-81cd-4d3f-b58e-a6e7bb72a1d7">
+				<semantic:literalExpression id="_3ba8d6cf-8214-43c0-9825-bd6f311f997d">
+					<semantic:text>"Lender A"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_64b77b5a-5af9-49d3-bcc8-963568c1a755">
+					<semantic:text>"Fixed30-NoPoints"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_78d10bc7-1a9a-4222-ba6d-e59b9e5f67c9">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_f3b92f21-6167-4504-8f6a-2923cabbd162">
+					<semantic:text>3.95</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_e46ceb71-6b97-42cf-8d33-c245b616c7c8">
+					<semantic:text>0</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_92bc2fe0-1216-4245-9fc0-9fb4ade20ad9">
+					<semantic:text>1925</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_900c25ab-02b3-46a7-b457-77f3831dc753">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_184a163a-cb2c-4489-8a22-4de4fef406b9">
+				<semantic:literalExpression id="_c6e45571-88f1-4816-a24b-1765422bcae9">
+					<semantic:text>"Lender C"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_cf500c46-72a8-4ed9-9ee3-8226c2ecf2a4">
+					<semantic:text>"Fixed30-Standard"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_e2f8ab27-ae9c-4264-8f6c-a7dd40b360c6">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_53856576-077c-4988-b8ac-b7ac465fb6a8">
+					<semantic:text>3.75</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_8f3386e0-29ce-4fa4-a7e2-0b8e270a8844">
+					<semantic:text>0.972</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_82cf4301-1226-4132-b419-23dee50bed09">
+					<semantic:text>1975</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_0843a5ad-b82d-438c-b091-161cd47dc6bb">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_302e3d3d-acfa-40d0-ab1a-ce38f782bd1d">
+				<semantic:literalExpression id="_1ebcdb41-3976-4749-96f6-f32b69d6c9e6">
+					<semantic:text>"Lender A"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_f999c9ea-ff2c-42cb-ac6b-5924e08c9bfd">
+					<semantic:text>"Fixed15-NoPoints"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_f8d0b9df-de26-4fc8-95ab-c95f0f784a50">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_b0986269-60dd-428a-8699-fb236bbfd691">
+					<semantic:text>3.625</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_ebe2805a-a19f-442b-bdfc-dee167933ab2">
+					<semantic:text>0</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_ef312ad1-b939-49f0-8295-6d509d7c4878">
+					<semantic:text>816</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_bc05b731-a50d-483e-b3bf-23860fcaadd8">
+					<semantic:text>180</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_f26625f3-ae64-4d94-bf30-c4203f82c5eb">
+				<semantic:literalExpression id="_00fd08b7-1e72-44fa-9a42-be22eeab2375">
+					<semantic:text>"Lender C"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_4264e9e4-e87b-4fbc-bdc5-cbeb7f84a515">
+					<semantic:text>"Fixed15-Standard"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_12556708-df14-459a-826d-4feef43f217f">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_909c2e7f-b66f-4c54-b67e-9e15365fa079">
+					<semantic:text>3.25</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_03d91914-b1cb-4817-9d7a-ed90713dd98e">
+					<semantic:text>0.767</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_3f078ef4-bf72-4047-8aa1-9b428b33134d">
+					<semantic:text>1975</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_37fa7c61-1a48-4cdf-ac50-b804ad4f3ea0">
+					<semantic:text>180</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_80e5f122-e823-456d-9830-19d60cfed5b3">
+				<semantic:literalExpression id="_3684907f-e753-46df-ad57-3a3babc050ef">
+					<semantic:text>"Lender B"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_400d2423-28a5-432f-8594-d2c84d660a3a">
+					<semantic:text>"ARM5/1-NoPoints"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_bfe3c0db-cf51-4788-82a1-a44a5f5f1b70">
+					<semantic:text>"Variable rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_fba9705c-1435-42eb-88de-66f6e92a0873">
+					<semantic:text>3.875</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_063e9e4c-2182-4682-9709-6721f60e6be1">
+					<semantic:text>0</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_ce5bf73c-948c-4d22-8715-42eaad213575">
+					<semantic:text>1776</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_7e55f606-5dc2-41d2-987b-088f6bf6fccc">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_586da39c-9153-48e4-9754-bb1a2da9410a">
+				<semantic:literalExpression id="_f07de042-8dfd-4b20-ab98-3b082e2480f7">
+					<semantic:text>"Lender B"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_873c448d-4b39-46fb-8919-1f2f7abe8a0d">
+					<semantic:text>"ARM5/1-Standard"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_c913876c-a538-478e-84e2-72c9d167fcad">
+					<semantic:text>"Variable rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_6a510f8e-d185-485f-9fc9-70533a040864">
+					<semantic:text>3.625</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_bd151c87-85fd-4ee8-bcd9-2da601afb061">
+					<semantic:text>0.667</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_077fedc9-db07-4e6d-810e-f55ccd4ba39f">
+					<semantic:text>1975</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_81b8eb03-d078-4e4b-af88-c45f503ffe94">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+		</semantic:relation>
+	</semantic:decision>
+	<semantic:decision id="_0459fb1e-3d09-427d-9201-ea74a1b57864" name="Loan Info Table">
+		<semantic:variable name="Loan Info Table" id="_6820b177-357b-4a69-9d00-0d084abd13c9" typeRef="tLoanInfoTable"/>
+		<semantic:informationRequirement id="_4af51bdd-1651-42ec-8350-bc551facdffc">
+			<semantic:requiredDecision href="#_93f33bde-df66-4731-82ad-0cf0d86a3294"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_b3b8e3b8-ae4d-4192-8e96-f6abda717c16">
+			<semantic:requiredInput href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_fc2723b2-1ebd-45cc-a640-93f2cb2a6b4e">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_7cba5baa-07f0-4e12-b6a2-bb25a86d203a">
+			<semantic:requiredInput href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_88a16649-4696-4d01-84f3-130be7caba3b">
+			<semantic:requiredKnowledge href="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed#_f5761a7f-090d-4177-a06a-7f21f925c6ff"/>
+		</semantic:knowledgeRequirement>
+		<semantic:literalExpression id="_88fbacc7-8ce7-4147-93f0-4d70c7668842" typeRef="tLoanInfoTable">
+			<semantic:text>for x in Loan Products return Services.Loan Info Service(x,Down Payment,Property,Credit Score)</semantic:text>
+		</semantic:literalExpression>
+	</semantic:decision>
+	<semantic:decision id="_49ced667-1cff-4fce-a4b8-b5b480b28cd3" name="Eligibility Table">
+		<semantic:variable name="Eligibility Table" id="_45bace05-407b-4ea2-a580-066f711cd1c9" typeRef="tEligibilityTable"/>
+		<semantic:informationRequirement id="_08f900ff-aea1-419b-8e80-138343254a26">
+			<semantic:requiredDecision href="#_0459fb1e-3d09-427d-9201-ea74a1b57864"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_84630610-2554-4a74-a7e7-d185d10fd933">
+			<semantic:requiredInput href="#_a177b73e-7064-4140-8757-23bdf7a5d696"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_aa3ff8c4-2379-4609-8296-8474d14607e7">
+			<semantic:requiredInput href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_56fb1a8d-9a03-4e87-b234-b3b9c941e3ff">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_c83ae553-f658-4823-a18f-f404f447f859">
+			<semantic:requiredDecision href="#_93f33bde-df66-4731-82ad-0cf0d86a3294"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_4e13d93f-5461-4582-b6f7-afda9b6e6584">
+			<semantic:requiredInput href="#_7ed0a891-7b25-4c0e-838e-0a3cd5ec46be"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_4d86d4b2-4dee-426b-a1ff-6e91c6846585">
+			<semantic:requiredKnowledge href="#_f286d938-0042-4f0d-a889-6838d2c83a17"/>
+		</semantic:knowledgeRequirement>
+		<semantic:literalExpression id="_fef5d8f6-7c52-4df4-9203-2b56333b4b5f" typeRef="tEligibilityTable">
+			<semantic:text>for i in 1..count(Loan Products) return Eligibility(Loan Products[i], Borrower, Loan Info Table[i],
+Property, Credit Score, Lender Ratings) </semantic:text>
+		</semantic:literalExpression>
+	</semantic:decision>
+	<semantic:businessKnowledgeModel id="_f286d938-0042-4f0d-a889-6838d2c83a17" name="Eligibility">
+		<semantic:variable name="Eligibility" id="_33c71a05-13ba-4040-9ce3-394aa5513d28" typeRef="Any"/>
+		<semantic:encapsulatedLogic id="_0c7fd6f0-3c0f-43fc-8689-de083430e010" kind="FEEL" typeRef="Any">
+			<semantic:formalParameter name="Loan Product" typeRef="tLoanProduct" id="_d91e73be-a2fa-4224-a673-07e5cafe2235"/>
+			<semantic:formalParameter name="Borrower" typeRef="tBorrower" id="_6828f434-c3cb-4c22-909c-e21c34f66416"/>
+			<semantic:formalParameter name="Loan Info" typeRef="tLoanInfoRow" id="_cf041290-0a54-4e2b-80ef-c3a3a04d6c21"/>
+			<semantic:formalParameter name="Property" typeRef="tProperty" id="_543c4f59-e888-42c3-aaf4-60dc5b572da3"/>
+			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore" id="_bc995e69-571d-4c4c-80ed-ec8edb372534"/>
+			<semantic:formalParameter name="Ratings" typeRef="tLenderRatings" id="_9d39d2ce-e8cc-4d79-829a-f0e532c415f6"/>
+			<semantic:context id="_fbf39f7b-79c3-470c-82ff-62d685f1f297" typeRef="Any">
+				<semantic:contextEntry id="_112e54d2-2e8b-4504-a73e-a6616457f8fc">
+					<semantic:variable name="Params" id="_27860cc7-70bd-4ae8-810d-399e8fe8e990" typeRef="tEligibilityParameters"/>
+					<semantic:literalExpression id="_05089619-0347-4cb5-8fe5-bfc8cd937f9c">
+						<semantic:text>Eligibility Parameters(Loan Product, Borrower, Loan Info,
+Property, Credit Score)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_3f5c47a3-27a4-48a5-a8a2-b338ec4d473a">
+					<semantic:variable name="Required Credit Score" id="_98e57fc0-85cf-4797-a599-d3820382d74e" typeRef="tCreditScore"/>
+					<semantic:literalExpression id="_6689c21f-53ec-486f-8a4f-9ec7cd1409c0">
+						<semantic:text>Min Credit Score(Params.DTI Pct, Loan Info.LTV, Params.Reserves)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_b3e2b084-f251-43c9-ae16-bcbb44f86839">
+					<semantic:variable name="Eligible" id="_5f91dbe0-0a26-4216-9c57-6d3fd3f5ec76" typeRef="boolean"/>
+					<semantic:literalExpression id="_dd8647ef-12f1-40e3-aac6-2b604d3a9ba8">
+						<semantic:text>if Required Credit Score != null then 
+Credit Score &gt;= Required Credit Score else false</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_bcb71bda-a193-4e3b-ba73-8a6665ee6370">
+					<semantic:variable name="Recommendation" id="_2f9591a3-8827-4b64-9539-7f99b9c44d47" typeRef="tRecommendation"/>
+					<semantic:decisionTable id="_1f65b543-5086-420c-b502-274e18a0d4ac" hitPolicy="PRIORITY" outputLabel="Recommendation">
+						<semantic:input id="_ae5200fc-ef39-4b69-973c-5c2979e5b1b1">
+							<semantic:inputExpression typeRef="tLoanProduct">
+								<semantic:text>Loan Product</semantic:text>
+							</semantic:inputExpression>
+						</semantic:input>
+						<semantic:input id="_52996440-a14c-4e6c-82e7-9884deb3d84d">
+							<semantic:inputExpression typeRef="boolean">
+								<semantic:text>Eligible</semantic:text>
+							</semantic:inputExpression>
+						</semantic:input>
+						<semantic:output id="_4c573eb2-dc05-45d6-9158-373fe3c83a0c">
+							<semantic:outputValues>
+								<semantic:text>"Best","Good","Not Recommended","Ineligible"</semantic:text>
+							</semantic:outputValues>
+						</semantic:output>
+						<semantic:annotation name="Description"/>
+						<semantic:rule id="_7b3d290c-0fde-4f3e-b220-35c49f0bd39b">
+							<semantic:inputEntry id="_e4c91cbe-7210-4249-8889-0e8624af7a0b">
+								<semantic:text>count(Ratings[Lender Name=?.Lender Name and Customer Rating &gt; 4] )&gt;0</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_72409463-559e-472d-ae0f-762f562b9a7b">
+								<semantic:text>true</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_a20c0261-66f8-458c-af98-9130e71b0764">
+								<semantic:text>"Best"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+						<semantic:rule id="_04ac4893-c441-4cc6-a437-d034b358c817">
+							<semantic:inputEntry id="_fee48560-c88d-4c30-b312-c4259bfdbd89">
+								<semantic:text>count(Ratings[Lender Name=?.Lender Name and Customer Rating in [3..4]] )&gt;0</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_1d664b74-70b0-4e0d-9edd-928911602bf3">
+								<semantic:text>true</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_f9bf975e-7e3a-4d9a-a8fc-7038f74359f8">
+								<semantic:text>"Good"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+						<semantic:rule id="_c4d79130-3848-4080-afaa-647146736125">
+							<semantic:inputEntry id="_cecfdc03-6cd4-407b-a8e6-c788f89521c2">
+								<semantic:text>count(Ratings[Lender Name=?.Lender Name and Customer Rating &lt;3] )&gt;0</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_781ad27e-faa8-436c-8d47-4a209479c7e2">
+								<semantic:text>true</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_74927ae6-514d-4c13-be6d-378665e8aed0">
+								<semantic:text>"Not Recommended"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+						<semantic:rule id="_15ef0d48-8d2c-4527-ba01-c85edb527fb2">
+							<semantic:inputEntry id="_39a73402-4a5f-42e5-be97-2ae3fbbc8e4a">
+								<semantic:text>-</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_13112ddb-cf4d-436c-a779-2be5b75e7e8b">
+								<semantic:text>-</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_a6f39264-79d3-49da-80ef-200c730981c4">
+								<semantic:text>"Ineligible"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+					</semantic:decisionTable>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_c5b0cb53-7f65-408d-b5cd-df0611538d99">
+					<semantic:variable name="Table Row" id="_f28d781b-9c25-4017-9c0b-d50ba3158b27" typeRef="tTableRow"/>
+					<semantic:context id="_e18faad2-a4bf-48df-8a9a-8af206da5392">
+						<semantic:contextEntry id="_df156b8b-b7ca-4abb-9e2c-184b1475bf3f">
+							<semantic:variable name="Product" id="_446c0304-a441-48ac-9c88-ffcb0fd4e11a" typeRef="string"/>
+							<semantic:literalExpression id="_60468906-dccb-41e6-a3d0-bc562134d3af">
+								<semantic:text>Loan Product.Lender Name + " - " + Loan Product.Product Name</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_6e2059dd-78d0-422d-bf5d-ba1ac699ab6a">
+							<semantic:variable name="Note Amount" id="_204838f8-5fab-43b6-b08a-90fd15af54e5" typeRef="number"/>
+							<semantic:literalExpression id="_73890cc6-b950-46c4-8533-f1b6d04eca37">
+								<semantic:text>Loan Info.Note Amount</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_a8c61057-bf8f-4661-bb9f-b1e3714f0249">
+							<semantic:variable name="Interest Rate Pct" id="_8526bae4-0b60-4bda-b117-1be37310aa6b" typeRef="tPercent"/>
+							<semantic:literalExpression id="_56907eca-faf9-45d8-8a13-04769f3f10a5">
+								<semantic:text>Loan Info.Initial Rate Pct</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_d791f2d6-dfa2-444a-98b4-d38222a232ba">
+							<semantic:variable name="Monthly Payment" id="_5a4156a0-4956-43be-9e5c-f5e2ccb45ad6" typeRef="number"/>
+							<semantic:literalExpression id="_fd0b5673-470a-4058-aeda-9c20e2be811b">
+								<semantic:text>Loan Info.Initial Monthly Payment</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7a0aa777-99a2-4fed-9bd8-65d484f447c2">
+							<semantic:variable name="LTV" id="_aec60c0b-682d-4a41-93ba-0aeb19a9dc06" typeRef="tPercent"/>
+							<semantic:literalExpression id="_d69d69d6-975c-4965-8204-0eaa25af7ed5">
+								<semantic:text>Loan Info.LTV</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7d8206c6-896b-47db-ba40-37825def24e1">
+							<semantic:variable name="DTI" id="_4ad07fa9-a657-41be-9611-0f78c04893a3" typeRef="tPercent"/>
+							<semantic:literalExpression id="_7dd61876-2271-4ee8-992c-f9eb5ec2ddce">
+								<semantic:text>Params.DTI Pct</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_11fbf31f-a07d-4c74-9cfd-737549d16e86">
+							<semantic:variable name="Cash to Close" id="_9f528784-9993-4fcd-b57d-cb97900a6b65" typeRef="number"/>
+							<semantic:literalExpression id="_4113bf58-a1ea-4207-982d-caa1fbcb042f">
+								<semantic:text>Loan Info.Cash to Close</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7e3665d3-420f-4f8c-8079-fd384405a002">
+							<semantic:variable name="Liquid Assets After Closing" id="_b3d05458-f835-436f-89ac-d77a56fef096" typeRef="number"/>
+							<semantic:literalExpression id="_77edeb7f-e455-46e2-a2ac-9b212444ce41">
+								<semantic:text>Params.Liquid Assets After Closing</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_6487e7a9-bd4a-40e4-9c3d-d13af46916a5">
+							<semantic:variable name="Reserves" id="_e70c07f9-1f8b-41c7-b494-5cb0021c61b3" typeRef="number"/>
+							<semantic:literalExpression id="_f41077a8-2982-4c77-bd9e-6248a6d86a93">
+								<semantic:text>Params.Reserves</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7186ab6a-029d-4abb-b62d-70cab97c8eb5">
+							<semantic:variable name="Required Credit Score" id="_0b2096ae-f7a6-4bf6-8813-7f78ce5c0f72" typeRef="tCreditScore"/>
+							<semantic:literalExpression id="_5c6a3c17-ea36-4f34-9934-907892af3ecb">
+								<semantic:text>Required Credit Score</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_40a95ad0-f105-4f89-94a5-c19ace99b19b">
+							<semantic:variable name="Recommendation" id="_3a347de8-c79e-4d15-993c-db8172800c9b" typeRef="tRecommendation"/>
+							<semantic:literalExpression id="_c80bff77-26ec-487b-a7d1-56efd17c8ff9">
+								<semantic:text>Recommendation</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+					</semantic:context>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_2f39070d-3c83-43aa-9058-aa3d288f4c05">
+					<semantic:literalExpression id="_a20b4947-5a1d-4085-8650-aa823cff1172">
+						<semantic:text>Table Row</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+			</semantic:context>
+		</semantic:encapsulatedLogic>
+		<semantic:knowledgeRequirement id="_0e52bb98-f219-45a8-8c29-3ed891143377">
+			<semantic:requiredKnowledge href="#_a6e2c692-4a0c-4385-bbc3-7280e94a8760"/>
+		</semantic:knowledgeRequirement>
+		<semantic:knowledgeRequirement id="_821c87b5-940c-4c25-91a5-dcac1481a647">
+			<semantic:requiredKnowledge href="#_813f0ad9-fae2-41fd-b99b-2c8e438b4e01"/>
+		</semantic:knowledgeRequirement>
+	</semantic:businessKnowledgeModel>
+	<semantic:decision id="_aefdf469-fc01-4081-b1e0-85d543b347df" name="Recommended Loan Products">
+		<semantic:variable name="Recommended Loan Products" id="_429ae560-d21a-411c-8b62-6d030ab28170" typeRef="tRecommendedTable"/>
+		<semantic:informationRequirement id="_a68f3c2d-409a-466c-9be8-aa4ee85640c2">
+			<semantic:requiredDecision href="#_49ced667-1cff-4fce-a4b8-b5b480b28cd3"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_b52032a0-6a00-4643-98aa-3fb4367f69ca">
+			<semantic:requiredKnowledge href="#_929201cb-cb3b-4326-b199-bb0f9149ebb0"/>
+		</semantic:knowledgeRequirement>
+		<semantic:context id="_58bfdd10-93f6-43d8-88df-efd285ba9c49" typeRef="tRecommendedTable">
+			<semantic:contextEntry id="_8107ef5d-7a84-4096-874b-6256370a4b27">
+				<semantic:variable name="precedes" id="_4c24fec3-9c76-4ad1-905a-dcb3184f9108" typeRef="boolean"/>
+				<semantic:functionDefinition id="_124804b5-4269-4e60-81bb-a359a60d7729" kind="FEEL">
+					<semantic:formalParameter name="x" typeRef="tTableRow" id="_cad699ce-69d9-4d25-8d5a-8d05864cd6bc"/>
+					<semantic:formalParameter name="y" typeRef="tTableRow" id="_52676e01-3f29-453a-a4d9-33eadf2a2686"/>
+					<semantic:literalExpression id="_f7c2b006-817c-49ef-918d-f5878f4e766c">
+						<semantic:text>if x.Recommendation != "Ineligible" and y.Recommendation != "Ineligible"
+then x.Monthly Payment&lt;y.Monthly Payment 
+else if x.Recommendation != "Ineligible" and y.Recommendation = "Ineligible"
+then true else false</semantic:text>
+					</semantic:literalExpression>
+				</semantic:functionDefinition>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_e2fffe29-ceb8-4d50-a291-f40af7f6fa0b">
+				<semantic:variable name="Sorted Table" id="_f7156ed8-c321-43cf-acd4-cd7835659522" typeRef="tEligibilityTable"/>
+				<semantic:literalExpression id="_b8cdb4fe-729b-4bf3-ab56-ec5af548eb89">
+					<semantic:text>sort(Eligibility Table, precedes)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_e918b3f1-645e-4525-bbe8-760c633f3e8e">
+				<semantic:literalExpression id="_ba066f10-e809-4cc4-8fe4-dd3a710e65d2">
+					<semantic:text>for row in Sorted Table return Format Row(row)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+		</semantic:context>
+	</semantic:decision>
+	<semantic:businessKnowledgeModel id="_813f0ad9-fae2-41fd-b99b-2c8e438b4e01" name="Eligibility Parameters">
+		<semantic:variable name="Eligibility Parameters" id="_de0fa861-531d-4983-9dd7-0b448af5d6a7" typeRef="tEligibilityParameters"/>
+		<semantic:encapsulatedLogic id="_0a63f9b7-5f09-47af-9bd7-0e6b10f0d457" kind="FEEL" typeRef="tEligibilityParameters">
+			<semantic:formalParameter name="Loan Product" typeRef="tLoanProduct" id="_1912abed-44d7-4728-a98b-f9edb9874014"/>
+			<semantic:formalParameter name="Borrower" typeRef="tBorrower" id="_53f8f293-a4ab-48e3-9285-1a50d9c7f384"/>
+			<semantic:formalParameter name="Loan Info" typeRef="tLoanInfoRow" id="_962c2fd9-96da-46b1-9532-234b60306665"/>
+			<semantic:formalParameter name="Property" typeRef="tProperty" id="_5ed2ddb8-33a3-4b96-beb5-a4367de0f26a"/>
+			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore" id="_0134c6e4-d273-4724-a5dd-4fe2b916f0db"/>
+			<semantic:context id="_d4558837-ad20-4ed3-8099-e5142be3797c" typeRef="tEligibilityParameters">
+				<semantic:contextEntry id="_f76319fe-179e-49e9-a733-97c8fb7957de">
+					<semantic:variable name="Housing Expense" id="_bda0bbad-27c6-4a78-a87a-a2c929ee939f" typeRef="number"/>
+					<semantic:literalExpression id="_f0f68868-ef1c-455d-a438-fd91c7378b16">
+						<semantic:text>sum([Loan Info.Qualifying Monthly Payment, Property.Monthly Tax Payment,
+Property.Monthly Insurance Payment, Property.Monthly HOA Condo Fee][item != null])</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_b9129263-8b2c-4849-83e0-363001dc91c2">
+					<semantic:variable name="Non-Housing Debt Payments" id="_ffbeddfa-93d4-4a77-a985-ed5b75648dfa" typeRef="number"/>
+					<semantic:literalExpression id="_cfac9257-10a2-4960-a3e7-af9e99aa59ab">
+						<semantic:text>sum(Borrower.Liabilities[Type!="Real estate loan" and To be paid off
+=false].Monthly payment)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_a0fbbf2c-3a6e-46ca-8c79-05807ee9ad65">
+					<semantic:variable name="Income" id="_6e77ef2c-a1c0-4a67-922d-3ce5907f3692" typeRef="number"/>
+					<semantic:literalExpression id="_baa76bb6-a451-4e70-9589-a9ac2e3b65ba">
+						<semantic:text>sum([Borrower.Employment Income, Borrower.Other Income][item != null])</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_18f391f4-7ad3-4b0b-935e-4a6de6f090c5">
+					<semantic:variable name="DTI Pct" id="_6a52a65a-76fa-4692-9628-b447b86354f9" typeRef="tPercent"/>
+					<semantic:literalExpression id="_6498e13a-258a-42b1-aadb-3d8b15da8521">
+						<semantic:text>decimal((Housing Expense+Non-Housing Debt Payments)/Income*100,2)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_d8d80977-a34d-45bc-8411-6eaaa1bcd68a">
+					<semantic:variable name="Liquid Assets Before Closing" id="_2cdcde07-05c3-4eac-bd4d-ac5c2c638100" typeRef="number"/>
+					<semantic:literalExpression id="_ae29c64b-14c7-4e52-aeef-cf411be4ae80">
+						<semantic:text>sum(Borrower.Assets[Type="Checking Savings Brokerage account" 
+or Type="Other Liquid"].Value)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_5d3d126e-f2e2-4800-a3ad-075482a66cbc">
+					<semantic:variable name="Debts Paid Off By Closing" id="_d97ec4d8-dbff-489b-9647-657bb156afd3" typeRef="number"/>
+					<semantic:literalExpression id="_7a92d594-063b-4d40-9936-f8fb0bb6d287">
+						<semantic:text>sum(Borrower.Liabilities[Type!="Real estate loan" 
+and To be paid off=true].Balance[item!=null])</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_607017c3-e91a-4780-b339-db6f4a1e8ddd">
+					<semantic:variable name="Liquid Assets After Closing" id="_2daf54ff-6d4e-41b3-9efb-979ff415c180" typeRef="number"/>
+					<semantic:literalExpression id="_45d39beb-f0a0-4289-92a0-cf1a3c17a6e8">
+						<semantic:text>Liquid Assets Before Closing - Debts Paid Off By Closing - Loan Info.Cash to Close</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_3931d8a9-d99f-4fa2-a821-66940a297dd2">
+					<semantic:variable name="Reserves" id="_51fb843d-9e41-4e41-bb4a-cbe45cdedc16" typeRef="number"/>
+					<semantic:literalExpression id="_c5188525-c1a5-4cc4-9366-7fac3b857dba">
+						<semantic:text>decimal(Liquid Assets After Closing/Housing Expense,2)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+			</semantic:context>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:inputData id="_7ed0a891-7b25-4c0e-838e-0a3cd5ec46be" name="Lender Ratings">
+		<semantic:variable name="Lender Ratings" id="_2c92c03e-a395-4af5-ae8c-387b37ba1d71" typeRef="tLenderRatings"/>
+	</semantic:inputData>
+	<semantic:businessKnowledgeModel id="_929201cb-cb3b-4326-b199-bb0f9149ebb0" name="Format Row">
+		<semantic:variable name="Format Row" id="_517952d5-64e8-4dc8-8815-ac6732b851a6" typeRef="tformattedrow_1"/>
+		<semantic:encapsulatedLogic id="_e6de2d7e-3623-449f-b238-63d2eadc31d6" kind="FEEL" typeRef="tformattedrow_1">
+			<semantic:formalParameter name="row" typeRef="tTableRow" id="_984e3a72-a34e-4957-beb5-471b1a972ed5"/>
+			<semantic:context id="_5ccce417-75fd-4d60-b014-695bb847cb31" typeRef="tformattedrow_1">
+				<semantic:contextEntry id="_b5fcf3db-2bf1-4b11-ac61-88234e8ff31a">
+					<semantic:variable name="string format" id="_1094d90c-0ad3-4f59-ad87-8e76ca4b7307" typeRef="string"/>
+					<semantic:functionDefinition id="_96359ad3-5b52-4798-b1e7-103bdc7f07b7" kind="Java">
+						<semantic:formalParameter name="mask" typeRef="string" id="_4dbb8658-6073-432d-b51a-f65d2beea042"/>
+						<semantic:formalParameter name="value" typeRef="number" id="_08b8eb1c-8e5d-4e94-b0fa-845f046f4b89"/>
+						<semantic:context>
+							<semantic:contextEntry id="_ba1bd7c1-6f16-4c7d-b1d1-cff9aa7e832e">
+								<semantic:variable name="class" id="_6756decc-097e-402b-ab9a-a5f8ad48182f" typeRef="string"/>
+								<semantic:literalExpression id="_4a34e305-c238-4477-b407-6b4348685108">
+									<semantic:text>"java.lang.String"</semantic:text>
+								</semantic:literalExpression>
+							</semantic:contextEntry>
+							<semantic:contextEntry id="_3c44080c-65f2-4a2f-8df4-54ba75c004be">
+								<semantic:variable name="method signature" id="_fda512ff-d00a-4a2a-be7b-288daae61550" typeRef="string"/>
+								<semantic:literalExpression id="_c73133d7-fd79-42a3-980c-9720e2812afd">
+									<semantic:text>"format( java.lang.String, [Ljava.lang.Object; )"</semantic:text>
+								</semantic:literalExpression>
+							</semantic:contextEntry>
+						</semantic:context>
+					</semantic:functionDefinition>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_60f2eefa-f7dd-4d80-ac3d-aea0caa577ac">
+					<semantic:variable name="formatted row" id="_562a5d65-2c21-4575-bca9-9dc6addf9388" typeRef="tformattedrow_1"/>
+					<semantic:context id="_9da73807-1031-4622-9b65-f1fbe8b1b7ed">
+						<semantic:contextEntry id="_58e15f84-d002-4ae0-b0dc-e4d5961cd42b">
+							<semantic:variable name="Product" id="_ea14919a-68c2-4d45-84de-be03a259be25" typeRef="string"/>
+							<semantic:literalExpression id="_bf722194-b9e2-4c30-b4ff-408cb1152f19">
+								<semantic:text>row.Product</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_81abd4de-4a7f-47cf-9d31-11a7421185ad">
+							<semantic:variable name="Note Amount" id="_41f4b93c-ac0f-4c96-8db7-e32298eb44f0" typeRef="string"/>
+							<semantic:literalExpression id="_8e6ef746-ca5e-4e92-af09-92c6137b851e">
+								<semantic:text>string format("$%,4.2f", row.Note Amount)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_9098479f-635d-4af4-a3d0-4605692c3cfc">
+							<semantic:variable name="Interest Rate Pct" id="_2c4f2fce-de35-41f0-b8b4-0679fdeec4fd" typeRef="string"/>
+							<semantic:literalExpression id="_8dd2672c-9a6c-499e-9b4c-fa1f859d8ab4">
+								<semantic:text>string format(" %,4.2f", row.Interest Rate Pct)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_720cf2db-4a1e-482d-aa9a-8dea2d91d11c">
+							<semantic:variable name="Monthly Payment" id="_1652042c-c4e1-4bac-9e11-e281b9f21498" typeRef="string"/>
+							<semantic:literalExpression id="_32dd7994-6506-417e-93d0-62485724411e">
+								<semantic:text>string format("$%,4.2f", row.Monthly Payment)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_d17a962b-1c9d-472d-bedd-e13a30f9640b">
+							<semantic:variable name="Cash to Close" id="_e4715ea0-6389-4a73-9568-35f8a1ed5697" typeRef="string"/>
+							<semantic:literalExpression id="_ca131f04-b7c8-497f-b4cf-2ef52e4bdf10">
+								<semantic:text>string format("$%,4.2f", row.Cash to Close)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_2086ead6-f35d-4807-bbad-f1c41eca6b58">
+							<semantic:variable name="Required Credit Score" id="_26b82f93-7b44-4e98-b623-ccf5c95a14a7" typeRef="tCreditScore"/>
+							<semantic:literalExpression id="_74b6dcd5-0b30-486f-ad21-ffdc50e84031">
+								<semantic:text>row.Required Credit Score</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_2a47f396-0029-4cad-94ab-7179c963bd3a">
+							<semantic:variable name="Recommendation" id="_06faad8c-3d0e-41f2-aec1-44a267bc8eee" typeRef="string"/>
+							<semantic:literalExpression id="_f7df45c0-9486-4baf-b9d9-be813f5d6aed">
+								<semantic:text>row.Recommendation</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+					</semantic:context>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_67cf635f-87ff-4613-b00c-c1def8f7158a">
+					<semantic:literalExpression id="_58517f86-e5cc-42c9-8ebb-0622f94bf23e">
+						<semantic:text>formatted row</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+			</semantic:context>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<dmndi:DMNDI xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/">
+		<dmndi:DMNDiagram id="_0b101bf8-a9c5-4e7c-8763-c8fcb4263a32" name="Page 1">
+			<di:extension xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"/>
+			<dmndi:Size height="1050" width="1550.4755458831787"/>
+			<dmndi:DMNShape id="_c1bba5d5-fa68-482c-9856-62553328432f" dmnElementRef="_a177b73e-7064-4140-8757-23bdf7a5d696">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="221.7520332336426" y="508.99999618530273" width="135.4823417663574" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_a3898cf2-06c3-4ff6-aee8-ff1980e1df26" dmnElementRef="_e0cfe605-3068-42a2-946f-c7db3774de1e">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="365.234375" y="630.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_4b1fc771-634e-4074-b5fa-9fddc959704d" dmnElementRef="_d78ee6d5-96ed-43e6-89d2-123e0f388a67">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="221.7520332336426" y="630.9999961853027" width="135.4823417663574" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_9fdb64c0-601f-47bf-8592-01d5144ef096" dmnElementRef="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="690.9864082336426" y="630.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_be0cf71f-9d15-48dc-b705-06f25e958624" dmnElementRef="_a6e2c692-4a0c-4385-bbc3-7280e94a8760">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="912.4932041168213" y="349" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_dc10415e-38d4-42af-a5bd-5d7458fc841c" dmnElementRef="_93f33bde-df66-4731-82ad-0cf0d86a3294">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="521.734375" y="631" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_b5fd3a66-fd67-48a9-8b4c-c18df2632c01" dmnElementRef="_0459fb1e-3d09-427d-9201-ea74a1b57864">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="610.2275791168213" y="445" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_f128a162-c0d5-4e7d-a96f-fc953d9fcae1" dmnElementRef="_49ced667-1cff-4fce-a4b8-b5b480b28cd3">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="521.734375" y="349" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_a7fc8244-5fcc-4caa-80fc-f9c00a540a44" dmnElementRef="_f286d938-0042-4f0d-a889-6838d2c83a17">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="719" y="349.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_cabd0351-2058-4d41-9d9a-4e0c2f2f30dd" dmnElementRef="_aefdf469-fc01-4081-b1e0-85d543b347df">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="521.734375" y="250.00000000000003" width="153" height="59.99999999999997"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_d4d663f4-e804-4601-a50a-da743ce86419" dmnElementRef="_813f0ad9-fae2-41fd-b99b-2c8e438b4e01">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="912.9932041168213" y="267.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_dc1bb3d6-b254-4464-94c3-46b5f0ec09f9" dmnElementRef="include1:_f5761a7f-090d-4177-a06a-7f21f925c6ff" isCollapsed="true">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="860.7361043356821" y="445" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_14e3646c-50fc-4b3a-8e40-40c99c6a54c7" dmnElementRef="_7ed0a891-7b25-4c0e-838e-0a3cd5ec46be">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="221.7520332336426" y="387.00346411608245" width="135.4823417663574" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_ec10fdad-2a7c-4238-b6f8-e581f0b772d8" dmnElementRef="_929201cb-cb3b-4326-b199-bb0f9149ebb0">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="281.2361043356818" y="250.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="_0670a8b5-bc66-453c-8a48-b691469e5dd0" dmnElementRef="_4af51bdd-1651-42ec-8350-bc551facdffc">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="588.234375" y="631"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="676.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_a3f9e2b4-99d2-4186-a50c-b6622948628e" dmnElementRef="_b3b8e3b8-ae4d-4192-8e96-f6abda717c16">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="329.49000549316406" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="646.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_1f922953-3c60-4457-8183-c5365813d936" dmnElementRef="_fc2723b2-1ebd-45cc-a640-93f2cb2a6b4e">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="432.9723472595215" y="690.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="656.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_f3f1d471-e9d2-4e9a-8594-140d7e341b72" dmnElementRef="_7cba5baa-07f0-4e12-b6a2-bb25a86d203a">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="748.7243804931641" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="716.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_fcf3aa6e-ce2a-408e-aa0c-4a10795fbe6d" dmnElementRef="_0e52bb98-f219-45a8-8c29-3ed891143377">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="912.4932041168213" y="378.49152542372883"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="871" y="378.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_5bb524fc-5aec-4ec6-8d2a-dd91e7ffef84" dmnElementRef="_08f900ff-aea1-419b-8e80-138343254a26">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="686.7275791168213" y="445"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598.234375" y="409"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_9f91df8c-ebb4-4e2b-b579-b153c1df09b9" dmnElementRef="_84630610-2554-4a74-a7e7-d185d10fd933">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="319.49000549316406" y="508.99999618530273"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="379"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_e9dc41c9-1998-47e6-ac1a-992a9a98fe4b" dmnElementRef="_4d86d4b2-4dee-426b-a1ff-6e91c6846585">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="719" y="378.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="674.734375" y="379"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_dddf7b22-df2a-418e-904f-c13f4e01b63d" dmnElementRef="_aa3ff8c4-2379-4609-8296-8474d14607e7">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="289.49000549316406" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="399"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_bc4016d5-51eb-453a-aa1e-edfb1448cbd6" dmnElementRef="_56fb1a8d-9a03-4e87-b234-b3b9c941e3ff">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="432.9723472595215" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="476.60336112976074" y="496.99999809265137"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="538.234375" y="409"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_72c23e8d-0fd3-45f9-8cad-1cf8858bce11" dmnElementRef="_c83ae553-f658-4823-a18f-f404f447f859">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="568.234375" y="631"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="578.234375" y="409"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_c562e786-cdc6-47e6-98e2-ede2203b8799" dmnElementRef="_a68f3c2d-409a-466c-9be8-aa4ee85640c2">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598.234375" y="349"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598.234375" y="310"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_ca21c22e-c882-4a27-ae3b-36d491872e26" dmnElementRef="_821c87b5-940c-4c25-91a5-dcac1481a647">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="912.9932041168213" y="296.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="871" y="358.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_72fc05b4-d034-4c54-a55c-f8c756a4f4d7" dmnElementRef="_88a16649-4696-4d01-84f3-130be7caba3b">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="860.7361043356821" y="475"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="763.2275791168213" y="475"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_d6f96ec8-84ff-431b-be9b-488df35abc45" dmnElementRef="_4e13d93f-5461-4582-b6f7-afda9b6e6584">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="357.234375" y="417.00346411608245"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="369"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_dce5de3c-bbbc-4333-985c-a4618049a4a4" dmnElementRef="_b52032a0-6a00-4643-98aa-3fb4367f69ca">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="433.2361043356818" y="279.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="280"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+		<dmndi:DMNDiagram id="_63ffcf37-6958-4078-8118-bff7842f8c39" name="Services.Loan Info Service">
+			<di:extension xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"/>
+			<dmndi:Size height="1050" width="1485"/>
+			<dmndi:DMNShape id="_27064364-5b02-4f0e-a10d-dcbe208edad1" dmnElementRef="include1:_d78ee6d5-96ed-43e6-89d2-123e0f388a67">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="358" y="661" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_2822112c-279b-4ac8-9085-ffa29e5e3772" dmnElementRef="include1:_29a44873-e886-42de-bc2f-6d5704b6b298">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="733" y="356.75" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_7913007e-de82-490b-ba57-64076c5f7dbb" dmnElementRef="include1:_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="821" y="469.75" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_73693581-59c2-47cf-b99d-edb869148e62" dmnElementRef="include1:_e0cfe605-3068-42a2-946f-c7db3774de1e">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="941" y="551.0000000000001" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_d873815e-50da-4839-955e-c4a66d8a72f6" dmnElementRef="include1:_f5761a7f-090d-4177-a06a-7f21f925c6ff" isCollapsed="false">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="338" y="329" width="260" height="282"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+				<dmndi:DMNDecisionServiceDividerLine>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="338" y="470"/>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598" y="470"/>
+				</dmndi:DMNDecisionServiceDividerLine>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_cb197420-797b-49d7-882d-b0a982941241" dmnElementRef="include1:_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="358" y="510" width="154" height="61"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_276339e5-a4a0-41d3-b035-80df3320a1f4" dmnElementRef="include1:_8a182857-b5a1-4389-9a76-01a316938cea">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="358" y="369" width="154" height="61"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_3705344c-2a10-4927-96d1-f86916bb02e2" dmnElementRef="include1:_0d2a6f36-0403-41ad-a191-f793743649d4">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="623" y="610.5034679307797" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_94efa65c-e784-4e88-9807-627d768b1aae" dmnElementRef="include1:_aeaa30db-0f84-424a-b2f5-af9b2538a9ce">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="130.4687421975863" y="600.5034679307797" width="151.99999999999997" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="_35eff1f0-be88-46e7-91f2-2f550c8bc64c" dmnElementRef="include1:_8304cbac-5619-459b-92a8-b389aaaf2aff">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="434.5" y="661"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="571"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_1987d0a2-82d0-409c-90b4-03c83213da8d" dmnElementRef="include1:_70f3db04-5830-45d2-ba12-7c355e571fcd">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="733" y="386.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="399.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_fa64a0fe-f9c8-44e8-befb-ea8bea160d0b" dmnElementRef="include1:_ffe87244-b1ab-4075-a243-5f2a87f170d0">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="733" y="386.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="540.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_c089b2a8-ff15-4e9b-9c8e-b0d93b6c7a87" dmnElementRef="include1:_da7d6551-1fd0-49ea-9723-ec51d15005a8">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="821" y="499.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="399.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_1d657839-84f5-4d7b-a9a9-0836a535cff0" dmnElementRef="include1:_d9d4a780-7427-4000-b2c7-575717ebcae5">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="821" y="499.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="540.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_c02edce6-9373-4cca-9ad2-475e6233ac29" dmnElementRef="include1:_8d9ec740-a917-4215-88ec-e531ee90a348">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="941" y="581.0000000000001"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="399.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_96c3213d-d7f4-40f6-8087-16a6af11474b" dmnElementRef="include1:_e47777c4-b10c-4aa8-8087-371824560192">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="941" y="581.0000000000001"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="540.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_b40c4be4-a3d0-4180-9d75-455f9da96ddd" dmnElementRef="include1:_1f641b45-5ad1-4dfa-bdc5-19d0f52b87b4">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="510"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="430"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_516ea932-dbcb-4e57-9686-f2401224ec7e" dmnElementRef="include1:_ff803e3f-9159-401f-b22c-edbb48cbf164">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="699" y="611.5034679307797"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="571"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_d094e1a0-eb98-4f74-b775-df535297ee20" dmnElementRef="include1:_28360d50-9eee-4fa1-9f4d-a19c5bc9bbcb">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="206.4687421975863" y="601.5034679307797"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="571"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+		<dmndi:DMNStyle id="LS_736fa164-03d8-429f-8318-4913a548c3a6_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+	</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/simple.dmn
+++ b/kie-dmn/kie-dmn-backend/src/test/resources/org/kie/dmn/backend/marshalling/v1_3/simple.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:include1="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" xmlns:drools="http://www.drools.org/kie/dmn/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:feel="https://www.omg.org/spec/DMN/20191111/FEEL/"              xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" name="Chapter 11 Example" namespace="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" exporter="DMN Modeler" exporterVersion="6.2.2.1" triso:logoChoice="None">
+<semantic:extensionElements/>
+<semantic:decisionService id="_61a137fa-eedd-4cf0-8969-827591267b4b_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+    <semantic:variable name="Whole Model Decision Service" id="_61a137fa-eedd-4cf0-8969-827591267b4b_DS_VAR" typeRef="Any"/>
+    <semantic:outputDecision href="#_938e8026-7825-47c1-8890-a0bed982db6f"/>
+    <semantic:inputData href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+</semantic:decisionService>
+<semantic:decisionService id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3_DS" name="Diagram Page 1" triso:dynamicDecisionService="true">
+    <semantic:variable name="Diagram Page 1" id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3_DS_VAR" typeRef="Any"/>
+    <semantic:outputDecision href="#_938e8026-7825-47c1-8890-a0bed982db6f"/>
+    <semantic:inputData href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+</semantic:decisionService>
+<semantic:inputData id="_e4e47ee0-ff98-41fd-922a-f80bac93bcc3" name="name">
+    <semantic:variable name="name" id="_7a9307f0-fa0d-4e15-9a3a-b8009558c758" typeRef="string"/>
+</semantic:inputData>
+<semantic:decision id="_938e8026-7825-47c1-8890-a0bed982db6f" name="salutation">
+    <semantic:variable name="salutation" id="_4c00fc87-5c90-4cf7-96ba-49a5b3c05807" typeRef="string"/>
+    <semantic:informationRequirement id="_db797801-9e06-49ba-8384-6f7c6a15019b">
+        <semantic:requiredInput href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression id="_6bae1586-dff3-442c-99c4-57cb2ca8813f" typeRef="string" triso:expressionId="_875337f7-4847-4d98-926c-957c71626d79">
+        <semantic:text>"Hello, "+name</semantic:text>
+    </semantic:literalExpression>
+</semantic:decision>
+<dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3" triso:modelElementRef="_7dc00112-0d6b-4d89-a677-9c99cbf29bcf" name="Page 1">
+        <di:extension/>
+        <dmndi:Size height="1050" width="1485"/>
+        <dmndi:DMNShape id="_3ed3ded2-30be-46b8-872f-0d9db4b572d2" dmnElementRef="_e4e47ee0-ff98-41fd-922a-f80bac93bcc3">
+            <dc:Bounds x="295.7588291168213" y="223" width="135.48234176635742" height="60"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" trisodmn:defaultBounds="true"/>
+        </dmndi:DMNShape>
+        <dmndi:DMNShape id="_cd689688-c21d-4d97-8e84-147eb7ef12e2" dmnElementRef="_938e8026-7825-47c1-8890-a0bed982db6f">
+            <dc:Bounds x="486.2411708831787" y="223" width="153" height="60"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" trisodmn:defaultBounds="true"/>
+        </dmndi:DMNShape>
+        <dmndi:DMNEdge id="_f6ec1781-c8d6-4abc-9290-d682e3d2c6ef" dmnElementRef="_db797801-9e06-49ba-8384-6f7c6a15019b">
+            <di:waypoint x="431.9968013763428" y="253"/>
+            <di:waypoint x="486.2411708831787" y="253"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0"/>
+        </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+    <dmndi:DMNStyle id="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.compiler;
 
 import java.io.Reader;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -90,7 +90,6 @@ import org.kie.dmn.model.api.KnowledgeRequirement;
 import org.kie.dmn.model.api.NamedElement;
 import org.kie.dmn.model.api.OutputClause;
 import org.kie.dmn.model.api.UnaryTests;
-import org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase;
 import org.kie.dmn.model.v1_1.TInformationItem;
 import org.kie.dmn.model.v1_1.extensions.DecisionServices;
 import org.kie.internal.io.ResourceFactory;
@@ -666,7 +665,7 @@ public class DMNCompilerImpl implements DMNCompiler {
      * @return
      */
     public static QName getNamespaceAndName(DMNModelInstrumentedBase localElement, Map<String, QName> importAliases, QName typeRef, String modelNamespace) {
-        if (localElement instanceof KieDMNModelInstrumentedBase) {
+        if (localElement instanceof org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase) {
             if (!typeRef.getPrefix().equals(XMLConstants.DEFAULT_NS_PREFIX)) {
                 return new QName(localElement.getNamespaceURI(typeRef.getPrefix()), typeRef.getLocalPart());
             } else {
@@ -678,7 +677,7 @@ public class DMNCompilerImpl implements DMNCompiler {
                 }
                 return new QName(localElement.getNamespaceURI(typeRef.getPrefix()), typeRef.getLocalPart());
             }
-        } else {
+        } else { // DMN v1.2 onwards:
             for (BuiltInType bi : DMNTypeRegistryV12.ITEMDEF_TYPEREF_FEEL_BUILTIN) {
                 for (String biName : bi.getNames()) {
                     if (biName.equals(typeRef.getLocalPart())) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.compiler;
 
 import java.util.ArrayList;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.compiler;
 
 import java.util.ArrayList;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNScope.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNScope.java
@@ -1,9 +1,25 @@
-package org.kie.dmn.core.compiler;
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.kie.dmn.api.core.DMNType;
+package org.kie.dmn.core.compiler;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.kie.dmn.api.core.DMNType;
 
 public class DMNScope {
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistry.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.compiler;
 
 import org.kie.dmn.api.core.DMNType;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV12.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV12.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.compiler;
 
 import java.util.Arrays;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV13.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNTypeRegistryV13.java
@@ -16,17 +16,19 @@
 
 package org.kie.dmn.core.compiler;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.kie.dmn.api.core.DMNType;
 import org.kie.dmn.core.impl.CompositeTypeImpl;
 import org.kie.dmn.core.impl.SimpleTypeImpl;
 import org.kie.dmn.feel.lang.types.BuiltInType;
-import org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 
-public class DMNTypeRegistryV11 implements DMNTypeRegistry {
+public class DMNTypeRegistryV13 implements DMNTypeRegistry {
 
     private Map<String, Map<String, DMNType>> types = new HashMap<>(  );
 
@@ -40,7 +42,19 @@ public class DMNTypeRegistryV11 implements DMNTypeRegistry {
         return UNKNOWN;
     }
 
-    public DMNTypeRegistryV11() {
+    public static final List<BuiltInType> ITEMDEF_TYPEREF_FEEL_BUILTIN = Collections.unmodifiableList(Arrays.asList(BuiltInType.NUMBER,
+                                                                                                                    BuiltInType.STRING,
+                                                                                                                    BuiltInType.BOOLEAN,
+                                                                                                                    BuiltInType.DURATION,
+                                                                                                                    BuiltInType.DATE,
+                                                                                                                    BuiltInType.TIME,
+                                                                                                                    BuiltInType.DATE_TIME,
+                                                                                                                    BuiltInType.UNKNOWN,
+                                                                                                                    BuiltInType.LIST,
+                                                                                                                    BuiltInType.FUNCTION,
+                                                                                                                    BuiltInType.CONTEXT));
+
+    public DMNTypeRegistryV13() {
         String feelNamespace = KieDMNModelInstrumentedBase.URI_FEEL;
         Map<String, DMNType> feelTypes = new HashMap<>(  );
         types.put( feelNamespace, feelTypes );

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ExecModelCompilerOption.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ExecModelCompilerOption.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2005 JBoss Inc
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.compiler;
 
 import java.util.Collection;
@@ -63,6 +79,7 @@ public class ImportDMNResolverUtil {
             case org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_DMN:
             case "http://www.omg.org/spec/DMN1-2Alpha/20160929/MODEL":
             case org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_DMN:
+            case org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase.URI_DMN:
                 return ImportType.DMN;
             case NamespaceConsts.PMML_3_0:
             case NamespaceConsts.PMML_3_1:

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNModelImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNModelImpl.java
@@ -59,11 +59,11 @@ import org.kie.dmn.core.compiler.DMNCompilerImpl;
 import org.kie.dmn.core.compiler.DMNTypeRegistry;
 import org.kie.dmn.core.compiler.DMNTypeRegistryV11;
 import org.kie.dmn.core.compiler.DMNTypeRegistryV12;
+import org.kie.dmn.core.compiler.DMNTypeRegistryV13;
 import org.kie.dmn.core.pmml.DMNImportPMMLInfo;
 import org.kie.dmn.core.util.DefaultDMNMessagesManager;
 import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.dmn.model.api.Definitions;
-import org.kie.dmn.model.v1_1.TDefinitions;
 
 public class DMNModelImpl
         implements DMNModel, DMNMessageManager, Externalizable {
@@ -112,10 +112,12 @@ public class DMNModelImpl
     }
 
     private void wireTypeRegistry(Definitions definitions) {
-        if (definitions instanceof TDefinitions) {
+        if (definitions instanceof org.kie.dmn.model.v1_1.TDefinitions) {
             types = new DMNTypeRegistryV11();
-        } else {
+        } else if (definitions instanceof org.kie.dmn.model.v1_2.TDefinitions) {
             types = new DMNTypeRegistryV12();
+        } else {
+            types = new DMNTypeRegistryV13();
         }
     }
     

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
@@ -17,6 +17,7 @@
 package org.kie.dmn.core.v1_3;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
@@ -70,7 +71,7 @@ public class DMN13specificTest extends BaseInterpretedVsCompiledTest {
 
         final DMNContext context = DMNFactory.newContext();
         context.set("Applicant data", mapOf(entry("Age", new BigDecimal(51)),
-                                            entry("MaritalStatus", "M"),
+                                            entry("MartitalStatus", "M"), // typo is present in DMNv1.3
                                             entry("EmploymentStatus", "EMPLOYED"),
                                             entry("ExistingCustomer", false),
                                             entry("Monthly", mapOf(entry("Income", new BigDecimal(100_000)),
@@ -90,6 +91,149 @@ public class DMN13specificTest extends BaseInterpretedVsCompiledTest {
         final DMNContext result = dmnResult.getContext();
         assertThat(result.get("Strategy"), is("THROUGH"));
         assertThat(result.get("Routing"), is("ACCEPT"));
+    }
+
+    @Test
+    public void testDMNv1_3_ch11_asSpecInputDataValues() {
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Chapter 11 Example.dmn", this.getClass(), "Financial.dmn");
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4", "Chapter 11 Example");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final DMNContext context = DMNFactory.newContext();
+        context.set("Applicant data", mapOf(entry("Age", new BigDecimal(51)),
+                                            entry("MartitalStatus", "M"), // typo is present in DMNv1.3
+                                            entry("EmploymentStatus", "EMPLOYED"),
+                                            entry("ExistingCustomer", false),
+                                            entry("Monthly", mapOf(entry("Income", new BigDecimal(10_000)),
+                                                                   entry("Repayments", new BigDecimal(2_500)),
+                                                                   entry("Expenses", new BigDecimal(3_000))))));
+        context.set("Bureau data", mapOf(entry("Bankrupt", false),
+                                         entry("CreditScore", new BigDecimal(600))));
+        context.set("Requested product", mapOf(entry("ProductType", "STANDARD LOAN"),
+                                               entry("Rate", new BigDecimal(0.08)),
+                                               entry("Term", new BigDecimal(36)),
+                                               entry("Amount", new BigDecimal(100_000))));
+        context.set("Supporting documents", null);
+        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
+        LOG.debug("{}", dmnResult);
+        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+
+        final DMNContext result = dmnResult.getContext();
+        assertThat(result.get("Strategy"), is("THROUGH"));
+        assertThat(result.get("Routing"), is("ACCEPT"));
+    }
+
+    @Test
+    public void testDMNv1_3_ch11_Example2() {
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntimeWithAdditionalResources("Recommended Loan Products.dmn", this.getClass(), "Loan info.dmn");
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6", "Recommended Loan Products");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final DMNContext context = DMNFactory.newContext();
+        context.set("Credit Score", new BigDecimal(735));
+        context.set("Property", mapOf(entry("Address", mapOf(entry("Street", "272 10th St."),
+                                                             entry("Unit", null),
+                                                             entry("City", "Marina"),
+                                                             entry("State", "CA"),
+                                                             entry("ZIP", "93933"))),
+                                      entry("Purchase Price", new BigDecimal(340_000)),
+                                      entry("Monthly Tax Payment", new BigDecimal(350)),
+                                      entry("Monthly Insurance Payment",new BigDecimal( 100)),
+                                      entry("Monthly HOA Condo Fee", new BigDecimal(0))));
+        context.set("Down Payment", new BigDecimal(70_000));
+        context.set("Borrower", mapOf(entry("Full Name", "Ken Customer"),
+                                      entry("Tax ID", "111223333"),
+                                      entry("Employment Income", new BigDecimal(10_000)),
+                                      entry("Other Income", new BigDecimal(0)),
+                                      entry("Assets", Arrays.asList(mapOf(entry("Type", "Checking Savings Brokerage account"),
+                                                                          entry("Institution Account or Description", "Chase"),
+                                                                          entry("Value", new BigDecimal(35_000))),
+                                                                    mapOf(entry("Type", "Checking Savings Brokerage account"),
+                                                                          entry("Institution Account or Description", "Vanguard"),
+                                                                          entry("Value", new BigDecimal(45_000))),
+                                                                    mapOf(entry("Type", "Other Non-Liquid"),
+                                                                          entry("Institution Account or Description", null),
+                                                                          entry("Value", new BigDecimal(17_000))))),
+                                      entry("Liabilities", Arrays.asList(mapOf(entry("Type", "Credit card"),
+                                                                               entry("Payee", "Chase"),
+                                                                               entry("Monthly payment", new BigDecimal(300)),
+                                                                               entry("Balance", new BigDecimal(0)),
+                                                                               entry("To be paid off", false)),
+                                                                         mapOf(entry("Type", "Lease"),
+                                                                               entry("Payee", "BMW Finance"),
+                                                                               entry("Monthly payment", new BigDecimal(450)),
+                                                                               entry("Balance", new BigDecimal(0)),
+                                                                               entry("To be paid off", false)),
+                                                                         mapOf(entry("Type", "Alimony child support"),
+                                                                               entry("Payee", null),
+                                                                               entry("Monthly payment", new BigDecimal(1_000)),
+                                                                               entry("Balance", new BigDecimal(0)),
+                                                                               entry("To be paid off", false)),
+                                                                         mapOf(entry("Type", "Lien"),
+                                                                               entry("Payee", "LA County"),
+                                                                               entry("Monthly payment", new BigDecimal(100)),
+                                                                               entry("Balance", new BigDecimal(850)),
+                                                                               entry("To be paid off", true))
+                                      ))));
+        context.set("Lender Ratings", Arrays.asList(mapOf(entry("Lender Name", "Lender A"),
+                                                          entry("Customer Rating", new BigDecimal(4.2))),
+                                                    mapOf(entry("Lender Name", "Lender B"),
+                                                          entry("Customer Rating", new BigDecimal(3.6))),
+                                                    mapOf(entry("Lender Name", "Lender C"),
+                                                          entry("Customer Rating", new BigDecimal(4.9))),
+                                                    mapOf(entry("Lender Name", "Lender D"),
+                                                          entry("Customer Rating", new BigDecimal(4.05)))
+                                        ));
+
+        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
+        LOG.debug("{}", dmnResult);
+        assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+
+        final DMNContext result = dmnResult.getContext();
+        assertThat(result.get("Recommended Loan Products"), is(Arrays.asList(mapOf(entry("Product", "Lender B - ARM5/1-Standard"),
+                                                                                   entry("Note Amount", "$273,775.90"),
+                                                                                   entry("Interest Rate Pct", " 3.75"),
+                                                                                   entry("Monthly Payment", "$1,267.90"),
+                                                                                   entry("Cash to Close", "$75,475.52"),
+                                                                                   entry("Required Credit Score", new BigDecimal(720)),
+                                                                                   entry("Recommendation", "Good")),
+                                                                             mapOf(entry("Product", "Lender C - Fixed30-Standard"),
+                                                                                   entry("Note Amount", "$274,599.40"),
+                                                                                   entry("Interest Rate Pct", " 3.88"),
+                                                                                   entry("Monthly Payment", "$1,291.27"),
+                                                                                   entry("Cash to Close", "$75,491.99"),
+                                                                                   entry("Required Credit Score", new BigDecimal(680)),
+                                                                                   entry("Recommendation", "Best")),
+                                                                             mapOf(entry("Product", "Lender B - ARM5/1-NoPoints"),
+                                                                                   entry("Note Amount", "$271,776.00"),
+                                                                                   entry("Interest Rate Pct", " 4.00"),
+                                                                                   entry("Monthly Payment", "$1,297.50"),
+                                                                                   entry("Cash to Close", "$75,435.52"),
+                                                                                   entry("Required Credit Score", new BigDecimal(720)),
+                                                                                   entry("Recommendation", "Good")),
+                                                                             mapOf(entry("Product", "Lender A - Fixed30-NoPoints"),
+                                                                                   entry("Note Amount", "$271,925.00"),
+                                                                                   entry("Interest Rate Pct", " 4.08"),
+                                                                                   entry("Monthly Payment", "$1,310.00"),
+                                                                                   entry("Cash to Close", "$75,438.50"),
+                                                                                   entry("Required Credit Score", new BigDecimal(680)),
+                                                                                   entry("Recommendation", "Best")),
+                                                                             mapOf(entry("Product", "Lender C - Fixed15-Standard"),
+                                                                                   entry("Note Amount", "$274,045.90"),
+                                                                                   entry("Interest Rate Pct", " 3.38"),
+                                                                                   entry("Monthly Payment", "$1,942.33"),
+                                                                                   entry("Cash to Close", "$75,480.92"),
+                                                                                   entry("Required Credit Score", new BigDecimal(720)),
+                                                                                   entry("Recommendation", "Best")),
+                                                                             mapOf(entry("Product", "Lender A - Fixed15-NoPoints"),
+                                                                                   entry("Note Amount", "$270,816.00"),
+                                                                                   entry("Interest Rate Pct", " 3.75"),
+                                                                                   entry("Monthly Payment", "$1,969.43"),
+                                                                                   entry("Cash to Close", "$75,416.32"),
+                                                                                   entry("Required Credit Score", new BigDecimal(720)),
+                                                                                   entry("Recommendation", "Best")))));
     }
        
 }

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Chapter 11 Example.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Chapter 11 Example.dmn
@@ -1,0 +1,2995 @@
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:include1="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" xmlns:drools="http://www.drools.org/kie/dmn/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:feel="https://www.omg.org/spec/DMN/20191111/FEEL/"              xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" name="Chapter 11 Example" namespace="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" exporter="DMN Modeler" exporterVersion="6.2.2.1" triso:logoChoice="None">
+    <semantic:description/>
+    <semantic:extensionElements>
+        <triso:ProjectCharter>
+            <triso:projectGoals/>
+            <triso:projectChallenges/>
+            <triso:projectStakeholders/>
+        </triso:ProjectCharter>
+    </semantic:extensionElements>
+    <semantic:import namespace="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" name="Financial" triso:fileId="eyJmIjp7InNrdSI6IjU1ZTFkZDA5LTdjYTUtNGUyMC04NzI1LWVlOTI5NzI2OTZkYiIsIm5hbWUiOiJGaW5hbmNpYWwifSwiciI6eyJhcGlrZXkiOiIyOTIwMDNmNjk4NDBlNzEyIn19" triso:fileName="Chapter 11 Example/Financial" importType="https://www.omg.org/spec/DMN/20191111/MODEL/" drools:modelName="Financial"/>
+    <semantic:itemDefinition isCollection="false" name="tStrategy" label="tStrategy">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE","BUREAU","THROUGH"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tEligibility" label="tEligibility">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tBureauCallType" label="tBureauCallType">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"FULL","MINI","NONE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tRiskCategory" label="tRiskCategory">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tApplicantData" label="tApplicantData">
+        <semantic:itemComponent isCollection="false" name="Age" id="_df3aab6f-1610-41fa-a407-09678a89d6da">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="MartitalStatus" id="_d39ad810-7781-4ffb-9644-de51d1ca7f7a">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"S","M"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="EmploymentStatus" id="_9242f7aa-a9fc-451e-a8ee-60f1ff992664">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"EMPLOYED","SELF-EMPLOYED","STUDENT","UNEMPLOYED"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="ExistingCustomer" id="_5b4cce4a-bb99-41d5-99f2-0b2d7deeea8e">
+            <semantic:typeRef>boolean</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Monthly" id="_c3ad187d-246f-4707-aa05-b9d5d8da1f58">
+            <semantic:itemComponent isCollection="false" name="Income" id="_0ff9ec7c-ef0f-425a-af5c-d251135e3631">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+            <semantic:itemComponent isCollection="false" name="Repayments" id="_d4389c69-0a87-4db9-96fa-99674bff6b97">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+            <semantic:itemComponent isCollection="false" name="Expenses" id="_c0bd1a20-826f-4fe4-86bc-b6cca2af06a1">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tBureauData" label="tBureauData">
+        <semantic:itemComponent isCollection="false" name="Bankrupt" id="_4b58e0c0-649b-472a-8a28-f8dde1e40068">
+            <semantic:typeRef>boolean</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="CreditScore" id="_42350ffd-8f82-4500-b9cb-696758cc287e">
+            <semantic:typeRef>number</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>[0..999], null</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tRouting" label="tRouting">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE","REFER","ACCEPT"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition isCollection="false" name="tRequestedProduct" label="tRequestedProduct">
+        <semantic:itemComponent isCollection="false" name="ProductType" id="_c993adad-698b-477d-a395-f4021d38ef8b">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"STANDARD LOAN","SPECIAL LOAN"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Rate" id="_5ddc6d4c-67d2-4a00-a9c0-3614d228964b">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Term" id="_4e47a0e8-ab4a-46a2-ae8c-209401ebdd8f">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent isCollection="false" name="Amount" id="_24103ee1-2867-4e01-abfc-d40b3aed0ce5">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:decisionService id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Whole Model Decision Service" id="_650ef4de-168c-4d69-80aa-f697971e49a2" typeRef="Any"/>
+        <semantic:outputDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:encapsulatedDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:encapsulatedDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_ce4a4c00-c3a3-46a6-8938-055239f6b326_DS" name="Diagram DRD of all automated decisionmaking" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD of all automated decisionmaking" id="_0a28bdea-cbbd-4454-9cc8-c91a76322790" typeRef="Any"/>
+        <semantic:outputDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:encapsulatedDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:encapsulatedDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262_DS" name="Diagram DRD for Decide bureau strategy decision point" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Decide bureau strategy decision point" id="_8848054f-a6dc-4c89-b419-470ad7bf3c56" typeRef="Any"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:encapsulatedDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_3275163a-921d-48f8-967a-21c4373b1197_DS" name="Diagram DRD for Decide routing decision point" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Decide routing decision point" id="_9dfc2eb7-fbb2-485f-9591-5a26a242339d" typeRef="Any"/>
+        <semantic:outputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b_DS" name="Diagram DRD for Review application decision point" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Review application decision point" id="_42af205f-c1cb-4bb6-b48a-40b4944359c7" typeRef="Any"/>
+        <semantic:outputDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:inputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_5c111794-4c6b-4747-8dfc-99d2ad0b6313_DS" name="Diagram Bureau Strategy Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram Bureau Strategy Decision Service" id="_e69084e3-2a45-49f1-9bd0-7da468de75f8" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_69750f88-f46f-4b47-bb3c-fb77f574f2b3_DS" name="Diagram Routing Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram Routing Decision Service" id="_5bb6af75-1df6-4f84-a2c7-1e106a313c94" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_95e871bf-e58f-4976-b1bf-d9b220fdb2cb_DS" name="Diagram DRD for Credit Risk Analytics" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram DRD for Credit Risk Analytics" id="_b6a75564-fdf6-44ec-a1cf-2141befbc189" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decision id="_4bd33d4a-741b-444a-968b-64e1841211e7" name="Adjudication" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span lang="JA"&gt;Determine if&amp;nbsp;an application requiring adjudication should be accepted or declined given the available application data and supporting documents.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Should this application that has been referred for adjudication be accepted?</semantic:question>
+        <semantic:allowedAnswers>Yes/No</semantic:allowedAnswers>
+        <semantic:variable name="Adjudication" id="_12f285f8-ae4e-4421-98bd-d9b1fd236e10" typeRef="Any"/>
+        <semantic:informationRequirement id="_290b4df4-ffe6-4106-9e22-07a339146161">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+            <semantic:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+            <semantic:requiredDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+            <semantic:requiredInput href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
+        </semantic:informationRequirement>
+        <semantic:authorityRequirement id="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+            <semantic:requiredAuthority href="#_989d137f-86ff-4249-813f-af67c08a2762"/>
+        </semantic:authorityRequirement>
+        <semantic:impactedPerformanceIndicator href="#_4d7ae526-d994-4ea2-9f26-81b9c693a45a"/>
+        <semantic:impactedPerformanceIndicator href="#_18c16494-3da7-42d8-8a7d-599b158dd840"/>
+        <semantic:decisionMaker href="#_036e1231-d563-4c1c-8a68-6b89df81d7c0"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+    </semantic:decision>
+    <semantic:knowledgeSource id="_989d137f-86ff-4249-813f-af67c08a2762" name="Credit officer experience">
+        <semantic:description>&lt;p&gt;The collected wisdom of the credit officers as collected in their best practice wiki.&lt;/p&gt;</semantic:description>
+        <semantic:type>Expertise</semantic:type>
+        <semantic:owner href="#_036e1231-d563-4c1c-8a68-6b89df81d7c0"/>
+    </semantic:knowledgeSource>
+    <semantic:inputData id="_34cd3187-8764-4249-959d-2664bf9f1847" name="Supporting documents">
+        <semantic:description>&lt;p&gt;Documents associated with a loan that are not processed electronically but are available for manual adjudication.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Supporting documents" id="_d996b907-be17-4ff1-a54e-6fe7d62f55b1" typeRef="Any"/>
+    </semantic:inputData>
+    <semantic:decision id="_5b8356f3-2cf2-40e8-8f80-324937e8b276" name="Bureau call type" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Bureau call type&amp;nbsp;&lt;/span&gt;table, passing the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>How much data should be requested from the credit bureau for this application?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Full", "Mini", "None"</semantic:allowedAnswers>
+        <semantic:variable name="Bureau call type" id="_207da57c-29a0-487b-b591-751807636337" typeRef="tBureauCallType"/>
+        <semantic:informationRequirement id="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+            <semantic:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+            <semantic:requiredKnowledge href="#_a654be71-b54d-4d6e-90f0-ae505125e9a6"/>
+        </semantic:knowledgeRequirement>
+        <semantic:impactedPerformanceIndicator href="#_0519e753-66a5-43cd-ad04-caf4de93b7f0"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" typeRef="tBureauCallType" triso:expressionId="_6ed18a0f-24e0-46ab-a13d-67c8090ef4dc">
+            <semantic:literalExpression id="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd">
+                <semantic:text>Bureau call type table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_8f5b7ce8-b4f9-4af4-8aa5-5580682382c6" name="Pre-Bureau Risk Category"/>
+                <semantic:literalExpression id="_40020f96-0afd-405c-828a-0aa6684d150d">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="_8b838f06-968a-4c66-875e-f5412fd692cf" name="Strategy" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Strategy&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, unique-hit decision table deriving Strategy from&amp;nbsp;&lt;/span&gt;Eligibility and Bureau call type.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>What is the appropriate handling strategy for this application?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Decline", "Bureau", "Through"</semantic:allowedAnswers>
+        <semantic:variable name="Strategy" id="_80c9b3dd-f6c3-412b-9ee9-48e3e0812746" typeRef="tStrategy"/>
+        <semantic:informationRequirement id="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+            <semantic:requiredDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+            <semantic:requiredDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        </semantic:informationRequirement>
+        <semantic:impactedPerformanceIndicator href="#_4d7ae526-d994-4ea2-9f26-81b9c693a45a"/>
+        <semantic:impactedPerformanceIndicator href="#_3a51a3c5-06f5-471f-88ef-8a3ea99b0d49"/>
+        <semantic:impactedPerformanceIndicator href="#_18c16494-3da7-42d8-8a7d-599b158dd840"/>
+        <semantic:impactedPerformanceIndicator href="#_96b30012-a6e7-4545-89d3-068ec722469c"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:decisionTable id="_0991d970-7c58-4669-89ec-a5e3e9d264df" hitPolicy="UNIQUE" outputLabel="Strategy" typeRef="tStrategy" triso:expressionId="_1e25316a-8ac8-47b6-b423-0e24cbb03d30">
+            <semantic:input id="_661471d5-5028-4910-b070-1e3bad0125c7">
+                <semantic:inputExpression typeRef="tEligibility">
+                    <semantic:text>Eligibility</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="enumeration">
+                    <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:input id="_b48e30f7-0a90-42d0-ba06-ad931fdfe5da">
+                <semantic:inputExpression typeRef="tBureauCallType">
+                    <semantic:text>Bureau call type</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="enumeration">
+                    <semantic:text>"FULL","MINI","NONE"</semantic:text>
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:output id="_f722c4f0-299d-4492-9b0c-fa0177239d08">
+                <semantic:outputValues triso:constraintsType="enumeration">
+                    <semantic:text>"DECLINE","BUREAU","THROUGH"</semantic:text>
+                </semantic:outputValues>
+            </semantic:output>
+            <semantic:annotation/>
+            <semantic:rule id="_799a874e-d695-4683-9774-a4a911bbda7c">
+                <semantic:inputEntry id="_a1e93932-14d9-41aa-b408-418df532584e">
+                    <semantic:text>"INELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_46a2c9c2-10ba-4ebd-b596-d8d50ef4e27d">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_ddad297d-4a7e-45b4-bfc5-78cfc1504f8e">
+                    <semantic:text>"DECLINE"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_8e10bf87-3308-4cb5-84fd-231656eb15f3">
+                <semantic:inputEntry id="_27b85f52-29db-4114-8393-4c307fda69de">
+                    <semantic:text>"ELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_658b9e6d-4039-4a30-a14f-b9af59e9ff3e">
+                    <semantic:text>"FULL", "MINI"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_4099772e-6ec4-48e2-a4ac-daa6d7aa1148">
+                    <semantic:text>"BUREAU"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_cec87cd2-9715-47b2-97df-087698d8fc70">
+                <semantic:inputEntry id="_617a19de-dd6d-4448-be7b-dc5c0f57de9c">
+                    <semantic:text>"ELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_0600d1e9-3293-4c91-b0f1-f1fecb10f422">
+                    <semantic:text>"NONE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_f17c18da-fb15-401b-88a5-550d1918583b">
+                    <semantic:text>"THROUGH"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text/>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" name="Eligibility" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Eligibility rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Applicant data.Age as the Age parameter, the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter, and the output of the Pre-bureau affordability decision as the Pre-Bureau Affordability parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Does this applicant appear eligible for the loan they applied for given only their application data?</semantic:question>
+        <semantic:allowedAnswers>Value from the explicit list "Eligible", "Not Eligible"</semantic:allowedAnswers>
+        <semantic:variable name="Eligibility" id="_a160fe23-8110-4242-9944-86278d32000e" typeRef="tEligibility"/>
+        <semantic:informationRequirement id="_94475973-9022-46d7-a520-756538ba9c00">
+            <semantic:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+            <semantic:requiredDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+            <semantic:requiredKnowledge href="#_dc2ca64d-2044-4806-9d0e-e705b3b14447"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" typeRef="tEligibility" triso:expressionId="_4063907e-d25c-4857-887c-edb2f73682c7">
+            <semantic:literalExpression id="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979">
+                <semantic:text>Eligibility rules</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_07fdfb40-acac-4098-8a66-f09f216cd9ec" name="Age"/>
+                <semantic:literalExpression id="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca">
+                    <semantic:text>Applicant data.Age</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_a2bc5321-7041-40c0-be9d-4e53c22442d1" name="Pre-Bureau Risk Category"/>
+                <semantic:literalExpression id="_91986b6f-d45e-4aa7-926d-00b35a47686f">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_c3432a72-40b0-4213-9f94-7f5e8e15ee85" name="Pre-Bureau Affordability"/>
+                <semantic:literalExpression id="_719504be-6121-4c16-9c00-1480b58f2ecb">
+                    <semantic:text>Pre-bureau affordability</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="_dc2ca64d-2044-4806-9d0e-e705b3b14447" name="Eligibility rules">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Eligibility rules" id="_fe2d2049-704b-4a88-88be-3d1a56c3d376" typeRef="tEligibility"/>
+        <semantic:encapsulatedLogic typeRef="tEligibility" triso:expressionId="_e89d2f82-6356-4541-9a92-4d9829ecdf40">
+            <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:formalParameter name="Pre-Bureau Affordability" typeRef="boolean"/>
+            <semantic:formalParameter name="Age" typeRef="number"/>
+            <semantic:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" outputLabel="Eligibility rules">
+                <semantic:input id="_2bab5dc0-be18-4098-b9b4-6b3486955d1b">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Pre-Bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_836645fe-83ba-4f36-9b6d-279b017c59ea">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Pre-Bureau Affordability</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_4946be73-cb1e-43b4-ac03-b01e378c298a">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Age</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_81aab6dd-d832-4c9e-8a3c-55f5f4a89cc7">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_3352c79c-5aa5-4f2a-bf7e-c1e24f72a7ed">
+                    <semantic:inputEntry id="_51fa1535-776a-411f-ba5d-4915f04adf46">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_209c0b4c-7e1f-4758-bb2d-ff56116ebf70">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e5e44a50-b664-4ce1-8b48-a7c5b73bec50">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f506afa7-a3fe-48d5-8ec6-4bf2cc2dd28b">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_1e4a3e10-0d85-4160-85eb-6d3ad7adee82">
+                    <semantic:inputEntry id="_0366fd41-b16b-4848-8759-1c1b2f5defc9">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4c4d51a8-0927-47d1-bf5d-732eeaf9af50">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_bc0c7201-97b5-41ea-8427-31a3923d674c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3611f774-9b66-468d-be7f-06bf14407161">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_c871d706-98a2-4d65-903c-7cbd1571f17c">
+                    <semantic:inputEntry id="_4e174888-d7ca-4561-aba8-5fd8dfb3b35b">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6e1f9fc4-69b2-4e8c-bcf9-8878ec8bd455">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a120264e-f028-4b2b-8b94-b29b68aa5499">
+                        <semantic:text>&lt; 18</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_504ac7aa-2538-48d1-b518-f10a5ff1d87c">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_11673d64-2390-42c1-bc6f-43074ee90097">
+                    <semantic:inputEntry id="_d1ca6c94-6088-43be-bcfe-83b9de492d8a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_c19d2814-6733-46dc-92cc-48c7b0e59fa8">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_bac13f3d-00eb-49f7-b715-0d379562c1c3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_0d0dd4a4-0468-44cc-97fc-6cf243ee28b9">
+                        <semantic:text>"ELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+            <semantic:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:knowledgeSource id="_a5f9b126-7853-4037-9e23-3dd7e93c4032" name="Product specification">
+        <semantic:description>&lt;p&gt;Definitions of the products, their cost structure and eligibility criteria.&lt;/p&gt;</semantic:description>
+        <semantic:type>Policy</semantic:type>
+        <semantic:owner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_536d7a39-87a6-4651-b743-6ee03e16e535" name="Routing rules">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Routing rules" id="_08f4f63e-54e4-4b19-b0d2-08aeed21605c" typeRef="tRouting"/>
+        <semantic:encapsulatedLogic typeRef="tRouting" triso:expressionId="_9f0b535e-87b4-43e3-a818-8d47d1b109bd">
+            <semantic:formalParameter name="Post-bureau risk category" typeRef="tRiskCategory"/>
+            <semantic:formalParameter name="Post-bureau affordability" typeRef="boolean"/>
+            <semantic:formalParameter name="Bankrupt" typeRef="boolean"/>
+            <semantic:formalParameter name="Credit score" typeRef="number"/>
+            <semantic:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" outputLabel="Routing rules">
+                <semantic:input id="_b3bde44f-2274-41d5-8e04-5cb2f7529e6c">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Post-bureau risk category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_edb3efb0-2fea-4d55-9b5f-ae279ad5ecaa">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Post-bureau affordability</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_1fbd45e7-99d5-497d-beb0-a643dd558b63">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Bankrupt</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_83878ad8-a1fc-43b0-b601-f1b093e39b48">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Credit score</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>null, [0..999]</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_109021ab-349a-47f0-9c9e-564a9fbc20e8">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","REFER","ACCEPT"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_b9e04531-35ba-4562-9c9e-2a6900315e1c">
+                    <semantic:inputEntry id="_2844a3b1-bdcf-49f0-9c5c-f80990077a43">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7ac71a80-a65f-4b42-b125-682fec1c0cda">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e3ef460f-b05e-4d54-af1e-355c2d6d191e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ec772f81-1eee-475c-872a-596fb40c650c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_27239ae2-8529-4afd-8981-043bb51d2fb2">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_3ed8ac44-80a1-4e64-b610-f84d79c5b875">
+                    <semantic:inputEntry id="_64077b12-6193-4842-86e2-896290756562">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_07978900-95e3-4102-8916-eb439316c4e1">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2e822dc4-cba8-4594-82bd-b48b4be2180d">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b3856c1d-2067-483a-b6ca-ba3c8080f12c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_684c798b-7ade-4155-ad42-cc111cf920a9">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_0e511735-f478-4041-97f8-158ea173668b">
+                    <semantic:inputEntry id="_9ee5cc2a-42ce-4fc6-b4a2-b6ae3c6590c4">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_be5739cd-c1c9-47ca-af91-47109d2c288a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f4f9d322-ca0a-4a24-a967-916aa32f5136">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_fda948c5-43a7-4023-9c52-4020007ca482">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_000ea279-76af-4c1a-a2d6-b8eda969df7a">
+                        <semantic:text>"REFER"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_06c90e6c-99d1-4c99-a443-374ab1288c1b">
+                    <semantic:inputEntry id="_c87517c4-b47d-4653-a884-3a265dba1ec7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_0fc27099-c992-4041-b164-9c4d1dddb462">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_527df004-e723-46de-9475-aa2db4e0f4f7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_dbc688c4-064b-4fe1-ab7e-6992d6cbaf61">
+                        <semantic:text>&lt; 580</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_20941825-2c8b-4d94-9fde-0b3039b12a3c">
+                        <semantic:text>"REFER"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_3a1673bb-17ae-4b62-b686-d8ecc0f4657b">
+                    <semantic:inputEntry id="_7e258e45-824d-402b-b6e5-a46088e90e1e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2f51bdea-d5bc-4b8e-ac34-ae093f1ae170">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_913c21a5-d028-4c3b-8482-83d2a5eae2c6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4665c331-032d-4489-97bf-4e19eead103e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f77e29ae-79a3-4f1d-9eed-7b3795031861">
+                        <semantic:text>"ACCEPT"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+            <semantic:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_ca1e6032-12eb-428a-a80b-49028a88c0b5" name="Routing" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Routing rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Bureau data . Bankrupt as the Bankrupt parameter, Bureau data . CreditScore as the Credit Score parameter, the output of the Post-bureau risk category decision as the Post-Bureau Risk Category parameter, and the output of the Post-bureau affordability decision as the Post-Bureau Affordability parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Bankrupt and Credit Score parameters will be null.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>How this should this applicant be routed given all available data?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Decline", "Refer for Adjudication", "Accept without Review"</semantic:allowedAnswers>
+        <semantic:variable name="Routing" id="_da1b4341-41b8-4b67-b33a-f54d2782cf4e" typeRef="tRouting"/>
+        <semantic:informationRequirement id="_132debf9-e318-4710-a226-982da98dd278">
+            <semantic:requiredDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+            <semantic:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+            <semantic:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_839ccfec-8902-40ca-8767-df9073f797e5">
+            <semantic:requiredKnowledge href="#_536d7a39-87a6-4651-b743-6ee03e16e535"/>
+        </semantic:knowledgeRequirement>
+        <semantic:impactedPerformanceIndicator href="#_3a51a3c5-06f5-471f-88ef-8a3ea99b0d49"/>
+        <semantic:impactedPerformanceIndicator href="#_4d7ae526-d994-4ea2-9f26-81b9c693a45a"/>
+        <semantic:impactedPerformanceIndicator href="#_96b30012-a6e7-4545-89d3-068ec722469c"/>
+        <semantic:impactedPerformanceIndicator href="#_18c16494-3da7-42d8-8a7d-599b158dd840"/>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_78ce14d2-2c68-454a-b772-075b3f1395c3" typeRef="tRouting" triso:expressionId="_57b4d31c-ab28-4fee-8fdb-312ad13b3230">
+            <semantic:literalExpression id="literal__78ce14d2-2c68-454a-b772-075b3f1395c3">
+                <semantic:text>Routing rules</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_8a009394-dc06-4ee6-b039-dde94390bf6b" name="Bankrupt"/>
+                <semantic:literalExpression id="_32742ced-8b58-4be0-a6be-d48ab1126f69">
+                    <semantic:text>Bureau data.Bankrupt</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_5b79a0ff-62ed-4d3d-b512-ea706cc06f62" name="Credit score"/>
+                <semantic:literalExpression id="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a">
+                    <semantic:text>Bureau data.CreditScore</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_79216390-7bf1-4b14-9b3e-91ee83a5cd4a" name="Post-bureau risk category"/>
+                <semantic:literalExpression id="_30a91838-0f0a-4843-a6d0-6b5a655f36b2">
+                    <semantic:text>Post-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_6edce48a-be0d-4896-af06-f5c05980970b" name="Post-bureau affordability"/>
+                <semantic:literalExpression id="_7a672677-fd20-4174-87f9-ba5e9146ddba">
+                    <semantic:text>Post-bureau affordability</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="_a654be71-b54d-4d6e-90f0-ae505125e9a6" name="Bureau call type table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving&amp;nbsp;&lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Bureau call type table" id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3" typeRef="tBureauCallType"/>
+        <semantic:encapsulatedLogic typeRef="tBureauCallType" triso:expressionId="_309a5634-43bc-49cb-a5d1-b0b2a573404c">
+            <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" outputLabel="Bureau call type table">
+                <semantic:input id="_92e35546-27e5-43a5-b8e6-85a692f42eb8">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Pre-Bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_6254d113-6c92-400f-88d5-fdb340519336">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"FULL","MINI","NONE"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_49d3d12b-8572-4341-9102-6f68667bf81a">
+                    <semantic:inputEntry id="_7abba955-f604-4995-aea5-842f7eefa839">
+                        <semantic:text>"HIGH", "MEDIUM"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_573aec0a-0759-435a-ba0c-5f27498897a0">
+                        <semantic:text>"FULL"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_db49e5ea-da50-4b07-ae82-9db29f3730b9">
+                    <semantic:inputEntry id="_1f21c493-c6f2-4b81-92f0-59b6511f9ddd">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_9aa8475c-4b5e-4da3-8f3e-aae70f694f83">
+                        <semantic:text>"MINI"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_304ebea6-617f-4f47-949d-aa9ac1dd1227">
+                    <semantic:inputEntry id="_d3f0c96c-521d-4228-b073-c945aca7483d">
+                        <semantic:text>"VERY LOW", "DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_2174bcfa-2d27-44ad-8525-56fce28fb75e">
+                        <semantic:text>"NONE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:knowledgeSource id="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" name="Risk management strategy">
+        <semantic:description>&lt;p&gt;Overall risk management approach for the financial institution including its approach to&amp;nbsp;application risk, credit contingencies and credit risk scoring.&lt;/p&gt;</semantic:description>
+        <semantic:type>Policy</semantic:type>
+        <semantic:owner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_b982a42a-0b62-47fa-8911-6c9d1145d982" name="Credit contingency factor table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;/span&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;decision&lt;/span&gt; logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/p&gt;
+&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Credit contingency factor table" id="_40c0f987-7b90-4c3e-9dcd-411e56f66c92" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number" triso:expressionId="_2e0e5afc-8e62-46e4-9989-2f9d47015e53">
+            <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory"/>
+            <semantic:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table">
+                <semantic:input id="_2b8fecfd-e00f-4d4b-acf3-660ca3560ca0">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_8d0d6fe3-a352-48a7-a35e-1fc1dd192039"/>
+                <semantic:annotation/>
+                <semantic:rule id="_21ec60ae-6137-41e2-b8b5-37447708c47b">
+                    <semantic:inputEntry id="_8c7e14f8-23db-4645-8b2a-2c69aada207d">
+                        <semantic:text>"HIGH", "DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_6052bbc0-6f0e-45db-bdd3-3c0ac4c45793">
+                        <semantic:text>0.6</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_8c5eb4e3-1902-4bf5-8257-1e21636fc978">
+                    <semantic:inputEntry id="_fe0190b4-e2f3-441f-a989-f22e1d425fd8">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_6320ae5d-459e-4775-b492-f9c0d0d492bb">
+                        <semantic:text>0.7</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_93e2a1a2-b281-42a4-8e34-865c28557929">
+                    <semantic:inputEntry id="_cd63cc67-53a5-480f-abcd-f394e606a7bd">
+                        <semantic:text>"LOW", "VERY LOW"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_fdcb46a5-a23c-4e29-93f1-66ce4e3c25da">
+                        <semantic:text>0.8</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:knowledgeSource id="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" name="Affordability spreadsheet">
+        <semantic:description>&lt;p&gt;Internal spreadsheet showing the relationship of income, payments, expenses, risk and affordability.&lt;/p&gt;</semantic:description>
+        <semantic:type>Policy</semantic:type>
+        <semantic:owner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" name="Affordability calculation">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from&amp;nbsp;&lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Affordability calculation" id="_80af1aa7-e29c-47fc-9cce-1959a3e1e717" typeRef="boolean"/>
+        <semantic:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL" typeRef="boolean" triso:expressionId="_5087c77a-913c-4ab4-b600-0c5c182c2e6d">
+            <semantic:formalParameter name="Monthly Income" typeRef="number" id="_f916b091-cd6d-44cb-b32b-cc83cc27e333"/>
+            <semantic:formalParameter name="Monthly Repayments" typeRef="number" id="_d68b6438-cba5-4c02-a708-bce0d2762d35"/>
+            <semantic:formalParameter name="Monthly Expenses" typeRef="number" id="_5fd5609d-89ce-463e-a882-6827921edf54"/>
+            <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory" id="_2acfe2aa-892f-4a5c-b9ab-111c7a8bbd40"/>
+            <semantic:formalParameter name="Required Monthly Installment" typeRef="number" id="_3a423c76-11c7-4b66-b86a-07928181a631"/>
+            <semantic:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256">
+                <semantic:contextEntry id="_ec37158d-b49b-4ffd-88e0-1e2f05c9a023">
+                    <semantic:variable name="Disposable Income" id="_3cc56162-97c1-416e-acb9-3ae81d692e58" typeRef="number"/>
+                    <semantic:literalExpression id="_2fcda742-6d7b-49c5-afe6-6b334c8f049b">
+                        <semantic:text>Monthly Income - (Monthly Repayments + Monthly Expenses)</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_fccafa17-121e-436a-bbed-1927f01a898d">
+                    <semantic:variable name="Credit Contingency Factor" id="_0f406bed-56f5-422e-b6c3-ad4892a38291" typeRef="number"/>
+                    <semantic:invocation id="_78bc74d6-25a4-4639-8509-186534b3c67a">
+                        <semantic:literalExpression id="literal__78bc74d6-25a4-4639-8509-186534b3c67a">
+                            <semantic:text>Credit contingency factor table</semantic:text>
+                        </semantic:literalExpression>
+                        <semantic:binding>
+                            <semantic:parameter id="_7fed77e8-7d20-4f3f-9504-2c0c0706bd39" name="Risk Category"/>
+                            <semantic:literalExpression id="_a02265a9-3dd1-48cd-a254-84531f28a058">
+                                <semantic:text>Risk Category</semantic:text>
+                            </semantic:literalExpression>
+                        </semantic:binding>
+                    </semantic:invocation>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_7ef4d2b6-c294-4f9c-a483-99d1923daa31">
+                    <semantic:variable name="Affordability" id="_efb9411e-34c6-4e72-a664-85a30197f5d0" typeRef="boolean"/>
+                    <semantic:literalExpression id="_3051a016-282e-4f83-8cfa-4c57084e559f">
+                        <semantic:text>if Disposable Income * Credit Contingency Factor &gt; Required Monthly Installment
+then true
+else false</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_56470ec7-03b0-4ce2-bf7f-32c2ad584d37">
+                    <semantic:literalExpression id="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55">
+                        <semantic:text>Affordability</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+            </semantic:context>
+        </semantic:encapsulatedLogic>
+        <semantic:knowledgeRequirement id="_7f7c177a-5acb-4941-9654-23f9408200b3">
+            <semantic:requiredKnowledge href="#_b982a42a-0b62-47fa-8911-6c9d1145d982"/>
+        </semantic:knowledgeRequirement>
+        <semantic:authorityRequirement id="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+            <semantic:requiredAuthority href="#_18d836e7-6d61-490c-b9a8-be3ce0c60c1e"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_ed60265c-25e2-400f-a99f-fafd3b489838" name="Pre-bureau affordability" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Pre-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Can the applicant afford the loan they applied for given only their application data?</semantic:question>
+        <semantic:allowedAnswers>Yes/No</semantic:allowedAnswers>
+        <semantic:variable name="Pre-bureau affordability" id="_bd744aca-06aa-4438-81de-0754fc15a44e" typeRef="boolean"/>
+        <semantic:informationRequirement id="_00c137a3-a81c-42ff-af6d-5c3247151273">
+            <semantic:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+            <semantic:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+            <semantic:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+        <semantic:invocation id="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" typeRef="boolean" triso:expressionId="_5a9f0da6-f281-4d47-9bb2-76c2f107e3ce">
+            <semantic:literalExpression id="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86">
+                <semantic:text>Affordability calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_ea45f34e-c7f7-41fe-a2fa-c9329dc03ead" name="Monthly Income"/>
+                <semantic:literalExpression id="_63cbd20f-fab4-480e-9471-1367b2e1fc6c">
+                    <semantic:text>Applicant data.Monthly.Income</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_28b8d43b-e005-42f0-a432-5ea3c6547247" name="Monthly Repayments"/>
+                <semantic:literalExpression id="_c35a57bf-208c-4333-973f-c8a9e9ce85f4">
+                    <semantic:text>Applicant data.Monthly.Repayments</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_650b93d6-d6cd-46dc-8ebc-d1d80c5c4fa7" name="Monthly Expenses"/>
+                <semantic:literalExpression id="_174c9fb3-c940-455f-ab97-035989e83446">
+                    <semantic:text>Applicant data.Monthly.Expenses</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_70836844-402b-49b0-b07a-347c81e0f345" name="Risk Category"/>
+                <semantic:literalExpression id="_34d3db82-c899-45f6-b46c-ef7cb2f550c3">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_b94f43b0-69d0-4f20-9698-5f91b85f026a" name="Required Monthly Installment"/>
+                <semantic:literalExpression id="_47e0147f-030a-4020-a5d3-728c563c0bd2">
+                    <semantic:text>Required monthly installment</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" name="Post-bureau affordability" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Post-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Can the applicant afford the loan they applied for given all available data?</semantic:question>
+        <semantic:allowedAnswers>Yes/No</semantic:allowedAnswers>
+        <semantic:variable name="Post-bureau affordability" id="_b6f25146-5302-470e-a242-3d71c4311add" typeRef="boolean"/>
+        <semantic:informationRequirement id="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+            <semantic:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_9eeef063-346f-44d4-b722-2d8071d3d994">
+            <semantic:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_466b70d3-035a-413d-93bd-ae28c778d02d">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+            <semantic:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+        <semantic:invocation id="_3e5d9f10-9433-4853-b084-33790988de2a" typeRef="boolean" triso:expressionId="_fdcaffc9-aa3d-4c33-bc0c-09634cc64f05">
+            <semantic:literalExpression id="literal__3e5d9f10-9433-4853-b084-33790988de2a">
+                <semantic:text>Affordability calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_ecb484a1-1ca6-40d8-863f-ba95fea13779" name="Monthly Income"/>
+                <semantic:literalExpression id="_610d5776-9163-4707-85c4-c4f0ff35db0a">
+                    <semantic:text>Applicant data.Monthly.Income</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_b5f0835b-4dba-418b-a11c-3a23a76f3ae6" name="Monthly Repayments"/>
+                <semantic:literalExpression id="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36">
+                    <semantic:text>Applicant data.Monthly.Repayments</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_f8edc4a3-5000-4558-80f0-45efaee7e339" name="Monthly Expenses"/>
+                <semantic:literalExpression id="_3d3c099c-c287-45ff-82de-ca3079da67b0">
+                    <semantic:text>Applicant data.Monthly.Expenses</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_a8c6984b-8bca-41cc-b284-d056a18b43af" name="Risk Category"/>
+                <semantic:literalExpression id="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113">
+                    <semantic:text>Post-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_cac9db30-48f9-4b43-b9fa-699171ac858b" name="Required Monthly Installment"/>
+                <semantic:literalExpression id="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227">
+                    <semantic:text>Required monthly installment</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="_40b45659-9299-43a6-af30-04c948c5c0ec" name="Post-bureau risk category" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Post-bureau&amp;nbsp;&lt;/span&gt;risk category business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter, Bureau data.CreditScore as the Credit Score parameter, and the output of the Application risk score decision as the Application Risk Score parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Credit Score parameter will be null.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Which risk category is most appropriate for this applicant given all available data?</semantic:question>
+        <semantic:allowedAnswers>A value from the explicit list "Decline", "High Risk", "Medium Risk", "Low Risk", "Very Low Risk"</semantic:allowedAnswers>
+        <semantic:variable name="Post-bureau risk category" id="_34b85411-de9d-4d9a-8b03-ad1b1cec8777" typeRef="tRiskCategory"/>
+        <semantic:informationRequirement id="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+            <semantic:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_668fa95d-373d-4430-b833-7c27308d2a80">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_655fba60-b529-4c21-bd96-9c778998d3fb">
+            <semantic:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+            <semantic:requiredKnowledge href="#_1c72ed95-ec72-47b4-8639-5ed14ccb77df"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" typeRef="tRiskCategory" triso:expressionId="_dc37ff04-62ca-4b96-940c-dc7e63f3da80">
+            <semantic:literalExpression id="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b">
+                <semantic:text>Post-bureau risk category table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_a7faf416-0247-43c1-8827-9346540d13c3" name="Existing Customer"/>
+                <semantic:literalExpression id="_9eb92498-0de3-44b1-a8e2-301a2bc091d4">
+                    <semantic:text>Applicant data.ExistingCustomer</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_b0bb0d61-0ea4-4c10-8a97-94be610bee0b" name="Credit Score"/>
+                <semantic:literalExpression id="_ad652244-9438-4a76-9637-2ca8dde2cee4">
+                    <semantic:text>Bureau data.CreditScore</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_4bb7604e-18d8-4d57-8097-cd2585c59266" name="Application Risk Score"/>
+                <semantic:literalExpression id="_9ead8557-599e-4900-80b8-7157c0653d82">
+                    <semantic:text>Application risk score</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:inputData id="_e91de815-22ba-431c-8b46-55891f2a1ef6" name="Bureau data">
+        <semantic:description>&lt;p&gt;External credit score and bankruptcy information provided by a bureau.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Bureau data" id="_aa8440f8-8f48-4e37-b775-ab8d771d24eb" typeRef="tBureauData"/>
+    </semantic:inputData>
+    <semantic:businessKnowledgeModel id="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" name="Post-bureau risk category table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Post-bureau risk category table" id="_689c96f3-6dd3-4c74-9a8f-721a966eb1af" typeRef="tRiskCategory"/>
+        <semantic:encapsulatedLogic typeRef="tRiskCategory" triso:expressionId="_4c7a54ab-487d-44aa-94cd-6f8164f0857b">
+            <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
+            <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
+            <semantic:formalParameter name="Credit Score" typeRef="number"/>
+            <semantic:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" outputLabel="Post-bureau risk category table">
+                <semantic:input id="_fc4cfa6b-926b-4751-81d9-d363b6f19299">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Existing Customer</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_77a90f33-64d6-4050-a932-a9c8454b10ab">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Application Risk Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_129a63ca-ea08-460a-98f3-bbb9b9a11121">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Credit Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_44033e77-5b86-4040-83a3-63629ae25983">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_22d41220-e512-4248-bed3-935266abfac6">
+                    <semantic:inputEntry id="_2c44dae4-55da-4aad-8dca-6db78b1463ff">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f75f53c2-d798-4b12-bfbb-f3c2dcbb7d13">
+                        <semantic:text>&lt; 120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_19694f9e-0022-42bd-a10c-8ec5855d2608">
+                        <semantic:text>&lt; 590</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_04e9777f-143b-44f5-be3e-a17710658417">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ca0d34ce-5f88-489f-b07d-c153cfcc9a9f">
+                    <semantic:inputEntry id="_1a227ae6-84eb-46b5-a355-e9414e2b4c68">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d571de40-d13c-40d1-b4d8-7c9ef4f3d405">
+                        <semantic:text>&lt; 120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_eaad5ff9-9a13-4321-b1ed-b9b81a6bc7c3">
+                        <semantic:text>[590..610]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_e47b1857-760e-4a6a-ab76-575d57ed3d75">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_731cfff1-8846-4204-b2d8-d4273e7caf6d">
+                    <semantic:inputEntry id="_9398558c-7346-41e6-b466-6db6a65a6886">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_69198768-fbd1-48f4-a233-6a237f8759d3">
+                        <semantic:text>&lt; 120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_9853a883-301b-4134-8411-11fcc78cca01">
+                        <semantic:text>&gt; 610</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_e56ad1e0-521d-4648-9209-81909e453bec">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_7124ae55-0a5c-40a5-858a-2e97d3fcee2b">
+                    <semantic:inputEntry id="_d66444ed-d5af-47e9-9425-d41c72eab9d8">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a24e787d-5735-4086-b27e-b536108f0cab">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_801d5239-537e-4147-80ce-2226cf9bb6dd">
+                        <semantic:text>&lt; 600</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_27df9777-129b-4e9a-8e01-1c016b90f049">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_6849c070-ffaf-4afd-b739-c9516e093a2d">
+                    <semantic:inputEntry id="_d7cdde1c-c04e-4cf6-9c6e-58e73ceb48e4">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_79cd3d7c-5e16-48c1-bb40-b5f30dec9830">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1c63b959-c10b-4c66-b024-684fb3773c13">
+                        <semantic:text>[600..625]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ad886bab-7ca9-466a-873e-a7fdc7dc0e29">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_abe53d6c-0c5e-4de6-8835-452442e07761">
+                    <semantic:inputEntry id="_8a73641d-2a45-423e-ba92-cc6463dcdefe">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a4131075-a73f-46cf-9e6b-4cf014f95567">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d81f0359-dab6-4813-a818-62bebe59d2c6">
+                        <semantic:text>&gt; 625</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_28527dae-a87d-4cd3-9f2e-7d244c617b17">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_1a267a70-0937-42cd-a778-9ef369309660">
+                    <semantic:inputEntry id="_6d4e7030-c29d-4f31-b1a5-8e57323425fd">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d0be0dbe-0ef4-4198-b612-7a415e569e73">
+                        <semantic:text>&gt; 130</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ffb1d0e3-4ecb-4497-8df0-6262f0e56ff2">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3de03ecf-f018-4135-add5-fd54737cee48">
+                        <semantic:text>"VERY LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4ec01cc3-2dce-453f-a195-e8a598be44ab">
+                    <semantic:inputEntry id="_69c5f5cb-c384-4596-8fd7-615cdcc4abf4">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_86661a8a-4179-4df7-9556-5e5937b676b9">
+                        <semantic:text>&lt;= 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7580e93d-f53b-405c-b6ab-87d9cb1f5fa1">
+                        <semantic:text>&lt; 580</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_00ef5d95-f613-41c8-8bf5-35aeee1e55e8">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_2ca1a47c-33b0-426d-87b4-d1dd23de3e30">
+                    <semantic:inputEntry id="_d9bafc07-3e85-442e-bb8a-99f7f2b7488a">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_005e60af-83b1-471c-aa1c-1a1bc9e8f197">
+                        <semantic:text>&lt;= 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_0a6e9560-ff9a-4b30-b5e4-1f218b8ea6c2">
+                        <semantic:text>[580..600]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_2bd1761e-b0f6-4eed-8df0-0f3bedf84817">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4ad8a80e-0e44-4512-8925-6f3ef0bcf67e">
+                    <semantic:inputEntry id="_25c987a9-40dd-4f40-a7b2-7b6b7020f729">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a8c73104-1d46-4c4d-ba3b-25ac8b812a4b">
+                        <semantic:text>&lt;= 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_295d25f5-f29a-456e-a000-7b26c3a3ba1d">
+                        <semantic:text>&gt; 600</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ae145544-b4e9-4c07-95d4-9e77237813f6">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_a14b851e-8b11-416e-806b-59222b4b0cc9">
+                    <semantic:inputEntry id="_77185ff7-c946-46cc-b93a-dabdc111f5dd">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_be1969ad-6a34-4e7f-8e14-cfabf84c9d33">
+                        <semantic:text>&gt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b93f37d5-afe8-40e1-aa4f-272d19da02d9">
+                        <semantic:text>&lt; 590</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_d7479784-014d-497f-9d06-1b111fa9c29f">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4377ced8-b8d9-4069-9dcf-098007969563">
+                    <semantic:inputEntry id="_28eee2fe-8a48-4a73-8488-10c506a7add5">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7c50c99a-c045-42c5-a647-22a4eae50036">
+                        <semantic:text>&gt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a71f7fc4-f200-4694-9738-23b01485ba78">
+                        <semantic:text>[590..615]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_02efcf34-86b8-411c-81bc-98668fe07bb3">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_20a9e6e8-bab5-4d49-803c-12d3b574fdd3">
+                    <semantic:inputEntry id="_2ba73fd9-c951-45dc-ac77-f6904c26e37c">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_cf3a2739-9a36-4702-b0f3-e8b0a0338db1">
+                        <semantic:text>&gt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_56cc9c15-43a9-4d81-975a-ab69f53a528b">
+                        <semantic:text>&gt; 615</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_13bc4965-9c91-44bd-973c-25dd9c1bebab">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_9997fcfd-0f50-4933-939e-88a235b5e2a0" name="Pre-bureau risk category" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-Bureau Risk Category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Pre-bureau&amp;nbsp;&lt;/span&gt;risk category table business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter and the output of the Application risk score decision as the Application Risk Score parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>Which risk category is most appropriate for this applicant given only their application data?</semantic:question>
+        <semantic:allowedAnswers>Value from explicit list "Decline", "High Risk", "Medium Risk", "Low Risk", "Very Low Risk"</semantic:allowedAnswers>
+        <semantic:variable name="Pre-bureau risk category" id="_a739014d-8c5e-438b-b76a-805e3689c977" typeRef="tRiskCategory"/>
+        <semantic:informationRequirement id="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+            <semantic:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+            <semantic:requiredKnowledge href="#_51cc9510-3bfa-4e5a-a119-9bf83efdd266"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_6a80329f-9577-4497-aca3-67bf5aa41a7a"/>
+        <semantic:invocation id="_04337ddb-db98-40e9-81cd-12802e74401e" typeRef="tRiskCategory" triso:expressionId="_7084eef5-12a7-40e1-9774-ccf6170679c2">
+            <semantic:literalExpression id="literal__04337ddb-db98-40e9-81cd-12802e74401e">
+                <semantic:text>Pre-bureau risk category table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_74d8aa6b-838e-4d87-8d64-8b734146aac6" name="Existing Customer"/>
+                <semantic:literalExpression id="_4b5e5cfb-d6fa-4d41-a13a-783170887126">
+                    <semantic:text>Applicant data.ExistingCustomer</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_929d5796-6174-41eb-b27c-52f956fd44dd" name="Application Risk Score"/>
+                <semantic:literalExpression id="_b93f253e-7f93-4356-a98b-3fae510485e3">
+                    <semantic:text>Application risk score</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" name="Pre-bureau risk category table">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Pre-bureau risk category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Pre-bureau risk category table" id="_cfb1bb8c-ad27-42e2-b52a-50eadea198a6" typeRef="tRiskCategory"/>
+        <semantic:encapsulatedLogic typeRef="tRiskCategory" triso:expressionId="_b1819f1c-d9c9-4c39-91e2-9d87640b7422">
+            <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
+            <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
+            <semantic:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table">
+                <semantic:input id="_1ee6291f-423f-47d9-8774-858b392d4762">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Existing Customer</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_22607edc-31dd-4d18-982f-b3d4b4606804">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Application Risk Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_f482a2b4-eed1-4dfc-84b6-4860edec088d">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation/>
+                <semantic:rule id="_05c9836c-6f21-49e9-8e4b-0ad029d1a38c">
+                    <semantic:inputEntry id="_5dc5082d-6dc3-46ce-821f-3fe0981a0407">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f9c9f1c0-dba5-4adc-8764-c740d55abc5e">
+                        <semantic:text>&lt; 100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_520b6480-8c90-4ab0-bfd2-2e6107c9c2aa">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_7d1fbf47-e150-44d1-aa1c-b6c15ccc92c3">
+                    <semantic:inputEntry id="_2c0451d5-f065-41a4-ada7-4a3fb29a668d">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e7f1fb9b-32d4-4a45-95f3-8390801435a8">
+                        <semantic:text>[100..120)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_699696bd-226d-4dca-bba3-1a5b7ad0a8f0">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_da654f4f-3a18-44ec-8087-f27715c1e12b">
+                    <semantic:inputEntry id="_5df3c3df-0bed-4171-b915-e084fce11e51">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_dd71d0af-cfb7-4472-a745-28a36251b945">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_331e4bd4-397e-44dd-a403-44b3cf4ad15d">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_524a197c-3981-41ee-baed-1de02c55fac3">
+                    <semantic:inputEntry id="_a76ff1d9-f651-4833-8773-7d75925b5fe4">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_123b03ad-4815-4f98-8870-9c25e06fac6b">
+                        <semantic:text>&gt; 130</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f33f040b-a116-43c1-9791-bef711299be6">
+                        <semantic:text>"VERY LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ab1dfe10-5fbc-47fc-8ade-fd56c0a334c5">
+                    <semantic:inputEntry id="_acf40b4c-d68c-49d6-a2a4-2a88ace33016">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ce80bf8c-6cad-400b-8b18-23c920d6f594">
+                        <semantic:text>&lt; 80</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_44ea4ff9-e85c-40b6-b1a8-c9a76b1ae13e">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_a297a507-5206-4903-94f6-9b6fd6619195">
+                    <semantic:inputEntry id="_9a3f8732-e85f-4111-a3f1-2284065f64fe">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7d398c94-e4c1-4d9c-bf06-cf40f2c04d64">
+                        <semantic:text>[80..90)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f54b6b94-ec25-451d-8d7d-1049155b3e2b">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_740e7ddb-0834-4705-bbb3-7b092e9570dc">
+                    <semantic:inputEntry id="_7fe40ffd-bd8e-4405-8719-0bd706933fd5">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4b77407a-565f-40ad-b324-6e3940134518">
+                        <semantic:text>[90..110]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_894b1284-9923-4727-bbc4-fc621b47a28b">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_95fb462f-6435-44b7-8c21-84427ce71bc9">
+                    <semantic:inputEntry id="_3e033f1d-a632-41d4-9eb9-63d66e5e4380">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_753f756e-cdee-49d2-8953-dfad7aa9b092">
+                        <semantic:text>&gt; 110</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_2fb8f713-e746-4a65-aff0-fa1de216f57a">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decision id="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" name="Application risk score" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application Risk Score&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Application&amp;nbsp;&lt;/span&gt;risk score model business knowledge model, passing Applicant data.Age as the Age parameter, Applicant data.MaritalStatus as the Marital Status parameter and Applicant data.EmploymentStatus as the Employment Status parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>What is the risk score for this applicant?</semantic:question>
+        <semantic:allowedAnswers>A number greater than 70 and less than 150</semantic:allowedAnswers>
+        <semantic:variable name="Application risk score" id="_f2abe78f-d5d0-4b9e-8d05-f1ea2bd7fc9b" typeRef="number"/>
+        <semantic:informationRequirement id="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_c94de723-def1-49e4-9aae-5270fe39630f">
+            <semantic:requiredKnowledge href="#_e9e07f04-0ff2-40c4-bd14-e5f06a91f942"/>
+        </semantic:knowledgeRequirement>
+        <semantic:impactedPerformanceIndicator href="#_0519e753-66a5-43cd-ad04-caf4de93b7f0"/>
+        <semantic:decisionOwner href="#_b6554413-30ba-4320-be7f-98efdf73ea08"/>
+        <semantic:invocation id="_348139f6-7fd0-40be-952d-66a8bb83d59c" typeRef="number" triso:expressionId="_954ca6de-2248-404d-8c85-7d620a39330b">
+            <semantic:literalExpression id="literal__348139f6-7fd0-40be-952d-66a8bb83d59c">
+                <semantic:text>Application risk score model</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_aba556aa-0e5b-4d01-bd6e-d25b780bbf28" name="Age"/>
+                <semantic:literalExpression id="_9c3009af-9a1b-4821-8901-7edf800ac60b">
+                    <semantic:text>Applicant data.Age</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_259966f2-bf40-4139-b587-6c9b989f1aa0" name="Marital Status"/>
+                <semantic:literalExpression id="_610941db-8c4e-483c-9d75-789b3d5c2333">
+                    <semantic:text>Applicant data.MartitalStatus</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_dc6d2bc7-3bde-4994-838d-b3fa1fe1ab2c" name="Employment Status"/>
+                <semantic:literalExpression id="_c08280b8-beb0-4eb1-a0d0-f022de521d25">
+                    <semantic:text>Applicant data.EmploymentStatus</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:knowledgeSource id="_821a6840-e910-418f-809e-4c7d60b0b21a" name="Credit risk analytics">
+        <semantic:description>&lt;p&gt;Credit risk scorecard analysis to determine the relevant factors for application risk scoring&lt;/p&gt;</semantic:description>
+        <semantic:authorityRequirement id="_7891c386-9a9f-43e8-92e2-a41c8500ff12">
+            <semantic:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        </semantic:authorityRequirement>
+        <semantic:authorityRequirement id="_dc1087cb-ba0c-4c8a-9a3a-a318d966ab58">
+            <semantic:requiredInput href="#_2240bb79-1848-4b49-ac1b-8cf7db432770"/>
+        </semantic:authorityRequirement>
+        <semantic:authorityRequirement id="_e154a8ca-866b-42d2-aae0-226fc994789f">
+            <semantic:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
+        </semantic:authorityRequirement>
+        <semantic:type>Analytic Insight</semantic:type>
+        <semantic:owner href="#_b6554413-30ba-4320-be7f-98efdf73ea08"/>
+    </semantic:knowledgeSource>
+    <semantic:businessKnowledgeModel id="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" name="Application risk score model">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table&amp;nbsp;&lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Application risk score model" id="_645f4911-6a95-4dbd-8efb-13fac8154fa2" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number" triso:expressionId="_2385cee1-8ce7-4ccb-b75d-b233362e2054">
+            <semantic:formalParameter name="Age" typeRef="number"/>
+            <semantic:formalParameter name="Marital Status" typeRef="string"/>
+            <semantic:formalParameter name="Employment Status" typeRef="string"/>
+            <semantic:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM">
+                <semantic:input id="_09b90043-cccb-4cf7-b8bc-44e97787443f">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Age</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="simple">
+                        <semantic:text>[18..120]</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_803f1aa0-731a-4541-bfba-6211a564af69">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Marital Status</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"S","M"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_e32f7b2c-5837-4e18-acea-a100115f412d">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Employment Status</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"UNEMPLOYED","STUDENT","EMPLOYED","SELF-EMPLOYED"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_e7b50872-4ad3-496a-ac06-15dc98c9d526"/>
+                <semantic:annotation/>
+                <semantic:rule id="_cd986c20-a58b-413e-96c3-37d2f48fe361">
+                    <semantic:inputEntry id="_b5fa1bbc-0cc3-462c-b978-429e932a83ab">
+                        <semantic:text>[18..22)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_43189918-aecd-4713-8e23-231b35b299d7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f8be0751-2823-46d8-8007-c4fb601fcba8">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_dab1ccbe-edc2-4cc2-9167-1d452b4ad0c2">
+                        <semantic:text>32</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_271d1521-3fb9-4b1d-a74d-0abf1c131186">
+                    <semantic:inputEntry id="_57a0f913-e95b-4941-b868-e306d484f045">
+                        <semantic:text>[22..26)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_23b572c3-9c6f-4e17-8bdb-95fd58f404d5">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_85a87989-40c4-4027-b674-6d21b6d5bb64">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_8f6c2458-a000-4d1f-b6a1-a553f8b3c4db">
+                        <semantic:text>35</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_558f8923-cd42-484a-b6b0-7cb28bfa7480">
+                    <semantic:inputEntry id="_795dc738-ca79-4c60-9746-e44bc1b34663">
+                        <semantic:text>[26..36)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_8492546f-c66a-46e5-9e86-9b0a79ec99d6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2efe9985-1475-426d-abb3-760fed744a14">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_7146afbc-d68f-415d-9abf-da3ad5a87527">
+                        <semantic:text>40</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_389ee4a2-47d3-42fc-ad04-e8798d638d33">
+                    <semantic:inputEntry id="_cf08fa6c-084d-4f2c-ae60-aa0abb5d7b2a">
+                        <semantic:text>[36..50)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7b81f517-a79a-4213-b74b-4cf01ee9a7c3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1101bb57-178a-4c25-9d79-7759553e9d7d">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_10c870e9-f72d-45f0-bcfd-bc6bcc0d2315">
+                        <semantic:text>43</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_8c355a92-0f8b-4d41-ada2-b98b05237249">
+                    <semantic:inputEntry id="_c28cca26-4eda-4d37-a056-15b23eec9690">
+                        <semantic:text>&gt;=50</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_29ab6240-13dd-478f-ac73-0805778efe30">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_3ddc0313-cd5b-40f3-8858-87a384ee1f23">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_c2fe72a6-2591-413b-b4e8-a73a3fca33bc">
+                        <semantic:text>48</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ffdf62cd-9909-4dd0-a15e-19fcb5a5ce6f">
+                    <semantic:inputEntry id="_90065ca5-703d-4b29-9924-c949f210683e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_5167d8a0-f82c-4f9b-b948-94ee8ef9b753">
+                        <semantic:text>"S"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d9f2e10b-80c2-4f8e-af9b-83d3317e14b9">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f1dd8303-3db4-4fe2-879c-fd5b0ecd970d">
+                        <semantic:text>25</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_cf192d51-2d52-4280-a41f-4941f1611b60">
+                    <semantic:inputEntry id="_b1e8abb2-ecee-4fdf-8d75-a292d8bf8b0f">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_35f4590a-63a0-4a46-a875-9b37b6e8ada2">
+                        <semantic:text>"M"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e50ee6a1-78bc-4ee0-8030-6f9654057e9a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f36c68f8-b188-4675-bb7b-ea5347a08fff">
+                        <semantic:text>45</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_90b8f62c-6ca6-4234-97c4-4de2011374b9">
+                    <semantic:inputEntry id="_a1de40fe-8951-4ecb-bfc7-516a2d77bf55">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_63f774ad-98ab-44e6-8ebf-83a00437e7d6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_9e4a3948-ec86-4987-a80d-2f0bc9c63530">
+                        <semantic:text>"UNEMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3f14a6c0-3829-41c2-a57c-154574752788">
+                        <semantic:text>15</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_bc447e0a-a445-4029-804b-138b76a766ef">
+                    <semantic:inputEntry id="_9196a27c-a829-43d7-b973-73bf13915ec3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1d672363-4080-4dd8-82cd-d30ff16d4383">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_28ca5667-24ac-4c8c-8557-ede60e51b461">
+                        <semantic:text>"STUDENT"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_90a363e8-d80d-4d78-9e33-2be7cbb9fd05">
+                        <semantic:text>18</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_5651d55b-18a5-4ff4-bc28-30ce10385a2d">
+                    <semantic:inputEntry id="_93400b3b-bdda-4370-878b-e221bf8521c6">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_df5d20cf-6971-4911-832f-683d2a790c11">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_a0b06347-1422-4b9d-bdd0-ede06b7e5d0b">
+                        <semantic:text>"EMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_78582066-9c90-4b16-88a3-1709b784a4ff">
+                        <semantic:text>45</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_07c9f995-1814-4a77-9ab1-f03c21337165">
+                    <semantic:inputEntry id="_b377eba2-90f6-4913-8a84-e0e358cb4ae5">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_c515456a-3519-4446-aeaa-6f3f613a8812">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6d9fc071-2870-4397-83de-802aa5f398a5">
+                        <semantic:text>"SELF-EMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_233be7af-2d3f-4b9c-bb69-561f8378e870">
+                        <semantic:text>36</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text/>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+            <semantic:requiredAuthority href="#_821a6840-e910-418f-809e-4c7d60b0b21a"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:inputData id="_d14df033-f4a2-47e3-9590-84e9ff04db4e" name="Applicant data">
+        <semantic:description>&lt;p&gt;Information about the applicant including personal information, marital status and household income/expenses.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Applicant data" id="_76597f43-a435-4d85-bc82-98007b9e0d1d" typeRef="tApplicantData"/>
+    </semantic:inputData>
+    <semantic:decision id="_3c8cee68-99dd-418c-847d-0b54697354f2" name="Required monthly installment" triso:useOutputTypeAsAnswer="false">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Required monthly installment&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Installment calculation business knowledge model, passing Requested product.ProductType as the Product Type parameter, Requested product.Rate as the Rate parameter, Requested product.Term as the Term parameter, and Requested product.Amount as the Amount parameter.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:question>What is the minimum monthly installment payment required for this loan product?</semantic:question>
+        <semantic:allowedAnswers>A dollar amount greater than zero</semantic:allowedAnswers>
+        <semantic:variable name="Required monthly installment" id="_f581169e-828d-45cd-9af5-e401eebc8f27" typeRef="number"/>
+        <semantic:informationRequirement id="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <semantic:requiredInput href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+            <semantic:requiredKnowledge href="#_7235d875-2426-4869-b6df-92ca06ae80c5"/>
+        </semantic:knowledgeRequirement>
+        <semantic:decisionOwner href="#_2fb957d8-e426-49a0-a6d2-67c26a40560b"/>
+        <semantic:invocation id="_2cc659df-0249-417c-8074-d3a375c6b5f5" typeRef="number" triso:expressionId="_9530fe45-acf2-49a5-8232-b9613375ed18">
+            <semantic:literalExpression id="literal__2cc659df-0249-417c-8074-d3a375c6b5f5">
+                <semantic:text>Installment calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_fa5953c6-c8f2-449e-ac2b-4bc04cb000c2" name="Product Type"/>
+                <semantic:literalExpression id="_87dccb4c-d416-42ca-9c72-a0b591b4ba88">
+                    <semantic:text>Requested product.ProductType</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_78623557-831b-47e4-81fe-349a0743fc5a" name="Rate"/>
+                <semantic:literalExpression id="_3ba44309-b466-42d8-8126-bb2ef2d0544e">
+                    <semantic:text>Requested product.Rate</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_48ac3dfb-dc98-420f-b051-2a9a3035e5f3" name="Term"/>
+                <semantic:literalExpression id="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce">
+                    <semantic:text>Requested product.Term</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_a8c6ca38-2e6c-42cb-8d5d-2e40469a4e4a" name="Amount"/>
+                <semantic:literalExpression id="_df160506-5551-4fe3-bf04-1fcb462bcaec">
+                    <semantic:text>Requested product.Amount</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:inputData id="_fe938494-ee59-425e-8728-2347ea703563" name="Requested product">
+        <semantic:description>&lt;p&gt;Details of the loan the applicant has applied for.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Requested product" id="_480bcfd2-2643-4d1c-852b-3034dfa62790" typeRef="tRequestedProduct"/>
+    </semantic:inputData>
+    <semantic:businessKnowledgeModel id="_7235d875-2426-4869-b6df-92ca06ae80c5" name="Installment calculation">
+        <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment&amp;nbsp;&lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Installment calculation" id="_c02274e9-a6c8-4498-9d43-eaa33be7a0d9" typeRef="number"/>
+        <semantic:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL" typeRef="number" triso:expressionId="_d246e55f-0397-487d-925a-853e41d17f07">
+            <semantic:formalParameter name="Product Type" typeRef="string" id="_f6831cd9-3eab-4399-8d29-42b141fd9968"/>
+            <semantic:formalParameter name="Rate" typeRef="number" id="_c6f48aeb-b65d-4307-8722-dd44f7335566"/>
+            <semantic:formalParameter name="Term" typeRef="number" id="_708eb9af-fe19-418c-8547-1647cb50f596"/>
+            <semantic:formalParameter name="Amount" typeRef="number" id="_fddc99bb-3be6-45b0-bf8c-d8d4c016a90b"/>
+            <semantic:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4">
+                <semantic:contextEntry id="_d773da17-a45c-4a3b-8b70-565058cb6e1d">
+                    <semantic:variable name="Monthly Fee" id="_2db6ada1-2a67-4c84-bb31-e78178cf6b32" typeRef="number"/>
+                    <semantic:literalExpression id="_ad1e4499-e806-42f1-8069-254e98f5d498">
+                        <semantic:text>if Product Type = "STANDARD LOAN"
+then 20.00
+else if Product Type = "SPECIAL LOAN"
+then 25.00
+else null</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_f4156a0c-ea28-475d-8025-9e209280bd2c">
+                    <semantic:variable name="Monthly Repayment" id="_594996b3-1aea-4557-bf8e-f3bc91470fee" typeRef="number"/>
+                    <semantic:literalExpression id="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3">
+                        <semantic:text>Financial.PMT(Rate, Term, Amount)</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_cebe4ac7-7aa7-4ef9-ae70-b6caf6cbb593">
+                    <semantic:literalExpression id="_f6293695-dc2e-4e16-9dc7-1595423f0f91">
+                        <semantic:text>Monthly Repayment + Monthly Fee</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+            </semantic:context>
+        </semantic:encapsulatedLogic>
+        <semantic:knowledgeRequirement id="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+            <semantic:requiredKnowledge href="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514#_a30c75ec-7d81-4606-802c-b31ea308392d"/>
+        </semantic:knowledgeRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:decisionService id="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" name="Bureau Strategy Decision Service">
+        <semantic:variable name="Bureau Strategy Decision Service" id="_81ad8660-56e2-40b3-be19-1c9349367081" typeRef="Any"/>
+        <semantic:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:outputDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_4d91e3a5-acec-4254-81e4-8535a1d336ee" name="Routing Decision Service">
+        <semantic:variable name="Routing Decision Service" id="_23c674f4-a331-472c-b32d-246ad6d5f51d" typeRef="Any"/>
+        <semantic:outputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+        <semantic:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+        <semantic:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
+        <semantic:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
+        <semantic:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
+    </semantic:decisionService>
+    <semantic:inputData id="_2240bb79-1848-4b49-ac1b-8cf7db432770" name="Loan default data">
+        <semantic:description>&lt;p&gt;Information about historical loan defaults.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Loan default data" id="_4b912c7d-9f4c-4475-a2e1-1a090f9a1abf" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:textAnnotation id="_f319ab16-ff1a-4629-93b3-c48a7613d874">
+        <semantic:text>The credit risk scorecard is built from past applicants' data and information about those loans that defaulted. It must conform to the overall risk management strategy.</semantic:text>
+    </semantic:textAnnotation>
+    <semantic:organizationUnit id="_036e1231-d563-4c1c-8a68-6b89df81d7c0" name="Credit officers">
+        <semantic:description>&lt;p&gt;Individuals in the Retail Banking organization responsible for manual adjudication of loans.&lt;/p&gt;</semantic:description>
+        <semantic:decisionMade href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+    </semantic:organizationUnit>
+    <semantic:organizationUnit id="_2fb957d8-e426-49a0-a6d2-67c26a40560b" name="Product management">
+        <semantic:description>&lt;p&gt;Organization responsible for defining loan and other banking products, how those products are priced, sold and tracked for profitability.&lt;/p&gt;</semantic:description>
+        <semantic:decisionOwned href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
+        <semantic:decisionOwned href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
+        <semantic:decisionOwned href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
+    </semantic:organizationUnit>
+    <semantic:organizationUnit id="_6a80329f-9577-4497-aca3-67bf5aa41a7a" name="Credit risk">
+        <semantic:description>&lt;p&gt;Organization within the bank responsible for defining credit risk strategies and policies and providing tools for managing against these.&lt;/p&gt;</semantic:description>
+        <semantic:decisionOwned href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:decisionOwned href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:decisionOwned href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:decisionOwned href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
+        <semantic:decisionOwned href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+        <semantic:decisionOwned href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
+        <semantic:decisionOwned href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
+    </semantic:organizationUnit>
+    <semantic:organizationUnit id="_b6554413-30ba-4320-be7f-98efdf73ea08" name="Credit risk analytics group">
+        <semantic:description>&lt;p&gt;Organization responsible for credit risk models and the use of data to predict credit risk for customers and loan applicants.&lt;/p&gt;</semantic:description>
+        <semantic:decisionOwned href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+    </semantic:organizationUnit>
+    <semantic:performanceIndicator id="_4d7ae526-d994-4ea2-9f26-81b9c693a45a" name="Monthly loan accept rate">
+        <semantic:description>&lt;p&gt;The percentage of loans accepted in a calendar month.&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_3a51a3c5-06f5-471f-88ef-8a3ea99b0d49" name="Monthly auto-adjudication rate">
+        <semantic:description>&lt;p&gt;The percentage of loans that did not require a credit officer to review the case in a calendar month.&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_18c16494-3da7-42d8-8a7d-599b158dd840" name="Monthly value of loans written">
+        <semantic:description>&lt;p&gt;The total value of Loans written in a calendar month&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_4bd33d4a-741b-444a-968b-64e1841211e7"/>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_96b30012-a6e7-4545-89d3-068ec722469c" name="Auto-adjudication rate 90%">
+        <semantic:description>&lt;p&gt;By end of the current year, have an auto-adjudication rate of at least 90 percent&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
+        <semantic:impactingDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
+    </semantic:performanceIndicator>
+    <semantic:performanceIndicator id="_0519e753-66a5-43cd-ad04-caf4de93b7f0" name="Monthly bureau costs">
+        <semantic:description>&lt;p&gt;The total cost charged by the bureau for all Bureau Data requested while originating Loans in a calendar month.&lt;/p&gt;</semantic:description>
+        <semantic:impactingDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
+        <semantic:impactingDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
+    </semantic:performanceIndicator>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_ce4a4c00-c3a3-46a6-8938-055239f6b326" triso:modelElementRef="_ce4a4c00-c3a3-46a6-8938-055239f6b326" name="DRD of all automated decision-making">
+            <di:extension/>
+            <dmndi:Size height="1050.9786834716797" width="1411.2411708831787"/>
+            <dmndi:DMNShape id="_71b16a12-bf83-47a5-ad8b-68c0d302beec" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7">
+                <dc:Bounds x="1069" y="54.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_679112c3-6972-441f-b33c-04fac539b373" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762">
+                <dc:Bounds x="893.5" y="50" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="899" y="58.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_05c030a4-e19b-45d0-991a-864c3590cb59" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847">
+                <dc:Bounds x="1225.7588291168213" y="262.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_446c9f43-6c05-4bb6-b256-9f9a7c15bddb" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276">
+                <dc:Bounds x="177" y="262.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d29344c2-6e50-4b8c-a5b3-a40ffea37690" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf">
+                <dc:Bounds x="277" y="142.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_11d165e6-b609-483c-a6c8-3b29d0f57007" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3">
+                <dc:Bounds x="374" y="262.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d9aca572-c374-446b-858b-cb4ab805e3e8" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447">
+                <dc:Bounds x="591.5" y="263.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_5d3ed3ec-3569-4871-80a0-ca6463ff4822" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032">
+                <dc:Bounds x="721.5" y="150" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a1b2549e-ebfd-48f9-9eb9-26cf2a633197" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535">
+                <dc:Bounds x="810.5" y="263.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c52f4be2-14a9-492d-b43c-414509221ef1" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="1024" y="262.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ce794d2d-6915-4449-94f3-6c696f13735f" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6">
+                <dc:Bounds x="88.5" y="370.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_740df4b9-aae6-48c2-a043-2afd5c49f652" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="50" y="476.4786796569824" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1a770b99-fccb-4815-89f9-81f5e095745e" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982">
+                <dc:Bounds x="567" y="365" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3c91f051-3f67-4cc8-b264-1a2cc439a21f" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e">
+                <dc:Bounds x="789" y="365" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b1693c26-379c-4de0-b67e-bea8432e6952" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5">
+                <dc:Bounds x="695.5" y="476.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4f00c139-48a7-4bb4-8e10-972ce790bbd9" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838">
+                <dc:Bounds x="494.5" y="475.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_22d6f112-9f15-4326-8412-6db0a794275e" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474">
+                <dc:Bounds x="918.5" y="475.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_e1b06a01-5f9e-4212-8814-019fbcf06122" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec">
+                <dc:Bounds x="1024" y="587.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_68899272-8eb1-48e2-815e-707a9ecd8083" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="1225.7588291168213" y="715.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a82d0133-35e7-43d1-a642-60caa2d04b90" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df">
+                <dc:Bounds x="1024.5" y="716.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_662479c8-e054-4e52-9db4-6ef922c56c39" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0">
+                <dc:Bounds x="277" y="587.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3fd27363-f5e5-4374-93c8-7067576ed30b" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266">
+                <dc:Bounds x="138" y="716.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_343c2b83-2e04-4f08-8dfa-dac81d2b0331" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="277" y="822.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9152652c-9f2a-4b64-9ff3-f136cb69dbe7" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="50" y="818" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c98a40a9-1e93-4fe0-96db-719739d88bbe" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="138" y="941.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_99a17d09-ffa6-4b9f-be2b-4506aaf73b34" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="503.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_317dd163-3d23-4ea3-b027-8ce87da1cad1" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="840.5" y="822.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_96ac6a43-4e04-4ceb-be85-89ffd1dc3006" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="736.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_254ffe68-6cd4-432e-bc44-2de5252d947f" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5">
+                <dc:Bounds x="945" y="941.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_43001462-46a2-4d67-9f54-eb8381decbf6" dmnElementRef="include1:_a30c75ec-7d81-4606-802c-b31ea308392d">
+                <dc:Bounds x="1173" y="941.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_1" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16" width="94" x="1201" y="962.4786796569824"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_ff5e52a4-5bea-448c-bd90-bda28eec9323" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+                <di:waypoint x="993.5" y="84.5"/>
+                <di:waypoint x="1069" y="84.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_92d9b87b-d396-448f-a004-349cf0ca6f45" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+                <di:waypoint x="1293.4968013763428" y="262.97867584228516"/>
+                <di:waypoint x="1195.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_8ddc01e9-ef2c-4f20-a070-e0a9b45c47b9" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+                <di:waypoint x="962.5" y="292.4786796569824"/>
+                <di:waypoint x="1024" y="292.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_06486f6d-6994-41ef-a8db-81770fc7e9b7" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+                <di:waypoint x="1100.5" y="262.9786796569824"/>
+                <di:waypoint x="1135.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_21562fd6-873a-4e83-b8cc-a16df4057da6" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+                <di:waypoint x="784" y="203"/>
+                <di:waypoint x="885.5" y="263.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_c4a7713d-e0d0-4764-bae8-e63f3537b42a" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+                <di:waypoint x="734" y="217"/>
+                <di:waypoint x="666.5" y="263.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_79cc7227-2172-46cd-8376-e6db749153ef" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+                <di:waypoint x="253.5" y="262.9786796569824"/>
+                <di:waypoint x="323.5" y="202.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f7b69077-9a1f-439b-ba5c-c5ddd7e9dea9" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+                <di:waypoint x="440.5" y="262.9786796569824"/>
+                <di:waypoint x="373.5" y="202.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_90f39c58-82a0-405e-ad2f-9c6f8ffa5bdd" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+                <di:waypoint x="591.5" y="292.4786796569824"/>
+                <di:waypoint x="527" y="292.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7987705d-5788-4ff1-9497-819e523b8ac1" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+                <di:waypoint x="692" y="424"/>
+                <di:waypoint x="740.5" y="476.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_57295a64-8277-4df4-9054-5c99cbd13b9c" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+                <di:waypoint x="826.5" y="432"/>
+                <di:waypoint x="800.5" y="476.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1a9b2354-b389-47d9-8d38-a81e2da67f46" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+                <di:waypoint x="173.5" y="370.4786796569824"/>
+                <di:waypoint x="223.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_810cbec7-bd9e-4d9b-898c-47161d5162cf" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+                <di:waypoint x="333.5" y="587.9786796569824"/>
+                <di:waypoint x="253.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_97a3b1e2-1eba-4a28-9812-358358f94d0b" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+                <di:waypoint x="100" y="476.4786796569824"/>
+                <di:waypoint x="153.5" y="429.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_788d6f7c-bbfa-4040-bd8d-e401f65f3fe0" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+                <di:waypoint x="353.5" y="587.9786796569824"/>
+                <di:waypoint x="440.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3b1a8ae8-d120-454c-8607-e0893ef2d352" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+                <di:waypoint x="383.5" y="587.9786796569824"/>
+                <di:waypoint x="531" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b9c4734a-bf1e-4873-91fb-17603b453dda" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+                <di:waypoint x="150" y="490.9786796569824"/>
+                <di:waypoint x="567" y="394"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_19f3493f-378f-4b01-9e8f-6c947e2a1c92" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+                <di:waypoint x="847.5" y="505.4786796569824"/>
+                <di:waypoint x="918.5" y="505.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_79b6d42a-a88d-4bbe-af92-7eb43530f212" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+                <di:waypoint x="695.5" y="505.4786796569824"/>
+                <di:waypoint x="647.5" y="505.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7d9886a9-b720-449b-a9ee-b9ff19214215" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+                <di:waypoint x="995" y="475.9786796569824"/>
+                <di:waypoint x="1080.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7a184012-35d0-4ccd-bab4-75b682532e75" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+                <di:waypoint x="1100.5" y="587.9786796569824"/>
+                <di:waypoint x="1100.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_28f25ecb-1438-4c3f-b479-409dc62e8ea3" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+                <di:waypoint x="1293.4968013763428" y="715.9786758422852"/>
+                <di:waypoint x="1155.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0592b263-628a-4188-84fa-ebcb5db3f7ae" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+                <di:waypoint x="590.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="1105.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_dd46ade9-b5f3-4c69-be62-2fba4d2ccad3" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+                <di:waypoint x="1099.5" y="716.4786796569824"/>
+                <di:waypoint x="1100.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1e2df774-a85d-47d3-9b69-e9b658a5c7de" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+                <di:waypoint x="1263.4968013763428" y="715.9786758422852"/>
+                <di:waypoint x="1140.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_98bf15a8-c171-408c-8640-7ef2614ff482" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+                <di:waypoint x="1283.4968013763428" y="715.9786758422852"/>
+                <di:waypoint x="1120.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_10c5c589-256f-4a8b-a30d-94d4f77112a6" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+                <di:waypoint x="570.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="571" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b02f656c-ac89-403c-940b-5e737be2b638" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="813.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="887" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d5609aac-93d8-466d-955a-9c322f903260" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+                <di:waypoint x="1010" y="941.4786796569824"/>
+                <di:waypoint x="937" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b8b060fc-0deb-4079-8d6b-b93daf1133bc" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+                <di:waypoint x="1090.5" y="587.9786796569824"/>
+                <di:waypoint x="995" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0e6ee14b-6806-4593-b398-efc4da3e1feb" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+                <di:waypoint x="927" y="822.9786796569824"/>
+                <di:waypoint x="985" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_fc769965-b6c4-4f77-9d11-33ff625cf58a" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+                <di:waypoint x="610.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="965" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_44deed7d-0ca8-4e9c-a972-7f4e8397e064" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+                <di:waypoint x="632.4968013763428" y="950.9786758422852"/>
+                <di:waypoint x="1060.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2465cbb3-0279-4117-9a10-27172b9c3a28" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+                <di:waypoint x="87.5" y="543.4786796569824"/>
+                <di:waypoint x="146.5" y="724.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_54e9b93b-7633-4983-9150-232a3565b0a3" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+                <di:waypoint x="213" y="716.4786796569824"/>
+                <di:waypoint x="313.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e0f5f874-01e6-4730-8f0b-61376728eb86" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="87.5" y="885"/>
+                <di:waypoint x="138" y="980.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b14c232b-e4ea-41aa-9f67-6413c8423675" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+                <di:waypoint x="223" y="941.4786796569824"/>
+                <di:waypoint x="323.5" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2cafac50-1bf7-4841-bb88-7eb1400af07a" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="510.4968013763428" y="950.9786758422852"/>
+                <di:waypoint x="403.5" y="882.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d8760f3a-1108-4efd-ba5f-2bdf21f90a81" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+                <di:waypoint x="530.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="373.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_097af913-509c-4cd8-bdd6-45fce884bbab" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+                <di:waypoint x="353.5" y="822.9786796569824"/>
+                <di:waypoint x="353.5" y="647.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2819cfea-477d-4652-8ebf-4c90456ccef1" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+                <di:waypoint x="150" y="510.9786796569824"/>
+                <di:waypoint x="1024.5" y="735.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0093086e-95dc-4ba9-9edb-2e249d1cf967" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+                <di:waypoint x="907" y="822.9786796569824"/>
+                <di:waypoint x="601" y="535.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_972a19bf-350a-47be-8afe-74540f14a4d0" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+                <di:waypoint x="550.9968013763428" y="940.9786758422852"/>
+                <di:waypoint x="450.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_71fe7cd9-0e0d-4a6a-989f-3842a965bb64" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+                <di:waypoint x="571" y="475.9786796569824"/>
+                <di:waypoint x="460.5" y="322.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a770742b-4ff3-40a5-95be-92d8d9e470f0" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+                <di:waypoint x="430" y="842.9786796569824"/>
+                <di:waypoint x="1024" y="617.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2de39711-33bb-4aad-94be-036606811a00" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+                <di:waypoint x="1173" y="970.4786796569824"/>
+                <di:waypoint x="1097" y="970.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262" triso:modelElementRef="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262" name="DRD for Decide bureau strategy decision point">
+            <di:extension/>
+            <dmndi:Size height="978.5" width="979.8080854415894"/>
+            <dmndi:DMNShape id="_80a2a8fd-9bc7-49cb-8b91-bea566d2324b" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="594" y="740.9999923706055" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_119017a3-7e0d-4324-800f-3e088e498c75" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="698.2411708831787" y="622.9999961853027" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3b1d8f15-d493-4fa9-bcfb-42fcbd6a7287" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="513.7588291168213" y="856.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_68dc56c3-7930-4816-b843-089a9de5c1a6" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="148.5" y="857.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9f98c1ca-1354-49dc-95a7-c5dd85cac42d" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="29.5" y="736.0213203430176" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="35" y="744.3681896596715"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_0f1008a0-ae96-4e27-aa5d-b3bc11c05fac" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="275.5" y="741" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_191faa22-22f9-4c0e-a7d7-b16b8a44d560" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266">
+                <dc:Bounds x="148.5" y="623.4999961853027" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3ee31f31-9681-4389-8bfa-4a3643ee85db" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0">
+                <dc:Bounds x="287.5" y="532" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6943ac13-5ec7-47f5-a93e-00df738f8362" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838">
+                <dc:Bounds x="505" y="383" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_cec4eba7-8505-4ef2-ab1f-a6b997f4d43e" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5">
+                <dc:Bounds x="706" y="383.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_65f0b61c-ece5-4d43-9fb0-57288f3900c3" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e">
+                <dc:Bounds x="799.5" y="272.0213203430176" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="805" y="280.3681896596715"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_0cc08173-136b-42d3-9fa1-09c690920b37" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982">
+                <dc:Bounds x="572.5" y="290.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c1903235-a689-4c6c-9dcc-479e982b57d8" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="29.5" y="417.0213203430176" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="89" x="35" y="416.3681896596715"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6d63627c-90c4-49fd-9230-c3eb47926594" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6">
+                <dc:Bounds x="89" y="290.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4a8fd722-4d10-4234-b2d2-e8408a4e65fa" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032">
+                <dc:Bounds x="732" y="57.02132034301758" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="737.5" y="65.36818965967151"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_641f3b03-7f81-468a-b326-e89b881e9c9b" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447">
+                <dc:Bounds x="602" y="170.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7076cd45-5bf9-47a2-9fed-6df474257bfb" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3">
+                <dc:Bounds x="384.5" y="170" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_fe28b5fd-85bb-4254-a3a3-22f5feff055e" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf">
+                <dc:Bounds x="287.5" y="50" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d3099e88-e780-4a4f-affc-c8169158a5e8" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276">
+                <dc:Bounds x="187.5" y="170" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_326709ad-71e2-4e73-ace4-0cc197b3f536" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5">
+                <dc:Bounds x="777.8080854415894" y="741.4999961853027" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_bd1b4da0-c300-467c-bc4d-f3876dac57b9" dmnElementRef="include1:_a30c75ec-7d81-4606-802c-b31ea308392d">
+                <dc:Bounds x="777.8080854415894" y="856.4999961853027" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_1" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16" width="94" x="805.8080854415894" y="877.4999961853027"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_9af973d8-43d2-4c7e-a1b8-073379713699" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+                <di:waypoint x="581.5" y="383"/>
+                <di:waypoint x="471" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_df0420fd-e9e5-4e41-935a-16ef8dc7e88c" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+                <di:waypoint x="551.4968013763428" y="856.9999961853027"/>
+                <di:waypoint x="461" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_91bbd80d-6ea4-41e2-883f-2e8acf5ba7a5" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+                <di:waypoint x="764.7411708831787" y="622.9999961853027"/>
+                <di:waypoint x="611.5" y="443"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3d004781-db04-4465-8cfb-302ea51eb8d1" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+                <di:waypoint x="352" y="741"/>
+                <di:waypoint x="354" y="592"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a2dad098-4b9a-4131-8a0c-1be284eb0539" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+                <di:waypoint x="541.4968013763428" y="856.9999961853027"/>
+                <di:waypoint x="384" y="592"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2880c9ff-4f28-421e-8fae-34b89b06c204" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="520.9968013763428" y="866.9999961853027"/>
+                <di:waypoint x="402" y="801"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_024c0689-9ed4-491b-a2e1-2d02b7d42383" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+                <di:waypoint x="233.5" y="857.5"/>
+                <di:waypoint x="322" y="801"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_39fbc611-0e1b-4af1-883b-aa77e1e2061f" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="67" y="803.0213203430176"/>
+                <di:waypoint x="148.5" y="886.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_8f610d6c-98f2-45b3-85f6-312ff212bc7b" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+                <di:waypoint x="223.5" y="623.4999961853027"/>
+                <di:waypoint x="324" y="592"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_bd8e70ee-0662-4e8a-8f9a-a7ebf404a46b" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+                <di:waypoint x="67" y="484.0213203430176"/>
+                <di:waypoint x="148.5" y="662.4999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_cb7eaa51-8619-48c6-a0d6-3b10f40a1eac" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+                <di:waypoint x="852.8080854415894" y="741.4999961853027"/>
+                <di:waypoint x="794.7411708831787" y="682.9999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2533deda-855f-48ba-8fdc-3675fb2df3ce" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="671.7379722595215" y="740.9999923706055"/>
+                <di:waypoint x="744.7411708831787" y="682.9999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e786b1f0-c3ef-4060-a3b7-eb16e0edf2ea" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+                <di:waypoint x="581.4968013763428" y="856.9999961853027"/>
+                <di:waypoint x="581.5" y="443"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_effc3ae5-2fca-402b-aece-4e9fa58f9812" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+                <di:waypoint x="706" y="412.5"/>
+                <di:waypoint x="658" y="413"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2d19fb5f-d272-4cd3-8297-6fb9740f4342" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+                <di:waypoint x="129.5" y="431.5213203430176"/>
+                <di:waypoint x="572.5" y="319.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ad0db5e4-a620-4a97-872f-a8c9289a538c" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+                <di:waypoint x="394" y="532"/>
+                <di:waypoint x="541.5" y="443"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_64bf8314-a651-4f52-a99e-e6457550ad59" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+                <di:waypoint x="364" y="532"/>
+                <di:waypoint x="451" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_20e13ac5-c830-4bd4-bce5-2ce61c3963a9" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+                <di:waypoint x="79.5" y="417.0213203430176"/>
+                <di:waypoint x="154" y="349.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_89190762-0fd1-4cf5-a43b-1b072a8640a0" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+                <di:waypoint x="344" y="532"/>
+                <di:waypoint x="264" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9b46cfcc-256b-4660-8763-36e297fb8800" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+                <di:waypoint x="174" y="290.5"/>
+                <di:waypoint x="234" y="230"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3cdffa98-f7e4-4ea3-a65f-2cfb83d58f2c" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+                <di:waypoint x="837" y="339.0213203430176"/>
+                <di:waypoint x="811" y="383.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b7a08e14-77cf-489c-bd66-df8e548beacf" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+                <di:waypoint x="697.5" y="349.5"/>
+                <di:waypoint x="751" y="383.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_93a83c4a-576a-47ec-bc9d-d8b0c1a95b97" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+                <di:waypoint x="602" y="199.5"/>
+                <di:waypoint x="537.5" y="200"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_16370eb0-b28e-481e-bb2b-ae0466659220" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+                <di:waypoint x="451" y="170"/>
+                <di:waypoint x="384" y="110"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9f4799aa-52da-4bc5-a5e3-8bd8e6ae0d78" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+                <di:waypoint x="264" y="170"/>
+                <di:waypoint x="334" y="110"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0cfb20a2-fd2a-4911-b754-bab4f138c1d6" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+                <di:waypoint x="744.5" y="124.02132034301758"/>
+                <di:waypoint x="677" y="170.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_94766029-ffee-43b9-a472-2a47cabd92d5" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+                <di:waypoint x="853.8080854415894" y="857.4999961853027"/>
+                <di:waypoint x="853.8080854415894" y="800.4999961853027"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_3275163a-921d-48f8-967a-21c4373b1197" triso:modelElementRef="_3275163a-921d-48f8-967a-21c4373b1197" name="DRD for Decide routing decision point">
+            <di:extension/>
+            <dmndi:Size height="768.4786834716797" width="1140.5"/>
+            <dmndi:DMNShape id="_7b4cf31d-6e5e-4654-9dc6-44fbaa21b105" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5">
+                <dc:Bounds x="338.2411708831787" y="658.9786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_8841d4b9-1fe6-4238-b473-9500efb152c9" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="129.5" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_e25734f2-0621-4de4-a551-7a2e3ff4b4e3" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="233.7411708831787" y="528.4786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7106a296-cf23-402e-ba5a-da68d3b2cbf6" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="542.7588291168213" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_85ca2722-c63d-4bee-b4a2-20865788790b" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="938.5" y="528.9786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c5b281c8-65f9-4170-8d91-bc4356eb0199" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="990.5" y="393" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="996" y="401.3468693166539"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_12e52af3-c2f4-4838-9312-77ae9d9367e2" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="716" y="528.4786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_cdf6ea09-1597-4ce6-baad-32bd9bfab22a" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df">
+                <dc:Bounds x="233.87058544158936" y="398.4786796569824" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3668effc-4c16-48eb-af14-8807dcae39ef" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="815.7588291168213" y="397.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_8bc5b940-7c9b-4ad4-ba19-3c8ca4fbfd15" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec">
+                <dc:Bounds x="598" y="397.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_644f0ba0-4030-4fe1-8719-e2a96687da4b" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474">
+                <dc:Bounds x="482.5" y="248.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b9c5cd5a-548c-4616-9969-1a9612959967" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5">
+                <dc:Bounds x="259.5" y="249.47867965698242" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_c9bf39d1-bbb8-4229-a138-bf899e6c35ba" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e">
+                <dc:Bounds x="363.87058544158936" y="142" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="369.37058544158936" y="150.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2dd25d60-5458-4699-91d3-61afb5bdc9f4" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982">
+                <dc:Bounds x="50" y="249.47867965698242" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7a72af18-3e24-42c0-9e88-782c7d298182" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="76" y="393" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="89" x="81.5" y="392.3468693166539"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_18491c1e-7e4f-4930-8e41-96fea4126b9f" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="598" y="54.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16.000000000000004" width="146" x="600.5064935064935" y="76.4868763782939"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_85bcfbfb-3697-42f8-86d5-e09f06265ceb" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535">
+                <dc:Bounds x="374.5" y="55.47867965698242" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_86c8b375-241a-422b-b7ee-0aa92acdf4f3" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032">
+                <dc:Bounds x="192.5" y="50" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="198" y="58.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_e70a052a-708c-4039-af18-6c7cc2c5cc0d" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+                <di:waypoint x="792.5" y="528.4786796569824"/>
+                <di:waypoint x="714.5" y="457.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9df5af62-acc5-4bd6-8bde-1844b9898b1a" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+                <di:waypoint x="176" y="427.5"/>
+                <di:waypoint x="233.87058544158936" y="427.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_bcc15c66-942e-444f-9622-0b46e4bb9452" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="620.4968013763428" y="658.4786758422852"/>
+                <di:waypoint x="792.5" y="588.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_75625c72-7057-4063-aad5-51c1b2fba93b" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+                <di:waypoint x="938.5" y="557.9786796569824"/>
+                <di:waypoint x="869" y="558.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0f4486ba-53a9-44b1-bfca-1c5ffb4cb6b3" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="1028" y="460"/>
+                <di:waypoint x="1023.5" y="528.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2c2611a4-223c-4066-a90a-e676fd9bcac8" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+                <di:waypoint x="610.4968013763428" y="658.4786758422852"/>
+                <di:waypoint x="664.5" y="457.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0a1d74e7-65e1-4e55-977a-cf3c6d3259fe" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+                <di:waypoint x="600.4968013763428" y="658.4786758422852"/>
+                <di:waypoint x="549" y="308.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_110dc4e7-e6f6-4ed3-a99f-5360386496e6" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+                <di:waypoint x="320.2411708831787" y="528.4786796569824"/>
+                <di:waypoint x="509" y="308.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2d5b24a8-4a8b-4e16-8b84-c0d4a8345335" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+                <di:waypoint x="664.5" y="397.9786796569824"/>
+                <di:waypoint x="609" y="308.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a5d92ccd-57bd-4b21-a415-caf534fe7e73" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+                <di:waypoint x="403.2411708831787" y="658.9786796569824"/>
+                <di:waypoint x="330.2411708831787" y="588.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7d743acb-874e-4b70-a1ed-fedf58bb3362" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="207.23797225952148" y="658.4786758422852"/>
+                <di:waypoint x="280.2411708831787" y="588.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_cd1178b0-dbee-4718-8393-227565d10f7d" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+                <di:waypoint x="873.4968013763428" y="397.97867584228516"/>
+                <di:waypoint x="694.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ca2d3a25-e73e-4416-9f52-cc2505773bf2" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+                <di:waypoint x="815.9968013763428" y="427.97867584228516"/>
+                <di:waypoint x="751" y="427.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ca70ee2f-e133-4214-b0ff-955d68df06f1" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+                <di:waypoint x="385.87058544158936" y="427.4786796569824"/>
+                <di:waypoint x="598" y="427.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f0f2802e-aea3-48ce-bec1-82ed35845063" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+                <di:waypoint x="674.5" y="397.9786796569824"/>
+                <di:waypoint x="674.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e817868c-79fa-4b31-8903-10b612c6470c" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+                <di:waypoint x="559" y="248.97867965698242"/>
+                <di:waypoint x="654.5" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1b100239-3889-4410-b03f-85577ad57026" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+                <di:waypoint x="411.5" y="278.4786796569824"/>
+                <di:waypoint x="482.5" y="278.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f83178d6-4e9d-4751-ad72-78932a93e2f7" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+                <di:waypoint x="126" y="393"/>
+                <di:waypoint x="126" y="308.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_91491d86-be6e-4b14-8795-dff66e50c320" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+                <di:waypoint x="401.37058544158936" y="209"/>
+                <di:waypoint x="364.5" y="249.47867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f3bd7301-1563-482b-89d7-8fdd2354f121" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+                <di:waypoint x="202" y="278.4786796569824"/>
+                <di:waypoint x="259.5" y="278.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_afc6bacd-7d75-4c22-9379-87dae05a7ec3" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+                <di:waypoint x="292.5" y="84.5"/>
+                <di:waypoint x="374.5" y="84.47867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_919da30d-975c-4b80-b974-5ce79d1f8c0a" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+                <di:waypoint x="526.5" y="84.47867965698242"/>
+                <di:waypoint x="598" y="84.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b" triso:modelElementRef="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b" name="DRD for Review application decision point">
+            <di:extension/>
+            <dmndi:Size height="430.9786834716797" width="665.7411708831787"/>
+            <dmndi:DMNShape id="_8753a9cc-cdac-4090-93e3-27e9b1080619" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="57.75882911682129" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b2b2db6e-d9b3-4fa5-bb7d-42ecf849a6a6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="382.2588291168213" y="320.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_031ba6ca-c73e-42ae-917b-70726dab086c" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="179.5" y="320.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6dc46488-4b09-4ca2-a116-31b1dd57ec22" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847">
+                <dc:Bounds x="480.2588291168213" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1ee7ca06-5141-461b-8df0-6396c924f424" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762">
+                <dc:Bounds x="50" y="50" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="55.5" y="58.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_fa882c2e-c721-42e2-927b-629c58481dc9" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7">
+                <dc:Bounds x="225.5" y="54.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_997dab16-04be-4787-ae98-b893a7731df9" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+                <di:waypoint x="135.49680137634277" y="222.97867584228516"/>
+                <di:waypoint x="272" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_87998c24-d099-4504-8f7d-d85d0d25aa87" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+                <di:waypoint x="449.9968013763428" y="320.97867584228516"/>
+                <di:waypoint x="302" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_45119ce3-3629-49af-8b1a-735ab94ec94c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+                <di:waypoint x="256" y="320.9786796569824"/>
+                <di:waypoint x="292" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9aad460e-772e-44b4-a8b0-956fc8a63bdf" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+                <di:waypoint x="547.9968013763428" y="222.97867584228516"/>
+                <di:waypoint x="322" y="114.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_137fbdfd-56c6-4c13-8ee1-b9fd8f6438d3" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+                <di:waypoint x="150" y="84.5"/>
+                <di:waypoint x="225.5" y="84.97867965698242"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_5c111794-4c6b-4747-8dfc-99d2ad0b6313" triso:modelElementRef="_5c111794-4c6b-4747-8dfc-99d2ad0b6313" name="Bureau Strategy Decision Service" documentation="&lt;p&gt;Stateless, side-effect free service to determine the appropriate bureau strategy for a specific applicant and product&lt;/p&gt;">
+            <di:extension/>
+            <dmndi:Size height="893.0000038146973" width="743.8705854415894"/>
+            <dmndi:DMNShape id="_58aa9ca2-9b70-489b-a992-ab9a11c7cbc9" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="308.1470727920532" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_58f9e0e3-cfcc-4f08-aef4-e192d06975f4" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="524.6294145584106" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_392bc431-eb67-4350-9671-2a0677db09f4" dmnElementRef="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" isCollapsed="false">
+                <dc:Bounds x="50" y="50" width="643.8705854415894" height="670"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+                <dmndi:DMNDecisionServiceDividerLine>
+                    <di:waypoint x="50" y="275"/>
+                    <di:waypoint x="693.8705854415894" y="275"/>
+                </dmndi:DMNDecisionServiceDividerLine>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9e34a4d1-45da-4831-badc-73d8677348c0" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf">
+                <dc:Bounds x="299.38824367523193" y="88" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_eca64fdc-9a9b-4437-a09c-985f20e5aa97" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276">
+                <dc:Bounds x="136" y="197" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_5f9bf062-d0e9-447f-89c9-77e4c469182e" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3">
+                <dc:Bounds x="299.38824367523193" y="307" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6afc8123-61b9-4532-beeb-47ef0a188d18" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838">
+                <dc:Bounds x="479.5" y="461.5" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_502c37dd-dea7-4fde-b8df-8837fba3d41b" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0">
+                <dc:Bounds x="136" y="461.5" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_587c02f7-6b33-4183-a2a7-7b66ea54c018" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="79" y="600" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4319ac14-8191-4f5b-90ed-143062b9b6b2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="515.8705854415894" y="583" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_949bf535-e11a-49e9-9ce8-e3ad4840ea27" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+                <di:waypoint x="212.5" y="197"/>
+                <di:waypoint x="345.88824367523193" y="148"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_648d510e-45f5-4f6b-85ce-f6c0d78bd2cf" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+                <di:waypoint x="375.88824367523193" y="307"/>
+                <di:waypoint x="375.88824367523193" y="148"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b10bc203-1c9c-40d0-bf3d-3c2bb420ca22" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+                <di:waypoint x="212.5" y="461.5"/>
+                <di:waypoint x="212.5" y="257"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d2e1b2a4-8675-4791-a021-b037a51db9cd" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+                <di:waypoint x="232.5" y="461.5"/>
+                <di:waypoint x="365.88824367523193" y="367"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_19ae4b52-8660-46d8-8c20-3321766662ee" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+                <di:waypoint x="289" y="491.5"/>
+                <di:waypoint x="479.5" y="491.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_6b91c9bc-cb17-4f49-824d-ed044d77345c" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+                <di:waypoint x="415.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="496" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_077dfe7c-521b-472e-b93e-9037c54103ea" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="592.3673868179321" y="782.9999961853027"/>
+                <di:waypoint x="592.3705854415894" y="643"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_56de7caf-fbd7-440c-ba61-82db11f56f89" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="335.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="155.5" y="660"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3478b12f-259d-4a1a-8a9e-63c6633d2d17" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+                <di:waypoint x="365.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="232.5" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4fd6e1df-93a4-422c-9cd5-816a0a9f54ae" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+                <di:waypoint x="155.5" y="600"/>
+                <di:waypoint x="212.5" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4dac9a2f-c185-429a-8a34-ed4df45333c2" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+                <di:waypoint x="592.3705854415894" y="583"/>
+                <di:waypoint x="556" y="521.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_86e67447-9abc-411f-9e0c-7f96590ae288" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+                <di:waypoint x="375.8850450515747" y="782.9999961853027"/>
+                <di:waypoint x="375.88824367523193" y="367"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_580f903e-7d68-42db-8a25-5349993b2c25" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+                <di:waypoint x="556" y="461.5"/>
+                <di:waypoint x="385.88824367523193" y="367"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_69750f88-f46f-4b47-bb3c-fb77f574f2b3" triso:modelElementRef="_69750f88-f46f-4b47-bb3c-fb77f574f2b3" name="Routing Decision Service" documentation="&lt;p&gt;Stateless, side-effect free service for determining the recommending handling approach for an applicant given their details, the loan applied for and any relevant bureau data.&lt;/p&gt;">
+            <di:extension/>
+            <dmndi:Size height="789.4573631286621" width="793"/>
+            <dmndi:DMNShape id="_9796f837-6893-4090-8b2e-2a7683cc76b5" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6">
+                <dc:Bounds x="607.5176582336426" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7544fd3e-8acb-4f69-8c9f-10f617ed28ac" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="269.7588291168213" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_7a126b99-6aa3-4152-b7f5-c8a62b928c51" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563">
+                <dc:Bounds x="83.75882911682129" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_448a6614-664f-4aa1-b68f-b8e5286db1b3" dmnElementRef="_4d91e3a5-acec-4254-81e4-8535a1d336ee" isCollapsed="false">
+                <dc:Bounds x="50" y="50" width="693" height="562.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+                <dmndi:DMNDecisionServiceDividerLine>
+                    <di:waypoint x="50" y="190"/>
+                    <di:waypoint x="743" y="190"/>
+                </dmndi:DMNDecisionServiceDividerLine>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_0cc014c9-e77f-42b7-9db9-d191dc1282b3" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5">
+                <dc:Bounds x="400.62941455841064" y="82" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_06d6329b-0290-40a8-afa7-9c013a5c11ef" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474">
+                <dc:Bounds x="179.62941455841064" y="219.97867965698242" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_08ff0bda-72ca-4f4f-b97c-8086e256dc37" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec">
+                <dc:Bounds x="400.62941455841064" y="369.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_918c03e8-0a27-402a-bcb6-c73ce6bf7b68" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46">
+                <dc:Bounds x="400.62941455841064" y="496.4786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1736d75d-d232-49ef-b240-40f54606c120" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2">
+                <dc:Bounds x="75" y="369.9786796569824" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_10959e18-49b9-47f2-9857-616a5475f978" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+                <di:waypoint x="256.12941455841064" y="219.97867965698242"/>
+                <di:waypoint x="427.12941455841064" y="142"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4954a232-9bb2-4b69-aa27-980d05026a6a" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+                <di:waypoint x="477.12941455841064" y="369.9786796569824"/>
+                <di:waypoint x="477.12941455841064" y="142"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e943ad5c-b09f-497e-b27b-897baa3821cb" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+                <di:waypoint x="655.2556304931641" y="679.4573554992676"/>
+                <di:waypoint x="527.1294145584106" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_20993320-b2cc-4c5f-a70b-41c76e8fe5de" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+                <di:waypoint x="675.2556304931641" y="679.4573554992676"/>
+                <di:waypoint x="527.1294145584106" y="142"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4c9ff6d6-e7cd-4026-9613-fc79c17bf9f3" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+                <di:waypoint x="151.49680137634277" y="679.4573554992676"/>
+                <di:waypoint x="151.5" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7ca313c0-de73-455a-98ba-3bc5ff24ce8f" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+                <di:waypoint x="467.12941455841064" y="369.9786796569824"/>
+                <di:waypoint x="306.12941455841064" y="279.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f7a5e094-bbf5-492e-89a7-069a267f8a32" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+                <di:waypoint x="161.5" y="369.9786796569824"/>
+                <di:waypoint x="206.12941455841064" y="279.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ec68e6ae-4cbd-44b4-9102-7239b40c83d9" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+                <di:waypoint x="327.4968013763428" y="679.4573554992676"/>
+                <di:waypoint x="256.12941455841064" y="279.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1d2a10bb-7892-47b4-88cf-d8c3bccb62a4" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+                <di:waypoint x="337.4968013763428" y="679.4573554992676"/>
+                <di:waypoint x="407.12941455841064" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1cafa890-64c6-456f-b7e6-44f7779d6155" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+                <di:waypoint x="347.4968013763428" y="679.4573554992676"/>
+                <di:waypoint x="477.12941455841064" y="556.4786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_582cea04-bab2-44de-991d-b7f4335b0a1e" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+                <di:waypoint x="477.12941455841064" y="496.4786796569824"/>
+                <di:waypoint x="477.12941455841064" y="429.9786796569824"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNDiagram id="_95e871bf-e58f-4976-b1bf-d9b220fdb2cb" triso:modelElementRef="_55b83dbb-d659-43c6-a102-0851a75d92e8" name="DRD for Credit Risk Analytics">
+            <di:extension/>
+            <dmndi:Size height="491.9786834716797" width="885"/>
+            <dmndi:DMNShape id="_9e8b811b-13d7-4805-a5f2-46b151a47adf" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942">
+                <dc:Bounds x="540.5" y="81" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="94.00000000000001" x="568.512987012987" y="84.01639344262296"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_da6554ff-51c3-496d-b930-df6df3cc9a2a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a">
+                <dc:Bounds x="340.5" y="81" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="34" width="89" x="346" y="89.34686931665394"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_13e7c4d4-5b40-463b-a8cd-88bee6c7a954" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e">
+                <dc:Bounds x="46.75882911682129" y="37.978675842285156" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="16" width="93.99999999999999" x="66.17174174738867" y="58.978679529825854"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ca52df5c-3325-48b9-bd4b-81a570049173" dmnElementRef="_2240bb79-1848-4b49-ac1b-8cf7db432770">
+                <dc:Bounds x="46.75882911682129" y="119.99999618530273" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="66.17174174738867" y="142.99999987284343"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2060b4cc-ad14-44c3-89a7-5dfd1b485865" dmnElementRef="_f319ab16-ff1a-4629-93b3-c48a7613d874">
+                <dc:Bounds x="376.5" y="188" width="235" height="65"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="54" width="229" x="381.5" y="196"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_726b3d32-779b-4320-85bb-58f7b2786cc2" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9">
+                <dc:Bounds x="232" y="286" width="100" height="69.95735931396484"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="52.00000000000001" width="89" x="237.5" y="285.3468693166539"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_3070db6b-665c-4d35-8bf0-68acdf4a3c2e" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+                <di:waypoint x="440.5" y="105.4"/>
+                <di:waypoint x="540.5" y="110"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a4ccd46c-7516-488a-a436-835dd42b8b5e" dmnElementRef="_7891c386-9a9f-43e8-92e2-a41c8500ff12">
+                <di:waypoint x="182.99680137634277" y="67.97867584228516"/>
+                <di:waypoint x="340.5" y="105.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ddb69903-2486-420a-b2d5-7572b53f3858" dmnElementRef="_dc1087cb-ba0c-4c8a-9a3a-a318d966ab58">
+                <di:waypoint x="182.99680137634277" y="149.99999618530273"/>
+                <di:waypoint x="340.5" y="125.4"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0dec0070-d1e3-4ab1-b427-7e29abe158e7" dmnElementRef="_e154a8ca-866b-42d2-aae0-226fc994789f">
+                <di:waypoint x="282" y="286"/>
+                <di:waypoint x="353" y="148"/>
+                <dmndi:DMNLabel sharedStyle="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_0" fontFamily="arial,helvetica,sans-serif" fontSize="14" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+        <dmndi:DMNStyle id="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_1" fontFamily="arial,helvetica,sans-serif" fontSize="14" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+        <dmndi:DMNStyle id="LS_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4_2" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Financial.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Financial.dmn
@@ -1,0 +1,31 @@
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:rss="http://purl.org/rss/2.0/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:feel="https://www.omg.org/spec/DMN/20191111/FEEL/"           xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" id="_5e8e877a-af87-434b-9c36-ed51c8d6b514" name="Financial" namespace="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" exporter="DMN Modeler" exporterVersion="6.2.2.1" triso:logoChoice="None">
+    <semantic:decisionService id="_5e8e877a-af87-434b-9c36-ed51c8d6b514_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+        <semantic:variable name="Whole Model Decision Service" id="_7510044d-9f94-4b5a-a172-bb5412031a86" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:decisionService id="_78d4b1b3-d780-407d-b8ba-b7c28c334551_DS" name="Diagram Page 1" triso:dynamicDecisionService="true">
+        <semantic:variable name="Diagram Page 1" id="_077c39ab-7b07-490e-bd40-bdc6d7bb0a48" typeRef="Any"/>
+    </semantic:decisionService>
+    <semantic:businessKnowledgeModel id="_a30c75ec-7d81-4606-802c-b31ea308392d" name="PMT">
+        <semantic:description>&lt;p&gt;&lt;span lang="JA"&gt;Standard calculation of monthly installment&amp;nbsp;&lt;/span&gt;from Rate, Term and Amount.&lt;/p&gt;</semantic:description>
+        <semantic:variable name="PMT" id="_702e93e8-7d03-4400-aae4-a21543a4d631" typeRef="Any"/>
+        <semantic:encapsulatedLogic id="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" kind="FEEL" typeRef="Any" triso:expressionId="_3e686571-acdc-46c2-8fe0-8e399ee6a570">
+            <semantic:formalParameter name="Rate" typeRef="number" id="_1787cf94-5e76-4926-ac24-5b4096b28dca"/>
+            <semantic:formalParameter name="Term" typeRef="number" id="_0d037df5-8942-473f-9feb-2e16d6d7d631"/>
+            <semantic:formalParameter name="Amount" typeRef="number" id="_deb10bf3-97f0-4f6b-8ae4-5cbfd44debac"/>
+            <semantic:literalExpression id="_4d149dbb-89da-498e-853f-2c33f4e9b834">
+                <semantic:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</semantic:text>
+            </semantic:literalExpression>
+        </semantic:encapsulatedLogic>
+    </semantic:businessKnowledgeModel>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_78d4b1b3-d780-407d-b8ba-b7c28c334551" triso:modelElementRef="_78d4b1b3-d780-407d-b8ba-b7c28c334551" name="Page 1">
+            <di:extension/>
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_f3441ebe-15cd-435b-9451-206c147a6985" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d">
+                <dc:Bounds x="274.5" y="213.5" width="152" height="59"/>
+                <dmndi:DMNLabel sharedStyle="LS_5e8e877a-af87-434b-9c36-ed51c8d6b514_0"/>
+            </dmndi:DMNShape>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_5e8e877a-af87-434b-9c36-ed51c8d6b514_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Loan info.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Loan info.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" id="_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Loan info" namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" exporter="DMN Modeler" exporterVersion="6.2.2.3">
+<semantic:definitions id="_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Loan info" namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" exporter="DMN Modeler" exporterVersion="6.2.2.3" xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed">
 	<semantic:itemDefinition name="tBorrower" label="tBorrower">
 		<semantic:itemComponent id="_b7dcc14d-510d-4628-a510-ca774208e501" name="Full Name">
 			<semantic:typeRef>string</semantic:typeRef>
@@ -125,7 +125,7 @@
 		<semantic:itemComponent id="_aa55fa1a-3e82-4439-b422-21921c6a64b0" name="Monthly Insurance Payment">
 			<semantic:typeRef>number</semantic:typeRef>
 		</semantic:itemComponent>
-		<semantic:itemComponent id="_77f3b202-47ba-432b-9ada-e81700db445f" name="Monthly HOA/Condo Fee">
+		<semantic:itemComponent id="_77f3b202-47ba-432b-9ada-e81700db445f" name="Monthly HOA Condo Fee">
 			<semantic:typeRef>number</semantic:typeRef>
 		</semantic:itemComponent>
 	</semantic:itemDefinition>
@@ -204,7 +204,7 @@
 		<semantic:itemComponent id="_cd96db58-d312-41dc-a3e4-6fa93766b49d" name="Initial Monthly Payment" isCollection="false">
 			<semantic:typeRef>number</semantic:typeRef>
 		</semantic:itemComponent>
-		<semantic:itemComponent id="_c05792fd-417f-4662-b6b8-7cf708c26976" name="Quallifying Monthly Payment" isCollection="false">
+		<semantic:itemComponent id="_c05792fd-417f-4662-b6b8-7cf708c26976" name="Qualifying Monthly Payment" isCollection="false">
 			<semantic:typeRef>number</semantic:typeRef>
 		</semantic:itemComponent>
 		<semantic:itemComponent id="_30babadc-60b5-4879-b233-410b43349ef4" name="Points Amount">

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Loan info.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Loan info.dmn
@@ -1,0 +1,758 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" id="_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Loan info" namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" exporter="DMN Modeler" exporterVersion="6.2.2.3">
+	<semantic:itemDefinition name="tBorrower" label="tBorrower">
+		<semantic:itemComponent id="_b7dcc14d-510d-4628-a510-ca774208e501" name="Full Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8cb2dd31-072e-48f0-8358-65cf75fcfda9" name="Tax ID">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_88b9503a-d677-4fd0-9f4c-3e16cb4f5ec0" name="Employment Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dc653a3f-5bc0-4aa3-ae82-d25db1e5abbc" name="Other Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1033e487-e687-48e2-b763-74cc29e2f242" name="Assets">
+			<semantic:typeRef>tAssets</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0ef27863-fb82-48f6-b7d9-dd006feaba60" name="Liabilities">
+			<semantic:typeRef>tLiabilities</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAsset" isCollection="false" label="tAsset">
+		<semantic:itemComponent id="_178a9712-768e-4150-860a-62fadcca989f" name="Type">
+			<semantic:typeRef>tAssetType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c977d77b-4c8a-486d-b177-0a5859662c97" name="Institution Account or Description">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_591c646d-eeb9-4011-bc7f-69b157a6f591" name="Value">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssets" isCollection="true" label="tAssets">
+		<semantic:typeRef>tAsset</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssetType" label="tAssetType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Checking Savings Brokerage account","Real Estate","Other Liquid","Other Non-Liquid"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiability" label="tLiability">
+		<semantic:itemComponent id="_57fce471-2342-4fc7-8116-405daa3ef433" name="Type">
+			<semantic:typeRef>tLiabilityType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dd30338f-9852-4149-8896-0efd298b4ac0" name="Payee">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_05fa38d8-21e6-4da2-a839-af266bb235f8" name="Monthly payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_81e5630b-f15a-4b4b-912e-6400bdb1cc36" name="Balance">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0b284d1f-d87a-4f80-846c-70f128074f49" name="To be paid off">
+			<semantic:typeRef>boolean</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilities" isCollection="true" label="tLiabilities">
+		<semantic:typeRef>tLiability</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilityType" label="tLiabilityType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Credit card","Auto loan","Student loan","Lease","Lien","Real estate loan","Alimony child support","Other"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAmortizationType" label="tAmortizationType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanProduct" label="tLoanProduct">
+		<semantic:itemComponent id="_1833883f-633d-4212-920d-1954b412bea6" name="Lender Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8d009922-d11e-4c23-8c14-f141f3ba94a8" name="Product Name">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1414b396-63f4-4f4b-825d-bce4ea87a07f" name="Type">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_27d5f2e4-a73a-464d-a80b-c05ed1a95471" name="Best Rate Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e44b0b2f-71a7-4233-9fd7-0cdcdb79f80b" name="Points Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f2d16774-2421-4e39-8412-512dadf40cd6" name="Fees Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0a6f5fef-4cb1-4d50-94a3-d22cf903a8c7" name="Term">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProperty" label="tProperty">
+		<semantic:itemComponent id="_5e820b14-1f14-44e2-bee1-a35fbedc477f" name="Address">
+			<semantic:itemComponent id="_d40919e3-168d-46dc-a7da-ccefeead8a49" name="Street">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_a03ae467-fb6a-46f0-ab1a-dc0992d81095" name="Unit">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_f902cd87-2c95-4b90-95cf-a2c6b1b87a1e" name="City">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_97f12b0d-be5c-4d42-abb5-d565599fee87" name="State">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_2fdc92bc-55da-4ff7-8a9d-c5213b69a0a8" name="ZIP">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cc0e8c3f-ae44-4080-88db-555d8a2f8560" name="Purchase Price">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3fb7e2b1-6ad9-4858-ae46-45e6b83e063d" name="Monthly Tax Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_aa55fa1a-3e82-4439-b422-21921c6a64b0" name="Monthly Insurance Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_77f3b202-47ba-432b-9ada-e81700db445f" name="Monthly HOA/Condo Fee">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercentList" isCollection="true" label="tPercentList">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercent" label="tPercent">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tCreditScore" label="tCreditScore">
+		<semantic:typeRef>number</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>[300..850]</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProductName" label="tProductName">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanData" isCollection="false" label="tLoanData">
+		<semantic:itemComponent id="_fd6a3e80-4ffe-438c-9e39-9f77a67c1f91" name="Points Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_6f71ccdc-b275-43c6-985a-31559b523c6c" name="Note Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_35c2796b-c800-4803-92e6-9cb5a96fcdc8" name="LTV" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_82b33b6f-e7c3-4016-a69d-f15d55a56d58" name="Closing Costs" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3a485bc8-8c27-4395-99ab-32c0d53616e2" name="Funds Toward Purchase" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_97e275f6-5776-4b55-86cb-f5e392c73307" name="Interest Rate Percent" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7a9b65fd-ca47-4788-bdde-246237480654" name="Qualifying Rate Percent" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f74f4b87-3684-4345-98b1-eaef7732385f" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_d6ba831e-226f-4284-9035-b1fcb7e40f21" name="Qualifying Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanInfo" isCollection="false" label="tLoanInfo">
+		<semantic:itemComponent id="_4307deb6-caba-4a7b-9075-820459281679" name="Product" isCollection="false">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_689ecdaf-4b3b-40ca-9eff-b7dff7e10bc3" name="Amortization Type" isCollection="false">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f96fc5bd-ecad-497f-931e-1d2ba0cc0ac7" name="LTV" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3445d602-de4b-44b6-afa2-a3c7d04368d7" name="Note Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_4ea4f624-c68b-47a0-9161-5244585e4898" name="Initial Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_81c9c31a-8d89-4d7f-856d-c6642499ed29" name="Qualifying Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cd96db58-d312-41dc-a3e4-6fa93766b49d" name="Initial Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c05792fd-417f-4662-b6b8-7cf708c26976" name="Quallifying Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_30babadc-60b5-4879-b233-410b43349ef4" name="Points Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_6c1aedf8-5d23-448d-acca-e91b5845a746" name="Fees Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_d7c3f0b8-f0d7-4bc9-95be-414530c2c23c" name="Funds Toward Purchase" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_37e9699c-e1bd-40b7-aafb-6e9b9e51e532" name="Down Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ec560b2b-0a1d-43fc-9a72-4ce30a92030e" name="Closing Costs" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7751d0b1-c992-4c52-a7c1-ea89b0226033" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:inputData id="_e0cfe605-3068-42a2-946f-c7db3774de1e" name="Property">
+		<semantic:variable name="Property" id="_35fe76b3-4304-4a45-bbc5-c3ac926fd494" typeRef="tProperty"/>
+	</semantic:inputData>
+	<semantic:inputData id="_d78ee6d5-96ed-43e6-89d2-123e0f388a67" name="Credit Score">
+		<semantic:variable name="Credit Score" id="_3bf8b83f-789a-4e98-bb0d-34ab6a6e01d9" typeRef="tCreditScore"/>
+	</semantic:inputData>
+	<semantic:inputData id="_29a44873-e886-42de-bc2f-6d5704b6b298" name="Loan Product">
+		<semantic:variable name="Loan Product" id="_45a92729-62fc-413d-a811-5aae30277a87" typeRef="tLoanProduct"/>
+	</semantic:inputData>
+	<semantic:decision id="_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5" name="Loan Data">
+		<semantic:variable name="Loan Data" id="_b864ab4b-b825-4740-b287-8f31eef41881" typeRef="tLoanData"/>
+		<semantic:informationRequirement id="_e47777c4-b10c-4aa8-8087-371824560192">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_ffe87244-b1ab-4075-a243-5f2a87f170d0">
+			<semantic:requiredInput href="#_29a44873-e886-42de-bc2f-6d5704b6b298"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_d9d4a780-7427-4000-b2c7-575717ebcae5">
+			<semantic:requiredInput href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_8304cbac-5619-459b-92a8-b389aaaf2aff">
+			<semantic:requiredInput href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_28360d50-9eee-4fa1-9f4d-a19c5bc9bbcb">
+			<semantic:requiredKnowledge href="#_aeaa30db-0f84-424a-b2f5-af9b2538a9ce"/>
+		</semantic:knowledgeRequirement>
+		<semantic:knowledgeRequirement id="_ff803e3f-9159-401f-b22c-edbb48cbf164">
+			<semantic:requiredKnowledge href="#_0d2a6f36-0403-41ad-a191-f793743649d4"/>
+		</semantic:knowledgeRequirement>
+		<semantic:context id="_99e0f553-477c-424f-ab66-017e789d2070" typeRef="tLoanData">
+			<semantic:contextEntry id="_e5e58153-cc87-4746-96f8-fa7926db2f8d">
+				<semantic:variable name="Points Amount" id="_ed35ac71-a2fa-48c6-9221-838374aebce4" typeRef="number"/>
+				<semantic:literalExpression id="_abf4629a-d2cb-4d54-b700-84820144b429">
+					<semantic:text>decimal((Property.Purchase Price - Down Payment)*Loan Product.Points Pct/100,2)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_f99be8be-baee-4480-a493-42355b9fcdaf">
+				<semantic:variable name="Note Amount" id="_73c0d2bc-6d72-41ac-a2cf-611eb0fd3bc8" typeRef="number"/>
+				<semantic:literalExpression id="_9a509356-5d67-44b1-a7b7-943af81a998a">
+					<semantic:text>Property.Purchase Price - Down Payment + Loan Product.Fees Amount + Points Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_c8f5c8ed-7b41-456c-89bb-0855e69c8c33">
+				<semantic:variable name="LTV" id="_d33843ed-4131-477e-9487-ce397ccdd90b" typeRef="tPercent"/>
+				<semantic:literalExpression id="_0a20e467-7ccf-43c8-a6c3-62790a118f04">
+					<semantic:text>decimal(100*Note Amount/Property.Purchase Price,2)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_139b25d4-2c14-46d8-8e30-f026113d2ccb">
+				<semantic:variable name="Closing Costs" id="_032891c4-ff8a-42cf-a7a3-78e7eb443996" typeRef="number"/>
+				<semantic:literalExpression id="_835a0c7a-e31c-464f-8b22-5fa51dab7a5d">
+					<semantic:text>decimal(0.02*Note Amount,2)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_5ee98bf7-7992-4f7d-8537-178747da47f0">
+				<semantic:variable name="Funds Toward Purchase" id="_cbb00b9e-859a-4370-994a-157c12110ab1" typeRef="number"/>
+				<semantic:literalExpression id="_f5715792-e937-48ad-b5f5-311c1d7c4006">
+					<semantic:text>Note Amount - Loan Product.Fees Amount - Points Amount - Closing Costs</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_9a74db9e-53c6-40ba-beb7-9bee87a08d46">
+				<semantic:variable name="Interest Rate Percent" id="_1c30ac25-201c-4935-85ed-2d3382f47e70" typeRef="tPercent"/>
+				<semantic:literalExpression id="_6c63b7c3-33ea-4c39-b672-dd20c99fd0ea">
+					<semantic:text>Loan Product.Best Rate Pct + Rate Adjustment(Credit Score, LTV)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_c33c71e3-dde8-40ec-a7c3-acba227fd1f6">
+				<semantic:variable name="Qualifying Rate Percent" id="_c3c44b72-ad66-4557-a2fa-c75d461b6b4d" typeRef="tPercent"/>
+				<semantic:literalExpression id="_67cb42ba-fbec-4f4a-88af-13a645097147">
+					<semantic:text>if Loan Product.Type="Variable rate" then Interest Rate Percent+2 else Interest Rate Percent</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_6285cef3-5c41-4a30-a5ff-a77ea05903cc">
+				<semantic:variable name="Monthly Payment" id="_293149c4-e398-4063-a199-872942d1ebd5" typeRef="number"/>
+				<semantic:invocation id="_b5712b08-217d-4a76-9312-63b8ff789307">
+					<semantic:literalExpression id="literal__b5712b08-217d-4a76-9312-63b8ff789307">
+						<semantic:text>payment</semantic:text>
+					</semantic:literalExpression>
+					<semantic:binding>
+						<semantic:parameter id="_95656f17-902e-44fe-8fb5-4cd509618f05" name="p"/>
+						<semantic:literalExpression id="_89014d7d-040f-40ba-b1cc-d4f38b3ae033">
+							<semantic:text>Note Amount</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_a15a5721-2b87-403c-9793-dca7092091cf" name="r"/>
+						<semantic:literalExpression id="_a228a99c-bbd3-4951-8a57-76cc2ac09079">
+							<semantic:text>Interest Rate Percent/100</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_ce45382c-f637-4fd6-9ac4-73266f044c4d" name="n"/>
+						<semantic:literalExpression id="_c0e4f3fc-b3fc-4920-94a7-b8dc8d97df9f">
+							<semantic:text>Loan Product.Term</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+				</semantic:invocation>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_0840a234-bfed-4f58-8ab9-309be8fbfb10">
+				<semantic:variable name="Qualifying Payment" id="_051a1c8b-dd3a-4162-bdcc-d599b2d9d464" typeRef="number"/>
+				<semantic:invocation id="_6ddbe47b-b38c-4a5e-89e9-a9bf40dbc7b9">
+					<semantic:literalExpression id="literal__6ddbe47b-b38c-4a5e-89e9-a9bf40dbc7b9">
+						<semantic:text>payment</semantic:text>
+					</semantic:literalExpression>
+					<semantic:binding>
+						<semantic:parameter id="_f911095f-98db-44e6-8f63-68009fb81074" name="p"/>
+						<semantic:literalExpression id="_8dd85c93-aac3-4d6e-b521-1c5eb251b7a6">
+							<semantic:text>Note Amount</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_092230d5-5427-4a63-b814-12378ee5faee" name="r"/>
+						<semantic:literalExpression id="_70d85747-3e76-4277-9889-53042cb495b9">
+							<semantic:text>Qualifying Rate Percent/100</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+					<semantic:binding>
+						<semantic:parameter id="_91d4257c-3c3f-4159-8f76-157234246efe" name="n"/>
+						<semantic:literalExpression id="_8db10de0-2c74-4aa7-8753-76874706af14">
+							<semantic:text>Loan Product.Term</semantic:text>
+						</semantic:literalExpression>
+					</semantic:binding>
+				</semantic:invocation>
+			</semantic:contextEntry>
+		</semantic:context>
+	</semantic:decision>
+	<semantic:inputData id="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c" name="Down Payment">
+		<semantic:variable name="Down Payment" id="_bbe3f7c0-d59c-472b-9266-73bcdcc0fbb6" typeRef="number"/>
+	</semantic:inputData>
+	<semantic:businessKnowledgeModel id="_aeaa30db-0f84-424a-b2f5-af9b2538a9ce" name="Rate Adjustment">
+		<semantic:variable name="Rate Adjustment" id="_3199df2d-5734-481f-a201-933b41d6196e" typeRef="tPercent"/>
+		<semantic:encapsulatedLogic typeRef="tPercent">
+			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore"/>
+			<semantic:formalParameter name="LTV" typeRef="tPercent"/>
+			<semantic:decisionTable id="_cd20f4b0-fbc2-4b9d-b31f-4a83d951e989" hitPolicy="UNIQUE" outputLabel="Rate Adjustment" typeRef="tPercent">
+				<semantic:input id="_b66906d2-f62e-47ba-856b-538a97bb3fa5">
+					<semantic:inputExpression typeRef="tCreditScore">
+						<semantic:text>Credit Score</semantic:text>
+					</semantic:inputExpression>
+					<semantic:inputValues>
+						<semantic:text>[300..850]</semantic:text>
+					</semantic:inputValues>
+				</semantic:input>
+				<semantic:input id="_b8ec7502-1b2a-409e-93c1-cb3771025154">
+					<semantic:inputExpression typeRef="tPercent">
+						<semantic:text>LTV</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:output id="_b7f72972-4ba1-4b2f-912e-349803135418"/>
+				<semantic:annotation name="Description"/>
+				<semantic:rule id="_3e460ca6-9b4f-42f3-b88c-4917970f788c">
+					<semantic:inputEntry id="_829ad9b0-0cf3-4d00-9200-8ec1758e0552">
+						<semantic:text>&gt;=660</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_30142347-09ce-4888-8efb-1c46b9f33ab9">
+						<semantic:text>&lt;=60</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_22bb07d5-518d-4a68-9133-afd49eecf707">
+						<semantic:text>0</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_b4193cc2-fa9d-4225-bd43-d01def7a7b99">
+					<semantic:inputEntry id="_51b2a53b-a6c2-482a-be44-5bcb429fe000">
+						<semantic:text>[620..660)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_f06826ef-835c-4f38-a54d-ae1c0a310146">
+						<semantic:text>&lt;=60</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_9def10dd-fefa-415d-af70-57e604100c35">
+						<semantic:text>0.125</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_aa33035d-70c3-46c7-8a03-091aa1cac209">
+					<semantic:inputEntry id="_b5d9d461-0c25-4696-a0f0-fef4db24e091">
+						<semantic:text>&gt;=700</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_c1af9407-d7da-4375-aa32-ae6718024876">
+						<semantic:text>&gt;60</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_02773f21-ff28-4953-871f-79e11247a4ea">
+						<semantic:text>0.125</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_ab605848-4621-46b1-b004-72e2cfb0790d">
+					<semantic:inputEntry id="_7989b770-8e8e-408d-b2f6-8645a9907948">
+						<semantic:text>[660..700)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_6d21df38-d485-444b-88ab-df7f96b2acf9">
+						<semantic:text>(60..70]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_2dc38af3-2e5e-4209-9b4c-efc01ea7bbf3">
+						<semantic:text>0.125</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_af2ccda3-bdbe-4765-b77b-5e3dbb511d67">
+					<semantic:inputEntry id="_79b63a75-ab77-4ab6-887a-ae469a742628">
+						<semantic:text>[620..660)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_7bed0211-a515-48a2-bd57-60f79342b1b5">
+						<semantic:text>(60..70]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_519343cd-1c7a-4bc0-af66-d70cac2ee465">
+						<semantic:text>0.25</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_496169e5-073b-4387-a929-05cbe62bc98b">
+					<semantic:inputEntry id="_45f13f95-6f0f-48bf-8f3c-ab7f9bd99fde">
+						<semantic:text>[680..700)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_62afa937-c3b1-46c9-9e93-88a9fa3e1149">
+						<semantic:text>&gt;70</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_19aa90b1-12a9-4e53-83dd-e4555b05b27c">
+						<semantic:text>0.25</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_62273267-d968-4124-8f47-17c93eb7b46e">
+					<semantic:inputEntry id="_388d54da-b672-4f0c-8b01-605cf210bd09">
+						<semantic:text>[640..680)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_dbc8b85c-222f-4503-b6c5-64a39e15cdae">
+						<semantic:text>&gt;70</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_4ffd9f8b-91e7-4e49-89b6-a58e3dd26ed7">
+						<semantic:text>0.375</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_8fc1174c-a757-4549-af9f-99700065c077">
+					<semantic:inputEntry id="_ea897caa-1470-4fab-af36-c97059f147fd">
+						<semantic:text>[620..640)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_3d5c2935-ffe9-415b-a3f1-97eb34d6df76">
+						<semantic:text>(70..80]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_8bb7e26c-c2d7-44c8-aea0-fa9a90e1427f">
+						<semantic:text>0.375</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_2e26421d-08e6-4a80-a661-5985b0a9b3ac">
+					<semantic:inputEntry id="_5af33bef-309c-4df0-a59c-646a33c54be5">
+						<semantic:text>[620..640)</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_6e811648-5954-43d4-8e3e-6668ebf3cd16">
+						<semantic:text>&gt;80</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_a24d5aab-d03f-4fb1-988d-a7cf034975b8">
+						<semantic:text>0.5</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_e215d517-2d2a-4117-acfc-a982c8fb0353">
+					<semantic:inputEntry id="_9c12fc0d-2fa9-4a74-8b16-2ff02aebcaf6">
+						<semantic:text>&lt;620</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_c4dcb9aa-226a-43b8-badc-7f04f763d8b5">
+						<semantic:text>-</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_b47625d7-01f3-4284-98bf-ff9d3b86c81e">
+						<semantic:text>0.5</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+			</semantic:decisionTable>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:businessKnowledgeModel id="_0d2a6f36-0403-41ad-a191-f793743649d4" name="payment">
+		<semantic:variable name="payment" id="_8c231b6d-165f-4c36-bcd3-617498b36e0e" typeRef="number"/>
+		<semantic:encapsulatedLogic id="_97168569-14dd-4533-8d8c-497681134e3b" kind="FEEL" typeRef="number">
+			<semantic:formalParameter name="p" typeRef="number" id="_b65fd962-b719-4dca-b37b-4c4d2b7e9867"/>
+			<semantic:formalParameter name="r" typeRef="number" id="_22bb5be8-b3dd-4a05-8e0d-6458fe53aa4a"/>
+			<semantic:formalParameter name="n" typeRef="number" id="_6a169eec-28b4-4789-ac5e-141348bcc99a"/>
+			<semantic:literalExpression id="_0c92187a-2412-4f49-a635-3e8cdd6e58fe" typeRef="number">
+				<semantic:text>decimal(p*r/12/(1-(1+r/12)**-n),2)</semantic:text>
+			</semantic:literalExpression>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:decision id="_8a182857-b5a1-4389-9a76-01a316938cea" name="Loan Info">
+		<semantic:variable name="Loan Info" id="_edac09bb-d679-46a5-b363-ede359f2dfd9" typeRef="tLoanInfo"/>
+		<semantic:informationRequirement id="_1f641b45-5ad1-4dfa-bdc5-19d0f52b87b4">
+			<semantic:requiredDecision href="#_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_70f3db04-5830-45d2-ba12-7c355e571fcd">
+			<semantic:requiredInput href="#_29a44873-e886-42de-bc2f-6d5704b6b298"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_da7d6551-1fd0-49ea-9723-ec51d15005a8">
+			<semantic:requiredInput href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_8d9ec740-a917-4215-88ec-e531ee90a348">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:context id="_b61ecb51-0c30-4cb0-bc0b-db503e7e03cd" typeRef="tLoanInfo">
+			<semantic:contextEntry id="_305a8898-1350-49ed-b827-0a59a76f9216">
+				<semantic:variable name="Product" id="_07481b52-07d7-4257-a124-2bffd7a7e080" typeRef="tProductName"/>
+				<semantic:literalExpression id="_404ff614-bed5-44bc-a64d-abae8419e748">
+					<semantic:text>Loan Product.Product Name</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_b3a59630-4f96-4fab-9a75-eb50b5e745c0">
+				<semantic:variable name="Amortization Type" id="_1e05445b-6883-41d8-9ae5-cdfb5205bc19" typeRef="tAmortizationType"/>
+				<semantic:literalExpression id="_ce1727a9-2ae4-4646-93a4-7e02924e908a">
+					<semantic:text>Loan Product.Type</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_2cdc74c5-b2aa-48ca-8cf4-588db17d4f2f">
+				<semantic:variable name="LTV" id="_6cf1a718-ae6c-490b-acbd-5bec33561d2b" typeRef="tPercent"/>
+				<semantic:literalExpression id="_59388af1-8e25-4bc9-860a-a1b0c189f6cf">
+					<semantic:text>Loan Data.LTV</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_c8d181a9-e299-4779-a8db-e8233e6fb37d">
+				<semantic:variable name="Note Amount" id="_d999ea55-7695-43e0-9154-527ca2199e4b" typeRef="number"/>
+				<semantic:literalExpression id="_866f935f-7366-4cfa-92b3-d04801d2847e">
+					<semantic:text>Loan Data.Note Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_111bd935-e736-459d-85e9-e00c46941198">
+				<semantic:variable name="Initial Rate Pct" id="_32dae540-bdc9-457b-850c-ab5b377cae20" typeRef="tPercent"/>
+				<semantic:literalExpression id="_37bdb610-6e92-4586-a76c-41ed00bceba8">
+					<semantic:text>Loan Data.Interest Rate Percent</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_75c82e82-f510-4d03-9b64-6dee23866637">
+				<semantic:variable name="Qualifying Rate Pct" id="_d1c92a72-78f9-4dae-9d5a-0df028f75ca0" typeRef="tPercent"/>
+				<semantic:literalExpression id="_d57fa679-94ea-4b23-a148-79b5b7440384">
+					<semantic:text>Loan Data.Qualifying Rate Percent</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_7b3c0475-18f1-46ae-b14c-bd10f2e01a6d">
+				<semantic:variable name="Initial Monthly Payment" id="_948cfa68-d3eb-449b-b16e-323fd0b77ea7" typeRef="number"/>
+				<semantic:literalExpression id="_c2ebcf27-03cd-47ee-94e9-414f37db18bd">
+					<semantic:text>Loan Data.Monthly Payment</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_e1274c1b-069b-4010-8663-08f5e27382f7">
+				<semantic:variable name="Qualifying Monthly Payment" id="_b1ea078d-4dfa-442b-98d7-4cbccce12ea5" typeRef="number"/>
+				<semantic:literalExpression id="_57b45210-6690-4432-ba16-80418853025c">
+					<semantic:text>Loan Data.Qualifying Payment</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_d5306ff6-04a9-41cd-88c6-655edd2ff712">
+				<semantic:variable name="Points Amount" id="_fdc165a7-8b0f-4888-8ff3-ad7580d8fce3" typeRef="number"/>
+				<semantic:literalExpression id="_81052536-49c2-4590-850f-cef72e3df7e9">
+					<semantic:text>Loan Data.Points Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_ae4ba9f9-40a3-40e8-9b34-a331be00d6f9">
+				<semantic:variable name="Fees Amount" id="_a8834bb9-4be1-47af-a668-afc17efc6d54" typeRef="number"/>
+				<semantic:literalExpression id="_282885e1-a60f-48c2-90b2-dbe621f1317f">
+					<semantic:text>Loan Product.Fees Amount</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_bfc9b305-8e2d-4a0a-98f7-602ebd533497">
+				<semantic:variable name="Funds Toward Purchase" id="_272c1b83-e45c-4066-8e38-4f476d7e948f" typeRef="number"/>
+				<semantic:literalExpression id="_b22eaafb-59c9-4db6-8824-c33b8c303ec8">
+					<semantic:text>Loan Data.Funds Toward Purchase</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_26d4d85d-1b77-4be3-9ec3-79c36296c8ce">
+				<semantic:variable name="Down Payment" id="_591ebd13-c2be-47c7-a3dd-fb5561131e02" typeRef="number"/>
+				<semantic:literalExpression id="_d95db62e-5b4c-4c91-95d8-55b0be6f3b09">
+					<semantic:text>Down Payment</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_26dd9af6-d1d9-4965-ac86-b9e68044b675">
+				<semantic:variable name="Closing Costs" id="_839e434c-41f0-45c3-9f43-605b865c2005" typeRef="number"/>
+				<semantic:literalExpression id="_8147cce9-e3b5-486f-ba40-77a6749a5063">
+					<semantic:text>Loan Data.Closing Costs</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_885eb1b1-58a1-43ba-85aa-5fe90fd9a2af">
+				<semantic:variable name="Cash to Close" id="_133b174b-6408-4546-84dd-66b0ef52bb7d" typeRef="number"/>
+				<semantic:literalExpression id="_d4a59c37-c285-4486-a1f4-7a70131171db">
+					<semantic:text>Property.Purchase Price - Funds Toward Purchase</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+		</semantic:context>
+	</semantic:decision>
+	<semantic:decisionService id="_f5761a7f-090d-4177-a06a-7f21f925c6ff" name="Loan Info Service">
+		<semantic:variable name="Loan Info Service" id="_f8f5ffe8-362f-4cdf-8c5e-d5c2e7bdadde" typeRef="Any"/>
+		<semantic:outputDecision href="#_8a182857-b5a1-4389-9a76-01a316938cea"/>
+		<semantic:encapsulatedDecision href="#_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5"/>
+		<semantic:inputData href="#_29a44873-e886-42de-bc2f-6d5704b6b298"/>
+		<semantic:inputData href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		<semantic:inputData href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		<semantic:inputData href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+	</semantic:decisionService>
+	<dmndi:DMNDI xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/">
+		<dmndi:DMNDiagram id="_0b101bf8-a9c5-4e7c-8763-c8fcb4263a32" name="Page 1">
+			<di:extension xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"/>
+			<dmndi:Size height="1054.996529420125" width="1803.949344176753"/>
+			<dmndi:DMNShape id="_a3898cf2-06c3-4ff6-aee8-ff1980e1df26" dmnElementRef="_e0cfe605-3068-42a2-946f-c7db3774de1e">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="1131.4602065272172" y="422.99652560542773" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94" x="1150.6981787867387" y="445.99652560542773"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_4b1fc771-634e-4074-b5fa-9fddc959704d" dmnElementRef="_d78ee6d5-96ed-43e6-89d2-123e0f388a67">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="923.7588291168213" y="403.9965256054276" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94" x="942.9968013763428" y="426.9965256054276"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_514ee41e-624f-49ab-bbd4-bc72290d220f" dmnElementRef="_29a44873-e886-42de-bc2f-6d5704b6b298">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="1215.460206527217" y="328.9965256054276" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="93.99999999999999" x="1234.8731191577845" y="351.9965292929683"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_9fdb64c0-601f-47bf-8592-01d5144ef096" dmnElementRef="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="1215.4602065272172" y="228.0034667651778" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="93.99999999999999" x="1234.8731191577847" y="251.0034704527185"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_6946a3af-1379-4948-831f-8b40c6fa8b52" dmnElementRef="_aeaa30db-0f84-424a-b2f5-af9b2538a9ce">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="671.734375" y="364.49652942012494" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94.00000000000001" x="699.747362012987" y="387.51292286274787"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_aa434c2c-6b3b-4799-b1e3-628a27162558" dmnElementRef="_0d2a6f36-0403-41ad-a191-f793743649d4">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="671.7343750000001" y="278.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="94" x="699.7343750000001" y="301.5"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_9244509d-f461-4336-8b36-04a1a6954423" dmnElementRef="_f5761a7f-090d-4177-a06a-7f21f925c6ff" isCollapsed="false">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="878.7013774103955" y="156.00347057987508" width="260" height="219.99652942012492"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12.21875" width="254" x="894.7013774103955" y="172.00347057987508"/>
+				</dmndi:DMNLabel>
+				<dmndi:DMNDecisionServiceDividerLine>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="878.7013774103955" y="271.00347057987506"/>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1138.7013774103955" y="271.00347057987506"/>
+				</dmndi:DMNDecisionServiceDividerLine>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_e23c0c63-fda2-411e-9a7f-12226a908c91" dmnElementRef="_8a182857-b5a1-4389-9a76-01a316938cea">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="932.2013774103956" y="196.00347057987508" width="153.0000000000001" height="59.99999999999997"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12" width="146" x="935.2013774103956" y="220.00347057987508"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_ec44949f-5a92-40a5-8165-5192c916e4ac" dmnElementRef="_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="932.2013774103958" y="291" width="152.9999999999999" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0">
+					<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" height="12.000000000000004" width="146" x="934.7078709168893" y="314.5081967213115"/>
+				</dmndi:DMNLabel>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="_76f6f123-fc4f-460b-8ea7-1aaab6959d9b" dmnElementRef="_e47777c4-b10c-4aa8-8087-371824560192">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1189.1981787867387" y="422.99652560542773"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1048.7013774103957" y="351"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_98386957-cfad-49d1-bce7-6259d54d5ba3" dmnElementRef="_ffe87244-b1ab-4075-a243-5f2a87f170d0">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1217.6981787867385" y="348.9965256054276"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="341"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_8d4993ba-08a6-4e98-96bd-dc339f359d2d" dmnElementRef="_d9d4a780-7427-4000-b2c7-575717ebcae5">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1263.1981787867387" y="228.0034667651778"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="301"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_2f96d770-5269-42e9-baed-ea78445b3e46" dmnElementRef="_8304cbac-5619-459b-92a8-b389aaaf2aff">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="971.4968013763428" y="403.9965256054276"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="968.7013774103958" y="351"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_382e7238-103d-4aa7-9438-7832b2ea88d2" dmnElementRef="_28360d50-9eee-4fa1-9f4d-a19c5bc9bbcb">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="823.734375" y="393.49652942012494"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="932.2013774103958" y="331"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_bf0dd31b-d9f6-4b3e-9546-f59a29795a16" dmnElementRef="_ff803e3f-9159-401f-b22c-edbb48cbf164">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="671.7343750000001" y="307.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="321"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_e20fb50a-b082-434d-892a-869950f1d79d" dmnElementRef="_1f641b45-5ad1-4dfa-bdc5-19d0f52b87b4">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="968.7013774103958" y="291"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="968.7013774103956" y="256.00347057987506"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_4515e28c-f7ea-40ff-859f-65fd5d310072" dmnElementRef="_70f3db04-5830-45d2-ba12-7c355e571fcd">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1273.1981787867385" y="328.9965256054276"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="236.00347057987508"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_3affdb18-a0c8-4e50-9e36-73c650b2467b" dmnElementRef="_da7d6551-1fd0-49ea-9723-ec51d15005a8">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1217.6981787867387" y="248.0034667651778"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1085.2013774103957" y="226.00347057987508"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_9b2c749a-da49-43cc-8688-e72f394f0b32" dmnElementRef="_8d9ec740-a917-4215-88ec-e531ee90a348">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1209.1981787867387" y="422.99652560542773"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="1078.7013774103957" y="256.00347057987506"/>
+				<dmndi:DMNLabel sharedStyle="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+		<dmndi:DMNStyle id="LS_5c8b9296-96cf-4898-bba5-3a2d21d34eed_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+	</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Recommended Loan Products.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Recommended Loan Products.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   id="_736fa164-03d8-429f-8318-4913a548c3a6" name="Recommended Loan Products" namespace="http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6" exporter="DMN Modeler" exporterVersion="6.2.3" xmlns:include1="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed">
+<semantic:definitions id="_736fa164-03d8-429f-8318-4913a548c3a6" name="Recommended Loan Products" namespace="http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6" exporter="DMN Modeler" exporterVersion="6.2.3" xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:include1="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" xmlns="http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6">
 	<semantic:import namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Services" importType="https://www.omg.org/spec/DMN/20191111/MODEL/"/>
 	<semantic:itemDefinition name="tBorrower" label="tBorrower">
 		<semantic:itemComponent id="_b7dcc14d-510d-4628-a510-ca774208e501" name="Full Name">
@@ -152,7 +152,7 @@
 		<semantic:itemComponent id="_68f6a641-5e2d-4b1b-9f2b-41f933976dee" name="Product Name" isCollection="false">
 			<semantic:typeRef>tProductName</semantic:typeRef>
 			<semantic:allowedValues>
-				<semantic:text>"Fixed30-NoPointsOrFees","Fixed30-Standard","Fixed30-LowestRate","Fixed15-NoPointsOrFees","Fixed15-Standard"</semantic:text>
+				<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed30-LowestRate","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
 			</semantic:allowedValues>
 		</semantic:itemComponent>
 		<semantic:itemComponent id="_39c5300a-339c-4bde-8dfc-17e5d3f6f535" name="Type" isCollection="false">

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Recommended Loan Products.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/Recommended Loan Products.dmn
@@ -1,0 +1,1412 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   id="_736fa164-03d8-429f-8318-4913a548c3a6" name="Recommended Loan Products" namespace="http://www.trisotech.com/definitions/_736fa164-03d8-429f-8318-4913a548c3a6" exporter="DMN Modeler" exporterVersion="6.2.3" xmlns:include1="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed">
+	<semantic:import namespace="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed" name="Services" importType="https://www.omg.org/spec/DMN/20191111/MODEL/"/>
+	<semantic:itemDefinition name="tBorrower" label="tBorrower">
+		<semantic:itemComponent id="_b7dcc14d-510d-4628-a510-ca774208e501" name="Full Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8cb2dd31-072e-48f0-8358-65cf75fcfda9" name="Tax ID">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_88b9503a-d677-4fd0-9f4c-3e16cb4f5ec0" name="Employment Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dc653a3f-5bc0-4aa3-ae82-d25db1e5abbc" name="Other Income">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1033e487-e687-48e2-b763-74cc29e2f242" name="Assets">
+			<semantic:typeRef>tAssets</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0ef27863-fb82-48f6-b7d9-dd006feaba60" name="Liabilities">
+			<semantic:typeRef>tLiabilities</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAsset" isCollection="false" label="tAsset">
+		<semantic:itemComponent id="_178a9712-768e-4150-860a-62fadcca989f" name="Type">
+			<semantic:typeRef>tAssetType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c977d77b-4c8a-486d-b177-0a5859662c97" name="Institution Account or Description">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_591c646d-eeb9-4011-bc7f-69b157a6f591" name="Value">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssets" isCollection="true" label="tAssets">
+		<semantic:typeRef>tAsset</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAssetType" label="tAssetType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Checking Savings Brokerage account","Real Estate","Other Liquid","Other Non-Liquid"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiability" label="tLiability">
+		<semantic:itemComponent id="_57fce471-2342-4fc7-8116-405daa3ef433" name="Type">
+			<semantic:typeRef>tLiabilityType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_dd30338f-9852-4149-8896-0efd298b4ac0" name="Payee">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_05fa38d8-21e6-4da2-a839-af266bb235f8" name="Monthly payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_81e5630b-f15a-4b4b-912e-6400bdb1cc36" name="Balance">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0b284d1f-d87a-4f80-846c-70f128074f49" name="To be paid off">
+			<semantic:typeRef>boolean</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilities" isCollection="true" label="tLiabilities">
+		<semantic:typeRef>tLiability</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLiabilityType" label="tLiabilityType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Credit card","Auto loan","Student loan","Lease","Lien","Real estate loan","Alimony child support","Other"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAmortizationType" label="tAmortizationType">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoan" label="tLoan">
+		<semantic:itemComponent id="_1414b396-63f4-4f4b-825d-bce4ea87a07f" name="Type">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_27d5f2e4-a73a-464d-a80b-c05ed1a95471" name="Best Rate Percent">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_0a6f5fef-4cb1-4d50-94a3-d22cf903a8c7" name="Term Months">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e44b0b2f-71a7-4233-9fd7-0cdcdb79f80b" name="Points Percent">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f2d16774-2421-4e39-8412-512dadf40cd6" name="Fee Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProperty" label="tProperty">
+		<semantic:itemComponent id="_5e820b14-1f14-44e2-bee1-a35fbedc477f" name="Address">
+			<semantic:itemComponent id="_d40919e3-168d-46dc-a7da-ccefeead8a49" name="Street">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_a03ae467-fb6a-46f0-ab1a-dc0992d81095" name="Unit">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_f902cd87-2c95-4b90-95cf-a2c6b1b87a1e" name="City">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_97f12b0d-be5c-4d42-abb5-d565599fee87" name="State">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+			<semantic:itemComponent id="_2fdc92bc-55da-4ff7-8a9d-c5213b69a0a8" name="ZIP">
+				<semantic:typeRef>string</semantic:typeRef>
+			</semantic:itemComponent>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cc0e8c3f-ae44-4080-88db-555d8a2f8560" name="Purchase Price">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ce17ee0b-f1e1-43cf-8a5e-4a18390fc6d6" name="Monthly Tax Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_338c3f84-8ff7-404d-9b61-d211a5cebe4b" name="Monthly Insurance Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_fe427d63-1cf3-4d2d-b268-f7e01dccad59" name="Monthly HOA Condo Fee">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercentList" isCollection="true" label="tPercentList">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tPercent" label="tPercent">
+		<semantic:typeRef>number</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tCreditScore" label="tCreditScore">
+		<semantic:typeRef>number</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>[300..850]</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tAffordability" label="tAffordability">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Affordable","Marginal","Unaffordable"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tProductName" label="tProductName">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Fixed30-NoPoints","Fixed30-Standard","Fixed15-NoPoints","Fixed15-Standard","ARM5/1-NoPoints","ARM5/1-Standard"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanProduct" isCollection="false" label="tLoanProduct">
+		<semantic:itemComponent id="_c94dcf22-5cd0-4b41-9f1c-e39d3e1eecd7" name="Lender Name" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_68f6a641-5e2d-4b1b-9f2b-41f933976dee" name="Product Name" isCollection="false">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed30-NoPointsOrFees","Fixed30-Standard","Fixed30-LowestRate","Fixed15-NoPointsOrFees","Fixed15-Standard"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_39c5300a-339c-4bde-8dfc-17e5d3f6f535" name="Type" isCollection="false">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Fixed rate","Variable rate"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_5f8e2576-2c33-49b1-8fce-7bb5e5a253e7" name="Best Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_905aac44-b95e-4159-9b30-08326a07d633" name="Points Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_bcaa6e47-3a6b-443c-b99e-a363aff93346" name="Fees Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a540971e-df77-456a-8499-349cef053ca6" name="Term" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanProducts" isCollection="true" label="tLoanProducts">
+		<semantic:typeRef>tLoanProduct</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanInfoRow" label="tLoanInfoRow">
+		<semantic:itemComponent id="_7a448de3-c619-44d1-bc17-9a63ca82f05c" name="Product">
+			<semantic:typeRef>tProductName</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_16b32188-4c17-4990-801e-cbaa9b68e749" name="Amortization Type">
+			<semantic:typeRef>tAmortizationType</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_4548db4e-81d2-41ed-b3ad-1ad35237826a" name="LTV">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_34bde427-441e-417f-9b24-a3d5b808bb38" name="Note Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_84a1e8ef-747e-4dbe-879a-56795b578faf" name="Initial Rate Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3ee1f841-148c-42f3-9242-1ef327a5d98f" name="Qualifying Rate Pct">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ea618291-896a-4948-9922-0d3e46d6f724" name="Initial Monthly Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_bbecbf22-7afd-4284-af29-ba2ddcaeec40" name="Qualifying Monthly Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_30057076-38a0-4e11-b0fa-e327b56c37a6" name="Points Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_4b18ec63-ad34-4af8-bc92-bb10e0f5d5aa" name="Fees Amount">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_cecc7cc5-945b-4bd2-9dca-2134a14f80fa" name="Funds Toward Purchase">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_bfc26334-ceb5-4adb-9bf4-31202aac793c" name="Down Payment">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c9f217e8-def9-4123-8fdc-fc1b092f433a" name="Closing Costs">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_ae1f758c-5647-4c06-a982-c12c50f1e9c9" name="Cash to Close">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLoanInfoTable" isCollection="true" label="tLoanInfoTable">
+		<semantic:typeRef>tLoanInfoRow</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tEligibilityTable" isCollection="true" label="tEligibilityTable">
+		<semantic:typeRef>tTableRow</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLTVCategory" label="tLTVCategory">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Low","Medium","High"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tEligibilityParams" label="tEligibilityParams">
+		<semantic:itemComponent id="_d3a02da5-731e-4633-833a-cf999edc2136" name="DTI Category">
+			<semantic:typeRef>tAffordability</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_14f97cec-f1ff-44bb-916d-074aaf58380f" name="Reserves">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7e123ec1-4a76-4cd5-beb5-522dbac1b92b" name="LTV Category">
+			<semantic:typeRef>tLTVCategory</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tParams" isCollection="false" label="tParams">
+		<semantic:itemComponent id="_7af54197-7bf4-4a81-8036-dfdac7cdf990" name="DTI" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_8c2c0b73-9319-4c06-ba25-14518ea1d470" name="DTI Category" isCollection="false">
+			<semantic:typeRef>tAffordability</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Affordable","Marginal","Unaffordable"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_23df4d83-c124-4dc7-a0bd-355d7312e43f" name="LTV Category" isCollection="false">
+			<semantic:typeRef>tLTVCategory</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Low","Medium","High"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c0943b8f-dd9b-426a-9f6c-2fd2c966f514" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7ed22b26-68a3-4974-8dcf-6da2b50479ce" name="Reserves" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tEligibilityParameters" isCollection="false" label="tEligibilityParameters">
+		<semantic:itemComponent id="_2422f664-556a-475e-af82-abb361de56a0" name="Housing Expense" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_971c1e75-1682-4d14-809c-04d72ed16a48" name="Non-Housing Debt Payments" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e12ae77f-3732-4867-a511-69717cc57cfc" name="Income" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a7888cf8-5b7e-42b6-8e4c-3ebb96c3c0a6" name="DTI Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_9ee8adf0-94a0-405e-ba57-a3cfb1fe86e3" name="Liquid Assets Before Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_05b991b0-dad0-486f-b933-8866a45a5b37" name="Debts Paid Off By Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_73a12edf-4608-4462-90d5-f8e2c37141a1" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e0556de3-256b-465e-bdd7-00b00e4d714a" name="Reserves" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLenderRating" label="tLenderRating">
+		<semantic:itemComponent id="_1e6fda10-128f-48e1-a8b8-cd34ce9381c3" name="Lender Name">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_339f91a8-da05-43cf-b6ea-2c5f1ea6180a" name="Customer Rating">
+			<semantic:typeRef>number</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>[1..5]</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tLenderRatings" isCollection="true" label="tLenderRatings">
+		<semantic:typeRef>tLenderRating</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tRecommendation" label="tRecommendation">
+		<semantic:typeRef>string</semantic:typeRef>
+		<semantic:allowedValues>
+			<semantic:text>"Best","Good","Not Recommended","Ineligible"</semantic:text>
+		</semantic:allowedValues>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tTableRow" isCollection="false" label="tTableRow">
+		<semantic:itemComponent id="_7688fc87-c042-438c-9490-acd8c35c6179" name="Product" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_d247bfbe-d417-4b7e-b902-b8d507c6084a" name="Note Amount" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e6838dc2-2e38-4ba5-80b0-7c05b352fb5f" name="Interest Rate Pct" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_da010099-9782-43c6-8494-5894031e581f" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a1f11f10-52db-401c-b5db-57fa2f194672" name="LTV" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_20cc2106-8782-41c0-8aa0-86a77cc6a659" name="DTI" isCollection="false">
+			<semantic:typeRef>tPercent</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_b8a09bf2-4dc5-48a6-9a98-8f2297f6f595" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_e894eadb-85ef-417a-941e-02b1ab15f508" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_5e4f7ce5-1df8-4ae8-803e-ba90e8e6e17c" name="Reserves" isCollection="false">
+			<semantic:typeRef>number</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_014b70a0-68c5-472e-a177-9b85a4849115" name="Required Credit Score" isCollection="false">
+			<semantic:typeRef>tCreditScore</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>[300..850]</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_2a7e3a86-ab04-44e5-a811-819e8bee4969" name="Recommendation" isCollection="false">
+			<semantic:typeRef>tRecommendation</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>"Best","Good","Not Recommended","Ineligible"</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tformattedrow" isCollection="false" label="tformattedrow">
+		<semantic:itemComponent id="_f068f917-e759-4337-8d1a-fdbb13e75b5d" name="Product" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a095eec9-ccfc-4354-8a1d-aba195858993" name="Note Amount" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_430c983c-3f73-4373-9c46-b2ac5f6ff249" name="Interest Rate Pct" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_7801d6b3-4639-4246-8852-ed2e3d491a7a" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f68971e8-0a0a-41fa-aa6a-5c95385ddcbc" name="LTV" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_fd8fe4ba-45a9-4a7b-8de1-a63435fbeecb" name="DTI" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_9d8a1274-95c4-40c1-93a6-66e3fcfcc214" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_de9dad22-a6ea-4ddb-9632-252c11cb03b3" name="Liquid Assets After Closing" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1ccce7a0-26c7-48ea-bc7c-184d32880b5a" name="Reserves" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c2254b61-d9d1-4e99-afdd-585456b1ab4e" name="Required Credit Score">
+			<semantic:typeRef>tCreditScore</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_16338ccf-00da-4f59-9e3e-eaa3bd773d79" name="Recommendation" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tRecommendedTable" isCollection="true" label="tRecommendedTable">
+		<semantic:typeRef>tformattedrow_1</semantic:typeRef>
+	</semantic:itemDefinition>
+	<semantic:itemDefinition name="tformattedrow_1" isCollection="false" label="tformattedrow_1">
+		<semantic:itemComponent id="_7364c8f4-075a-4537-8e71-37e9849ad953" name="Product" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_a3bdaa50-87e1-44a7-8903-381b7cdfa3ba" name="Note Amount" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_c1d3d41c-77a3-4e49-aab1-fe43ed490672" name="Interest Rate Pct" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_f3b926fb-8b55-47bc-81ca-b007fff1edb4" name="Monthly Payment" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_215d51c3-eef2-434c-8c93-45d1fb95435e" name="Cash to Close" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_3cc6467e-8205-4cfa-88d3-fc41dfc19d20" name="Required Credit Score" isCollection="false">
+			<semantic:typeRef>tCreditScore</semantic:typeRef>
+			<semantic:allowedValues>
+				<semantic:text>[300..850]</semantic:text>
+			</semantic:allowedValues>
+		</semantic:itemComponent>
+		<semantic:itemComponent id="_1d1dd9c0-2610-4b26-93f6-ab946de39a49" name="Recommendation" isCollection="false">
+			<semantic:typeRef>string</semantic:typeRef>
+		</semantic:itemComponent>
+	</semantic:itemDefinition>
+	<semantic:inputData id="_a177b73e-7064-4140-8757-23bdf7a5d696" name="Borrower">
+		<semantic:variable name="Borrower" id="_90f520cc-f1a6-4e0e-b4d1-9bf07ada89d6" typeRef="tBorrower"/>
+	</semantic:inputData>
+	<semantic:inputData id="_e0cfe605-3068-42a2-946f-c7db3774de1e" name="Property">
+		<semantic:variable name="Property" id="_35fe76b3-4304-4a45-bbc5-c3ac926fd494" typeRef="tProperty"/>
+	</semantic:inputData>
+	<semantic:inputData id="_d78ee6d5-96ed-43e6-89d2-123e0f388a67" name="Credit Score">
+		<semantic:variable name="Credit Score" id="_3bf8b83f-789a-4e98-bb0d-34ab6a6e01d9" typeRef="tCreditScore"/>
+	</semantic:inputData>
+	<semantic:inputData id="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c" name="Down Payment">
+		<semantic:variable name="Down Payment" id="_bbe3f7c0-d59c-472b-9266-73bcdcc0fbb6" typeRef="number"/>
+	</semantic:inputData>
+	<semantic:businessKnowledgeModel id="_a6e2c692-4a0c-4385-bbc3-7280e94a8760" name="Min Credit Score">
+		<semantic:variable name="Min Credit Score" id="_bafc7628-ede7-40ed-8229-b79e1760b8ee" typeRef="tCreditScore"/>
+		<semantic:encapsulatedLogic typeRef="tCreditScore">
+			<semantic:formalParameter name="DTI" typeRef="tPercent"/>
+			<semantic:formalParameter name="LTV" typeRef="tPercent"/>
+			<semantic:formalParameter name="Reserves" typeRef="number"/>
+			<semantic:decisionTable id="_a99db8c3-9663-41dc-967e-b4f635506dcd" hitPolicy="COLLECT" outputLabel="Min Credit Score" typeRef="tCreditScore" aggregation="MIN" >
+				<semantic:input id="_5e4ee90f-583a-4a8f-bf42-2616c139ce31">
+					<semantic:inputExpression typeRef="tPercent">
+						<semantic:text>DTI</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:input id="_51e71746-911d-4256-b751-b711e2476c4f">
+					<semantic:inputExpression typeRef="tPercent">
+						<semantic:text>LTV</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:input id="_7ba31eb3-c907-4d20-a4c4-b41b0172112d">
+					<semantic:inputExpression typeRef="number">
+						<semantic:text>Reserves</semantic:text>
+					</semantic:inputExpression>
+				</semantic:input>
+				<semantic:output id="_f2d9e49b-793e-4a7e-8749-5e3ddcfd2a3a">
+					<semantic:outputValues>
+						<semantic:text>[300..850]</semantic:text>
+					</semantic:outputValues>
+				</semantic:output>
+				<semantic:annotation name="Description"/>
+				<semantic:rule id="_60fb255d-3cca-406e-96aa-145e5c3134e2">
+					<semantic:inputEntry id="_2dfcbc28-2f05-4c34-9360-ce1274be0344">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_48bdac5c-e2a4-4103-a3e8-adcfad17008b">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_82ef54c3-234c-4384-aca6-645eaa900410">
+						<semantic:text>&gt;2</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_aba459a7-a9bd-48ea-86d0-c964ebb54b4d">
+						<semantic:text>620</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_8fdabf93-b884-49a4-9768-ed496c1eca15">
+					<semantic:inputEntry id="_2e12a1da-8528-4941-a36f-05eae403e2ba">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_7940fa44-e304-45b9-9e33-a291f2d4701e">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_ede7214c-676e-46d0-bda7-8e70f7523a09">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_7e96c5da-327c-4055-9e1f-743e794fe3ed">
+						<semantic:text>640</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_ce04eb2e-2f8f-4bcb-bf21-b90bfc039de5">
+					<semantic:inputEntry id="_28251421-0039-4e33-81ca-5a69720605b1">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_da168d60-5fc2-45e4-ad80-49881e0dcec4">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_05b04b38-4ad5-481e-9f88-4532da0a65f5">
+						<semantic:text>&gt;6</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_f64cf229-d24f-4128-bd62-fc7560cb2017">
+						<semantic:text>660</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_ab97313e-cdac-4984-8888-28abbfd52e67">
+					<semantic:inputEntry id="_62505674-40e1-4691-956a-7050a140861a">
+						<semantic:text>&lt;=36</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_50988719-00c1-4671-8edf-beef5a5ae529">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_ac71f56c-c4b5-4ada-8f4b-c012fb1bc170">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_fd8a25ff-8896-400b-b15d-bff667d11d5c">
+						<semantic:text>680</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_c6aef964-bebc-4372-a9e8-518bca51140d">
+					<semantic:inputEntry id="_38a12a6c-9644-4904-8f28-0939dc344636">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_6e913c66-7fe4-4597-a088-fc9bb1baf64a">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_e7a7856c-eb23-4b84-933a-33e54d5efbec">
+						<semantic:text>&gt;6</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_c3991353-5446-4083-be12-e10cd21dbfd1">
+						<semantic:text>660</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_4364e403-a2cf-411b-a91e-649ded6ebb53">
+					<semantic:inputEntry id="_2de00a53-a95a-4226-9bd3-bbd1fa466f32">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_2fc2a147-b745-499d-8183-9b73b39beb6e">
+						<semantic:text>&lt;=75</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_f04775d9-a126-42e6-8123-e7e71e793092">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_5aca97fc-636c-48bf-8787-59ce61d8ee65">
+						<semantic:text>680</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_05db9a53-f530-4c35-bffd-4f8e07e35e12">
+					<semantic:inputEntry id="_38e6e020-7be4-4f0a-b93e-c46ab65bcd0f">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_086a842d-995a-43f9-8881-99560fc964ee">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_d2e65076-26a7-4735-9427-38e3fe02fc2f">
+						<semantic:text>&gt;6</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_2db22546-005a-4f3a-a76e-b8f11a777225">
+						<semantic:text>700</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+				<semantic:rule id="_5c867367-a339-48df-8423-262f36bc2e48">
+					<semantic:inputEntry id="_ef6f0eeb-5f35-48b1-a662-52db20addb51">
+						<semantic:text>(36..45]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_f3a182bb-5598-4a9c-9504-54d182068498">
+						<semantic:text>(75..95]</semantic:text>
+					</semantic:inputEntry>
+					<semantic:inputEntry id="_d074833b-4e28-413f-ab2d-212aae14448d">
+						<semantic:text>&gt;0</semantic:text>
+					</semantic:inputEntry>
+					<semantic:outputEntry id="_1b3be1eb-1387-439f-adb5-96837c31cdbd">
+						<semantic:text>720</semantic:text>
+					</semantic:outputEntry>
+					<semantic:annotationEntry>
+						<semantic:text/>
+					</semantic:annotationEntry>
+				</semantic:rule>
+			</semantic:decisionTable>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:decision id="_93f33bde-df66-4731-82ad-0cf0d86a3294" name="Loan Products">
+		<semantic:variable name="Loan Products" id="_8712a5d0-d218-473d-9c41-45d31851f560" typeRef="tLoanProducts"/>
+		<semantic:relation id="_93baa493-4725-4ebf-97f7-addb340f7a83" typeRef="tLoanProducts">
+			<semantic:column id="_9820a1a8-19e6-4f13-9fa3-70bab7ea306a" name="Lender Name" typeRef="string"/>
+			<semantic:column id="_6cd3cab8-c436-48e9-b80f-945543a6c93c" name="Product Name" typeRef="tProductName"/>
+			<semantic:column id="_4746448d-cdfa-43e5-9c5a-05ebbbbe6ca2" name="Type" typeRef="tAmortizationType"/>
+			<semantic:column id="_2ca00325-916f-434d-a831-0448c32e9250" name="Best Rate Pct" typeRef="tPercent"/>
+			<semantic:column id="_542134a3-08b6-42cd-ad09-9d86a29871bd" name="Points Pct" typeRef="tPercent"/>
+			<semantic:column id="_f549bb90-f2f0-489e-bfec-8e06da0151d3" name="Fees Amount" typeRef="number"/>
+			<semantic:column id="_366d18ad-119a-4284-a6e5-49b7ef89b160" name="Term" typeRef="number"/>
+			<semantic:row id="_cc6ef300-81cd-4d3f-b58e-a6e7bb72a1d7">
+				<semantic:literalExpression id="_3ba8d6cf-8214-43c0-9825-bd6f311f997d">
+					<semantic:text>"Lender A"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_64b77b5a-5af9-49d3-bcc8-963568c1a755">
+					<semantic:text>"Fixed30-NoPoints"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_78d10bc7-1a9a-4222-ba6d-e59b9e5f67c9">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_f3b92f21-6167-4504-8f6a-2923cabbd162">
+					<semantic:text>3.95</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_e46ceb71-6b97-42cf-8d33-c245b616c7c8">
+					<semantic:text>0</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_92bc2fe0-1216-4245-9fc0-9fb4ade20ad9">
+					<semantic:text>1925</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_900c25ab-02b3-46a7-b457-77f3831dc753">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_184a163a-cb2c-4489-8a22-4de4fef406b9">
+				<semantic:literalExpression id="_c6e45571-88f1-4816-a24b-1765422bcae9">
+					<semantic:text>"Lender C"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_cf500c46-72a8-4ed9-9ee3-8226c2ecf2a4">
+					<semantic:text>"Fixed30-Standard"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_e2f8ab27-ae9c-4264-8f6c-a7dd40b360c6">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_53856576-077c-4988-b8ac-b7ac465fb6a8">
+					<semantic:text>3.75</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_8f3386e0-29ce-4fa4-a7e2-0b8e270a8844">
+					<semantic:text>0.972</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_82cf4301-1226-4132-b419-23dee50bed09">
+					<semantic:text>1975</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_0843a5ad-b82d-438c-b091-161cd47dc6bb">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_302e3d3d-acfa-40d0-ab1a-ce38f782bd1d">
+				<semantic:literalExpression id="_1ebcdb41-3976-4749-96f6-f32b69d6c9e6">
+					<semantic:text>"Lender A"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_f999c9ea-ff2c-42cb-ac6b-5924e08c9bfd">
+					<semantic:text>"Fixed15-NoPoints"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_f8d0b9df-de26-4fc8-95ab-c95f0f784a50">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_b0986269-60dd-428a-8699-fb236bbfd691">
+					<semantic:text>3.625</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_ebe2805a-a19f-442b-bdfc-dee167933ab2">
+					<semantic:text>0</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_ef312ad1-b939-49f0-8295-6d509d7c4878">
+					<semantic:text>816</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_bc05b731-a50d-483e-b3bf-23860fcaadd8">
+					<semantic:text>180</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_f26625f3-ae64-4d94-bf30-c4203f82c5eb">
+				<semantic:literalExpression id="_00fd08b7-1e72-44fa-9a42-be22eeab2375">
+					<semantic:text>"Lender C"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_4264e9e4-e87b-4fbc-bdc5-cbeb7f84a515">
+					<semantic:text>"Fixed15-Standard"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_12556708-df14-459a-826d-4feef43f217f">
+					<semantic:text>"Fixed rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_909c2e7f-b66f-4c54-b67e-9e15365fa079">
+					<semantic:text>3.25</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_03d91914-b1cb-4817-9d7a-ed90713dd98e">
+					<semantic:text>0.767</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_3f078ef4-bf72-4047-8aa1-9b428b33134d">
+					<semantic:text>1975</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_37fa7c61-1a48-4cdf-ac50-b804ad4f3ea0">
+					<semantic:text>180</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_80e5f122-e823-456d-9830-19d60cfed5b3">
+				<semantic:literalExpression id="_3684907f-e753-46df-ad57-3a3babc050ef">
+					<semantic:text>"Lender B"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_400d2423-28a5-432f-8594-d2c84d660a3a">
+					<semantic:text>"ARM5/1-NoPoints"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_bfe3c0db-cf51-4788-82a1-a44a5f5f1b70">
+					<semantic:text>"Variable rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_fba9705c-1435-42eb-88de-66f6e92a0873">
+					<semantic:text>3.875</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_063e9e4c-2182-4682-9709-6721f60e6be1">
+					<semantic:text>0</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_ce5bf73c-948c-4d22-8715-42eaad213575">
+					<semantic:text>1776</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_7e55f606-5dc2-41d2-987b-088f6bf6fccc">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+			<semantic:row id="_586da39c-9153-48e4-9754-bb1a2da9410a">
+				<semantic:literalExpression id="_f07de042-8dfd-4b20-ab98-3b082e2480f7">
+					<semantic:text>"Lender B"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_873c448d-4b39-46fb-8919-1f2f7abe8a0d">
+					<semantic:text>"ARM5/1-Standard"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_c913876c-a538-478e-84e2-72c9d167fcad">
+					<semantic:text>"Variable rate"</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_6a510f8e-d185-485f-9fc9-70533a040864">
+					<semantic:text>3.625</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_bd151c87-85fd-4ee8-bcd9-2da601afb061">
+					<semantic:text>0.667</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_077fedc9-db07-4e6d-810e-f55ccd4ba39f">
+					<semantic:text>1975</semantic:text>
+				</semantic:literalExpression>
+				<semantic:literalExpression id="_81b8eb03-d078-4e4b-af88-c45f503ffe94">
+					<semantic:text>360</semantic:text>
+				</semantic:literalExpression>
+			</semantic:row>
+		</semantic:relation>
+	</semantic:decision>
+	<semantic:decision id="_0459fb1e-3d09-427d-9201-ea74a1b57864" name="Loan Info Table">
+		<semantic:variable name="Loan Info Table" id="_6820b177-357b-4a69-9d00-0d084abd13c9" typeRef="tLoanInfoTable"/>
+		<semantic:informationRequirement id="_4af51bdd-1651-42ec-8350-bc551facdffc">
+			<semantic:requiredDecision href="#_93f33bde-df66-4731-82ad-0cf0d86a3294"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_b3b8e3b8-ae4d-4192-8e96-f6abda717c16">
+			<semantic:requiredInput href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_fc2723b2-1ebd-45cc-a640-93f2cb2a6b4e">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_7cba5baa-07f0-4e12-b6a2-bb25a86d203a">
+			<semantic:requiredInput href="#_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_88a16649-4696-4d01-84f3-130be7caba3b">
+			<semantic:requiredKnowledge href="http://www.trisotech.com/definitions/_5c8b9296-96cf-4898-bba5-3a2d21d34eed#_f5761a7f-090d-4177-a06a-7f21f925c6ff"/>
+		</semantic:knowledgeRequirement>
+		<semantic:literalExpression id="_88fbacc7-8ce7-4147-93f0-4d70c7668842" typeRef="tLoanInfoTable">
+			<semantic:text>for x in Loan Products return Services.Loan Info Service(x,Down Payment,Property,Credit Score)</semantic:text>
+		</semantic:literalExpression>
+	</semantic:decision>
+	<semantic:decision id="_49ced667-1cff-4fce-a4b8-b5b480b28cd3" name="Eligibility Table">
+		<semantic:variable name="Eligibility Table" id="_45bace05-407b-4ea2-a580-066f711cd1c9" typeRef="tEligibilityTable"/>
+		<semantic:informationRequirement id="_08f900ff-aea1-419b-8e80-138343254a26">
+			<semantic:requiredDecision href="#_0459fb1e-3d09-427d-9201-ea74a1b57864"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_84630610-2554-4a74-a7e7-d185d10fd933">
+			<semantic:requiredInput href="#_a177b73e-7064-4140-8757-23bdf7a5d696"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_aa3ff8c4-2379-4609-8296-8474d14607e7">
+			<semantic:requiredInput href="#_d78ee6d5-96ed-43e6-89d2-123e0f388a67"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_56fb1a8d-9a03-4e87-b234-b3b9c941e3ff">
+			<semantic:requiredInput href="#_e0cfe605-3068-42a2-946f-c7db3774de1e"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_c83ae553-f658-4823-a18f-f404f447f859">
+			<semantic:requiredDecision href="#_93f33bde-df66-4731-82ad-0cf0d86a3294"/>
+		</semantic:informationRequirement>
+		<semantic:informationRequirement id="_4e13d93f-5461-4582-b6f7-afda9b6e6584">
+			<semantic:requiredInput href="#_7ed0a891-7b25-4c0e-838e-0a3cd5ec46be"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_4d86d4b2-4dee-426b-a1ff-6e91c6846585">
+			<semantic:requiredKnowledge href="#_f286d938-0042-4f0d-a889-6838d2c83a17"/>
+		</semantic:knowledgeRequirement>
+		<semantic:literalExpression id="_fef5d8f6-7c52-4df4-9203-2b56333b4b5f" typeRef="tEligibilityTable">
+			<semantic:text>for i in 1..count(Loan Products) return Eligibility(Loan Products[i], Borrower, Loan Info Table[i],
+Property, Credit Score, Lender Ratings) </semantic:text>
+		</semantic:literalExpression>
+	</semantic:decision>
+	<semantic:businessKnowledgeModel id="_f286d938-0042-4f0d-a889-6838d2c83a17" name="Eligibility">
+		<semantic:variable name="Eligibility" id="_33c71a05-13ba-4040-9ce3-394aa5513d28" typeRef="Any"/>
+		<semantic:encapsulatedLogic id="_0c7fd6f0-3c0f-43fc-8689-de083430e010" kind="FEEL" typeRef="Any">
+			<semantic:formalParameter name="Loan Product" typeRef="tLoanProduct" id="_d91e73be-a2fa-4224-a673-07e5cafe2235"/>
+			<semantic:formalParameter name="Borrower" typeRef="tBorrower" id="_6828f434-c3cb-4c22-909c-e21c34f66416"/>
+			<semantic:formalParameter name="Loan Info" typeRef="tLoanInfoRow" id="_cf041290-0a54-4e2b-80ef-c3a3a04d6c21"/>
+			<semantic:formalParameter name="Property" typeRef="tProperty" id="_543c4f59-e888-42c3-aaf4-60dc5b572da3"/>
+			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore" id="_bc995e69-571d-4c4c-80ed-ec8edb372534"/>
+			<semantic:formalParameter name="Ratings" typeRef="tLenderRatings" id="_9d39d2ce-e8cc-4d79-829a-f0e532c415f6"/>
+			<semantic:context id="_fbf39f7b-79c3-470c-82ff-62d685f1f297" typeRef="Any">
+				<semantic:contextEntry id="_112e54d2-2e8b-4504-a73e-a6616457f8fc">
+					<semantic:variable name="Params" id="_27860cc7-70bd-4ae8-810d-399e8fe8e990" typeRef="tEligibilityParameters"/>
+					<semantic:literalExpression id="_05089619-0347-4cb5-8fe5-bfc8cd937f9c">
+						<semantic:text>Eligibility Parameters(Loan Product, Borrower, Loan Info,
+Property, Credit Score)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_3f5c47a3-27a4-48a5-a8a2-b338ec4d473a">
+					<semantic:variable name="Required Credit Score" id="_98e57fc0-85cf-4797-a599-d3820382d74e" typeRef="tCreditScore"/>
+					<semantic:literalExpression id="_6689c21f-53ec-486f-8a4f-9ec7cd1409c0">
+						<semantic:text>Min Credit Score(Params.DTI Pct, Loan Info.LTV, Params.Reserves)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_b3e2b084-f251-43c9-ae16-bcbb44f86839">
+					<semantic:variable name="Eligible" id="_5f91dbe0-0a26-4216-9c57-6d3fd3f5ec76" typeRef="boolean"/>
+					<semantic:literalExpression id="_dd8647ef-12f1-40e3-aac6-2b604d3a9ba8">
+						<semantic:text>if Required Credit Score != null then 
+Credit Score &gt;= Required Credit Score else false</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_bcb71bda-a193-4e3b-ba73-8a6665ee6370">
+					<semantic:variable name="Recommendation" id="_2f9591a3-8827-4b64-9539-7f99b9c44d47" typeRef="tRecommendation"/>
+					<semantic:decisionTable id="_1f65b543-5086-420c-b502-274e18a0d4ac" hitPolicy="PRIORITY" outputLabel="Recommendation">
+						<semantic:input id="_ae5200fc-ef39-4b69-973c-5c2979e5b1b1">
+							<semantic:inputExpression typeRef="tLoanProduct">
+								<semantic:text>Loan Product</semantic:text>
+							</semantic:inputExpression>
+						</semantic:input>
+						<semantic:input id="_52996440-a14c-4e6c-82e7-9884deb3d84d">
+							<semantic:inputExpression typeRef="boolean">
+								<semantic:text>Eligible</semantic:text>
+							</semantic:inputExpression>
+						</semantic:input>
+						<semantic:output id="_4c573eb2-dc05-45d6-9158-373fe3c83a0c">
+							<semantic:outputValues>
+								<semantic:text>"Best","Good","Not Recommended","Ineligible"</semantic:text>
+							</semantic:outputValues>
+						</semantic:output>
+						<semantic:annotation name="Description"/>
+						<semantic:rule id="_7b3d290c-0fde-4f3e-b220-35c49f0bd39b">
+							<semantic:inputEntry id="_e4c91cbe-7210-4249-8889-0e8624af7a0b">
+								<semantic:text>count(Ratings[Lender Name=?.Lender Name and Customer Rating &gt; 4] )&gt;0</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_72409463-559e-472d-ae0f-762f562b9a7b">
+								<semantic:text>true</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_a20c0261-66f8-458c-af98-9130e71b0764">
+								<semantic:text>"Best"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+						<semantic:rule id="_04ac4893-c441-4cc6-a437-d034b358c817">
+							<semantic:inputEntry id="_fee48560-c88d-4c30-b312-c4259bfdbd89">
+								<semantic:text>count(Ratings[Lender Name=?.Lender Name and Customer Rating in [3..4]] )&gt;0</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_1d664b74-70b0-4e0d-9edd-928911602bf3">
+								<semantic:text>true</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_f9bf975e-7e3a-4d9a-a8fc-7038f74359f8">
+								<semantic:text>"Good"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+						<semantic:rule id="_c4d79130-3848-4080-afaa-647146736125">
+							<semantic:inputEntry id="_cecfdc03-6cd4-407b-a8e6-c788f89521c2">
+								<semantic:text>count(Ratings[Lender Name=?.Lender Name and Customer Rating &lt;3] )&gt;0</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_781ad27e-faa8-436c-8d47-4a209479c7e2">
+								<semantic:text>true</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_74927ae6-514d-4c13-be6d-378665e8aed0">
+								<semantic:text>"Not Recommended"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+						<semantic:rule id="_15ef0d48-8d2c-4527-ba01-c85edb527fb2">
+							<semantic:inputEntry id="_39a73402-4a5f-42e5-be97-2ae3fbbc8e4a">
+								<semantic:text>-</semantic:text>
+							</semantic:inputEntry>
+							<semantic:inputEntry id="_13112ddb-cf4d-436c-a779-2be5b75e7e8b">
+								<semantic:text>-</semantic:text>
+							</semantic:inputEntry>
+							<semantic:outputEntry id="_a6f39264-79d3-49da-80ef-200c730981c4">
+								<semantic:text>"Ineligible"</semantic:text>
+							</semantic:outputEntry>
+							<semantic:annotationEntry>
+								<semantic:text/>
+							</semantic:annotationEntry>
+						</semantic:rule>
+					</semantic:decisionTable>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_c5b0cb53-7f65-408d-b5cd-df0611538d99">
+					<semantic:variable name="Table Row" id="_f28d781b-9c25-4017-9c0b-d50ba3158b27" typeRef="tTableRow"/>
+					<semantic:context id="_e18faad2-a4bf-48df-8a9a-8af206da5392">
+						<semantic:contextEntry id="_df156b8b-b7ca-4abb-9e2c-184b1475bf3f">
+							<semantic:variable name="Product" id="_446c0304-a441-48ac-9c88-ffcb0fd4e11a" typeRef="string"/>
+							<semantic:literalExpression id="_60468906-dccb-41e6-a3d0-bc562134d3af">
+								<semantic:text>Loan Product.Lender Name + " - " + Loan Product.Product Name</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_6e2059dd-78d0-422d-bf5d-ba1ac699ab6a">
+							<semantic:variable name="Note Amount" id="_204838f8-5fab-43b6-b08a-90fd15af54e5" typeRef="number"/>
+							<semantic:literalExpression id="_73890cc6-b950-46c4-8533-f1b6d04eca37">
+								<semantic:text>Loan Info.Note Amount</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_a8c61057-bf8f-4661-bb9f-b1e3714f0249">
+							<semantic:variable name="Interest Rate Pct" id="_8526bae4-0b60-4bda-b117-1be37310aa6b" typeRef="tPercent"/>
+							<semantic:literalExpression id="_56907eca-faf9-45d8-8a13-04769f3f10a5">
+								<semantic:text>Loan Info.Initial Rate Pct</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_d791f2d6-dfa2-444a-98b4-d38222a232ba">
+							<semantic:variable name="Monthly Payment" id="_5a4156a0-4956-43be-9e5c-f5e2ccb45ad6" typeRef="number"/>
+							<semantic:literalExpression id="_fd0b5673-470a-4058-aeda-9c20e2be811b">
+								<semantic:text>Loan Info.Initial Monthly Payment</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7a0aa777-99a2-4fed-9bd8-65d484f447c2">
+							<semantic:variable name="LTV" id="_aec60c0b-682d-4a41-93ba-0aeb19a9dc06" typeRef="tPercent"/>
+							<semantic:literalExpression id="_d69d69d6-975c-4965-8204-0eaa25af7ed5">
+								<semantic:text>Loan Info.LTV</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7d8206c6-896b-47db-ba40-37825def24e1">
+							<semantic:variable name="DTI" id="_4ad07fa9-a657-41be-9611-0f78c04893a3" typeRef="tPercent"/>
+							<semantic:literalExpression id="_7dd61876-2271-4ee8-992c-f9eb5ec2ddce">
+								<semantic:text>Params.DTI Pct</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_11fbf31f-a07d-4c74-9cfd-737549d16e86">
+							<semantic:variable name="Cash to Close" id="_9f528784-9993-4fcd-b57d-cb97900a6b65" typeRef="number"/>
+							<semantic:literalExpression id="_4113bf58-a1ea-4207-982d-caa1fbcb042f">
+								<semantic:text>Loan Info.Cash to Close</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7e3665d3-420f-4f8c-8079-fd384405a002">
+							<semantic:variable name="Liquid Assets After Closing" id="_b3d05458-f835-436f-89ac-d77a56fef096" typeRef="number"/>
+							<semantic:literalExpression id="_77edeb7f-e455-46e2-a2ac-9b212444ce41">
+								<semantic:text>Params.Liquid Assets After Closing</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_6487e7a9-bd4a-40e4-9c3d-d13af46916a5">
+							<semantic:variable name="Reserves" id="_e70c07f9-1f8b-41c7-b494-5cb0021c61b3" typeRef="number"/>
+							<semantic:literalExpression id="_f41077a8-2982-4c77-bd9e-6248a6d86a93">
+								<semantic:text>Params.Reserves</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_7186ab6a-029d-4abb-b62d-70cab97c8eb5">
+							<semantic:variable name="Required Credit Score" id="_0b2096ae-f7a6-4bf6-8813-7f78ce5c0f72" typeRef="tCreditScore"/>
+							<semantic:literalExpression id="_5c6a3c17-ea36-4f34-9934-907892af3ecb">
+								<semantic:text>Required Credit Score</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_40a95ad0-f105-4f89-94a5-c19ace99b19b">
+							<semantic:variable name="Recommendation" id="_3a347de8-c79e-4d15-993c-db8172800c9b" typeRef="tRecommendation"/>
+							<semantic:literalExpression id="_c80bff77-26ec-487b-a7d1-56efd17c8ff9">
+								<semantic:text>Recommendation</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+					</semantic:context>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_2f39070d-3c83-43aa-9058-aa3d288f4c05">
+					<semantic:literalExpression id="_a20b4947-5a1d-4085-8650-aa823cff1172">
+						<semantic:text>Table Row</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+			</semantic:context>
+		</semantic:encapsulatedLogic>
+		<semantic:knowledgeRequirement id="_0e52bb98-f219-45a8-8c29-3ed891143377">
+			<semantic:requiredKnowledge href="#_a6e2c692-4a0c-4385-bbc3-7280e94a8760"/>
+		</semantic:knowledgeRequirement>
+		<semantic:knowledgeRequirement id="_821c87b5-940c-4c25-91a5-dcac1481a647">
+			<semantic:requiredKnowledge href="#_813f0ad9-fae2-41fd-b99b-2c8e438b4e01"/>
+		</semantic:knowledgeRequirement>
+	</semantic:businessKnowledgeModel>
+	<semantic:decision id="_aefdf469-fc01-4081-b1e0-85d543b347df" name="Recommended Loan Products">
+		<semantic:variable name="Recommended Loan Products" id="_429ae560-d21a-411c-8b62-6d030ab28170" typeRef="tRecommendedTable"/>
+		<semantic:informationRequirement id="_a68f3c2d-409a-466c-9be8-aa4ee85640c2">
+			<semantic:requiredDecision href="#_49ced667-1cff-4fce-a4b8-b5b480b28cd3"/>
+		</semantic:informationRequirement>
+		<semantic:knowledgeRequirement id="_b52032a0-6a00-4643-98aa-3fb4367f69ca">
+			<semantic:requiredKnowledge href="#_929201cb-cb3b-4326-b199-bb0f9149ebb0"/>
+		</semantic:knowledgeRequirement>
+		<semantic:context id="_58bfdd10-93f6-43d8-88df-efd285ba9c49" typeRef="tRecommendedTable">
+			<semantic:contextEntry id="_8107ef5d-7a84-4096-874b-6256370a4b27">
+				<semantic:variable name="precedes" id="_4c24fec3-9c76-4ad1-905a-dcb3184f9108" typeRef="boolean"/>
+				<semantic:functionDefinition id="_124804b5-4269-4e60-81bb-a359a60d7729" kind="FEEL">
+					<semantic:formalParameter name="x" typeRef="tTableRow" id="_cad699ce-69d9-4d25-8d5a-8d05864cd6bc"/>
+					<semantic:formalParameter name="y" typeRef="tTableRow" id="_52676e01-3f29-453a-a4d9-33eadf2a2686"/>
+					<semantic:literalExpression id="_f7c2b006-817c-49ef-918d-f5878f4e766c">
+						<semantic:text>if x.Recommendation != "Ineligible" and y.Recommendation != "Ineligible"
+then x.Monthly Payment&lt;y.Monthly Payment 
+else if x.Recommendation != "Ineligible" and y.Recommendation = "Ineligible"
+then true else false</semantic:text>
+					</semantic:literalExpression>
+				</semantic:functionDefinition>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_e2fffe29-ceb8-4d50-a291-f40af7f6fa0b">
+				<semantic:variable name="Sorted Table" id="_f7156ed8-c321-43cf-acd4-cd7835659522" typeRef="tEligibilityTable"/>
+				<semantic:literalExpression id="_b8cdb4fe-729b-4bf3-ab56-ec5af548eb89">
+					<semantic:text>sort(Eligibility Table, precedes)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+			<semantic:contextEntry id="_e918b3f1-645e-4525-bbe8-760c633f3e8e">
+				<semantic:literalExpression id="_ba066f10-e809-4cc4-8fe4-dd3a710e65d2">
+					<semantic:text>for row in Sorted Table return Format Row(row)</semantic:text>
+				</semantic:literalExpression>
+			</semantic:contextEntry>
+		</semantic:context>
+	</semantic:decision>
+	<semantic:businessKnowledgeModel id="_813f0ad9-fae2-41fd-b99b-2c8e438b4e01" name="Eligibility Parameters">
+		<semantic:variable name="Eligibility Parameters" id="_de0fa861-531d-4983-9dd7-0b448af5d6a7" typeRef="tEligibilityParameters"/>
+		<semantic:encapsulatedLogic id="_0a63f9b7-5f09-47af-9bd7-0e6b10f0d457" kind="FEEL" typeRef="tEligibilityParameters">
+			<semantic:formalParameter name="Loan Product" typeRef="tLoanProduct" id="_1912abed-44d7-4728-a98b-f9edb9874014"/>
+			<semantic:formalParameter name="Borrower" typeRef="tBorrower" id="_53f8f293-a4ab-48e3-9285-1a50d9c7f384"/>
+			<semantic:formalParameter name="Loan Info" typeRef="tLoanInfoRow" id="_962c2fd9-96da-46b1-9532-234b60306665"/>
+			<semantic:formalParameter name="Property" typeRef="tProperty" id="_5ed2ddb8-33a3-4b96-beb5-a4367de0f26a"/>
+			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore" id="_0134c6e4-d273-4724-a5dd-4fe2b916f0db"/>
+			<semantic:context id="_d4558837-ad20-4ed3-8099-e5142be3797c" typeRef="tEligibilityParameters">
+				<semantic:contextEntry id="_f76319fe-179e-49e9-a733-97c8fb7957de">
+					<semantic:variable name="Housing Expense" id="_bda0bbad-27c6-4a78-a87a-a2c929ee939f" typeRef="number"/>
+					<semantic:literalExpression id="_f0f68868-ef1c-455d-a438-fd91c7378b16">
+						<semantic:text>sum([Loan Info.Qualifying Monthly Payment, Property.Monthly Tax Payment,
+Property.Monthly Insurance Payment, Property.Monthly HOA Condo Fee][item != null])</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_b9129263-8b2c-4849-83e0-363001dc91c2">
+					<semantic:variable name="Non-Housing Debt Payments" id="_ffbeddfa-93d4-4a77-a985-ed5b75648dfa" typeRef="number"/>
+					<semantic:literalExpression id="_cfac9257-10a2-4960-a3e7-af9e99aa59ab">
+						<semantic:text>sum(Borrower.Liabilities[Type!="Real estate loan" and To be paid off
+=false].Monthly payment)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_a0fbbf2c-3a6e-46ca-8c79-05807ee9ad65">
+					<semantic:variable name="Income" id="_6e77ef2c-a1c0-4a67-922d-3ce5907f3692" typeRef="number"/>
+					<semantic:literalExpression id="_baa76bb6-a451-4e70-9589-a9ac2e3b65ba">
+						<semantic:text>sum([Borrower.Employment Income, Borrower.Other Income][item != null])</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_18f391f4-7ad3-4b0b-935e-4a6de6f090c5">
+					<semantic:variable name="DTI Pct" id="_6a52a65a-76fa-4692-9628-b447b86354f9" typeRef="tPercent"/>
+					<semantic:literalExpression id="_6498e13a-258a-42b1-aadb-3d8b15da8521">
+						<semantic:text>decimal((Housing Expense+Non-Housing Debt Payments)/Income*100,2)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_d8d80977-a34d-45bc-8411-6eaaa1bcd68a">
+					<semantic:variable name="Liquid Assets Before Closing" id="_2cdcde07-05c3-4eac-bd4d-ac5c2c638100" typeRef="number"/>
+					<semantic:literalExpression id="_ae29c64b-14c7-4e52-aeef-cf411be4ae80">
+						<semantic:text>sum(Borrower.Assets[Type="Checking Savings Brokerage account" 
+or Type="Other Liquid"].Value)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_5d3d126e-f2e2-4800-a3ad-075482a66cbc">
+					<semantic:variable name="Debts Paid Off By Closing" id="_d97ec4d8-dbff-489b-9647-657bb156afd3" typeRef="number"/>
+					<semantic:literalExpression id="_7a92d594-063b-4d40-9936-f8fb0bb6d287">
+						<semantic:text>sum(Borrower.Liabilities[Type!="Real estate loan" 
+and To be paid off=true].Balance[item!=null])</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_607017c3-e91a-4780-b339-db6f4a1e8ddd">
+					<semantic:variable name="Liquid Assets After Closing" id="_2daf54ff-6d4e-41b3-9efb-979ff415c180" typeRef="number"/>
+					<semantic:literalExpression id="_45d39beb-f0a0-4289-92a0-cf1a3c17a6e8">
+						<semantic:text>Liquid Assets Before Closing - Debts Paid Off By Closing - Loan Info.Cash to Close</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_3931d8a9-d99f-4fa2-a821-66940a297dd2">
+					<semantic:variable name="Reserves" id="_51fb843d-9e41-4e41-bb4a-cbe45cdedc16" typeRef="number"/>
+					<semantic:literalExpression id="_c5188525-c1a5-4cc4-9366-7fac3b857dba">
+						<semantic:text>decimal(Liquid Assets After Closing/Housing Expense,2)</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+			</semantic:context>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<semantic:inputData id="_7ed0a891-7b25-4c0e-838e-0a3cd5ec46be" name="Lender Ratings">
+		<semantic:variable name="Lender Ratings" id="_2c92c03e-a395-4af5-ae8c-387b37ba1d71" typeRef="tLenderRatings"/>
+	</semantic:inputData>
+	<semantic:businessKnowledgeModel id="_929201cb-cb3b-4326-b199-bb0f9149ebb0" name="Format Row">
+		<semantic:variable name="Format Row" id="_517952d5-64e8-4dc8-8815-ac6732b851a6" typeRef="tformattedrow_1"/>
+		<semantic:encapsulatedLogic id="_e6de2d7e-3623-449f-b238-63d2eadc31d6" kind="FEEL" typeRef="tformattedrow_1">
+			<semantic:formalParameter name="row" typeRef="tTableRow" id="_984e3a72-a34e-4957-beb5-471b1a972ed5"/>
+			<semantic:context id="_5ccce417-75fd-4d60-b014-695bb847cb31" typeRef="tformattedrow_1">
+				<semantic:contextEntry id="_b5fcf3db-2bf1-4b11-ac61-88234e8ff31a">
+					<semantic:variable name="string format" id="_1094d90c-0ad3-4f59-ad87-8e76ca4b7307" typeRef="string"/>
+					<semantic:functionDefinition id="_96359ad3-5b52-4798-b1e7-103bdc7f07b7" kind="Java">
+						<semantic:formalParameter name="mask" typeRef="string" id="_4dbb8658-6073-432d-b51a-f65d2beea042"/>
+						<semantic:formalParameter name="value" typeRef="number" id="_08b8eb1c-8e5d-4e94-b0fa-845f046f4b89"/>
+						<semantic:context>
+							<semantic:contextEntry id="_ba1bd7c1-6f16-4c7d-b1d1-cff9aa7e832e">
+								<semantic:variable name="class" id="_6756decc-097e-402b-ab9a-a5f8ad48182f" typeRef="string"/>
+								<semantic:literalExpression id="_4a34e305-c238-4477-b407-6b4348685108">
+									<semantic:text>"java.lang.String"</semantic:text>
+								</semantic:literalExpression>
+							</semantic:contextEntry>
+							<semantic:contextEntry id="_3c44080c-65f2-4a2f-8df4-54ba75c004be">
+								<semantic:variable name="method signature" id="_fda512ff-d00a-4a2a-be7b-288daae61550" typeRef="string"/>
+								<semantic:literalExpression id="_c73133d7-fd79-42a3-980c-9720e2812afd">
+									<semantic:text>"format( java.lang.String, [Ljava.lang.Object; )"</semantic:text>
+								</semantic:literalExpression>
+							</semantic:contextEntry>
+						</semantic:context>
+					</semantic:functionDefinition>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_60f2eefa-f7dd-4d80-ac3d-aea0caa577ac">
+					<semantic:variable name="formatted row" id="_562a5d65-2c21-4575-bca9-9dc6addf9388" typeRef="tformattedrow_1"/>
+					<semantic:context id="_9da73807-1031-4622-9b65-f1fbe8b1b7ed">
+						<semantic:contextEntry id="_58e15f84-d002-4ae0-b0dc-e4d5961cd42b">
+							<semantic:variable name="Product" id="_ea14919a-68c2-4d45-84de-be03a259be25" typeRef="string"/>
+							<semantic:literalExpression id="_bf722194-b9e2-4c30-b4ff-408cb1152f19">
+								<semantic:text>row.Product</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_81abd4de-4a7f-47cf-9d31-11a7421185ad">
+							<semantic:variable name="Note Amount" id="_41f4b93c-ac0f-4c96-8db7-e32298eb44f0" typeRef="string"/>
+							<semantic:literalExpression id="_8e6ef746-ca5e-4e92-af09-92c6137b851e">
+								<semantic:text>string format("$%,4.2f", row.Note Amount)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_9098479f-635d-4af4-a3d0-4605692c3cfc">
+							<semantic:variable name="Interest Rate Pct" id="_2c4f2fce-de35-41f0-b8b4-0679fdeec4fd" typeRef="string"/>
+							<semantic:literalExpression id="_8dd2672c-9a6c-499e-9b4c-fa1f859d8ab4">
+								<semantic:text>string format(" %,4.2f", row.Interest Rate Pct)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_720cf2db-4a1e-482d-aa9a-8dea2d91d11c">
+							<semantic:variable name="Monthly Payment" id="_1652042c-c4e1-4bac-9e11-e281b9f21498" typeRef="string"/>
+							<semantic:literalExpression id="_32dd7994-6506-417e-93d0-62485724411e">
+								<semantic:text>string format("$%,4.2f", row.Monthly Payment)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_d17a962b-1c9d-472d-bedd-e13a30f9640b">
+							<semantic:variable name="Cash to Close" id="_e4715ea0-6389-4a73-9568-35f8a1ed5697" typeRef="string"/>
+							<semantic:literalExpression id="_ca131f04-b7c8-497f-b4cf-2ef52e4bdf10">
+								<semantic:text>string format("$%,4.2f", row.Cash to Close)</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_2086ead6-f35d-4807-bbad-f1c41eca6b58">
+							<semantic:variable name="Required Credit Score" id="_26b82f93-7b44-4e98-b623-ccf5c95a14a7" typeRef="tCreditScore"/>
+							<semantic:literalExpression id="_74b6dcd5-0b30-486f-ad21-ffdc50e84031">
+								<semantic:text>row.Required Credit Score</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+						<semantic:contextEntry id="_2a47f396-0029-4cad-94ab-7179c963bd3a">
+							<semantic:variable name="Recommendation" id="_06faad8c-3d0e-41f2-aec1-44a267bc8eee" typeRef="string"/>
+							<semantic:literalExpression id="_f7df45c0-9486-4baf-b9d9-be813f5d6aed">
+								<semantic:text>row.Recommendation</semantic:text>
+							</semantic:literalExpression>
+						</semantic:contextEntry>
+					</semantic:context>
+				</semantic:contextEntry>
+				<semantic:contextEntry id="_67cf635f-87ff-4613-b00c-c1def8f7158a">
+					<semantic:literalExpression id="_58517f86-e5cc-42c9-8ebb-0622f94bf23e">
+						<semantic:text>formatted row</semantic:text>
+					</semantic:literalExpression>
+				</semantic:contextEntry>
+			</semantic:context>
+		</semantic:encapsulatedLogic>
+	</semantic:businessKnowledgeModel>
+	<dmndi:DMNDI xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/">
+		<dmndi:DMNDiagram id="_0b101bf8-a9c5-4e7c-8763-c8fcb4263a32" name="Page 1">
+			<di:extension xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"/>
+			<dmndi:Size height="1050" width="1550.4755458831787"/>
+			<dmndi:DMNShape id="_c1bba5d5-fa68-482c-9856-62553328432f" dmnElementRef="_a177b73e-7064-4140-8757-23bdf7a5d696">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="221.7520332336426" y="508.99999618530273" width="135.4823417663574" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_a3898cf2-06c3-4ff6-aee8-ff1980e1df26" dmnElementRef="_e0cfe605-3068-42a2-946f-c7db3774de1e">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="365.234375" y="630.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_4b1fc771-634e-4074-b5fa-9fddc959704d" dmnElementRef="_d78ee6d5-96ed-43e6-89d2-123e0f388a67">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="221.7520332336426" y="630.9999961853027" width="135.4823417663574" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_9fdb64c0-601f-47bf-8592-01d5144ef096" dmnElementRef="_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="690.9864082336426" y="630.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_be0cf71f-9d15-48dc-b705-06f25e958624" dmnElementRef="_a6e2c692-4a0c-4385-bbc3-7280e94a8760">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="912.4932041168213" y="349" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_dc10415e-38d4-42af-a5bd-5d7458fc841c" dmnElementRef="_93f33bde-df66-4731-82ad-0cf0d86a3294">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="521.734375" y="631" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_b5fd3a66-fd67-48a9-8b4c-c18df2632c01" dmnElementRef="_0459fb1e-3d09-427d-9201-ea74a1b57864">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="610.2275791168213" y="445" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_f128a162-c0d5-4e7d-a96f-fc953d9fcae1" dmnElementRef="_49ced667-1cff-4fce-a4b8-b5b480b28cd3">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="521.734375" y="349" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_a7fc8244-5fcc-4caa-80fc-f9c00a540a44" dmnElementRef="_f286d938-0042-4f0d-a889-6838d2c83a17">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="719" y="349.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_cabd0351-2058-4d41-9d9a-4e0c2f2f30dd" dmnElementRef="_aefdf469-fc01-4081-b1e0-85d543b347df">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="521.734375" y="250.00000000000003" width="153" height="59.99999999999997"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_d4d663f4-e804-4601-a50a-da743ce86419" dmnElementRef="_813f0ad9-fae2-41fd-b99b-2c8e438b4e01">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="912.9932041168213" y="267.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_dc1bb3d6-b254-4464-94c3-46b5f0ec09f9" dmnElementRef="include1:_f5761a7f-090d-4177-a06a-7f21f925c6ff" isCollapsed="true">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="860.7361043356821" y="445" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_14e3646c-50fc-4b3a-8e40-40c99c6a54c7" dmnElementRef="_7ed0a891-7b25-4c0e-838e-0a3cd5ec46be">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="221.7520332336426" y="387.00346411608245" width="135.4823417663574" height="60.00000762939453"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_ec10fdad-2a7c-4238-b6f8-e581f0b772d8" dmnElementRef="_929201cb-cb3b-4326-b199-bb0f9149ebb0">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="281.2361043356818" y="250.5" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="_0670a8b5-bc66-453c-8a48-b691469e5dd0" dmnElementRef="_4af51bdd-1651-42ec-8350-bc551facdffc">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="588.234375" y="631"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="676.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_a3f9e2b4-99d2-4186-a50c-b6622948628e" dmnElementRef="_b3b8e3b8-ae4d-4192-8e96-f6abda717c16">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="329.49000549316406" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="646.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_1f922953-3c60-4457-8183-c5365813d936" dmnElementRef="_fc2723b2-1ebd-45cc-a640-93f2cb2a6b4e">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="432.9723472595215" y="690.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="656.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_f3f1d471-e9d2-4e9a-8594-140d7e341b72" dmnElementRef="_7cba5baa-07f0-4e12-b6a2-bb25a86d203a">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="748.7243804931641" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="716.7275791168213" y="505"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_fcf3aa6e-ce2a-408e-aa0c-4a10795fbe6d" dmnElementRef="_0e52bb98-f219-45a8-8c29-3ed891143377">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="912.4932041168213" y="378.49152542372883"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="871" y="378.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_5bb524fc-5aec-4ec6-8d2a-dd91e7ffef84" dmnElementRef="_08f900ff-aea1-419b-8e80-138343254a26">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="686.7275791168213" y="445"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598.234375" y="409"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_9f91df8c-ebb4-4e2b-b579-b153c1df09b9" dmnElementRef="_84630610-2554-4a74-a7e7-d185d10fd933">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="319.49000549316406" y="508.99999618530273"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="379"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_e9dc41c9-1998-47e6-ac1a-992a9a98fe4b" dmnElementRef="_4d86d4b2-4dee-426b-a1ff-6e91c6846585">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="719" y="378.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="674.734375" y="379"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_dddf7b22-df2a-418e-904f-c13f4e01b63d" dmnElementRef="_aa3ff8c4-2379-4609-8296-8474d14607e7">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="289.49000549316406" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="399"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_bc4016d5-51eb-453a-aa1e-edfb1448cbd6" dmnElementRef="_56fb1a8d-9a03-4e87-b234-b3b9c941e3ff">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="432.9723472595215" y="630.9999961853027"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="476.60336112976074" y="496.99999809265137"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="538.234375" y="409"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_72c23e8d-0fd3-45f9-8cad-1cf8858bce11" dmnElementRef="_c83ae553-f658-4823-a18f-f404f447f859">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="568.234375" y="631"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="578.234375" y="409"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_c562e786-cdc6-47e6-98e2-ede2203b8799" dmnElementRef="_a68f3c2d-409a-466c-9be8-aa4ee85640c2">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598.234375" y="349"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598.234375" y="310"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_ca21c22e-c882-4a27-ae3b-36d491872e26" dmnElementRef="_821c87b5-940c-4c25-91a5-dcac1481a647">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="912.9932041168213" y="296.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="871" y="358.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_72fc05b4-d034-4c54-a55c-f8c756a4f4d7" dmnElementRef="_88a16649-4696-4d01-84f3-130be7caba3b">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="860.7361043356821" y="475"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="763.2275791168213" y="475"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_d6f96ec8-84ff-431b-be9b-488df35abc45" dmnElementRef="_4e13d93f-5461-4582-b6f7-afda9b6e6584">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="357.234375" y="417.00346411608245"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="369"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_dce5de3c-bbbc-4333-985c-a4618049a4a4" dmnElementRef="_b52032a0-6a00-4643-98aa-3fb4367f69ca">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="433.2361043356818" y="279.5"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="521.734375" y="280"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+		<dmndi:DMNDiagram id="_63ffcf37-6958-4078-8118-bff7842f8c39" name="Services.Loan Info Service">
+			<di:extension xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"/>
+			<dmndi:Size height="1050" width="1485"/>
+			<dmndi:DMNShape id="_27064364-5b02-4f0e-a10d-dcbe208edad1" dmnElementRef="include1:_d78ee6d5-96ed-43e6-89d2-123e0f388a67">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="358" y="661" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_2822112c-279b-4ac8-9085-ffa29e5e3772" dmnElementRef="include1:_29a44873-e886-42de-bc2f-6d5704b6b298">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="733" y="356.75" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_7913007e-de82-490b-ba57-64076c5f7dbb" dmnElementRef="include1:_896a0a4a-0d0e-404c-a9e3-4500b4e2fd9c">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="821" y="469.75" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_73693581-59c2-47cf-b99d-edb869148e62" dmnElementRef="include1:_e0cfe605-3068-42a2-946f-c7db3774de1e">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="941" y="551.0000000000001" width="153" height="60"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_d873815e-50da-4839-955e-c4a66d8a72f6" dmnElementRef="include1:_f5761a7f-090d-4177-a06a-7f21f925c6ff" isCollapsed="false">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="338" y="329" width="260" height="282"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+				<dmndi:DMNDecisionServiceDividerLine>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="338" y="470"/>
+					<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="598" y="470"/>
+				</dmndi:DMNDecisionServiceDividerLine>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_cb197420-797b-49d7-882d-b0a982941241" dmnElementRef="include1:_91fa4ebe-d9c9-4608-b043-c27d99e1eaa5">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="358" y="510" width="154" height="61"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_276339e5-a4a0-41d3-b035-80df3320a1f4" dmnElementRef="include1:_8a182857-b5a1-4389-9a76-01a316938cea">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="358" y="369" width="154" height="61"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_3705344c-2a10-4927-96d1-f86916bb02e2" dmnElementRef="include1:_0d2a6f36-0403-41ad-a191-f793743649d4">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="623" y="610.5034679307797" width="152" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="_94efa65c-e784-4e88-9807-627d768b1aae" dmnElementRef="include1:_aeaa30db-0f84-424a-b2f5-af9b2538a9ce">
+				<dc:Bounds xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" x="130.4687421975863" y="600.5034679307797" width="151.99999999999997" height="59"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="_35eff1f0-be88-46e7-91f2-2f550c8bc64c" dmnElementRef="include1:_8304cbac-5619-459b-92a8-b389aaaf2aff">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="434.5" y="661"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="571"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_1987d0a2-82d0-409c-90b4-03c83213da8d" dmnElementRef="include1:_70f3db04-5830-45d2-ba12-7c355e571fcd">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="733" y="386.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="399.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_fa64a0fe-f9c8-44e8-befb-ea8bea160d0b" dmnElementRef="include1:_ffe87244-b1ab-4075-a243-5f2a87f170d0">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="733" y="386.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="540.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_c089b2a8-ff15-4e9b-9c8e-b0d93b6c7a87" dmnElementRef="include1:_da7d6551-1fd0-49ea-9723-ec51d15005a8">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="821" y="499.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="399.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_1d657839-84f5-4d7b-a9a9-0836a535cff0" dmnElementRef="include1:_d9d4a780-7427-4000-b2c7-575717ebcae5">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="821" y="499.75"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="540.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_c02edce6-9373-4cca-9ad2-475e6233ac29" dmnElementRef="include1:_8d9ec740-a917-4215-88ec-e531ee90a348">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="941" y="581.0000000000001"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="399.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_96c3213d-d7f4-40f6-8087-16a6af11474b" dmnElementRef="include1:_e47777c4-b10c-4aa8-8087-371824560192">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="941" y="581.0000000000001"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="512" y="540.5"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_b40c4be4-a3d0-4180-9d75-455f9da96ddd" dmnElementRef="include1:_1f641b45-5ad1-4dfa-bdc5-19d0f52b87b4">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="510"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="430"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_516ea932-dbcb-4e57-9686-f2401224ec7e" dmnElementRef="include1:_ff803e3f-9159-401f-b22c-edbb48cbf164">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="699" y="611.5034679307797"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="571"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+			<dmndi:DMNEdge id="_d094e1a0-eb98-4f74-b775-df535297ee20" dmnElementRef="include1:_28360d50-9eee-4fa1-9f4d-a19c5bc9bbcb">
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="206.4687421975863" y="601.5034679307797"/>
+				<di:waypoint xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" x="435" y="571"/>
+				<dmndi:DMNLabel sharedStyle="LS_736fa164-03d8-429f-8318-4913a548c3a6_0"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+		<dmndi:DMNStyle id="LS_736fa164-03d8-429f-8318-4913a548c3a6_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+	</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/simple.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/v1_3/simple.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:include1="http://www.trisotech.com/definitions/_5e8e877a-af87-434b-9c36-ed51c8d6b514" xmlns:drools="http://www.drools.org/kie/dmn/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:feel="https://www.omg.org/spec/DMN/20191111/FEEL/"              xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" name="Chapter 11 Example" namespace="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" exporter="DMN Modeler" exporterVersion="6.2.2.1" triso:logoChoice="None">
+<semantic:extensionElements/>
+<semantic:decisionService id="_61a137fa-eedd-4cf0-8969-827591267b4b_DS" name="Whole Model Decision Service" triso:dynamicDecisionService="true">
+    <semantic:variable name="Whole Model Decision Service" id="_61a137fa-eedd-4cf0-8969-827591267b4b_DS_VAR" typeRef="Any"/>
+    <semantic:outputDecision href="#_938e8026-7825-47c1-8890-a0bed982db6f"/>
+    <semantic:inputData href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+</semantic:decisionService>
+<semantic:decisionService id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3_DS" name="Diagram Page 1" triso:dynamicDecisionService="true">
+    <semantic:variable name="Diagram Page 1" id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3_DS_VAR" typeRef="Any"/>
+    <semantic:outputDecision href="#_938e8026-7825-47c1-8890-a0bed982db6f"/>
+    <semantic:inputData href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+</semantic:decisionService>
+<semantic:inputData id="_e4e47ee0-ff98-41fd-922a-f80bac93bcc3" name="name">
+    <semantic:variable name="name" id="_7a9307f0-fa0d-4e15-9a3a-b8009558c758" typeRef="string"/>
+</semantic:inputData>
+<semantic:decision id="_938e8026-7825-47c1-8890-a0bed982db6f" name="salutation">
+    <semantic:variable name="salutation" id="_4c00fc87-5c90-4cf7-96ba-49a5b3c05807" typeRef="string"/>
+    <semantic:informationRequirement id="_db797801-9e06-49ba-8384-6f7c6a15019b">
+        <semantic:requiredInput href="#_e4e47ee0-ff98-41fd-922a-f80bac93bcc3"/>
+    </semantic:informationRequirement>
+    <semantic:literalExpression id="_6bae1586-dff3-442c-99c4-57cb2ca8813f" typeRef="string" triso:expressionId="_875337f7-4847-4d98-926c-957c71626d79">
+        <semantic:text>"Hello, "+name</semantic:text>
+    </semantic:literalExpression>
+</semantic:decision>
+<dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_419129c5-55c0-48f6-bb2b-1ddacdb7aad3" triso:modelElementRef="_7dc00112-0d6b-4d89-a677-9c99cbf29bcf" name="Page 1">
+        <di:extension/>
+        <dmndi:Size height="1050" width="1485"/>
+        <dmndi:DMNShape id="_3ed3ded2-30be-46b8-872f-0d9db4b572d2" dmnElementRef="_e4e47ee0-ff98-41fd-922a-f80bac93bcc3">
+            <dc:Bounds x="295.7588291168213" y="223" width="135.48234176635742" height="60"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" trisodmn:defaultBounds="true"/>
+        </dmndi:DMNShape>
+        <dmndi:DMNShape id="_cd689688-c21d-4d97-8e84-147eb7ef12e2" dmnElementRef="_938e8026-7825-47c1-8890-a0bed982db6f">
+            <dc:Bounds x="486.2411708831787" y="223" width="153" height="60"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" trisodmn:defaultBounds="true"/>
+        </dmndi:DMNShape>
+        <dmndi:DMNEdge id="_f6ec1781-c8d6-4abc-9290-d682e3d2c6ef" dmnElementRef="_db797801-9e06-49ba-8384-6f7c6a15019b">
+            <di:waypoint x="431.9968013763428" y="253"/>
+            <di:waypoint x="486.2411708831787" y="253"/>
+            <dmndi:DMNLabel sharedStyle="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0"/>
+        </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+    <dmndi:DMNStyle id="LS_61a137fa-eedd-4cf0-8969-827591267b4b_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+</dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/FunctionItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.api;
+
+import java.util.List;
+
+/**
+ * @since DMN v1.3
+ */
+public interface FunctionItem {
+
+    List<InformationItem> getParameters();
+
+    String getOutputTypeRef();
+
+    void setOutputTypeRef(String value);
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Group.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/Group.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.api;
+
+/**
+ * @since DMN v1.3
+ */
+public interface Group {
+
+    String getName();
+
+    void setName(String value);
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/api/ItemDefinition.java
@@ -48,4 +48,14 @@ public interface ItemDefinition extends NamedElement {
 
     String toString();
 
+    /**
+     * @since DMN v1.3
+     */
+    FunctionItem getFunctionItem();
+
+    /**
+     * @since DMN v1.3
+     */
+    void setFunctionItem(FunctionItem value);
+
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_1/TItemDefinition.java
@@ -21,6 +21,7 @@ import java.util.StringJoiner;
 
 import javax.xml.namespace.QName;
 
+import org.kie.dmn.model.api.FunctionItem;
 import org.kie.dmn.model.api.ItemDefinition;
 import org.kie.dmn.model.api.UnaryTests;
 
@@ -91,5 +92,15 @@ public class TItemDefinition extends TNamedElement implements ItemDefinition {
                 .add("typeLanguage: " + typeLanguage)
                 .add("isCollection: " + isCollection)
                 .toString();
+    }
+
+    @Override
+    public FunctionItem getFunctionItem() {
+        throw new UnsupportedOperationException("Since DMNv1.3");
+    }
+
+    @Override
+    public void setFunctionItem(FunctionItem value) {
+        throw new UnsupportedOperationException("Since DMNv1.3");
     }
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/TItemDefinition.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
+import org.kie.dmn.model.api.FunctionItem;
 import org.kie.dmn.model.api.ItemDefinition;
 import org.kie.dmn.model.api.UnaryTests;
 
@@ -85,6 +86,16 @@ public class TItemDefinition extends TNamedElement implements ItemDefinition {
     @Override
     public void setIsCollection(Boolean value) {
         this.isCollection = value;
+    }
+
+    @Override
+    public FunctionItem getFunctionItem() {
+        throw new UnsupportedOperationException("Since DMNv1.3");
+    }
+
+    @Override
+    public void setFunctionItem(FunctionItem value) {
+        throw new UnsupportedOperationException("Since DMNv1.3");
     }
 
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNEdge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_2/dmndi/DMNEdge.java
@@ -71,4 +71,24 @@ public class DMNEdge extends Edge implements org.kie.dmn.model.api.dmndi.DMNEdge
         this.dmnElementRef = value;
     }
 
+    @Override
+    public QName getSourceElement() {
+        throw new UnsupportedOperationException("Since DMNv1.3");
+    }
+
+    @Override
+    public void setSourceElement(QName value) {
+        throw new UnsupportedOperationException("Since DMNv1.3");
+    }
+
+    @Override
+    public QName getTargetElement() {
+        throw new UnsupportedOperationException("Since DMNv1.3");
+    }
+
+    @Override
+    public void setTargetElement(QName value) {
+        throw new UnsupportedOperationException("Since DMNv1.3");
+    }
+
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/KieDMNModelInstrumentedBase.java
@@ -31,10 +31,10 @@ import org.kie.dmn.model.api.RowLocation;
 
 public abstract class KieDMNModelInstrumentedBase implements DMNModelInstrumentedBase {
 
-    public static final String URI_DMN = "http://www.omg.org/spec/DMN/20191111/MODEL/";
-    public static final String URI_FEEL = "http://www.omg.org/spec/DMN/20191111/FEEL/";
-    public static final String URI_KIE = "http://www.drools.org/kie/dmn/1.3";
-    public static final String URI_DMNDI = "http://www.omg.org/spec/DMN/20191111/DMNDI/";
+    public static final String URI_DMN = "https://www.omg.org/spec/DMN/20191111/MODEL/";
+    public static final String URI_FEEL = "https://www.omg.org/spec/DMN/20191111/FEEL/";
+    public static final String URI_KIE = "https://www.drools.org/kie/dmn/1.3";
+    public static final String URI_DMNDI = "https://www.omg.org/spec/DMN/20191111/DMNDI/";
     public static final String URI_DI = "http://www.omg.org/spec/DMN/20180521/DI/";
     public static final String URI_DC = "http://www.omg.org/spec/DMN/20180521/DC/";
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/KieDMNModelInstrumentedBase.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/KieDMNModelInstrumentedBase.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.RowLocation;
+
+public abstract class KieDMNModelInstrumentedBase implements DMNModelInstrumentedBase {
+
+    public static final String URI_DMN = "http://www.omg.org/spec/DMN/20191111/MODEL/";
+    public static final String URI_FEEL = "http://www.omg.org/spec/DMN/20191111/FEEL/";
+    public static final String URI_KIE = "http://www.drools.org/kie/dmn/1.3";
+    public static final String URI_DMNDI = "http://www.omg.org/spec/DMN/20191111/DMNDI/";
+    public static final String URI_DI = "http://www.omg.org/spec/DMN/20180521/DI/";
+    public static final String URI_DC = "http://www.omg.org/spec/DMN/20180521/DC/";
+
+    private Map<String, String> nsContext;
+
+    private DMNModelInstrumentedBase parent;
+    private final java.util.List<DMNModelInstrumentedBase> children = new ArrayList<>();
+    private Location location;
+    private Map<QName, String> additionalAttributes = new HashMap<>();
+
+    public String getIdentifierString() {
+        if( this instanceof TNamedElement && ((TNamedElement)this).getName() != null ) {
+            return ((TNamedElement)this).getName();
+        } else if( this instanceof TDMNElement && ((TDMNElement)this).getId() != null ) {
+            return ((TDMNElement)this).getId();
+        } else {
+            return "[unnamed "+getClass().getSimpleName()+"]";
+        }
+    }
+
+    public DMNModelInstrumentedBase getParentDRDElement() {
+        if( this instanceof TDRGElement
+                || (this instanceof TArtifact)
+                || (this instanceof TItemDefinition && parent != null && parent instanceof TDefinitions)) {
+            return this;
+        } else if( parent != null ) {
+            return parent.getParentDRDElement();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Map<String, String> getNsContext() {
+        if (nsContext == null) {
+            nsContext = new HashMap<String, String>();  
+        }
+        return nsContext;
+    }
+
+    @Override
+    public String getNamespaceURI( String prefix ) {
+        if( this.nsContext != null && this.nsContext.containsKey( prefix ) ) {
+            return this.nsContext.get( prefix );
+        }
+        if( this.parent != null ) {
+            return parent.getNamespaceURI( prefix );
+        }
+        return null;
+    }
+    
+    public Optional<String> getPrefixForNamespaceURI( String namespaceURI ) {
+        if( this.nsContext != null && this.nsContext.containsValue(namespaceURI) ) {
+            return this.nsContext.entrySet().stream().filter(kv -> kv.getValue().equals(namespaceURI)).findFirst().map(Map.Entry::getKey);
+        }
+        if( this.parent != null ) {
+            return parent.getPrefixForNamespaceURI( namespaceURI );
+        }
+        return Optional.empty();
+    }
+    
+    public void setAdditionalAttributes(Map<QName, String> additionalAttributes) {
+        this.additionalAttributes = additionalAttributes;
+    }
+    
+    public Map<QName, String> getAdditionalAttributes() {
+        return additionalAttributes;
+    }
+
+    public DMNModelInstrumentedBase getParent() {
+        return parent;
+    }
+
+    public void setParent(DMNModelInstrumentedBase parent) {
+        this.parent = parent;
+    }
+
+    /*
+     * children element references are populated during deserialization, enabling fast access for Validation.
+     */
+    public java.util.List<DMNModelInstrumentedBase> getChildren() {
+        return Collections.unmodifiableList(children);
+    }
+    
+    public void addChildren(DMNModelInstrumentedBase child) {
+        this.children.add(child);
+    }
+
+    @Override
+    public void setLocation(Location location) {
+        this.location = new RowLocation(location);
+    }
+    
+    /**
+     * Returns an approximated location of the XML origin for this DMN Model node.
+     */
+    @Override
+    public Location getLocation() {
+        return location;
+    }
+
+    @Override
+    public String getURIFEEL() {
+        return URI_FEEL;
+    }
+
+    @Override
+    public <T extends DMNModelInstrumentedBase> List<? extends T> findAllChildren(Class<T> clazz) {
+        if (clazz.isInstance(this)) {
+            T obj = (T) this;
+            return Collections.singletonList(obj);
+        }
+        List<T> results = new ArrayList<>();
+        for (DMNModelInstrumentedBase c : getChildren()) {
+            results.addAll(c.findAllChildren(clazz));
+        }
+        return results;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TArtifact.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TArtifact.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.Artifact;
+
+public class TArtifact extends TDMNElement implements Artifact {
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAssociation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAssociation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.Association;
+import org.kie.dmn.model.api.AssociationDirection;
+import org.kie.dmn.model.api.DMNElementReference;
+
+public class TAssociation extends TArtifact implements Association {
+
+    protected DMNElementReference sourceRef;
+    protected DMNElementReference targetRef;
+    protected AssociationDirection associationDirection;
+
+    @Override
+    public DMNElementReference getSourceRef() {
+        return sourceRef;
+    }
+
+    @Override
+    public void setSourceRef(DMNElementReference value) {
+        this.sourceRef = value;
+    }
+
+    @Override
+    public DMNElementReference getTargetRef() {
+        return targetRef;
+    }
+
+    @Override
+    public void setTargetRef(DMNElementReference value) {
+        this.targetRef = value;
+    }
+
+    @Override
+    public AssociationDirection getAssociationDirection() {
+        if (associationDirection == null) {
+            return AssociationDirection.NONE;
+        } else {
+            return associationDirection;
+        }
+    }
+
+    @Override
+    public void setAssociationDirection(AssociationDirection value) {
+        this.associationDirection = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAuthorityRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TAuthorityRequirement.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.DMNElementReference;
+
+public class TAuthorityRequirement extends TDMNElement implements AuthorityRequirement {
+
+    protected DMNElementReference requiredDecision;
+    protected DMNElementReference requiredInput;
+    protected DMNElementReference requiredAuthority;
+
+    @Override
+    public DMNElementReference getRequiredDecision() {
+        return requiredDecision;
+    }
+
+    @Override
+    public void setRequiredDecision(DMNElementReference value) {
+        this.requiredDecision = value;
+    }
+
+    @Override
+    public DMNElementReference getRequiredInput() {
+        return requiredInput;
+    }
+
+    @Override
+    public void setRequiredInput(DMNElementReference value) {
+        this.requiredInput = value;
+    }
+
+    @Override
+    public DMNElementReference getRequiredAuthority() {
+        return requiredAuthority;
+    }
+
+    @Override
+    public void setRequiredAuthority(DMNElementReference value) {
+        this.requiredAuthority = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBinding.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBinding.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.Binding;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.InformationItem;
+
+public class TBinding extends KieDMNModelInstrumentedBase implements Binding {
+
+    protected InformationItem parameter;
+    protected Expression expression;
+
+    @Override
+    public InformationItem getParameter() {
+        return parameter;
+    }
+
+    @Override
+    public void setParameter(InformationItem value) {
+        this.parameter = value;
+    }
+
+    @Override
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public void setExpression(Expression value) {
+        this.expression = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessContextElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessContextElement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.BusinessContextElement;
+
+public class TBusinessContextElement extends TNamedElement implements BusinessContextElement {
+
+    protected String uri;
+
+    @Override
+    public String getURI() {
+        return uri;
+    }
+
+    @Override
+    public void setURI(String value) {
+        this.uri = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessKnowledgeModel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TBusinessKnowledgeModel.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.BusinessKnowledgeModel;
+import org.kie.dmn.model.api.FunctionDefinition;
+import org.kie.dmn.model.api.KnowledgeRequirement;
+
+public class TBusinessKnowledgeModel extends TInvocable implements BusinessKnowledgeModel {
+
+    protected FunctionDefinition encapsulatedLogic;
+    protected List<KnowledgeRequirement> knowledgeRequirement;
+    protected List<AuthorityRequirement> authorityRequirement;
+
+    @Override
+    public FunctionDefinition getEncapsulatedLogic() {
+        return encapsulatedLogic;
+    }
+
+    @Override
+    public void setEncapsulatedLogic(FunctionDefinition value) {
+        this.encapsulatedLogic = value;
+    }
+
+    @Override
+    public List<KnowledgeRequirement> getKnowledgeRequirement() {
+        if (knowledgeRequirement == null) {
+            knowledgeRequirement = new ArrayList<KnowledgeRequirement>();
+        }
+        return this.knowledgeRequirement;
+    }
+
+    @Override
+    public List<AuthorityRequirement> getAuthorityRequirement() {
+        if (authorityRequirement == null) {
+            authorityRequirement = new ArrayList<AuthorityRequirement>();
+        }
+        return this.authorityRequirement;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContext.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.Context;
+import org.kie.dmn.model.api.ContextEntry;
+
+public class TContext extends TExpression implements Context {
+
+    protected List<ContextEntry> contextEntry;
+
+    @Override
+    public List<ContextEntry> getContextEntry() {
+        if (contextEntry == null) {
+            contextEntry = new ArrayList<ContextEntry>();
+        }
+        return this.contextEntry;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContextEntry.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TContextEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.ContextEntry;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.InformationItem;
+
+public class TContextEntry extends TDMNElement implements ContextEntry {
+
+    protected InformationItem variable;
+    protected Expression expression;
+
+    @Override
+    public InformationItem getVariable() {
+        return variable;
+    }
+
+    @Override
+    public void setVariable(InformationItem value) {
+        this.variable = value;
+    }
+
+    @Override
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public void setExpression(Expression value) {
+        this.expression = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElement.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.DMNElement;
+
+public class TDMNElement extends KieDMNModelInstrumentedBase implements DMNElement {
+
+    protected String description;
+    protected ExtensionElements extensionElements;
+    protected String id;
+    protected String label;
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    @Override
+    public ExtensionElements getExtensionElements() {
+        return extensionElements;
+    }
+
+    @Override
+    public void setExtensionElements(ExtensionElements value) {
+        this.extensionElements = value;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public void setLabel(String value) {
+        this.label = value;
+    }
+
+    public static class TExtensionElements extends KieDMNModelInstrumentedBase implements ExtensionElements {
+
+        protected List<Object> any;
+
+        @Override
+        public List<Object> getAny() {
+            if (any == null) {
+                any = new ArrayList<Object>();
+            }
+            return this.any;
+        }
+
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElementReference.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDMNElementReference.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.DMNElementReference;
+
+public class TDMNElementReference extends KieDMNModelInstrumentedBase implements DMNElementReference {
+
+    private String href;
+
+    @Override
+    public String getHref() {
+        return href;
+    }
+
+    @Override
+    public void setHref(String value) {
+        this.href = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDRGElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDRGElement.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.DRGElement;
+
+public class TDRGElement extends TNamedElement implements DRGElement {
+
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecision.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecision.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.Decision;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.InformationRequirement;
+import org.kie.dmn.model.api.KnowledgeRequirement;
+
+public class TDecision extends TDRGElement implements Decision {
+
+    protected String question;
+    protected String allowedAnswers;
+    protected InformationItem variable;
+    protected List<InformationRequirement> informationRequirement;
+    protected List<KnowledgeRequirement> knowledgeRequirement;
+    protected List<AuthorityRequirement> authorityRequirement;
+    protected List<DMNElementReference> supportedObjective;
+    protected List<DMNElementReference> impactedPerformanceIndicator;
+    protected List<DMNElementReference> decisionMaker;
+    protected List<DMNElementReference> decisionOwner;
+    protected List<DMNElementReference> usingProcess;
+    protected List<DMNElementReference> usingTask;
+    protected Expression expression;
+
+    @Override
+    public String getQuestion() {
+        return question;
+    }
+
+    @Override
+    public void setQuestion(String value) {
+        this.question = value;
+    }
+
+    @Override
+    public String getAllowedAnswers() {
+        return allowedAnswers;
+    }
+
+    @Override
+    public void setAllowedAnswers(String value) {
+        this.allowedAnswers = value;
+    }
+
+    @Override
+    public InformationItem getVariable() {
+        return variable;
+    }
+
+    @Override
+    public void setVariable(InformationItem value) {
+        this.variable = value;
+    }
+
+    @Override
+    public List<InformationRequirement> getInformationRequirement() {
+        if (informationRequirement == null) {
+            informationRequirement = new ArrayList<InformationRequirement>();
+        }
+        return this.informationRequirement;
+    }
+
+    @Override
+    public List<KnowledgeRequirement> getKnowledgeRequirement() {
+        if (knowledgeRequirement == null) {
+            knowledgeRequirement = new ArrayList<KnowledgeRequirement>();
+        }
+        return this.knowledgeRequirement;
+    }
+
+    @Override
+    public List<AuthorityRequirement> getAuthorityRequirement() {
+        if (authorityRequirement == null) {
+            authorityRequirement = new ArrayList<AuthorityRequirement>();
+        }
+        return this.authorityRequirement;
+    }
+
+    @Override
+    public List<DMNElementReference> getSupportedObjective() {
+        if (supportedObjective == null) {
+            supportedObjective = new ArrayList<DMNElementReference>();
+        }
+        return this.supportedObjective;
+    }
+
+    @Override
+    public List<DMNElementReference> getImpactedPerformanceIndicator() {
+        if (impactedPerformanceIndicator == null) {
+            impactedPerformanceIndicator = new ArrayList<DMNElementReference>();
+        }
+        return this.impactedPerformanceIndicator;
+    }
+
+    @Override
+    public List<DMNElementReference> getDecisionMaker() {
+        if (decisionMaker == null) {
+            decisionMaker = new ArrayList<DMNElementReference>();
+        }
+        return this.decisionMaker;
+    }
+
+    @Override
+    public List<DMNElementReference> getDecisionOwner() {
+        if (decisionOwner == null) {
+            decisionOwner = new ArrayList<DMNElementReference>();
+        }
+        return this.decisionOwner;
+    }
+
+    @Override
+    public List<DMNElementReference> getUsingProcess() {
+        if (usingProcess == null) {
+            usingProcess = new ArrayList<DMNElementReference>();
+        }
+        return this.usingProcess;
+    }
+
+    @Override
+    public List<DMNElementReference> getUsingTask() {
+        if (usingTask == null) {
+            usingTask = new ArrayList<DMNElementReference>();
+        }
+        return this.usingTask;
+    }
+
+    @Override
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public void setExpression(Expression value) {
+        this.expression = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionRule.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionRule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.DecisionRule;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.RuleAnnotation;
+import org.kie.dmn.model.api.UnaryTests;
+
+public class TDecisionRule extends TDMNElement implements DecisionRule {
+
+    protected List<UnaryTests> inputEntry;
+    protected List<LiteralExpression> outputEntry;
+    protected List<RuleAnnotation> annotationEntry;
+
+    @Override
+    public List<UnaryTests> getInputEntry() {
+        if (inputEntry == null) {
+            inputEntry = new ArrayList<UnaryTests>();
+        }
+        return this.inputEntry;
+    }
+
+    @Override
+    public List<LiteralExpression> getOutputEntry() {
+        if (outputEntry == null) {
+            outputEntry = new ArrayList<LiteralExpression>();
+        }
+        return this.outputEntry;
+    }
+
+    @Override
+    public List<RuleAnnotation> getAnnotationEntry() {
+        if (annotationEntry == null) {
+            annotationEntry = new ArrayList<RuleAnnotation>();
+        }
+        return this.annotationEntry;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionService.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.DecisionService;
+
+public class TDecisionService extends TInvocable implements DecisionService {
+
+    protected List<DMNElementReference> outputDecision;
+    protected List<DMNElementReference> encapsulatedDecision;
+    protected List<DMNElementReference> inputDecision;
+    protected List<DMNElementReference> inputData;
+
+    @Override
+    public List<DMNElementReference> getOutputDecision() {
+        if (outputDecision == null) {
+            outputDecision = new ArrayList<DMNElementReference>();
+        }
+        return this.outputDecision;
+    }
+
+    @Override
+    public List<DMNElementReference> getEncapsulatedDecision() {
+        if (encapsulatedDecision == null) {
+            encapsulatedDecision = new ArrayList<DMNElementReference>();
+        }
+        return this.encapsulatedDecision;
+    }
+
+    @Override
+    public List<DMNElementReference> getInputDecision() {
+        if (inputDecision == null) {
+            inputDecision = new ArrayList<DMNElementReference>();
+        }
+        return this.inputDecision;
+    }
+
+    @Override
+    public List<DMNElementReference> getInputData() {
+        if (inputData == null) {
+            inputData = new ArrayList<DMNElementReference>();
+        }
+        return this.inputData;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTable.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.BuiltinAggregator;
+import org.kie.dmn.model.api.DecisionRule;
+import org.kie.dmn.model.api.DecisionTable;
+import org.kie.dmn.model.api.DecisionTableOrientation;
+import org.kie.dmn.model.api.HitPolicy;
+import org.kie.dmn.model.api.InputClause;
+import org.kie.dmn.model.api.OutputClause;
+import org.kie.dmn.model.api.RuleAnnotationClause;
+
+
+public class TDecisionTable extends TExpression implements DecisionTable {
+
+    protected List<InputClause> input;
+    protected List<OutputClause> output;
+    protected List<RuleAnnotationClause> annotation;
+    protected List<DecisionRule> rule;
+    protected HitPolicy hitPolicy;
+    protected BuiltinAggregator aggregation;
+    protected DecisionTableOrientation preferredOrientation;
+    protected String outputLabel;
+
+    @Override
+    public List<InputClause> getInput() {
+        if (input == null) {
+            input = new ArrayList<InputClause>();
+        }
+        return this.input;
+    }
+
+    @Override
+    public List<OutputClause> getOutput() {
+        if (output == null) {
+            output = new ArrayList<OutputClause>();
+        }
+        return this.output;
+    }
+
+    @Override
+    public List<RuleAnnotationClause> getAnnotation() {
+        if (annotation == null) {
+            annotation = new ArrayList<RuleAnnotationClause>();
+        }
+        return this.annotation;
+    }
+
+    @Override
+    public List<DecisionRule> getRule() {
+        if (rule == null) {
+            rule = new ArrayList<DecisionRule>();
+        }
+        return this.rule;
+    }
+
+    @Override
+    public HitPolicy getHitPolicy() {
+        if (hitPolicy == null) {
+            return HitPolicy.UNIQUE;
+        } else {
+            return hitPolicy;
+        }
+    }
+
+    @Override
+    public void setHitPolicy(HitPolicy value) {
+        this.hitPolicy = value;
+    }
+
+    @Override
+    public BuiltinAggregator getAggregation() {
+        return aggregation;
+    }
+
+    @Override
+    public void setAggregation(BuiltinAggregator value) {
+        this.aggregation = value;
+    }
+
+    @Override
+    public DecisionTableOrientation getPreferredOrientation() {
+        if (preferredOrientation == null) {
+            return DecisionTableOrientation.RULE_AS_ROW;
+        } else {
+            return preferredOrientation;
+        }
+    }
+
+    @Override
+    public void setPreferredOrientation(DecisionTableOrientation value) {
+        this.preferredOrientation = value;
+    }
+
+    @Override
+    public String getOutputLabel() {
+        return outputLabel;
+    }
+
+    @Override
+    public void setOutputLabel(String value) {
+        this.outputLabel = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTableOrientation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDecisionTableOrientation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+public enum TDecisionTableOrientation {
+
+    RULE_AS_ROW("Rule-as-Row"),
+    RULE_AS_COLUMN("Rule-as-Column"),
+    CROSS_TABLE("CrossTable");
+    private final String value;
+
+    TDecisionTableOrientation(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static TDecisionTableOrientation fromValue(String v) {
+        for (TDecisionTableOrientation c: TDecisionTableOrientation.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDefinitions.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TDefinitions.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+
+import org.kie.dmn.model.api.Artifact;
+import org.kie.dmn.model.api.BusinessContextElement;
+import org.kie.dmn.model.api.DRGElement;
+import org.kie.dmn.model.api.DecisionService;
+import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.model.api.ElementCollection;
+import org.kie.dmn.model.api.Import;
+import org.kie.dmn.model.api.ItemDefinition;
+import org.kie.dmn.model.api.dmndi.DMNDI;
+
+
+public class TDefinitions extends TNamedElement implements Definitions {
+
+    public static final String DEFAULT_EXPRESSION_LANGUAGE = URI_FEEL;
+
+    public static final String DEFAULT_TYPE_LANGUAGE = URI_FEEL;
+
+    protected List<Import> _import;
+    protected List<ItemDefinition> itemDefinition;
+    protected List<DRGElement> drgElement;
+    protected List<Artifact> artifact;
+    protected List<ElementCollection> elementCollection;
+    protected List<BusinessContextElement> businessContextElement;
+    protected DMNDI dmndi;
+    protected String expressionLanguage;
+    protected String typeLanguage;
+    protected String namespace;
+    protected String exporter;
+    protected String exporterVersion;
+
+    @Override
+    public List<Import> getImport() {
+        if (_import == null) {
+            _import = new ArrayList<Import>();
+        }
+        return this._import;
+    }
+
+    @Override
+    public List<ItemDefinition> getItemDefinition() {
+        if (itemDefinition == null) {
+            itemDefinition = new ArrayList<ItemDefinition>();
+        }
+        return this.itemDefinition;
+    }
+
+    @Override
+    public List<DRGElement> getDrgElement() {
+        if (drgElement == null) {
+            drgElement = new ArrayList<DRGElement>();
+        }
+        return this.drgElement;
+    }
+
+    @Override
+    public List<Artifact> getArtifact() {
+        if (artifact == null) {
+            artifact = new ArrayList<Artifact>();
+        }
+        return this.artifact;
+    }
+
+    @Override
+    public List<ElementCollection> getElementCollection() {
+        if (elementCollection == null) {
+            elementCollection = new ArrayList<ElementCollection>();
+        }
+        return this.elementCollection;
+    }
+
+    @Override
+    public List<BusinessContextElement> getBusinessContextElement() {
+        if (businessContextElement == null) {
+            businessContextElement = new ArrayList<BusinessContextElement>();
+        }
+        return this.businessContextElement;
+    }
+
+    @Override
+    public DMNDI getDMNDI() {
+        return dmndi;
+    }
+
+    @Override
+    public void setDMNDI(DMNDI value) {
+        this.dmndi = value;
+    }
+
+    @Override
+    public String getExpressionLanguage() {
+        if (expressionLanguage == null) {
+            return DEFAULT_EXPRESSION_LANGUAGE;
+        } else {
+            return expressionLanguage;
+        }
+    }
+
+    @Override
+    public String getTypeLanguage() {
+        if (typeLanguage == null) {
+            return DEFAULT_TYPE_LANGUAGE;
+        } else {
+            return typeLanguage;
+        }
+    }
+
+    @Override
+    public void setExpressionLanguage(String value) {
+        this.expressionLanguage = value;
+    }
+
+    @Override
+    public void setTypeLanguage(String value) {
+        this.typeLanguage = value;
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public void setNamespace(String value) {
+        this.namespace = value;
+    }
+
+    @Override
+    public String getExporter() {
+        return exporter;
+    }
+
+    @Override
+    public void setExporter(String value) {
+        this.exporter = value;
+    }
+
+    @Override
+    public String getExporterVersion() {
+        return exporterVersion;
+    }
+
+    @Override
+    public void setExporterVersion(String value) {
+        this.exporterVersion = value;
+    }
+
+    /**
+     * Implementing support for internal model
+     */
+    @Override
+    public List<DecisionService> getDecisionService() {
+        return drgElement.stream().filter(DecisionService.class::isInstance).map(DecisionService.class::cast).collect(Collectors.toList());
+    }
+
+    public void normalize() {
+        for (ItemDefinition itemDefinition : this.getItemDefinition()) {
+            processQNameURIs(itemDefinition);
+        }
+    }
+
+    private static void processQNameURIs(ItemDefinition iDef) {
+        final QName typeRef = iDef.getTypeRef();
+        if (typeRef != null && XMLConstants.NULL_NS_URI.equals(typeRef.getNamespaceURI())) {
+            final String namespace = iDef.getNamespaceURI(typeRef.getPrefix());
+            iDef.setTypeRef(new QName(namespace, typeRef.getLocalPart(), typeRef.getPrefix()));
+        }
+        for (ItemDefinition comp : iDef.getItemComponent()) {
+            processQNameURIs(comp);
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TElementCollection.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TElementCollection.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.ElementCollection;
+
+public class TElementCollection extends TNamedElement implements ElementCollection {
+
+    protected List<DMNElementReference> drgElement;
+
+    @Override
+    public List<DMNElementReference> getDrgElement() {
+        if (drgElement == null) {
+            drgElement = new ArrayList<DMNElementReference>();
+        }
+        return this.drgElement;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,37 +14,27 @@
  * limitations under the License.
  */
 
-package org.kie.dmn.model.api.dmndi;
+package org.kie.dmn.model.v1_3;
 
 import javax.xml.namespace.QName;
 
-public interface DMNEdge extends Edge {
+import org.kie.dmn.model.api.Expression;
 
-    public DMNLabel getDMNLabel();
-
-    public void setDMNLabel(DMNLabel value);
-
-    public QName getDmnElementRef();
-
-    public void setDmnElementRef(QName value);
+public class TExpression extends TDMNElement implements Expression {
 
     /**
-     * @since DMN v1.3
+     * align with internal model
      */
-    QName getSourceElement();
+    protected QName typeRef;
 
-    /**
-     * @since DMN v1.3
-     */
-    void setSourceElement(QName value);
+    @Override
+    public QName getTypeRef() {
+        return this.typeRef;
+    }
 
-    /**
-     * @since DMN v1.3
-     */
-    QName getTargetElement();
+    @Override
+    public void setTypeRef(QName value) {
+        this.typeRef = value;
+    }
 
-    /**
-     * @since DMN v1.3
-     */
-    void setTargetElement(QName value);
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionDefinition.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.FunctionDefinition;
+import org.kie.dmn.model.api.FunctionKind;
+import org.kie.dmn.model.api.InformationItem;
+
+public class TFunctionDefinition extends TExpression implements FunctionDefinition {
+
+    protected List<InformationItem> formalParameter;
+    protected Expression expression;
+    protected FunctionKind kind;
+
+    @Override
+    public List<InformationItem> getFormalParameter() {
+        if (formalParameter == null) {
+            formalParameter = new ArrayList<InformationItem>();
+        }
+        return this.formalParameter;
+    }
+
+    @Override
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public void setExpression(Expression value) {
+        this.expression = value;
+    }
+
+    @Override
+    public FunctionKind getKind() {
+        if (kind == null) {
+            return FunctionKind.FEEL;
+        } else {
+            return kind;
+        }
+    }
+
+    @Override
+    public void setKind(FunctionKind value) {
+        this.kind = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TFunctionItem.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.FunctionItem;
+import org.kie.dmn.model.api.InformationItem;
+
+public class TFunctionItem extends TDMNElement implements FunctionItem {
+
+    protected List<InformationItem> parameters;
+    protected String outputTypeRef;
+
+    @Override
+    public List<InformationItem> getParameters() {
+        if (parameters == null) {
+            parameters = new ArrayList<InformationItem>();
+        }
+        return this.parameters;
+    }
+
+    @Override
+    public String getOutputTypeRef() {
+        return outputTypeRef;
+    }
+
+    @Override
+    public void setOutputTypeRef(String value) {
+        this.outputTypeRef = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TGroup.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TGroup.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.Group;
+
+public class TGroup extends TArtifact implements Group {
+
+    protected String name;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String value) {
+        this.name = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImport.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImport.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.Import;
+
+public class TImport extends TNamedElement implements Import {
+
+    protected String namespace;
+    protected String locationURI;
+    protected String importType;
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public void setNamespace(String value) {
+        this.namespace = value;
+    }
+
+    @Override
+    public String getLocationURI() {
+        return locationURI;
+    }
+
+    @Override
+    public void setLocationURI(String value) {
+        this.locationURI = value;
+    }
+
+    @Override
+    public String getImportType() {
+        return importType;
+    }
+
+    @Override
+    public void setImportType(String value) {
+        this.importType = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImportedValues.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TImportedValues.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.ImportedValues;
+
+public class TImportedValues extends TImport implements ImportedValues {
+
+    protected String importedElement;
+    protected String expressionLanguage;
+
+    @Override
+    public String getImportedElement() {
+        return importedElement;
+    }
+
+    @Override
+    public void setImportedElement(String value) {
+        this.importedElement = value;
+    }
+
+    @Override
+    public String getExpressionLanguage() {
+        return expressionLanguage;
+    }
+
+    @Override
+    public void setExpressionLanguage(String value) {
+        this.expressionLanguage = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationItem.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,37 +14,24 @@
  * limitations under the License.
  */
 
-package org.kie.dmn.model.api.dmndi;
+package org.kie.dmn.model.v1_3;
 
 import javax.xml.namespace.QName;
 
-public interface DMNEdge extends Edge {
+import org.kie.dmn.model.api.InformationItem;
 
-    public DMNLabel getDMNLabel();
+public class TInformationItem extends TNamedElement implements InformationItem {
 
-    public void setDMNLabel(DMNLabel value);
+    protected QName typeRef;
 
-    public QName getDmnElementRef();
+    @Override
+    public QName getTypeRef() {
+        return this.typeRef;
+    }
 
-    public void setDmnElementRef(QName value);
+    @Override
+    public void setTypeRef(QName value) {
+        this.typeRef = value;
+    }
 
-    /**
-     * @since DMN v1.3
-     */
-    QName getSourceElement();
-
-    /**
-     * @since DMN v1.3
-     */
-    void setSourceElement(QName value);
-
-    /**
-     * @since DMN v1.3
-     */
-    QName getTargetElement();
-
-    /**
-     * @since DMN v1.3
-     */
-    void setTargetElement(QName value);
 }

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInformationRequirement.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.InformationRequirement;
+
+public class TInformationRequirement extends TDMNElement implements InformationRequirement {
+
+    protected DMNElementReference requiredDecision;
+    protected DMNElementReference requiredInput;
+
+    @Override
+    public DMNElementReference getRequiredDecision() {
+        return requiredDecision;
+    }
+
+    @Override
+    public void setRequiredDecision(DMNElementReference value) {
+        this.requiredDecision = value;
+    }
+
+    @Override
+    public DMNElementReference getRequiredInput() {
+        return requiredInput;
+    }
+
+    @Override
+    public void setRequiredInput(DMNElementReference value) {
+        this.requiredInput = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputClause.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.InputClause;
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.UnaryTests;
+
+public class TInputClause extends TDMNElement implements InputClause {
+
+    protected LiteralExpression inputExpression;
+    protected UnaryTests inputValues;
+
+    @Override
+    public LiteralExpression getInputExpression() {
+        return inputExpression;
+    }
+
+    @Override
+    public void setInputExpression(LiteralExpression value) {
+        this.inputExpression = value;
+    }
+
+    @Override
+    public UnaryTests getInputValues() {
+        return inputValues;
+    }
+
+    @Override
+    public void setInputValues(UnaryTests value) {
+        this.inputValues = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputData.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInputData.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.InputData;
+
+public class TInputData extends TDRGElement implements InputData {
+
+    protected InformationItem variable;
+
+    @Override
+    public InformationItem getVariable() {
+        return variable;
+    }
+
+    @Override
+    public void setVariable(InformationItem value) {
+        this.variable = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocable.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.Invocable;
+
+
+public class TInvocable extends TDRGElement implements Invocable {
+
+    protected InformationItem variable;
+
+    @Override
+    public InformationItem getVariable() {
+        return variable;
+    }
+
+    @Override
+    public void setVariable(InformationItem value) {
+        this.variable = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TInvocation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.Binding;
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.Invocation;
+
+public class TInvocation extends TExpression implements Invocation {
+
+    protected Expression expression;
+    protected List<Binding> binding;
+
+    @Override
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public void setExpression(Expression value) {
+        this.expression = value;
+    }
+
+    @Override
+    public List<Binding> getBinding() {
+        if (binding == null) {
+            binding = new ArrayList<Binding>();
+        }
+        return this.binding;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TItemDefinition.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TItemDefinition.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import org.kie.dmn.model.api.FunctionItem;
+import org.kie.dmn.model.api.ItemDefinition;
+import org.kie.dmn.model.api.UnaryTests;
+
+public class TItemDefinition extends TNamedElement implements ItemDefinition {
+
+    /**
+     * align to internal model
+     */
+    protected QName typeRef;
+    protected UnaryTests allowedValues;
+    protected List<ItemDefinition> itemComponent;
+    protected FunctionItem functionItem;
+    protected String typeLanguage;
+    protected Boolean isCollection;
+
+    @Override
+    public QName getTypeRef() {
+        return typeRef;
+    }
+
+    @Override
+    public void setTypeRef(final QName value) {
+        this.typeRef = value;
+    }
+
+    @Override
+    public UnaryTests getAllowedValues() {
+        return allowedValues;
+    }
+
+    @Override
+    public void setAllowedValues(UnaryTests value) {
+        this.allowedValues = value;
+    }
+
+    @Override
+    public List<ItemDefinition> getItemComponent() {
+        if (itemComponent == null) {
+            itemComponent = new ArrayList<ItemDefinition>();
+        }
+        return this.itemComponent;
+    }
+
+    @Override
+    public String getTypeLanguage() {
+        return typeLanguage;
+    }
+
+    @Override
+    public void setTypeLanguage(String value) {
+        this.typeLanguage = value;
+    }
+
+    @Override
+    public boolean isIsCollection() {
+        if (isCollection == null) {
+            return false;
+        } else {
+            return isCollection;
+        }
+    }
+
+    @Override
+    public void setIsCollection(Boolean value) {
+        this.isCollection = value;
+    }
+
+    @Override
+    public FunctionItem getFunctionItem() {
+        return functionItem;
+    }
+
+    @Override
+    public void setFunctionItem(FunctionItem value) {
+        this.functionItem = value;
+    }
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeRequirement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeRequirement.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.KnowledgeRequirement;
+
+public class TKnowledgeRequirement extends TDMNElement implements KnowledgeRequirement {
+
+    protected DMNElementReference requiredKnowledge;
+
+    @Override
+    public DMNElementReference getRequiredKnowledge() {
+        return requiredKnowledge;
+    }
+
+    @Override
+    public void setRequiredKnowledge(DMNElementReference value) {
+        this.requiredKnowledge = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeSource.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TKnowledgeSource.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.AuthorityRequirement;
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.KnowledgeSource;
+
+
+public class TKnowledgeSource extends TDRGElement implements KnowledgeSource {
+
+    protected List<AuthorityRequirement> authorityRequirement;
+    protected String type;
+    protected DMNElementReference owner;
+    protected String locationURI;
+
+    @Override
+    public List<AuthorityRequirement> getAuthorityRequirement() {
+        if (authorityRequirement == null) {
+            authorityRequirement = new ArrayList<AuthorityRequirement>();
+        }
+        return this.authorityRequirement;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(String value) {
+        this.type = value;
+    }
+
+    @Override
+    public DMNElementReference getOwner() {
+        return owner;
+    }
+
+    @Override
+    public void setOwner(DMNElementReference value) {
+        this.owner = value;
+    }
+
+    @Override
+    public String getLocationURI() {
+        return locationURI;
+    }
+
+    @Override
+    public void setLocationURI(String value) {
+        this.locationURI = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TList.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TList.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+
+import org.kie.dmn.model.api.Expression;
+import org.kie.dmn.model.api.List;
+
+public class TList extends TExpression implements List {
+
+    protected java.util.List<Expression> expression;
+
+    @Override
+    public java.util.List<Expression> getExpression() {
+        if (expression == null) {
+            expression = new ArrayList<Expression>();
+        }
+        return this.expression;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TLiteralExpression.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TLiteralExpression.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.ImportedValues;
+import org.kie.dmn.model.api.LiteralExpression;
+
+public class TLiteralExpression extends TExpression implements LiteralExpression {
+
+    protected String text;
+    protected ImportedValues importedValues;
+    protected String expressionLanguage;
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setText(String value) {
+        this.text = value;
+    }
+
+    @Override
+    public ImportedValues getImportedValues() {
+        return importedValues;
+    }
+
+    @Override
+    public void setImportedValues(ImportedValues value) {
+        this.importedValues = value;
+    }
+
+    @Override
+    public String getExpressionLanguage() {
+        return expressionLanguage;
+    }
+
+    @Override
+    public void setExpressionLanguage(String value) {
+        this.expressionLanguage = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TNamedElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TNamedElement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.NamedElement;
+
+public class TNamedElement extends TDMNElement implements NamedElement {
+
+    protected String name;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String value) {
+        this.name = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOrganizationUnit.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOrganizationUnit.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.OrganizationUnit;
+
+public class TOrganizationUnit extends TBusinessContextElement implements OrganizationUnit {
+
+    protected List<DMNElementReference> decisionMade;
+    protected List<DMNElementReference> decisionOwned;
+
+    @Override
+    public List<DMNElementReference> getDecisionMade() {
+        if (decisionMade == null) {
+            decisionMade = new ArrayList<DMNElementReference>();
+        }
+        return this.decisionMade;
+    }
+
+    @Override
+    public List<DMNElementReference> getDecisionOwned() {
+        if (decisionOwned == null) {
+            decisionOwned = new ArrayList<DMNElementReference>();
+        }
+        return this.decisionOwned;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOutputClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TOutputClause.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import javax.xml.namespace.QName;
+
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.OutputClause;
+import org.kie.dmn.model.api.UnaryTests;
+
+public class TOutputClause extends TDMNElement implements OutputClause {
+
+    protected UnaryTests outputValues;
+    protected LiteralExpression defaultOutputEntry;
+    protected String name;
+    /**
+     * align to internal model
+     */
+    protected QName typeRef;
+
+    @Override
+    public UnaryTests getOutputValues() {
+        return outputValues;
+    }
+
+    @Override
+    public void setOutputValues(UnaryTests value) {
+        this.outputValues = value;
+    }
+
+    @Override
+    public LiteralExpression getDefaultOutputEntry() {
+        return defaultOutputEntry;
+    }
+
+    @Override
+    public void setDefaultOutputEntry(LiteralExpression value) {
+        this.defaultOutputEntry = value;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    @Override
+    public QName getTypeRef() {
+        return typeRef;
+    }
+
+    @Override
+    public void setTypeRef(QName value) {
+        this.typeRef = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TPerformanceIndicator.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TPerformanceIndicator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.api.DMNElementReference;
+import org.kie.dmn.model.api.PerformanceIndicator;
+
+
+public class TPerformanceIndicator extends TBusinessContextElement implements PerformanceIndicator {
+
+    protected List<DMNElementReference> impactingDecision;
+
+    @Override
+    public List<DMNElementReference> getImpactingDecision() {
+        if (impactingDecision == null) {
+            impactingDecision = new ArrayList<DMNElementReference>();
+        }
+        return this.impactingDecision;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRelation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRelation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+
+import java.util.ArrayList;
+
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.api.List;
+import org.kie.dmn.model.api.Relation;
+
+public class TRelation extends TExpression implements Relation {
+
+    protected java.util.List<InformationItem> column;
+    protected java.util.List<List> row;
+
+    @Override
+    public java.util.List<InformationItem> getColumn() {
+        if (column == null) {
+            column = new ArrayList<InformationItem>();
+        }
+        return this.column;
+    }
+
+    @Override
+    public java.util.List<List> getRow() {
+        if (row == null) {
+            row = new ArrayList<List>();
+        }
+        return this.row;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.RuleAnnotation;
+
+public class TRuleAnnotation extends KieDMNModelInstrumentedBase implements RuleAnnotation {
+
+    protected String text;
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setText(String value) {
+        this.text = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotationClause.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TRuleAnnotationClause.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.RuleAnnotationClause;
+
+
+public class TRuleAnnotationClause extends KieDMNModelInstrumentedBase implements RuleAnnotationClause {
+
+    protected String name;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String value) {
+        this.name = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TTextAnnotation.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TTextAnnotation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.TextAnnotation;
+
+public class TTextAnnotation extends TArtifact implements TextAnnotation {
+
+
+    private static final String DEFAULT_TEXT_FORMAT = "text/plain";
+
+    private String text;
+    private String textFormat;
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setText(final String value) {
+        this.text = value;
+    }
+
+    @Override
+    public String getTextFormat() {
+        if (textFormat == null) {
+            return DEFAULT_TEXT_FORMAT;
+        } else {
+            return textFormat;
+        }
+    }
+
+    @Override
+    public void setTextFormat(final String value) {
+        this.textFormat = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TUnaryTests.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/TUnaryTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3;
+
+import org.kie.dmn.model.api.UnaryTests;
+
+public class TUnaryTests extends TDMNElement implements UnaryTests {
+
+    protected String text;
+    protected String expressionLanguage;
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setText(String value) {
+        this.text = value;
+    }
+
+    @Override
+    public String getExpressionLanguage() {
+        return expressionLanguage;
+    }
+
+    @Override
+    public void setExpressionLanguage(String value) {
+        this.expressionLanguage = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Bounds.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Bounds.java
@@ -16,7 +16,7 @@
 
 package org.kie.dmn.model.v1_3.dmndi;
 
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 
 public class Bounds extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Bounds {
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Bounds.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Bounds.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
+public class Bounds extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Bounds {
+
+    protected double x;
+    protected double y;
+    protected double width;
+    protected double height;
+
+    /**
+     * Gets the value of the x property.
+     * 
+     */
+    public double getX() {
+        return x;
+    }
+
+    /**
+     * Sets the value of the x property.
+     * 
+     */
+    public void setX(double value) {
+        this.x = value;
+    }
+
+    /**
+     * Gets the value of the y property.
+     * 
+     */
+    public double getY() {
+        return y;
+    }
+
+    /**
+     * Sets the value of the y property.
+     * 
+     */
+    public void setY(double value) {
+        this.y = value;
+    }
+
+    /**
+     * Gets the value of the width property.
+     * 
+     */
+    public double getWidth() {
+        return width;
+    }
+
+    /**
+     * Sets the value of the width property.
+     * 
+     */
+    public void setWidth(double value) {
+        this.width = value;
+    }
+
+    /**
+     * Gets the value of the height property.
+     * 
+     */
+    public double getHeight() {
+        return height;
+    }
+
+    /**
+     * Sets the value of the height property.
+     * 
+     */
+    public void setHeight(double value) {
+        this.height = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Color.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Color.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
+public class Color extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Color {
+
+    protected int red;
+    protected int green;
+    protected int blue;
+
+    /**
+     * Gets the value of the red property.
+     * 
+     */
+    public int getRed() {
+        return red;
+    }
+
+    /**
+     * Sets the value of the red property.
+     * 
+     */
+    public void setRed(int value) {
+        this.red = value;
+    }
+
+    /**
+     * Gets the value of the green property.
+     * 
+     */
+    public int getGreen() {
+        return green;
+    }
+
+    /**
+     * Sets the value of the green property.
+     * 
+     */
+    public void setGreen(int value) {
+        this.green = value;
+    }
+
+    /**
+     * Gets the value of the blue property.
+     * 
+     */
+    public int getBlue() {
+        return blue;
+    }
+
+    /**
+     * Sets the value of the blue property.
+     * 
+     */
+    public void setBlue(int value) {
+        this.blue = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Color.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Color.java
@@ -16,7 +16,7 @@
 
 package org.kie.dmn.model.v1_3.dmndi;
 
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 
 public class Color extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Color {
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDI.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDI.java
@@ -25,8 +25,8 @@ import java.util.stream.Collectors;
 import org.kie.dmn.model.api.dmndi.DMNDiagram;
 import org.kie.dmn.model.api.dmndi.DMNStyle;
 import org.kie.dmn.model.api.dmndi.DiagramElement;
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
-import org.kie.dmn.model.v1_2.dmndi.Style.IDREFStubStyle;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.dmndi.Style.IDREFStubStyle;
 
 
 public class DMNDI extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.DMNDI {

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDI.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDI.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.kie.dmn.model.api.dmndi.DMNDiagram;
+import org.kie.dmn.model.api.dmndi.DMNStyle;
+import org.kie.dmn.model.api.dmndi.DiagramElement;
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_2.dmndi.Style.IDREFStubStyle;
+
+
+public class DMNDI extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.DMNDI {
+
+    protected List<DMNDiagram> dmnDiagram;
+    protected List<DMNStyle> dmnStyle;
+
+    /**
+     * Gets the value of the dmnDiagram property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the dmnDiagram property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDMNDiagram().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DMNDiagram }
+     * 
+     * 
+     */
+    @Override
+    public List<DMNDiagram> getDMNDiagram() {
+        if (dmnDiagram == null) {
+            dmnDiagram = new ArrayList<DMNDiagram>();
+        }
+        return this.dmnDiagram;
+    }
+
+    /**
+     * Gets the value of the dmnStyle property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the dmnStyle property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDMNStyle().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DMNStyle }
+     * 
+     * 
+     */
+    @Override
+    public List<DMNStyle> getDMNStyle() {
+        if (dmnStyle == null) {
+            dmnStyle = new ArrayList<DMNStyle>();
+        }
+        return this.dmnStyle;
+    }
+
+    @Override
+    public void normalize() {
+        if (dmnStyle == null || dmnDiagram == null) {
+            return;
+        }
+        Map<String, DMNStyle> styleById = dmnStyle.stream().collect(Collectors.toMap(DMNStyle::getId, Function.identity()));
+        for (DMNDiagram diagram : dmnDiagram) {
+            for (DiagramElement element : diagram.getDMNDiagramElement()) {
+                replaceSharedStyleIfStubbed(element, styleById);
+                if (element instanceof DMNShape) {
+                    DMNShape dmnShape = (DMNShape) element;
+                    replaceSharedStyleIfStubbed(dmnShape.getDMNLabel(), styleById);
+                }
+            }
+        }
+    }
+
+    private void replaceSharedStyleIfStubbed(DiagramElement element, Map<String, DMNStyle> styleById) {
+        if (element.getSharedStyle() instanceof IDREFStubStyle) {
+            DMNStyle locatedStyle = styleById.get(element.getSharedStyle().getId());
+            element.setSharedStyle(locatedStyle);
+        }
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDecisionServiceDividerLine.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDecisionServiceDividerLine.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+public class DMNDecisionServiceDividerLine extends Edge implements org.kie.dmn.model.api.dmndi.DMNDecisionServiceDividerLine {
+
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDiagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNDiagram.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+
+public class DMNDiagram extends Diagram implements org.kie.dmn.model.api.dmndi.DMNDiagram {
+
+    protected org.kie.dmn.model.api.dmndi.Dimension size;
+    protected List<org.kie.dmn.model.api.dmndi.DiagramElement> dmnDiagramElement;
+
+    /**
+     * Gets the value of the size property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Dimension }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Dimension getSize() {
+        return size;
+    }
+
+    /**
+     * Sets the value of the size property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Dimension }
+     *     
+     */
+    public void setSize(org.kie.dmn.model.api.dmndi.Dimension value) {
+        this.size = value;
+    }
+
+    /**
+     * Gets the value of the dmnDiagramElement property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the dmnDiagramElement property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDMNDiagramElement().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link JAXBElement }{@code <}{@link DMNShape }{@code >}
+     * {@link JAXBElement }{@code <}{@link DiagramElement }{@code >}
+     * {@link JAXBElement }{@code <}{@link DMNEdge }{@code >}
+     * 
+     * 
+     */
+    public List<org.kie.dmn.model.api.dmndi.DiagramElement> getDMNDiagramElement() {
+        if (dmnDiagramElement == null) {
+            dmnDiagramElement = new ArrayList<>();
+        }
+        return this.dmnDiagramElement;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNEdge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNEdge.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import javax.xml.namespace.QName;
+
+public class DMNEdge extends Edge implements org.kie.dmn.model.api.dmndi.DMNEdge {
+
+    protected org.kie.dmn.model.api.dmndi.DMNLabel dmnLabel;
+    protected QName dmnElementRef;
+    protected QName sourceElement;
+    protected QName targetElement;
+
+    /**
+     * Gets the value of the dmnLabel property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DMNLabel }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.DMNLabel getDMNLabel() {
+        return dmnLabel;
+    }
+
+    /**
+     * Sets the value of the dmnLabel property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DMNLabel }
+     *     
+     */
+    public void setDMNLabel(org.kie.dmn.model.api.dmndi.DMNLabel value) {
+        this.dmnLabel = value;
+    }
+
+    /**
+     * Gets the value of the dmnElementRef property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QName }
+     *     
+     */
+    public QName getDmnElementRef() {
+        return dmnElementRef;
+    }
+
+    /**
+     * Sets the value of the dmnElementRef property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QName }
+     *     
+     */
+    public void setDmnElementRef(QName value) {
+        this.dmnElementRef = value;
+    }
+
+    @Override
+    public QName getSourceElement() {
+        return sourceElement;
+    }
+
+    @Override
+    public void setSourceElement(QName value) {
+        this.sourceElement = value;
+    }
+
+    @Override
+    public QName getTargetElement() {
+        return targetElement;
+    }
+
+    @Override
+    public void setTargetElement(QName value) {
+        this.targetElement = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNLabel.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNLabel.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+public class DMNLabel extends Shape implements org.kie.dmn.model.api.dmndi.DMNLabel {
+
+    protected String text;
+
+    /**
+     * Gets the value of the text property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Sets the value of the text property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setText(String value) {
+        this.text = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNShape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNShape.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import javax.xml.namespace.QName;
+
+public class DMNShape extends Shape implements org.kie.dmn.model.api.dmndi.DMNShape {
+
+    protected org.kie.dmn.model.api.dmndi.DMNLabel dmnLabel;
+    protected org.kie.dmn.model.api.dmndi.DMNDecisionServiceDividerLine dmnDecisionServiceDividerLine;
+    protected QName dmnElementRef;
+    protected Boolean isListedInputData;
+    protected Boolean isCollapsed;
+
+    /**
+     * Gets the value of the dmnLabel property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DMNLabel }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.DMNLabel getDMNLabel() {
+        return dmnLabel;
+    }
+
+    /**
+     * Sets the value of the dmnLabel property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DMNLabel }
+     *     
+     */
+    public void setDMNLabel(org.kie.dmn.model.api.dmndi.DMNLabel value) {
+        this.dmnLabel = value;
+    }
+
+    /**
+     * Gets the value of the dmnDecisionServiceDividerLine property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DMNDecisionServiceDividerLine }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.DMNDecisionServiceDividerLine getDMNDecisionServiceDividerLine() {
+        return dmnDecisionServiceDividerLine;
+    }
+
+    /**
+     * Sets the value of the dmnDecisionServiceDividerLine property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DMNDecisionServiceDividerLine }
+     *     
+     */
+    public void setDMNDecisionServiceDividerLine(org.kie.dmn.model.api.dmndi.DMNDecisionServiceDividerLine value) {
+        this.dmnDecisionServiceDividerLine = value;
+    }
+
+    /**
+     * Gets the value of the dmnElementRef property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QName }
+     *     
+     */
+    public QName getDmnElementRef() {
+        return dmnElementRef;
+    }
+
+    /**
+     * Sets the value of the dmnElementRef property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QName }
+     *     
+     */
+    public void setDmnElementRef(QName value) {
+        this.dmnElementRef = value;
+    }
+
+    /**
+     * Gets the value of the isListedInputData property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isIsListedInputData() {
+        return isListedInputData;
+    }
+
+    /**
+     * Sets the value of the isListedInputData property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setIsListedInputData(Boolean value) {
+        this.isListedInputData = value;
+    }
+
+    /**
+     * Gets the value of the isCollapsed property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public boolean isIsCollapsed() {
+        if (isCollapsed == null) {
+            return false;
+        } else {
+            return isCollapsed;
+        }
+    }
+
+    /**
+     * Sets the value of the isCollapsed property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setIsCollapsed(Boolean value) {
+        this.isCollapsed = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNStyle.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DMNStyle.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import org.kie.dmn.model.api.dmndi.AlignmentKind;
+
+
+public class DMNStyle extends Style implements org.kie.dmn.model.api.dmndi.DMNStyle {
+
+    protected org.kie.dmn.model.api.dmndi.Color fillColor;
+    protected org.kie.dmn.model.api.dmndi.Color strokeColor;
+    protected org.kie.dmn.model.api.dmndi.Color fontColor;
+    protected String fontFamily;
+    protected Double fontSize;
+    protected Boolean fontItalic;
+    protected Boolean fontBold;
+    protected Boolean fontUnderline;
+    protected Boolean fontStrikeThrough;
+    protected AlignmentKind labelHorizontalAlignement;
+    protected AlignmentKind labelVerticalAlignment;
+
+    /**
+     * Gets the value of the fillColor property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Color }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Color getFillColor() {
+        return fillColor;
+    }
+
+    /**
+     * Sets the value of the fillColor property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Color }
+     *     
+     */
+    public void setFillColor(org.kie.dmn.model.api.dmndi.Color value) {
+        this.fillColor = value;
+    }
+
+    /**
+     * Gets the value of the strokeColor property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Color }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Color getStrokeColor() {
+        return strokeColor;
+    }
+
+    /**
+     * Sets the value of the strokeColor property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Color }
+     *     
+     */
+    public void setStrokeColor(org.kie.dmn.model.api.dmndi.Color value) {
+        this.strokeColor = value;
+    }
+
+    /**
+     * Gets the value of the fontColor property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Color }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Color getFontColor() {
+        return fontColor;
+    }
+
+    /**
+     * Sets the value of the fontColor property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Color }
+     *     
+     */
+    public void setFontColor(org.kie.dmn.model.api.dmndi.Color value) {
+        this.fontColor = value;
+    }
+
+    /**
+     * Gets the value of the fontFamily property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getFontFamily() {
+        return fontFamily;
+    }
+
+    /**
+     * Sets the value of the fontFamily property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setFontFamily(String value) {
+        this.fontFamily = value;
+    }
+
+    /**
+     * Gets the value of the fontSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Double }
+     *     
+     */
+    public Double getFontSize() {
+        return fontSize;
+    }
+
+    /**
+     * Sets the value of the fontSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Double }
+     *     
+     */
+    public void setFontSize(Double value) {
+        this.fontSize = value;
+    }
+
+    /**
+     * Gets the value of the fontItalic property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isFontItalic() {
+        return fontItalic;
+    }
+
+    /**
+     * Sets the value of the fontItalic property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setFontItalic(Boolean value) {
+        this.fontItalic = value;
+    }
+
+    /**
+     * Gets the value of the fontBold property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isFontBold() {
+        return fontBold;
+    }
+
+    /**
+     * Sets the value of the fontBold property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setFontBold(Boolean value) {
+        this.fontBold = value;
+    }
+
+    /**
+     * Gets the value of the fontUnderline property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isFontUnderline() {
+        return fontUnderline;
+    }
+
+    /**
+     * Sets the value of the fontUnderline property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setFontUnderline(Boolean value) {
+        this.fontUnderline = value;
+    }
+
+    /**
+     * Gets the value of the fontStrikeThrough property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isFontStrikeThrough() {
+        return fontStrikeThrough;
+    }
+
+    /**
+     * Sets the value of the fontStrikeThrough property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setFontStrikeThrough(Boolean value) {
+        this.fontStrikeThrough = value;
+    }
+
+    /**
+     * Gets the value of the labelHorizontalAlignement property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AlignmentKind }
+     *     
+     */
+    public AlignmentKind getLabelHorizontalAlignement() {
+        return labelHorizontalAlignement;
+    }
+
+    /**
+     * Sets the value of the labelHorizontalAlignement property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AlignmentKind }
+     *     
+     */
+    public void setLabelHorizontalAlignement(AlignmentKind value) {
+        this.labelHorizontalAlignement = value;
+    }
+
+    /**
+     * Gets the value of the labelVerticalAlignment property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AlignmentKind }
+     *     
+     */
+    public AlignmentKind getLabelVerticalAlignment() {
+        return labelVerticalAlignment;
+    }
+
+    /**
+     * Sets the value of the labelVerticalAlignment property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AlignmentKind }
+     *     
+     */
+    public void setLabelVerticalAlignment(AlignmentKind value) {
+        this.labelVerticalAlignment = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Diagram.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Diagram.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+public abstract class Diagram extends DiagramElement implements org.kie.dmn.model.api.dmndi.Diagram {
+
+    protected String name;
+    protected String documentation;
+    protected Double resolution;
+
+    /**
+     * Gets the value of the name property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the value of the name property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    /**
+     * Gets the value of the documentation property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getDocumentation() {
+        return documentation;
+    }
+
+    /**
+     * Sets the value of the documentation property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setDocumentation(String value) {
+        this.documentation = value;
+    }
+
+    /**
+     * Gets the value of the resolution property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Double }
+     *     
+     */
+    public Double getResolution() {
+        return resolution;
+    }
+
+    /**
+     * Sets the value of the resolution property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Double }
+     *     
+     */
+    public void setResolution(Double value) {
+        this.resolution = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DiagramElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DiagramElement.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
+public abstract class DiagramElement extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.DiagramElement {
+
+    protected org.kie.dmn.model.api.dmndi.DiagramElement.Extension extension;
+    protected org.kie.dmn.model.api.dmndi.Style style;
+    protected org.kie.dmn.model.api.dmndi.Style sharedStyle;
+    protected String id;
+
+    /**
+     * Gets the value of the extension property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DiagramElement.Extension }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.DiagramElement.Extension getExtension() {
+        return extension;
+    }
+
+    /**
+     * Sets the value of the extension property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DiagramElement.Extension }
+     *     
+     */
+    public void setExtension(org.kie.dmn.model.api.dmndi.DiagramElement.Extension value) {
+        this.extension = value;
+    }
+
+    /**
+     * an optional locally-owned style for this diagram element.
+     * 
+     * @return
+     *     possible object is
+     *     {@link JAXBElement }{@code <}{@link DMNStyle }{@code >}
+     *     {@link JAXBElement }{@code <}{@link Style }{@code >}
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Style getStyle() {
+        return style;
+    }
+
+    /**
+     * Sets the value of the style property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link JAXBElement }{@code <}{@link DMNStyle }{@code >}
+     *     {@link JAXBElement }{@code <}{@link Style }{@code >}
+     *     
+     */
+    public void setStyle(org.kie.dmn.model.api.dmndi.Style value) {
+        this.style = value;
+    }
+
+    /**
+     * Gets the value of the sharedStyle property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Object }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Style getSharedStyle() {
+        return sharedStyle;
+    }
+
+    /**
+     * Sets the value of the sharedStyle property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Object }
+     *     
+     */
+    public void setSharedStyle(org.kie.dmn.model.api.dmndi.Style value) {
+        this.sharedStyle = value;
+    }
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the value of the id property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setId(String value) {
+        this.id = value;
+    }
+
+
+
+    public static class Extension extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.DiagramElement.Extension {
+
+        protected List<Object> any;
+
+        public List<Object> getAny() {
+            if (any == null) {
+                any = new ArrayList<Object>();
+            }
+            return this.any;
+        }
+
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DiagramElement.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/DiagramElement.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import javax.xml.bind.JAXBElement;
 
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 
 public abstract class DiagramElement extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.DiagramElement {
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Dimension.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Dimension.java
@@ -16,7 +16,7 @@
 
 package org.kie.dmn.model.v1_3.dmndi;
 
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 
 public class Dimension extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Dimension {
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Dimension.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Dimension.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
+public class Dimension extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Dimension {
+
+    protected double width;
+    protected double height;
+
+    /**
+     * Gets the value of the width property.
+     * 
+     */
+    public double getWidth() {
+        return width;
+    }
+
+    /**
+     * Sets the value of the width property.
+     * 
+     */
+    public void setWidth(double value) {
+        this.width = value;
+    }
+
+    /**
+     * Gets the value of the height property.
+     * 
+     */
+    public double getHeight() {
+        return height;
+    }
+
+    /**
+     * Sets the value of the height property.
+     * 
+     */
+    public void setHeight(double value) {
+        this.height = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Edge.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Edge.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class Edge extends DiagramElement implements org.kie.dmn.model.api.dmndi.Edge {
+
+    protected List<org.kie.dmn.model.api.dmndi.Point> waypoint;
+
+    /**
+     * Gets the value of the waypoint property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the waypoint property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getWaypoint().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link Point }
+     * 
+     * 
+     */
+    public List<org.kie.dmn.model.api.dmndi.Point> getWaypoint() {
+        if (waypoint == null) {
+            waypoint = new ArrayList<>();
+        }
+        return this.waypoint;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Point.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Point.java
@@ -16,7 +16,7 @@
 
 package org.kie.dmn.model.v1_3.dmndi;
 
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 
 public class Point extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Point {
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Point.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Point.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
+public class Point extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Point {
+
+    protected double x;
+    protected double y;
+
+    /**
+     * Gets the value of the x property.
+     * 
+     */
+    public double getX() {
+        return x;
+    }
+
+    /**
+     * Sets the value of the x property.
+     * 
+     */
+    public void setX(double value) {
+        this.x = value;
+    }
+
+    /**
+     * Gets the value of the y property.
+     * 
+     */
+    public double getY() {
+        return y;
+    }
+
+    /**
+     * Sets the value of the y property.
+     * 
+     */
+    public void setY(double value) {
+        this.y = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Shape.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Shape.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+public abstract class Shape extends DiagramElement implements org.kie.dmn.model.api.dmndi.Shape {
+
+    protected org.kie.dmn.model.api.dmndi.Bounds bounds;
+
+    /**
+     * the optional bounds of the shape relative to the origin of its nesting plane.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Bounds }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Bounds getBounds() {
+        return bounds;
+    }
+
+    /**
+     * Sets the value of the bounds property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Bounds }
+     *     
+     */
+    public void setBounds(org.kie.dmn.model.api.dmndi.Bounds value) {
+        this.bounds = value;
+    }
+
+}

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Style.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Style.java
@@ -19,7 +19,7 @@ package org.kie.dmn.model.v1_3.dmndi;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_3.KieDMNModelInstrumentedBase;
 import org.w3c.dom.Element;
 
 

--- a/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Style.java
+++ b/kie-dmn/kie-dmn-model/src/main/java/org/kie/dmn/model/v1_3/dmndi/Style.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.model.v1_3.dmndi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.w3c.dom.Element;
+
+
+public abstract class Style extends KieDMNModelInstrumentedBase implements org.kie.dmn.model.api.dmndi.Style {
+
+    protected org.kie.dmn.model.api.dmndi.Style.Extension extension;
+    protected String id;
+
+    /**
+     * Gets the value of the extension property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Style.Extension }
+     *     
+     */
+    public org.kie.dmn.model.api.dmndi.Style.Extension getExtension() {
+        return extension;
+    }
+
+    /**
+     * Sets the value of the extension property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Style.Extension }
+     *     
+     */
+    public void setExtension(org.kie.dmn.model.api.dmndi.Style.Extension value) {
+        this.extension = value;
+    }
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the value of the id property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setId(String value) {
+        this.id = value;
+    }
+
+
+    public static class Extension implements org.kie.dmn.model.api.dmndi.Style.Extension {
+
+        protected List<Object> any;
+
+        /**
+         * Gets the value of the any property.
+         * 
+         * <p>
+         * This accessor method returns a reference to the live list,
+         * not a snapshot. Therefore any modification you make to the
+         * returned list will be present inside the JAXB object.
+         * This is why there is not a <CODE>set</CODE> method for the any property.
+         * 
+         * <p>
+         * For example, to add a new item, do as follows:
+         * <pre>
+         *    getAny().add(newItem);
+         * </pre>
+         * 
+         * 
+         * <p>
+         * Objects of the following type(s) are allowed in the list
+         * {@link Object }
+         * {@link Element }
+         * 
+         * 
+         */
+        public List<Object> getAny() {
+            if (any == null) {
+                any = new ArrayList<Object>();
+            }
+            return this.any;
+        }
+
+    }
+
+    public static class IDREFStubStyle extends Style {
+
+        public IDREFStubStyle(String id) {
+            this.id = id;
+        }
+    }
+
+}

--- a/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
+++ b/kie-dmn/kie-dmn-validation/src/main/java/org/kie/dmn/validation/DMNValidatorImpl.java
@@ -108,6 +108,19 @@ public class DMNValidatorImpl implements DMNValidator {
             throw new RuntimeException("Unable to initialize correctly DMNValidator.", e);
         }
     }
+    static final Schema schemav1_3;
+    static {
+        try {
+            schemav1_3 = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                                      .newSchema(new Source[]{new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20191111/DC.xsd")),
+                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20191111/DI.xsd")),
+                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20191111/DMNDI13.xsd")),
+                                                              new StreamSource(DMNValidatorImpl.class.getResourceAsStream("org/omg/spec/DMN/20191111/DMN13.xsd"))
+                                      });
+        } catch (SAXException e) {
+            throw new RuntimeException("Unable to initialize correctly DMNValidator.", e);
+        }
+    }
     
     /**
      * A KieContainer is normally available,
@@ -485,7 +498,16 @@ public class DMNValidatorImpl implements DMNValidator {
         try {
             DMN_VERSION inferDMNVersion = XStreamMarshaller.inferDMNVersion(new FileReader(xmlFile));
             Source s = new StreamSource(xmlFile);
-            return (inferDMNVersion == DMN_VERSION.DMN_v1_1) ? validateSchema(s, schemav1_1) : validateSchema(s, schemav1_2);
+            switch (inferDMNVersion) {
+                case DMN_v1_1:
+                    return validateSchema(s, schemav1_1);
+                case DMN_v1_2:
+                    return validateSchema(s, schemav1_2);
+                case DMN_v1_3:
+                case UNKNOWN:
+                default:
+                    return validateSchema(s, schemav1_3);
+            }
         } catch (Exception e) {
             problems.add(new DMNMessageImpl(DMNMessage.Severity.ERROR, MsgUtil.createMessage(Msg.FAILED_XML_VALIDATION, e.getMessage()), Msg.FAILED_XML_VALIDATION.getType(), null, e));
         }
@@ -498,7 +520,16 @@ public class DMNValidatorImpl implements DMNValidator {
             String xml = buffer.lines().collect(Collectors.joining("\n"));
             DMN_VERSION inferDMNVersion = XStreamMarshaller.inferDMNVersion(new StringReader(xml));
             Source s = new StreamSource(new StringReader(xml));
-            return (inferDMNVersion == DMN_VERSION.DMN_v1_1) ? validateSchema(s, schemav1_1) : validateSchema(s, schemav1_2);
+            switch (inferDMNVersion) {
+                case DMN_v1_1:
+                    return validateSchema(s, schemav1_1);
+                case DMN_v1_2:
+                    return validateSchema(s, schemav1_2);
+                case DMN_v1_3:
+                case UNKNOWN:
+                default:
+                    return validateSchema(s, schemav1_3);
+            }
         } catch (Exception e) {
             problems.add(new DMNMessageImpl(DMNMessage.Severity.ERROR, MsgUtil.createMessage(Msg.FAILED_XML_VALIDATION, e.getMessage()), Msg.FAILED_XML_VALIDATION.getType(), null, e));
         }

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DC.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DC.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DC/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+
+	<xsd:element name="Color" type="dc:Color"/>
+	<xsd:element name="Point" type="dc:Point"/>
+	<xsd:element name="Bounds" type="dc:Bounds"/>
+	<xsd:element name="Dimension" type="dc:Dimension"/>
+
+	<xsd:complexType name="Color">
+		<xsd:annotation>
+			<xsd:documentation>Color is a data type that represents a color value in the RGB format.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="red" type="dc:rgb" use="required"/>
+		<xsd:attribute name="green" type="dc:rgb" use="required"/>
+		<xsd:attribute name="blue" type="dc:rgb" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="rgb">
+		<xsd:restriction base="xsd:int">
+			<xsd:minInclusive value="0"/>
+			<xsd:maxInclusive value="255"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="Point">
+		<xsd:annotation>
+			<xsd:documentation>A Point specifies an location in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Dimension">
+		<xsd:annotation>
+			<xsd:documentation>Dimension specifies two lengths (width and height) along the x and y axes in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Bounds">
+	   <xsd:annotation>
+			<xsd:documentation>Bounds specifies a rectangular area in some x-y coordinate system that is defined by a location (x and y) and a size (width and height).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="AlignmentKind">
+		<xsd:annotation>
+			<xsd:documentation>AlignmentKind enumerates the possible options for alignment for layout purposes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="start"/>
+			<xsd:enumeration value="end"/>
+			<xsd:enumeration value="center"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="KnownColor">
+		<xsd:annotation>
+			<xsd:documentation>KnownColor is an enumeration of 17 known colors.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="maroon">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="red">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF0000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="orange">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFA500</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="yellow">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="olive">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="purple">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fuchsia">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF00FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="white">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lime">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="green">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="navy">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="blue">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #0000FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="aqua">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="teal">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="black">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="silver">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #C0C0C0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="gray">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DI.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DI.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DI/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation>The Diagram Interchange (DI) package enables interchange of graphical information that language users have control over, such as position of nodes and line routing points. Language specifications specialize elements of DI to define diagram interchange elements for a language.</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="Style" type="di:Style">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DiagramElement" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. When contained in a diagram, diagram elements are laid out relative to the diagram's origin.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element ref="di:Style" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>an optional locally-owned style for this diagram element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="sharedStyle" type="xsd:IDREF">
+			<xsd:annotation>
+				<xsd:documentation>a reference to an optional shared style element for this diagram element.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Diagram" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">			
+				<xsd:attribute name="name" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the name of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="documentation" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the documentation of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="resolution" type="xsd:double">
+					<xsd:annotation>
+						<xsd:documentation>the resolution of the diagram expressed in user units per inch.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Shape" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>the optional bounds of the shape relative to the origin of its nesting plane.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Edge" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element name="waypoint" type="dc:Point" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>an optional list of points relative to the origin of the nesting diagram that specifies the connected line segments of the edge</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Style" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Style contains formatting properties that affect the appearance or style of diagram elements, including diagram themselves.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DMN13.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DMN13.xsd
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified"
+	xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+	targetNamespace="https://www.omg.org/spec/DMN/20191111/MODEL/">
+
+	<xsd:import namespace="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+	            schemaLocation="DMNDI13.xsd">
+		<xsd:annotation>
+			<xsd:documentation>
+				Include the DMN Diagram Interchange (DI) schema
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:import>
+
+	<xsd:element name="DMNElement" type="tDMNElement" abstract="true"/>
+	<xsd:complexType name="tDMNElement">
+		<xsd:sequence>
+			<xsd:element name="description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="extensionElements" minOccurs="0" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="label" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:element name="namedElement" type="tNamedElement" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tNamedElement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tDMNElementReference">
+		<xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="definitions" type="tDefinitions" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="itemDefinition" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="drgElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="elementCollection" type="tElementCollection" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="businessContextElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dmndi:DMNDI" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20191111/FEEL/"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20191111/FEEL/"/>
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="exporter" type="xsd:string" use="optional"/>
+				<xsd:attribute name="exporterVersion" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="import" type="tImport" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tImport">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="elementCollection" type="tElementCollection" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tElementCollection">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="drgElement" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="drgElement" type="tDRGElement" abstract="true" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDRGElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decision" type="tDecision" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tDecision">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="question" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="allowedAnswers" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="informationRequirement" type="tInformationRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supportedObjective" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="impactedPerformanceIndicator" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionMaker" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwner" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingProcess" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingTask" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- decisionLogic -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessContextElement" type="tBusinessContextElement" abstract="true"/>
+	<xsd:complexType name="tBusinessContextElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="performanceIndicator" type="tPerformanceIndicator" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tPerformanceIndicator">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="impactingDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="organizationUnit" type="tOrganizationUnit" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tOrganizationUnit">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="decisionMade" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwned" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocable" type="tInvocable" abstract="true" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInvocable">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessKnowledgeModel" type="tBusinessKnowledgeModel" substitutionGroup="invocable"/>
+	<xsd:complexType name="tBusinessKnowledgeModel">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="encapsulatedLogic" type="tFunctionDefinition" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="inputData" type="tInputData" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInputData">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeSource" type="tKnowledgeSource" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tKnowledgeSource">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="owner" type="tDMNElementReference" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="informationRequirement" type="tInformationRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tInformationRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:choice minOccurs="1" maxOccurs="1">
+						<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+						<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					</xsd:choice>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tKnowledgeRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="requiredKnowledge" type="tDMNElementReference" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="authorityRequirement" type="tAuthorityRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tAuthorityRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:choice minOccurs="1" maxOccurs="1">
+					<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+					<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					<xsd:element name="requiredAuthority" type="tDMNElementReference"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="expression" type="tExpression" abstract="true"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element name="typeRef" type="xsd:string"/>
+						<xsd:element name="allowedValues" type="tUnaryTests" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:element name="itemComponent" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="functionItem" type="tFunctionItem" minOccurs="0" maxOccurs="1"/>
+				</xsd:choice>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionItem" type="tFunctionItem" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tFunctionItem">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="parameters" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="outputTypeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="literalExpression" type="tLiteralExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tLiteralExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:element name="text" type="xsd:string"/>
+					<xsd:element name="importedValues" type="tImportedValues"/>
+				</xsd:choice>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocation" type="tInvocation" substitutionGroup="expression"/>
+	<xsd:complexType name="tInvocation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- calledFunction -->
+					<xsd:element ref="expression" minOccurs="0"/>
+					<xsd:element name="binding" type="tBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tBinding">
+		<xsd:sequence>
+			<xsd:element name="parameter" type="tInformationItem" minOccurs="1" maxOccurs="1"/>
+			<!-- bindingFormula -->
+			<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="informationItem" type="tInformationItem" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tInformationItem">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionTable" type="tDecisionTable" substitutionGroup="expression"/>
+	<xsd:complexType name="tDecisionTable">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="input" type="tInputClause" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="output" type="tOutputClause" maxOccurs="unbounded"/>
+					<xsd:element name="annotation" type="tRuleAnnotationClause"  minOccurs="0" maxOccurs="unbounded"/>
+					<!-- NB: when the hit policy is FIRST or RULE ORDER, the ordering of the rules is significant and MUST be preserved -->
+					<xsd:element name="rule" type="tDecisionRule" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"/>
+				<xsd:attribute name="aggregation" type="tBuiltinAggregator" use="optional"/>
+				<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"/>
+				<xsd:attribute name="outputLabel" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputExpression" type="tLiteralExpression"/>
+					<xsd:element name="inputValues" type="tUnaryTests" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tOutputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="outputValues" type="tUnaryTests" minOccurs="0"/>
+					<xsd:element name="defaultOutputEntry" type="tLiteralExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotationClause">
+		<xsd:attribute name="name" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:complexType name="tDecisionRule">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputEntry" type="tUnaryTests" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputEntry" type="tLiteralExpression" maxOccurs="unbounded"/>
+					<xsd:element name="annotationEntry" type="tRuleAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotation">
+		<xsd:sequence>
+			<xsd:element name="text" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:simpleType name="tHitPolicy">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNIQUE"/>
+			<xsd:enumeration value="FIRST"/>
+			<xsd:enumeration value="PRIORITY"/>
+			<xsd:enumeration value="ANY"/>
+			<xsd:enumeration value="COLLECT"/>
+			<xsd:enumeration value="RULE ORDER"/>
+			<xsd:enumeration value="OUTPUT ORDER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tBuiltinAggregator">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SUM"/>
+			<xsd:enumeration value="COUNT"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tDecisionTableOrientation">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rule-as-Row"/>
+			<xsd:enumeration value="Rule-as-Column"/>
+			<xsd:enumeration value="CrossTable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="tImportedValues">
+		<xsd:complexContent>
+			<xsd:extension base="tImport">
+				<xsd:sequence>
+					<xsd:element name="importedElement" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="artifact" type="tArtifact" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tArtifact">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="group" type="tGroup" substitutionGroup="artifact"/>
+	<xsd:complexType name="tGroup">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="tDMNElementReference"/>
+					<xsd:element name="targetRef" type="tDMNElementReference"/>
+				</xsd:sequence>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="context" type="tContext" substitutionGroup="expression"/>
+	<xsd:complexType name="tContext">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element ref="contextEntry" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="contextEntry" type="tContextEntry" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tContextEntry">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0" maxOccurs="1"/>
+					<!-- value -->
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionDefinition" type="tFunctionDefinition" substitutionGroup="expression"/>
+	<xsd:complexType name="tFunctionDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="formalParameter" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- body -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="kind" type="tFunctionKind" default="FEEL"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tFunctionKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="FEEL"/>
+			<xsd:enumeration value="Java"/>
+			<xsd:enumeration value="PMML"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="relation" type="tRelation" substitutionGroup="expression"/>
+	<xsd:complexType name="tRelation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="column" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="row" type="tList" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="list" type="tList" substitutionGroup="expression"/>
+	<xsd:complexType name="tList">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- element -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tUnaryTests">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionService" type="tDecisionService" substitutionGroup="invocable"/>
+	<xsd:complexType name="tDecisionService">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="outputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="encapsulatedDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputData" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DMNDI13.xsd
+++ b/kie-dmn/kie-dmn-validation/src/main/resources/org/kie/dmn/validation/org/omg/spec/DMN/20191111/DMNDI13.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+            elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DI/"
+	            schemaLocation="DI.xsd"/>
+
+	<xsd:element name="DMNDI" type="dmndi:DMNDI"/>
+	<xsd:element name="DMNDiagram" type="dmndi:DMNDiagram"/>
+	<xsd:element name="DMNDiagramElement" type="di:DiagramElement">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="DMNShape" type="dmndi:DMNShape" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNEdge" type="dmndi:DMNEdge" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNStyle" type="dmndi:DMNStyle" substitutionGroup="di:Style"/>
+	<xsd:element name="DMNLabel" type="dmndi:DMNLabel"/>
+	<xsd:element name="DMNDecisionServiceDividerLine" type="dmndi:DMNDecisionServiceDividerLine"/>
+
+	<xsd:complexType name="DMNDI">
+		<xsd:sequence>
+			<xsd:element ref="dmndi:DMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="dmndi:DMNStyle" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDiagramElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDecisionServiceDividerLine" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="isListedInputData" type="xsd:boolean" use="optional"/>
+				<xsd:attribute name="isCollapsed" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+		<xsd:complexType name="DMNDecisionServiceDividerLine">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="sourceElement" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="targetElement" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element name="FillColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="StrokeColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="FontColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="fontFamily" type="xsd:string"/>
+				<xsd:attribute name="fontSize" type="xsd:double"/>
+				<xsd:attribute name="fontItalic" type="xsd:boolean"/>
+				<xsd:attribute name="fontBold" type="xsd:boolean"/>
+				<xsd:attribute name="fontUnderline" type="xsd:boolean"/>
+				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean"/>
+				<xsd:attribute name="labelHorizontalAlignement" type="dc:AlignmentKind"/>
+				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -430,9 +430,26 @@ public class ValidatorTest extends AbstractValidatorTest {
                                                             VALIDATE_COMPILATION)
                                              .theseModels(getReader("Financial.dmn", DMN13specificTest.class),
                                                           getReader("Chapter 11 Example.dmn", DMN13specificTest.class));
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
-        assertTrue(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(ValidatorUtil.formatMessages(validate),
+                   validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING && // <<<<<<<< THIS IS WIP
                                                    p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
                                                    p.getSourceId().equals("_4bd33d4a-741b-444a-968b-64e1841211e7")));
+        assertTrue(ValidatorUtil.formatMessages(validate),
+                   validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
+                                                   p.getMessageType().equals(DMNMessageType.INVALID_NAME) &&
+                                                   p.getSourceId().equals("_96b30012-a6e7-4545-89d3-068ec722469c")));
+
     }
+
+    @Test
+    public void testDMNv1_3_ch11example2() {
+        List<DMNMessage> validate = validator.validateUsing(
+                                                            VALIDATE_MODEL,
+                                                            VALIDATE_COMPILATION)
+                                             .theseModels(getReader("Recommended Loan Products.dmn", DMN13specificTest.class),
+                                                          getReader("Loan info.dmn", DMN13specificTest.class));
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -425,14 +425,14 @@ public class ValidatorTest extends AbstractValidatorTest {
 
     @Test
     public void testDMNv1_3_ch11example1() {
-        List<DMNMessage> validate = validator.validateUsing(
+        List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA,
                                                             VALIDATE_MODEL,
                                                             VALIDATE_COMPILATION)
                                              .theseModels(getReader("Financial.dmn", DMN13specificTest.class),
                                                           getReader("Chapter 11 Example.dmn", DMN13specificTest.class));
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(ValidatorUtil.formatMessages(validate),
-                   validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING && // <<<<<<<< THIS IS WIP
+                   validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
                                                    p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
                                                    p.getSourceId().equals("_4bd33d4a-741b-444a-968b-64e1841211e7")));
         assertTrue(ValidatorUtil.formatMessages(validate),
@@ -444,7 +444,7 @@ public class ValidatorTest extends AbstractValidatorTest {
 
     @Test
     public void testDMNv1_3_ch11example2() {
-        List<DMNMessage> validate = validator.validateUsing(
+        List<DMNMessage> validate = validator.validateUsing(VALIDATE_SCHEMA,
                                                             VALIDATE_MODEL,
                                                             VALIDATE_COMPILATION)
                                              .theseModels(getReader("Recommended Loan Products.dmn", DMN13specificTest.class),

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -439,7 +439,6 @@ public class ValidatorTest extends AbstractValidatorTest {
                    validate.stream().anyMatch(p -> p.getLevel() == Level.ERROR &&
                                                    p.getMessageType().equals(DMNMessageType.INVALID_NAME) &&
                                                    p.getSourceId().equals("_96b30012-a6e7-4545-89d3-068ec722469c")));
-
     }
 
     @Test

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -37,6 +37,7 @@ import org.kie.dmn.core.DMNRuntimeTest;
 import org.kie.dmn.core.decisionservices.DMNDecisionServicesTest;
 import org.kie.dmn.core.imports.ImportsTest;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
+import org.kie.dmn.core.v1_3.DMN13specificTest;
 import org.kie.dmn.model.api.Definitions;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -411,5 +412,27 @@ public class ValidatorTest extends AbstractValidatorTest {
                                              .theseModels(getReader("base join.dmn", ImportsTest.class),
                                                           getReader("use join.dmn", ImportsTest.class));
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
+    @Test
+    public void testDMNv1_3_simple() {
+        List<DMNMessage> validate = validator.validate(getReader("simple.dmn", DMN13specificTest.class),
+                                                       VALIDATE_SCHEMA,
+                                                       VALIDATE_MODEL,
+                                                       VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
+    @Test
+    public void testDMNv1_3_ch11example1() {
+        List<DMNMessage> validate = validator.validateUsing(
+                                                            VALIDATE_MODEL,
+                                                            VALIDATE_COMPILATION)
+                                             .theseModels(getReader("Financial.dmn", DMN13specificTest.class),
+                                                          getReader("Chapter 11 Example.dmn", DMN13specificTest.class));
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getLevel() == Level.WARNING &&
+                                                   p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION) &&
+                                                   p.getSourceId().equals("_4bd33d4a-741b-444a-968b-64e1841211e7")));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="debug"/>
+  <logger name="org.kie" level="info"/>
   <logger name="org.kie.dmn.validation.dtanalysis" level="info"/> 
 
   <root level="warn">

--- a/kie-dmn/kie-dmn-validation/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="debug"/>
   <logger name="org.kie.dmn.validation.dtanalysis" level="info"/> 
 
   <root level="warn">


### PR DESCRIPTION
/cc @etirelli @baldimir @jiripetrlik @hellowdan 

I am expecting SonarCloud will complain about code-duplication in some areas, but that is intentional as we have separate object models in separate packages corresponding to different DMN versions for: xml model, marshalling converters, type registry.

Please note the scope of this work is to support the unmarshalling, execution/evaluation and validation of DMNv1.3; other work will follow separately to support new features in DMNv1.3