### PR TITLE
Drools 4834 - Raise the timeout for concurrency tests 

### DIFF
--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/ConcurrentInsertionsToSubnetworksTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/ConcurrentInsertionsToSubnetworksTest.java
@@ -129,27 +129,27 @@ public class ConcurrentInsertionsToSubnetworksTest extends AbstractConcurrentIns
             "    System.out.println(\"R2\");" +
             "end\n";
 
-    @Test(timeout = 10000)
+    @Test(timeout = 40000)
     public void testConcurrentInsertionsFewObjectsManyThreads() throws InterruptedException {
         testConcurrentInsertions(drl, 1, 1000, false, false);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 40000)
     public void testConcurrentInsertionsManyObjectsFewThreads() throws InterruptedException {
         testConcurrentInsertions(drl, 500, 4, false, false);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 40000)
     public void testConcurrentInsertionsManyObjectsSingleThread() throws InterruptedException {
         testConcurrentInsertions(drl, 1000, 1, false, false);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 40000)
     public void testConcurrentInsertionsNewSessionEachThread() throws InterruptedException {
         testConcurrentInsertions(drl, 10, 1000, true, false);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 40000)
     public void testConcurrentInsertionsNewSessionEachThreadUpdate() throws InterruptedException {
         testConcurrentInsertions(drl, 10, 1000, true, true);
     }

--- a/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/ConcurrentInsertionsToSubnetworksTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/integrationtests/concurrency/ConcurrentInsertionsToSubnetworksTest.java
@@ -129,27 +129,27 @@ public class ConcurrentInsertionsToSubnetworksTest extends AbstractConcurrentIns
             "    System.out.println(\"R2\");" +
             "end\n";
 
-    @Test(timeout = 40000)
+    @Test(timeout = 10000)
     public void testConcurrentInsertionsFewObjectsManyThreads() throws InterruptedException {
         testConcurrentInsertions(drl, 1, 1000, false, false);
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 10000)
     public void testConcurrentInsertionsManyObjectsFewThreads() throws InterruptedException {
         testConcurrentInsertions(drl, 500, 4, false, false);
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 10000)
     public void testConcurrentInsertionsManyObjectsSingleThread() throws InterruptedException {
         testConcurrentInsertions(drl, 1000, 1, false, false);
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 10000)
     public void testConcurrentInsertionsNewSessionEachThread() throws InterruptedException {
         testConcurrentInsertions(drl, 10, 1000, true, false);
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 10000)
     public void testConcurrentInsertionsNewSessionEachThreadUpdate() throws InterruptedException {
         testConcurrentInsertions(drl, 10, 1000, true, true);
     }


### PR DESCRIPTION
On Jenkins the tests are slower so we need to raise the timeout. If this doesn't help we need to investigate more.
Time elapsed: 21.494
Timeout: 10.000
So I believe raising it up a little it at this moment is the best thing to do.