### PR TITLE
Use Java 9 Eclipse Compiler Options when running on Java 10+

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompilerSettings.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/EclipseJavaCompilerSettings.java
@@ -36,10 +36,7 @@ public final class EclipseJavaCompilerSettings extends JavaCompilerSettings {
     public static final String CompilerOptions_VERSION_1_6 = "1.6"; //$NON-NLS-1$
     public static final String CompilerOptions_VERSION_1_7 = "1.7"; //$NON-NLS-1$
     public static final String CompilerOptions_VERSION_1_8 = "1.8"; //$NON-NLS-1$
-    public static final String CompilerOptions_VERSION_9 = "9"; //$NON-NLS-1$
-    public static final String CompilerOptions_VERSION_10 = "10"; //$NON-NLS-1$
-    public static final String CompilerOptions_VERSION_11 = "11"; //$NON-NLS-1$
-    public static final String CompilerOptions_VERSION_12 = "12"; //$NON-NLS-1$
+    public static final String CompilerOptions_VERSION_1_9 = "1.9"; //$NON-NLS-1$
 
     public static final String CompilerOptions_GENERATE = "generate";//$NON-NLS-1$
     public static final String CompilerOptions_DO_NOT_GENERATE = "do not generate"; //$NON-NLS-1$
@@ -93,10 +90,12 @@ public final class EclipseJavaCompilerSettings extends JavaCompilerSettings {
         put("1.6", CompilerOptions_VERSION_1_6);
         put("1.7", CompilerOptions_VERSION_1_7);
         put("1.8", CompilerOptions_VERSION_1_8);
-        put("9", CompilerOptions_VERSION_9);
-        put("10", CompilerOptions_VERSION_10);
-        put("11", CompilerOptions_VERSION_11);
-        put("12", CompilerOptions_VERSION_12);
+        put("9", CompilerOptions_VERSION_1_9);
+        // TODO use Java 9 options when running on Java 10 and above. This should be fixed when ECJ is upgraded to a
+        // version that supports Java 10 and above
+        put("10", CompilerOptions_VERSION_1_9);
+        put("11", CompilerOptions_VERSION_1_9);
+        put("12", CompilerOptions_VERSION_1_9);
     }};
     
     private String toNativeVersion( final String pVersion ) {


### PR DESCRIPTION
#2650 set Eclipse Compiler options to Java 10, 11, 12 when using target/source of 10, 11, 12 respectively. But Eclipse Compiler 4.6.1 we currently use support Java only up to version 9. Without this fix, it is not possible to compile rules or processes because it will fall back to Java 1.4.