### PR TITLE
DROOLS-4850: ModelCompiler, rm RuleUnitDescription.getRuleUnitClass()

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -72,6 +72,7 @@ import org.drools.modelcompiler.builder.generator.QueryParameter;
 import org.drools.modelcompiler.util.lambdareplace.CreatedClass;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.rule.AccumulateFunction;
+import org.kie.internal.ruleunit.RuleUnitDescription;
 
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static java.util.stream.Collectors.joining;
@@ -145,7 +146,7 @@ public class PackageModel {
 
     private final String pkgUUID;
     private Map<String, CreatedClass> lambdaClasses = new HashMap<>();
-    private Set<Class<?>> ruleUnits = new HashSet<>();
+    private Set<RuleUnitDescription> ruleUnits = new HashSet<>();
 
     private boolean oneClassPerRule;
 
@@ -375,17 +376,17 @@ public class PackageModel {
     }
 
 
-    public void addRuleUnit(Class<?> ruleUnitType) {
-        this.ruleUnits.add(ruleUnitType);
+    public void addRuleUnit(RuleUnitDescription ruleUnitDescription) {
+        this.ruleUnits.add(ruleUnitDescription);
     }
 
-    public Collection<Class<?>> getRuleUnits() {
+    public Collection<RuleUnitDescription> getRuleUnits() {
         return ruleUnits;
     }
 
-    public void addQueryInRuleUnit(Class<?> ruleUnitType, QueryModel query) {
-        addRuleUnit(ruleUnitType);
-        queriesByRuleUnit.computeIfAbsent( ruleUnitType.getSimpleName(), k -> new HashSet<>() ).add(query);
+    public void addQueryInRuleUnit(RuleUnitDescription ruleUnitDescription, QueryModel query) {
+        addRuleUnit(ruleUnitDescription);
+        queriesByRuleUnit.computeIfAbsent( ruleUnitDescription.getSimpleName(), k -> new HashSet<>() ).add(query);
     }
 
     public Collection<QueryModel> getQueriesInRuleUnit(Class<?> ruleUnitType) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -569,7 +569,12 @@ public class DrlxParseUtil {
     }
 
     public static Type classToReferenceType(Class<?> declClass) {
-        Type parsedType = parseType(declClass.getCanonicalName());
+        String className = declClass.getCanonicalName();
+        return classNameToReferenceType(className);
+    }
+
+    public static Type classNameToReferenceType(String className) {
+        Type parsedType = parseType(className);
         return parsedType instanceof PrimitiveType ?
                 ((PrimitiveType) parsedType).toBoxedType() :
                 parsedType;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -16,8 +16,6 @@
 
 package org.drools.modelcompiler.builder.generator;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -90,7 +88,6 @@ import static org.drools.modelcompiler.builder.generator.DslMethodNames.UNIT_CAL
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.UNIT_DATA_CALL;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.WINDOW_CALL;
 import static org.drools.modelcompiler.util.ClassUtil.asJavaSourceName;
-import static org.drools.modelcompiler.util.ClassUtil.toRawClass;
 import static org.drools.modelcompiler.util.StringUtil.toId;
 
 public class ModelGenerator {
@@ -417,16 +414,6 @@ public class ModelGenerator {
 
         AssignExpr var_assign = new AssignExpr(var_, unitDataCall, AssignExpr.Operator.ASSIGN);
         ruleBlock.addStatement(var_assign);
-    }
-
-    private static Class<?> getClassForUnitData( java.lang.reflect.Type type, Class<?> rawClass ) {
-        if (Iterable.class.isAssignableFrom( rawClass ) && type instanceof ParameterizedType) {
-            return toRawClass( (( ParameterizedType ) type).getActualTypeArguments()[0] );
-        }
-        if (rawClass.isArray()) {
-            return rawClass.getComponentType();
-        }
-        return rawClass;
     }
 
     public static void createVariables(KnowledgeBuilderImpl kbuilder, BlockStmt block, PackageModel packageModel, RuleContext context) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -71,6 +71,7 @@ import org.kie.internal.ruleunit.RuleUnitVariable;
 import static java.util.stream.Collectors.toList;
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.drools.core.impl.StatefulKnowledgeSessionImpl.DEFAULT_RULE_UNIT;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.classNameToReferenceType;
 import static org.kie.internal.ruleunit.RuleUnitUtil.isLegacyRuleUnit;
 import static org.drools.modelcompiler.builder.PackageModel.DATE_TIME_FORMATTER_FIELD;
 import static org.drools.modelcompiler.builder.PackageModel.DOMAIN_CLASSESS_METADATA_FILE_NAME;
@@ -165,7 +166,7 @@ public class ModelGenerator {
         }
 
         for (RuleUnitDescription rud : ruleUnitDescriptions) {
-            packageModel.addRuleUnit(rud.getRuleUnitClass());
+            packageModel.addRuleUnit(rud);
         }
     }
 
@@ -200,7 +201,7 @@ public class ModelGenerator {
         ruleCall.addArgument( new StringLiteralExpr( ruleDescr.getName() ) );
 
         MethodCallExpr buildCallScope = ruleUnitDescr != null ?
-                new MethodCallExpr(ruleCall, UNIT_CALL).addArgument( new ClassExpr( classToReferenceType(ruleUnitDescr.getRuleUnitClass()) ) ) :
+                new MethodCallExpr(ruleCall, UNIT_CALL).addArgument( new ClassExpr( classNameToReferenceType(ruleUnitDescr.getRuleUnitName()) ) ) :
                 ruleCall;
 
         for (MethodCallExpr attributeExpr : ruleAttributes(context, ruleDescr)) {
@@ -224,7 +225,7 @@ public class ModelGenerator {
         ruleVariablesBlock.addStatement(new AssignExpr(ruleVar, buildCall, AssignExpr.Operator.ASSIGN));
 
         ruleVariablesBlock.addStatement( new ReturnStmt("rule") );
-        packageModel.putRuleMethod(ruleUnitDescr != null ? ruleUnitDescr.getRuleUnitClass().getSimpleName() : DEFAULT_RULE_UNIT, ruleMethod);
+        packageModel.putRuleMethod(ruleUnitDescr != null ? ruleUnitDescr.getSimpleName() : DEFAULT_RULE_UNIT, ruleMethod);
     }
 
     private static AndDescr getExtendedLhs(PackageDescr packageDescr, RuleDescr ruleDescr) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ModelGenerator.java
@@ -201,7 +201,7 @@ public class ModelGenerator {
         ruleCall.addArgument( new StringLiteralExpr( ruleDescr.getName() ) );
 
         MethodCallExpr buildCallScope = ruleUnitDescr != null ?
-                new MethodCallExpr(ruleCall, UNIT_CALL).addArgument( new ClassExpr( classNameToReferenceType(ruleUnitDescr.getRuleUnitName()) ) ) :
+                new MethodCallExpr(ruleCall, UNIT_CALL).addArgument( new ClassExpr( classNameToReferenceType(ruleUnitDescr.getCanonicalName()) ) ) :
                 ruleCall;
 
         for (MethodCallExpr attributeExpr : ruleAttributes(context, ruleDescr)) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/QueryGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/QueryGenerator.java
@@ -100,7 +100,7 @@ public class QueryGenerator {
                 }
             }
             QueryModel queryModel = new QueryModel( queryDescr.getName(), queryDescr.getNamespace(), queryDescr.getParameters(), queryBindings );
-            packageModel.addQueryInRuleUnit( context.getRuleUnitDescr().getRuleUnitClass(), queryModel );
+            packageModel.addQueryInRuleUnit( context.getRuleUnitDescr(), queryModel );
         }
 
         final Type queryType = parseType(Query.class.getCanonicalName());

--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitDescriptionImpl.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitDescriptionImpl.java
@@ -49,6 +49,16 @@ public class RuleUnitDescriptionImpl implements RuleUnitDescription {
         return ruleUnitClass;
     }
 
+    @Override
+    public String getSimpleName() {
+        return ruleUnitClass.getSimpleName();
+    }
+
+    @Override
+    public String getPackageName() {
+        return ruleUnitClass.getPackage().getName();
+    }
+
     public Optional<EntryPointId> getEntryPointId(String name ) {
         return varDeclarations.containsKey( name ) ? Optional.of( new EntryPointId( getEntryPointName(name) ) ) : Optional.empty();
     }


### PR DESCRIPTION
follow up to DROOLS-4837: remove usages of RuleUnitDescription.getRuleUnitClass() throughout model compiler so that non-reflective implementations are allowed.

For the time being we will keep the method for backwards compatibility with PMML impl

requires https://github.com/kiegroup/droolsjbpm-knowledge/pull/415
