### PR TITLE
NullPointer error for Memory loading class in customized classloader

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
+++ b/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
@@ -246,9 +246,11 @@ public class PhreakPropagationContext
 
 
         Class<?> classType = classObjectType.getClassType();
-        String pkgName = classType.getPackage().getName();
 
-        if (classType == modifiedClass || "java.lang".equals(pkgName) || !(classType.isInterface() || modifiedClass.isInterface())) {
+        Package pkg = classType.getPackage();
+
+        if (classType == modifiedClass || (pkg != null && "java.lang".equals(pkg.getName()))
+                || !(classType.isInterface() || modifiedClass.isInterface())) {
             if (typeBit) {
                 modificationMask = modificationMask.set(PropertySpecificUtil.TRAITABLE_BIT);
             }

--- a/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
+++ b/drools-core/src/main/java/org/drools/core/common/PhreakPropagationContext.java
@@ -243,13 +243,11 @@ public class PhreakPropagationContext
         modificationMask = originalMask;
         boolean typeBit = modificationMask.isSet(PropertySpecificUtil.TRAITABLE_BIT);
         modificationMask = modificationMask.reset(PropertySpecificUtil.TRAITABLE_BIT);
-
-
+        
         Class<?> classType = classObjectType.getClassType();
+        String pkgName = classType.getPackage() == null? null:classType.getPackage().getName();
 
-        Package pkg = classType.getPackage();
-
-        if (classType == modifiedClass || (pkg != null && "java.lang".equals(pkg.getName()))
+        if (classType == modifiedClass ||  "java.lang".equals(pkgName)
                 || !(classType.isInterface() || modifiedClass.isInterface())) {
             if (typeBit) {
                 modificationMask = modificationMask.set(PropertySpecificUtil.TRAITABLE_BIT);
@@ -284,7 +282,7 @@ public class PhreakPropagationContext
     }
 
     private List<String> getAccessibleProperties( InternalWorkingMemory workingMemory, Class<?> classType, String pkgName ) {
-        if ( pkgName.equals( "java.lang" ) || pkgName.equals( "java.util" ) ) {
+        if ( "java.lang".equals(pkgName) || "java.util".equals(pkgName) ) {
             return Collections.EMPTY_LIST;
         }
         InternalKnowledgePackage pkg = workingMemory.getKnowledgeBase().getPackage( pkgName );


### PR DESCRIPTION
Scenario:  1. Using KieFileSystem loading DRL file and dependency resource.
                  2. Dynamic load byte class into customized classloader, and transmit the classloader into KIESession.
                  3. in update working area case.
It will raise NullPointer Exception.