### PR TITLE
DROOLS-4340 - Contains can not be used for String with the Expression editor

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -2744,8 +2744,9 @@ public class RuleModelDRLPersistenceImpl
                 }
             }
             int opPos = expr.indexOf(opString);
-            if (opPos >= 0 && !isInQuote(expr,
-                                         opPos) &&
+            if (opPos >= 0 &&
+                    isNotMethodName(expr, opPos) &&
+                    !isInQuote(expr, opPos) &&
                     !(Character.isLetter(opString.charAt(0)) &&
                             (expr.length() == opPos + opString.length() || Character.isLetter(expr.charAt(opPos + opString.length())) ||
                                     (opPos > 0 && Character.isLetter(expr.charAt(opPos - 1)))))) {
@@ -2771,6 +2772,11 @@ public class RuleModelDRLPersistenceImpl
             return " in ";
         }
         return null;
+    }
+
+    private static boolean isNotMethodName(final String expression,
+                                           final int operatorPosition) {
+        return operatorPosition == 0 || expression.charAt(operatorPosition - 1) == ' ';
     }
 
     private static boolean isInQuote(final String expr,

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -8400,6 +8400,41 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
     }
 
     @Test
+    public void testExpressionWhenMethodNameIsExsistingOperator() {
+        String drl = "rule \"rule1\"\n"
+                + "when\n"
+                + "Applicant( name.contains(\"test\") ) \n"
+                + "then\n"
+                + "end\n";
+
+        final RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                                Collections.emptyList(),
+                                                                                dmo);
+
+        assertNotNull(m);
+
+        assertTrue(m.lhs[0] instanceof FactPattern);
+        FactPattern pattern = (FactPattern) m.lhs[0];
+        assertEquals("Applicant",
+                     pattern.getFactType());
+        assertEquals(1,
+                     pattern.getNumberOfConstraints());
+        assertEquals("contains(\"test\")",
+                     ((SingleFieldConstraint) pattern.getConstraint(0)).getFieldName());
+        assertNull(((SingleFieldConstraint) pattern.getConstraint(0)).getOperator());
+        assertNull(((SingleFieldConstraint) pattern.getConstraint(0)).getValue());
+        SingleFieldConstraintEBLeftSide constraint = (SingleFieldConstraintEBLeftSide) pattern.getConstraint(0);
+        List<ExpressionPart> expressionParts = constraint.getExpressionLeftSide().getParts();
+        assertEquals(3, expressionParts.size());
+        assertTrue(expressionParts.get(0) instanceof ExpressionUnboundFact);
+        assertEquals("Applicant", ((ExpressionUnboundFact) expressionParts.get(0)).getFactType());
+        assertTrue(expressionParts.get(1) instanceof ExpressionText);
+        assertEquals("name", expressionParts.get(1).getName());
+        assertTrue(expressionParts.get(2) instanceof ExpressionText);
+        assertEquals("contains(\"test\")", expressionParts.get(2).getName());
+    }
+
+    @Test
     public void testStringReplaceExpression() throws Exception {
         //https://bugzilla.redhat.com/show_bug.cgi?id=1264321
         String drl = "rule \"Replace_condition_Issue\"\n" +


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-4340

