### PR TITLE
NullPointer error for Memory loading class in custmized classloader

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
+++ b/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
@@ -246,9 +246,11 @@ public class PhreakPropagationContext
 
 
         Class<?> classType = classObjectType.getClassType();
-        String pkgName = classType.getPackage().getName();
 
-        if (classType == modifiedClass || "java.lang".equals(pkgName) || !(classType.isInterface() || modifiedClass.isInterface())) {
+        Package pkg = classType.getPackage();
+
+        if (classType == modifiedClass || (pkg != null && "java.lang".equals(pkg.getName()))
+                || !(classType.isInterface() || modifiedClass.isInterface())) {
             if (typeBit) {
                 modificationMask = modificationMask.set(PropertySpecificUtil.TRAITABLE_BIT);
             }


### PR DESCRIPTION
In my scenario,  I'm using KieFileSystem to build Rules. 
I have defined some dynamic class in memory and loaded into customized classloader,
However,  these classes loaded by classloader don't have package info, 
When the rule trigged update working area mechanism , it will cause NullPointer Exception. 
So I add this check to prevent  NullPointer Exception.
<img width="1246" alt="屏幕快照 2019-12-11 上午10 02 30" src="https://user-images.githubusercontent.com/26806302/70584859-6269d400-1bfd-11ea-9e35-a783425ded62.png">
