### PR TITLE
DROOLS-4837: Abstract reflective accesses from RuleUnitDescription

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -402,8 +402,8 @@ public class ModelGenerator {
 
   private static void addUnitData(RuleContext context, RuleUnitVariable unitVar, BlockStmt ruleBlock) {
         Type declType = classToReferenceType(unitVar.getBoxedVarType());
-        context.addRuleUnitVar( unitVar.getName(), unitVar.getType() );
-        context.addRuleUnitVarOriginalType( unitVar.getName(), unitVar.getDataSourceParameterType() );
+        context.addRuleUnitVar( unitVar.getName(), unitVar.getDataSourceParameterType() );
+        context.addRuleUnitVarOriginalType( unitVar.getName(), unitVar.getType() );
 
         ClassOrInterfaceType varType = toClassOrInterfaceType(UnitData.class);
         varType.setTypeArguments(declType);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -66,6 +66,7 @@ import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionType
 import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyperContext;
 import org.drools.modelcompiler.builder.generator.visitor.ModelGeneratorVisitor;
 import org.drools.core.addon.TypeResolver;
+import org.kie.internal.ruleunit.RuleUnitVariable;
 
 import static java.util.stream.Collectors.toList;
 import static com.github.javaparser.StaticJavaParser.parseExpression;
@@ -393,26 +394,24 @@ public class ModelGenerator {
 
     private static void createUnitData(RuleContext context, RuleUnitDescription ruleUnitDescr, BlockStmt ruleVariablesBlock ) {
         if (ruleUnitDescr != null) {
-            for (Map.Entry<String, Method> unitVar : ruleUnitDescr.getUnitVarAccessors().entrySet()) {
-                addUnitData(context, unitVar.getKey(), unitVar.getValue().getGenericReturnType(), ruleVariablesBlock);
+            for (RuleUnitVariable unitVar : ruleUnitDescr.getUnitVarDeclarations()) {
+                addUnitData(context, unitVar, ruleVariablesBlock);
             }
         }
     }
 
-    private static void addUnitData(RuleContext context, String unitVar, java.lang.reflect.Type type, BlockStmt ruleBlock) {
-        Class<?> rawClass = toRawClass(type);
-        Type declType = classToReferenceType( toRawClass(type) );
-
-        context.addRuleUnitVar( unitVar, getClassForUnitData( type, rawClass ) );
+    private static void addUnitData(RuleContext context, RuleUnitVariable unitVar, BlockStmt ruleBlock) {
+        Type declType = classToReferenceType(unitVar.getBoxedVarType());
+        context.addRuleUnitVar( unitVar.getName(), unitVar.getDataSourceParameterType() );
 
         ClassOrInterfaceType varType = toClassOrInterfaceType(UnitData.class);
         varType.setTypeArguments(declType);
-        VariableDeclarationExpr var_ = new VariableDeclarationExpr(varType, context.getVar(unitVar), Modifier.finalModifier());
+        VariableDeclarationExpr var_ = new VariableDeclarationExpr(varType, context.getVar(unitVar.getName()), Modifier.finalModifier());
 
         MethodCallExpr unitDataCall = new MethodCallExpr(null, UNIT_DATA_CALL);
 
         unitDataCall.addArgument(new ClassExpr( declType ));
-        unitDataCall.addArgument(new StringLiteralExpr(unitVar));
+        unitDataCall.addArgument(new StringLiteralExpr(unitVar.getName()));
 
         AssignExpr var_assign = new AssignExpr(var_, unitDataCall, AssignExpr.Operator.ASSIGN);
         ruleBlock.addStatement(var_assign);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -402,8 +402,8 @@ public class ModelGenerator {
 
   private static void addUnitData(RuleContext context, RuleUnitVariable unitVar, BlockStmt ruleBlock) {
         Type declType = classToReferenceType(unitVar.getBoxedVarType());
-        context.addRuleUnitVar( unitVar.getName(), unitVar.getDataSourceParameterType() );
-        context.addRuleUnitVarOriginalType( unitVar.getName(), unitVar.getType() );
+        context.addRuleUnitVar( unitVar.getName(), unitVar.getType() );
+        context.addRuleUnitVarOriginalType( unitVar.getName(), unitVar.getDataSourceParameterType() );
 
         ClassOrInterfaceType varType = toClassOrInterfaceType(UnitData.class);
         varType.setTypeArguments(declType);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -403,7 +403,7 @@ public class ModelGenerator {
   private static void addUnitData(RuleContext context, RuleUnitVariable unitVar, BlockStmt ruleBlock) {
         Type declType = classToReferenceType(unitVar.getBoxedVarType());
         context.addRuleUnitVar( unitVar.getName(), unitVar.getDataSourceParameterType() );
-        context.addRuleUnitVarOriginalType( unitVar, unitVar.getType() );
+        context.addRuleUnitVarOriginalType( unitVar.getName(), unitVar.getType() );
 
         ClassOrInterfaceType varType = toClassOrInterfaceType(UnitData.class);
         varType.setTypeArguments(declType);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -147,7 +147,7 @@ public class RuleContext {
                 addRuleUnitVar( unitVarName, resolvedType );
 
                 getPackageModel().addGlobal( unitVarName, unitVar.getType() );
-                if ( isDataSource( unitVar.getType() ) ) {
+                if ( unitVar.isDataSource() ) {
                     getPackageModel().addEntryPoint( unitVarName );
                 }
             }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -140,7 +140,7 @@ public class RuleContext {
 
     private void processUnitData() {
         findUnitDescr();
-        if (ruleUnitDescr != null) {
+        if (ruleUnitDescr != null && !isLegacyRuleUnit()) {
             for (RuleUnitVariable unitVar : ruleUnitDescr.getUnitVarDeclarations()) {
                 String unitVarName = unitVar.getName();
                 Class<?> resolvedType = unitVar.isDataSource() ? unitVar.getDataSourceParameterType() : unitVar.getType();

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -39,6 +39,7 @@ import org.kie.internal.builder.ResultSeverity;
 import org.kie.internal.builder.conf.PropertySpecificOption;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.drools.core.addon.TypeResolver;
+import org.kie.internal.ruleunit.RuleUnitVariable;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -136,18 +137,14 @@ public class RuleContext {
 
     private void processUnitData() {
         findUnitDescr();
-        if (ruleUnitDescr != null && !isLegacyRuleUnit()) {
-            for (Map.Entry<String, Method> unitVar : ruleUnitDescr.getUnitVarAccessors().entrySet()) {
-                String unitVarName = unitVar.getKey();
-                java.lang.reflect.Type type = unitVar.getValue().getGenericReturnType();
-                Class<?> rawClass = toRawClass( type );
-                Class<?> resolvedType = ruleUnitDescr.getDatasourceType( unitVarName ).orElse( rawClass );
-
-                Type declType = classToReferenceType( rawClass );
+        if (ruleUnitDescr != null) {
+            for (RuleUnitVariable unitVar : ruleUnitDescr.getUnitVarDeclarations()) {
+                String unitVarName = unitVar.getName();
+                Class<?> resolvedType = unitVar.isDataSource() ? unitVar.getDataSourceParameterType() : unitVar.getType();
                 addRuleUnitVar( unitVarName, resolvedType );
 
-                getPackageModel().addGlobal( unitVarName, rawClass );
-                if ( isDataSource( rawClass ) ) {
+                getPackageModel().addGlobal( unitVarName, unitVar.getType() );
+                if ( isDataSource( unitVar.getType() ) ) {
                     getPackageModel().addEntryPoint( unitVarName );
                 }
             }

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
@@ -1,0 +1,114 @@
+package org.drools.ruleunit.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+import org.drools.ruleunit.RuleUnit;
+import org.kie.internal.ruleunit.RuleUnitVariable;
+
+import static org.drools.reflective.util.ClassUtils.convertFromPrimitiveType;
+import static org.drools.reflective.util.ClassUtils.getter2property;
+
+public final class ReflectiveRuleUnitVariable implements RuleUnitVariable {
+
+    private final String name;
+    private final Class<?> type;
+    private final Class<?> dataSourceParameterType;
+    private final Class<?> boxedVarType;
+    private final String getter;
+    private final Method getterMethod;
+
+
+    public ReflectiveRuleUnitVariable(Method getterMethod) {
+        this(getter2property(getterMethod.getName()), getterMethod);
+    }
+
+    public ReflectiveRuleUnitVariable(String name, Method getterMethod) {
+        Objects.requireNonNull(name, "Invalid name was given: null");
+
+        if (getterMethod.getDeclaringClass() == RuleUnit.class) {
+            throw new IllegalArgumentException(
+                    String.format("The given method '%s' is not from a RuleUnit instance", getterMethod));
+        }
+
+        if (getterMethod.getParameterCount() == 0) {
+            throw new IllegalArgumentException(
+                    String.format("The given method '%s' not from a RuleUnit instance", getterMethod));
+        }
+
+        if (getterMethod.getName().equals("getClass")) {
+            throw new IllegalArgumentException("'getClass' is not a valid method for a rule unit variable");
+        }
+
+        String id = getter2property(getterMethod.getName());
+
+        if (id == null) {
+            throw new IllegalArgumentException(
+                    String.format("Could not parse getter name for method '%s'", getterMethod));
+        }
+
+        this.name = name;
+        this.getter = getterMethod.getName();
+        this.getterMethod = getterMethod;
+        this.type = getterMethod.getReturnType();
+        this.dataSourceParameterType = getUnitVarType(getterMethod);
+        this.boxedVarType = convertFromPrimitiveType(type);
+    }
+
+    private Class<?> getUnitVarType(Method m) {
+        Class<?> returnClass = m.getReturnType();
+        if (returnClass.isArray()) {
+            return returnClass.getComponentType();
+        } else if (Iterable.class.isAssignableFrom( returnClass )) {
+            Type returnType = m.getGenericReturnType();
+            Class<?> sourceType = returnType instanceof ParameterizedType ?
+                    (Class<?>) ( (ParameterizedType) returnType ).getActualTypeArguments()[0] :
+                    Object.class;
+            return sourceType;
+        } else {
+            return returnClass;
+        }
+    }
+
+
+    @Override
+    public boolean isDataSource() {
+        return dataSourceParameterType != null;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getter() {
+        return getter;
+    }
+
+    @Override
+    public Class<?> getType() {
+        return type;
+    }
+
+    @Override
+    public Class<?> getDataSourceParameterType() {
+        return dataSourceParameterType;
+    }
+
+    @Override
+    public Class<?> getBoxedVarType() {
+        return boxedVarType;
+    }
+
+    public Object getValue(RuleUnit ruleUnit) {
+        try {
+            return getterMethod.invoke(ruleUnit);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
@@ -22,14 +22,10 @@ public final class ReflectiveRuleUnitVariable implements RuleUnitVariable {
     private final Method getterMethod;
 
 
-    public ReflectiveRuleUnitVariable(Method getterMethod) {
-        this(getter2property(getterMethod.getName()), getterMethod);
-    }
-
     public ReflectiveRuleUnitVariable(String name, Method getterMethod) {
         Objects.requireNonNull(name, "Invalid name was given: null");
 
-        if (getterMethod.getDeclaringClass() != RuleUnit.class) {
+        if (!RuleUnit.class.isAssignableFrom(getterMethod.getDeclaringClass())) {
             throw new IllegalArgumentException(
                     String.format("The given method '%s' is not from a RuleUnit instance", getterMethod));
         }

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
@@ -29,14 +29,14 @@ public final class ReflectiveRuleUnitVariable implements RuleUnitVariable {
     public ReflectiveRuleUnitVariable(String name, Method getterMethod) {
         Objects.requireNonNull(name, "Invalid name was given: null");
 
-        if (getterMethod.getDeclaringClass() == RuleUnit.class) {
+        if (getterMethod.getDeclaringClass() != RuleUnit.class) {
             throw new IllegalArgumentException(
                     String.format("The given method '%s' is not from a RuleUnit instance", getterMethod));
         }
 
-        if (getterMethod.getParameterCount() == 0) {
+        if (getterMethod.getParameterCount() != 0) {
             throw new IllegalArgumentException(
-                    String.format("The given method '%s' not from a RuleUnit instance", getterMethod));
+                    String.format("The given method '%s' is not from a RuleUnit instance", getterMethod));
         }
 
         if (getterMethod.getName().equals("getClass")) {

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/ReflectiveRuleUnitVariable.java
@@ -107,4 +107,13 @@ public final class ReflectiveRuleUnitVariable implements RuleUnitVariable {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public String toString() {
+        return "ReflectiveRuleUnitVariable{" +
+                "name='" + name + '\'' +
+                ", type=" + type +
+                ", dataSourceParameterType=" + dataSourceParameterType +
+                '}';
+    }
 }

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitDescriptionImpl.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitDescriptionImpl.java
@@ -34,6 +34,8 @@ import org.kie.api.definition.KiePackage;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.kie.internal.ruleunit.RuleUnitVariable;
 
+import static org.drools.reflective.util.ClassUtils.getter2property;
+
 public class RuleUnitDescriptionImpl implements RuleUnitDescription {
     private final Class<? extends RuleUnit> ruleUnitClass;
     private final Map<String, ReflectiveRuleUnitVariable> varDeclarations = new HashMap<>();
@@ -144,9 +146,14 @@ public class RuleUnitDescriptionImpl implements RuleUnitDescription {
 
     private void indexUnitVars() {
         for (Method m : ruleUnitClass.getMethods()) {
-            if ( m.getDeclaringClass() != RuleUnit.class && m.getParameterCount() == 0 && !"getUnitIdentity".equals(m.getName())) {
-                ReflectiveRuleUnitVariable v = new ReflectiveRuleUnitVariable(m);
-                varDeclarations.put(v.getName(), v);
+            if ( m.getDeclaringClass() != RuleUnit.class && m.getParameterCount() == 0
+                    && !"getUnitIdentity".equals(m.getName())
+                    && !"getClass".equals(m.getName())) {
+                String id = getter2property(m.getName());
+                if (id != null) {
+                    ReflectiveRuleUnitVariable v = new ReflectiveRuleUnitVariable(id, m);
+                    varDeclarations.put(v.getName(), v);
+                }
             }
         }
     }

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitDescriptionImpl.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitDescriptionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,7 @@
 
 package org.drools.ruleunit.impl;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +24,7 @@ import java.util.Optional;
 
 import org.drools.core.WorkingMemoryEntryPoint;
 import org.drools.core.rule.EntryPointId;
-import org.drools.core.util.ClassUtils;
+import org.drools.ruleunit.RuleUnit;
 import org.drools.ruleunit.datasources.BindableArray;
 import org.drools.ruleunit.datasources.BindableDataProvider;
 import org.drools.ruleunit.datasources.BindableIterable;
@@ -35,16 +32,13 @@ import org.drools.ruleunit.datasources.BindableObject;
 import org.drools.ruleunit.executor.RuleUnitSessionImpl;
 import org.kie.api.definition.KiePackage;
 import org.kie.internal.ruleunit.RuleUnitDescription;
-import org.drools.ruleunit.RuleUnit;
+import org.kie.internal.ruleunit.RuleUnitVariable;
 
 public class RuleUnitDescriptionImpl implements RuleUnitDescription {
     private final Class<? extends RuleUnit> ruleUnitClass;
+    private final Map<String, ReflectiveRuleUnitVariable> varDeclarations = new HashMap<>();
 
-    private final Map<String, Class<?>> datasourceTypes = new HashMap<>();
-
-    private final Map<String, Method> varAccessors = new HashMap<>();
-
-    public RuleUnitDescriptionImpl( KiePackage pkg, Class<?> ruleUnitClass ) {
+    public RuleUnitDescriptionImpl(KiePackage pkg, Class<?> ruleUnitClass) {
         this.ruleUnitClass = (Class<? extends RuleUnit>) ruleUnitClass;
         indexUnitVars();
     }
@@ -53,42 +47,53 @@ public class RuleUnitDescriptionImpl implements RuleUnitDescription {
         return ruleUnitClass;
     }
 
-    public Optional<EntryPointId> getEntryPointId( String name ) {
-        return varAccessors.containsKey( name ) ? Optional.of( new EntryPointId( getEntryPointName(name) ) ) : Optional.empty();
+    public Optional<EntryPointId> getEntryPointId(String name ) {
+        return varDeclarations.containsKey( name ) ? Optional.of( new EntryPointId( getEntryPointName(name) ) ) : Optional.empty();
     }
 
-    public Optional<Class<?>> getDatasourceType( String name ) {
-        return Optional.ofNullable( datasourceTypes.get( name ) );
+
+    @Override
+    public Optional<Class<?>> getDatasourceType(String name) {
+        return Optional.ofNullable(varDeclarations.get(name))
+                .filter(RuleUnitVariable::isDataSource)
+                .map(RuleUnitVariable::getDataSourceParameterType);
     }
 
-    public Optional<Class<?>> getVarType( String name ) {
-        return Optional.ofNullable( varAccessors.get( name ) ).map( Method::getReturnType );
+
+    @Override
+    public Optional<Class<?>> getVarType(String name) {
+        return Optional.ofNullable(varDeclarations.get(name)).map(RuleUnitVariable::getType);
     }
 
-    public boolean hasVar( String name ) {
-        return varAccessors.containsKey( name );
+    @Override
+    public boolean hasVar(String name) {
+        return varDeclarations.containsKey(name);
     }
 
+    @Override
     public Collection<String> getUnitVars() {
-        return varAccessors.keySet();
+        return varDeclarations.keySet();
     }
 
-    public Map<String, Method> getUnitVarAccessors() {
-        return varAccessors;
+    @Override
+    public Collection<? extends RuleUnitVariable> getUnitVarDeclarations() {
+        return varDeclarations.values();
     }
 
-    public boolean hasDataSource( String name ) {
-        return varAccessors.containsKey( name );
+    @Override
+    public boolean hasDataSource(String name) {
+        RuleUnitVariable ruleUnitVariable = varDeclarations.get(name);
+        return ruleUnitVariable != null && ruleUnitVariable.isDataSource();
     }
 
-    public void bindDataSources( RuleUnitSessionImpl wm, RuleUnit ruleUnit ) {
-        varAccessors.forEach( (name, method) -> bindDataSource( wm, ruleUnit, name, method ) );
+    public void bindDataSources(RuleUnitSessionImpl wm, RuleUnit ruleUnit ) {
+        varDeclarations.values().forEach( v -> bindDataSource( wm, ruleUnit, v ) );
     }
 
-    private void bindDataSource( RuleUnitSessionImpl wm, RuleUnit ruleUnit, String name, Method method ) {
-        WorkingMemoryEntryPoint entryPoint = wm.getEntryPoint( getEntryPointName( name ) );
+    private void bindDataSource( RuleUnitSessionImpl wm, RuleUnit ruleUnit, ReflectiveRuleUnitVariable v ) {
+        WorkingMemoryEntryPoint entryPoint = wm.getEntryPoint(getEntryPointName(v.getName()) );
         if (entryPoint != null) {
-            BindableDataProvider dataSource = findDataSource( ruleUnit, method );
+            BindableDataProvider dataSource = findDataSource( ruleUnit, v );
             if (dataSource != null) {
                 entryPoint.setRuleUnit( ruleUnit );
                 dataSource.bind( ruleUnit, entryPoint );
@@ -97,35 +102,28 @@ public class RuleUnitDescriptionImpl implements RuleUnitDescription {
     }
 
     public void unbindDataSources( RuleUnitSessionImpl wm, RuleUnit ruleUnit ) {
-        varAccessors.values().forEach( method -> unbindDataSource( ruleUnit, method ) );
+        varDeclarations.values().forEach( v -> unbindDataSource( ruleUnit, v ) );
     }
 
-    private void unbindDataSource( RuleUnit ruleUnit, Method method ) {
-        BindableDataProvider dataSource = findDataSource( ruleUnit, method );
+    private void unbindDataSource( RuleUnit ruleUnit, ReflectiveRuleUnitVariable v ) {
+        BindableDataProvider dataSource = findDataSource( ruleUnit, v );
         if (dataSource != null) {
             dataSource.unbind( ruleUnit );
         }
     }
 
     public Object getValue(RuleUnit ruleUnit, String identifier) {
-        Method m = varAccessors.get(identifier);
-        if (m != null) {
-            try {
-                return m.invoke( ruleUnit );
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new RuntimeException( e );
-            }
-        }
-        return null;
+        ReflectiveRuleUnitVariable v = varDeclarations.get(identifier);
+        return v == null ? null : v.getValue(ruleUnit);
     }
 
     private BindableDataProvider findDataSource( RuleUnit ruleUnit, String name ) {
-        return findDataSource( ruleUnit, varAccessors.get( name ) );
+        return findDataSource( ruleUnit, varDeclarations.get( name ) );
     }
 
-    private BindableDataProvider findDataSource( RuleUnit ruleUnit, Method m ) {
+    private BindableDataProvider findDataSource(RuleUnit ruleUnit, ReflectiveRuleUnitVariable m ) {
         try {
-            Object value = m.invoke( ruleUnit );
+            Object value = m.getValue( ruleUnit );
             if (value == null) {
                 return null;
             }
@@ -147,23 +145,8 @@ public class RuleUnitDescriptionImpl implements RuleUnitDescription {
     private void indexUnitVars() {
         for (Method m : ruleUnitClass.getMethods()) {
             if ( m.getDeclaringClass() != RuleUnit.class && m.getParameterCount() == 0 && !"getUnitIdentity".equals(m.getName())) {
-                String id = ClassUtils.getter2property(m.getName());
-                if (id != null && !id.equals( "class" )) {
-                    varAccessors.put( id, m );
-
-                    Class<?> returnClass = m.getReturnType();
-                    if (returnClass.isArray()) {
-                        datasourceTypes.put( id, returnClass.getComponentType() );
-                    } else if (Iterable.class.isAssignableFrom( returnClass )) {
-                        Type returnType = m.getGenericReturnType();
-                        Class<?> sourceType = returnType instanceof ParameterizedType ?
-                                (Class<?>) ( (ParameterizedType) returnType ).getActualTypeArguments()[0] :
-                                Object.class;
-                        datasourceTypes.put( id, sourceType );
-                    } else {
-                        datasourceTypes.put( id, returnClass );
-                    }
-                }
+                ReflectiveRuleUnitVariable v = new ReflectiveRuleUnitVariable(m);
+                varDeclarations.put(v.getName(), v);
             }
         }
     }

--- a/drools-ruleunit/src/test/java/org/drools/ruleunit/RuleUnitDescriptionTest.java
+++ b/drools-ruleunit/src/test/java/org/drools/ruleunit/RuleUnitDescriptionTest.java
@@ -32,6 +32,7 @@ import org.drools.ruleunit.impl.RuleUnitDescriptionImpl;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.internal.ruleunit.RuleUnitVariable;
 
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
@@ -112,13 +113,12 @@ public class RuleUnitDescriptionTest {
 
     @Test
     public void getUnitVarAccessors() {
-        final Map<String, Method> unitVarAccessors = ruleUnitDescr.getUnitVarAccessors();
+        final Collection<? extends RuleUnitVariable> unitVarAccessors = ruleUnitDescr.getUnitVarDeclarations();
         Assertions.assertThat(unitVarAccessors).isNotEmpty();
         Assertions.assertThat(unitVarAccessors).hasSize(5);
-        Assertions.assertThat(unitVarAccessors).containsKeys("bound", "number", "numbersArray", "stringList", "simpleFactList");
-        Assertions.assertThat(unitVarAccessors.values())
+        Assertions.assertThat(unitVarAccessors)
                 .extracting("name", String.class)
-                .containsExactlyInAnyOrder("getBound", "getNumber", "getNumbersArray", "getStringList", "getSimpleFactList");
+                .containsExactlyInAnyOrder("bound", "number", "numbersArray", "stringList", "simpleFactList");
     }
 
     @Test


### PR DESCRIPTION
RuleUnitDescription interface returns `Method`s; in Kogito we need a way to abstract over class definitions so that a RuleUnit can be materialized at later stages of the compilation process.

with this JIRA, we introduce an abstraction over RuleUnitDescription, so that different implementations can be provided. The default implementation is reflective (uses Methods), but a non-reflective implementation will be allowed.

see also https://github.com/kiegroup/droolsjbpm-knowledge/pull/413