### PR TITLE
DROOLS-1084 Exclude 'provided', 'test' and 'system' scope before scanning full tree

### DIFF
--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -55,6 +55,7 @@ import static org.drools.compiler.kproject.ReleaseIdImpl.adapt;
 public class KieRepositoryScannerImpl extends AbstractKieScanner<Map<DependencyDescriptor, Artifact>> implements InternalKieScanner {
 
     private static final Logger log = LoggerFactory.getLogger(KieScanner.class);
+    private static final DependencyFilter.ExcludeScopeFilter DEPENDENCY_SCOPEFILTER = new DependencyFilter.ExcludeScopeFilter("test", "provided", "system");
 
     private DependencyDescriptor kieProjectDescr;
 
@@ -248,7 +249,7 @@ public class KieRepositoryScannerImpl extends AbstractKieScanner<Map<DependencyD
 
     private Map<ReleaseId, DependencyDescriptor> indexArtifacts() {
         Map<ReleaseId, DependencyDescriptor> depsMap = new HashMap<>();
-        for (DependencyDescriptor dep : artifactResolver.getAllDependecies()) {
+        for (DependencyDescriptor dep : artifactResolver.getAllDependecies(DEPENDENCY_SCOPEFILTER)) {
             if ( !"test".equals(dep.getScope()) && !"provided".equals(dep.getScope()) && !"system".equals(dep.getScope()) ) {
                 Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
                 if (artifact != null) {

--- a/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
+++ b/kie-ci/src/main/java/org/kie/scanner/KieRepositoryScannerImpl.java
@@ -250,20 +250,14 @@ public class KieRepositoryScannerImpl extends AbstractKieScanner<Map<DependencyD
     private Map<ReleaseId, DependencyDescriptor> indexArtifacts() {
         Map<ReleaseId, DependencyDescriptor> depsMap = new HashMap<>();
         for (DependencyDescriptor dep : artifactResolver.getAllDependecies(DEPENDENCY_SCOPEFILTER)) {
-            if ( !"test".equals(dep.getScope()) && !"provided".equals(dep.getScope()) && !"system".equals(dep.getScope()) ) {
-                Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
-                if (artifact != null) {
-                    if ( log.isDebugEnabled() ) {
-                        log.debug( artifact + " resolved to  " + artifact.getFile() );
-                    }
-                    if ( isKJar( artifact.getFile() ) ) {
-                        depsMap.put( adapt( dep.getReleaseIdWithoutVersion() ), new DependencyDescriptor( artifact ) );
-                    }
-                }
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug( "{} does not need to be resolved because in scope {}", dep, dep.getScope() );
-                }
+            Artifact artifact = artifactResolver.resolveArtifact(dep.getReleaseId());
+            if (artifact != null) {
+                if ( log.isDebugEnabled() ) {
+                     log.debug( artifact + " resolved to  " + artifact.getFile() );
+                 }
+                 if ( isKJar( artifact.getFile() ) ) {
+                     depsMap.put( adapt( dep.getReleaseIdWithoutVersion() ), new DependencyDescriptor( artifact ) );
+                 }
             }
         }
         return depsMap;


### PR DESCRIPTION
In a Dockerized environment with an empty local Maven repository getting all artefacts from a remote repository is an expensive operation. The same is true for very big dependency trees in a local environment.

As it seems even non-needed dependencies with _provided_, _test_ or _system_ scope are being fully traversed for transitive dependencies.

My proposition would be to exclude _'provided'_, _'test'_ and _'system'_ scope before scanning the full dependency tree.
As the results in the original code are already filtered after getting all transitive dependencies, it would just as well be filtered on the direct dependencies first as this restricts the scope already and should not be harmful therefore.

There is a report DROOLS-1084 issue describing the unwanted behaviour though it also describes some side effects likely not noticed if the scope filtering happens before getting the tree.

The original [commit](https://github.com/kiegroup/drools/commit/80a06ea4bbb542eb8b240b484145684618b05851) likely fixed the issue with respect to failing but it still traverses the tree if the top level dependency scopes can already be ignored.

The performance gain in a Dockerized Spring environment is huge, if there are no objections I would very much appreciate the code change to be merged. Thank you!

The kie-ci module was built without failing tests.