### PR TITLE
[DROOLS-4623] using a negated constraint in a not pattern doesn't wor…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
@@ -28,6 +28,7 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.UnaryExpr;
 import org.drools.model.Index;
 import org.drools.modelcompiler.builder.generator.TypedExpression;
 
@@ -262,6 +263,9 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
             }
             if (expr instanceof EnclosedExpr ) {
                 return isEnclosedExprValid( (( EnclosedExpr ) expr).getInner());
+            }
+            if (expr instanceof UnaryExpr && ((UnaryExpr) expr).getOperator() == UnaryExpr.Operator.LOGICAL_COMPLEMENT) {
+                return true;
             }
             return right != null;
         }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/alphaNetworkCompiler/ObjectTypeNodeCompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/alphaNetworkCompiler/ObjectTypeNodeCompilerTest.java
@@ -246,4 +246,22 @@ public class ObjectTypeNodeCompilerTest extends BaseModelTest {
         ksession.fireAllRules();
         assertTrue(luca.getAge() == 40);
     }
+
+    @Test
+    public void testAlphaConstraintNagate() {
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "rule R1 when\n" +
+                "    Person( !(age > 18) )\n" +
+                "then\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+        try {
+            ksession.insert(new Person("Mario", 45));
+            assertEquals(0, ksession.fireAllRules());
+        } finally {
+            ksession.dispose();
+        }
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/NotTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.drools.testcoverage.common.model.AFact;
+import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
@@ -99,4 +100,26 @@ public class NotTest {
         }
     }
 
+    @Test
+    public void testNegatedConstaintInNot() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests.operators;\n" +
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "rule R1 when\n" +
+                "    not( Person( !(age > 18) ) )\n" +
+                "then\n" +
+                "end";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("negated-not-test", kieBaseTestConfiguration, drl);
+
+        final KieSession ksession = kbase.newKieSession();
+        try {
+            ksession.insert(new Person("Mario", 45));
+            assertEquals(1, ksession.fireAllRules());
+        } finally {
+            ksession.dispose();
+        }
+    }
 }


### PR DESCRIPTION
…k with executable model

testNegatedConstaintInNot() is from Mario's PR https://github.com/kiegroup/drools/pull/2571

I also find that a simple negate constraint has the same issue so I added testAlphaConstraintNagate() to ObjectTypeNodeCompilerTest. If there is a better place for this test method, let me know (Firstly I considered ConstraintsTest in test-compiler-integration but the class turns off executable-model test "TestParametersUtil.getKieBaseCloudConfigurations(false)").

The problem was that SingleDrlxParseSuccess.isValidExpression() returned false for UnaryExpr (= nagete expression) so the expression became empty in the generated RuleMethod.