### PR TITLE
module name change

### DIFF
--- a/drools-model/drools-canonical-model/pom.xml
+++ b/drools-model/drools-canonical-model/pom.xml
@@ -14,7 +14,7 @@
   <packaging>bundle</packaging><!-- bundle = jar + OSGi metadata -->
 
   <properties>
-    <java.module.name>org.drools.canonical-model</java.module.name>
+    <java.module.name>org.drools.canonicalModel</java.module.name>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# Change Summary
Replacing module name with a valid one.

# Justification for change
- See https://docs.oracle.com/javase/specs/jls/se10/html/jls-7.html#jls-ModuleDeclaration
  - Specifically: `A module name consists of one or more Java identifiers (§3.8) separated by "." tokens`
- See https://docs.oracle.com/javase/9/docs/api/java/lang/module/ModuleFinder.html#automatic-modules

# Example error based on current module name (Oracle jdk-11.0.5)
```
Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for /home/wcarmon/.m2/repository/org/drools/drools-canonical-model/7.30.0.Final/drools-canonical-model-7.30.0.Final.jar
Caused by: java.lang.module.FindException: Automatic-Module-Name: org.drools.canonical-model: Invalid module name: 'canonical-model' is not a Java identifier
```