### PR TITLE
[DROOLS-4870] Materialize consequences using Drools

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
@@ -550,4 +550,30 @@ public class PropertyReactivityTest extends BaseModelTest {
 
         assertEquals( 2, ksession.fireAllRules(5) );
     }
+
+    @Test
+    public void testMultipleFieldUpdate() {
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "rule R1 when\n" +
+                "    $p : Person( name == \"Mario\" )\n" +
+                "then\n" +
+                "    modify($p) { setAge( $p.getAge()+1 ), setLikes(\"Cheese\") };\n" +
+                "end\n" +
+                "rule R2 when\n" +
+                "    $p : Person( name == \"Mario\", likes == \"Cheese\" )\n" +
+                "then\n" +
+                "    modify($p) { setAge( $p.getAge()+1 ) };\n" +
+                "end\n";
+
+        KieSession ksession = getKieSession( str );
+
+        Person p = new Person("Mario", 40);
+        p.setLikes("Beer");
+        ksession.insert( p );
+        ksession.fireAllRules();
+
+        assertEquals(42, p.getAge());
+    }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
@@ -36,26 +36,6 @@ public class ExecModelLambdaPostProcessorTest {
         assertThat(actual.toString(), equalToIgnoringWhiteSpace(expectedResult.toString()));
     }
 
-    @Test
-    public void convertFlowLambdaDoNotConvertConsequenceWhenDrools() throws Exception {
-
-        CompilationUnit inputCU = parseResource("org/drools/modelcompiler/util/lambdareplace/FlowConsequenceTestHarness.java");
-        CompilationUnit clone = inputCU.clone();
-
-        new ExecModelLambdaPostProcessor(new HashMap<>(), "mypackage", "rulename", new ArrayList<>(), new ArrayList<>(), clone).convertLambdas();
-
-        String FLOW_HARNESS = "FlowTestHarness";
-        MethodDeclaration expectedResultNotConverted = getMethodChangingName(inputCU, FLOW_HARNESS, "expectedOutputNotConverted");
-        MethodDeclaration actualNotConverted = getMethodChangingName(clone, FLOW_HARNESS, "inputMethodNotConverted");
-
-        assertThat(actualNotConverted.toString(), equalToIgnoringWhiteSpace(expectedResultNotConverted.toString()));
-
-        MethodDeclaration expectedResultConverted = getMethodChangingName(inputCU, FLOW_HARNESS, "expectedOutputConverted");
-        MethodDeclaration actualConverted = getMethodChangingName(clone, FLOW_HARNESS, "inputMethodConverted");
-
-        assertThat(actualConverted.toString(), equalToIgnoringWhiteSpace(expectedResultConverted.toString()));
-    }
-
     private MethodDeclaration getMethodChangingName(CompilationUnit inputCU, String className, String methodName) {
         return inputCU.getClassByName(className)
                 .map(c -> c.getMethodsByName(methodName))

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
@@ -1,6 +1,8 @@
 package org.drools.modelcompiler.util.lambdareplace;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -11,7 +13,7 @@ public class MaterializedLambdaConsequenceTest {
 
     @Test
     public void createConsequence() {
-        CreatedClass aClass = new MaterializedLambdaConsequence("org.drools.modelcompiler.util.lambdareplace", "rulename")
+        CreatedClass aClass = new MaterializedLambdaConsequence("org.drools.modelcompiler.util.lambdareplace", "rulename", new ArrayList<>())
                 .create("(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) -> result.setValue( p1.getName() + \" is older than \" + p2.getName())", new ArrayList<>(), new ArrayList<>());
 
         //language=JAVA
@@ -32,5 +34,121 @@ public class MaterializedLambdaConsequenceTest {
 
         assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
 
+    }
+
+    @Test
+    public void createConsequenceWithDrools() {
+        ArrayList<String> fields = new ArrayList<>();
+        fields.add("\"age\"");
+        MaterializedLambda.BitMaskVariable bitMaskVariable = new MaterializedLambda.BitMaskVariableWithFields("DomainClassesMetadataA3B8DE4BEBF13D94572A10FD20BBE729.org_drools_modelcompiler_domain_Person_Metadata_INSTANCE", fields, "mask_$p");
+
+        CreatedClass aClass = new MaterializedLambdaConsequence("defaultpkg", "defaultpkg.RulesA3B8DE4BEBF13D94572A10FD20BBE729", Collections.singletonList(bitMaskVariable))
+                .create("(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Person $p) -> {{($p).setAge($p.getAge() + 1); drools.update($p, mask_$p);}}", new ArrayList<>(), new ArrayList<>());
+
+        //language=JAVA
+        String expectedResult = "" +
+                "package defaultpkg;\n" +
+                "import static defaultpkg.RulesA3B8DE4BEBF13D94572A10FD20BBE729.*; " +
+                "import org.drools.modelcompiler.dsl.pattern.D; " +
+                "\n"+
+                "@org.drools.compiler.kie.builder.MaterializedLambda() " +
+                "public enum LambdaConsequenceB120B8921B17BB89EC2989BC02FAE9FF implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>  {\n" +
+                "        INSTANCE;\n" +
+                "        public static final String EXPRESSION_HASH = \"1FE08C27A04F37AADD1A62E562519E8D\";\n" +
+                "        private final org.drools.model.BitMask mask_$p = org.drools.model.BitMask.getPatternMask(DomainClassesMetadataA3B8DE4BEBF13D94572A10FD20BBE729.org_drools_modelcompiler_domain_Person_Metadata_INSTANCE, \"age\");\n" +
+                "        @Override()\n" +
+                "        public void execute(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Person $p) throws java.lang.Exception {\n" +
+                "            {\n" +
+                "                ($p).setAge($p.getAge() + 1);\n" +
+                "                drools.update($p, mask_$p);\n" +
+                "            }" +
+                "        }\n" +
+                "    }\n";
+
+        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+    }
+
+    @Test
+    public void createConsequenceWithMultipleFactUpdate() {
+        ArrayList<String> personFields = new ArrayList<>();
+        personFields.add("\"name\"");
+        MaterializedLambda.BitMaskVariable bitMaskPerson = new MaterializedLambda.BitMaskVariableWithFields("DomainClassesMetadataB45236F6195B110E0FA3A5447BC53274.org_drools_modelcompiler_domain_Person_Metadata_INSTANCE", personFields, "mask_$person");
+        ArrayList<String> petFields = new ArrayList<>();
+        petFields.add("\"age\"");
+        MaterializedLambda.BitMaskVariable bitMaskPet = new MaterializedLambda.BitMaskVariableWithFields("DomainClassesMetadataB45236F6195B110E0FA3A5447BC53274.org_drools_modelcompiler_domain_Pet_Metadata_INSTANCE", petFields, "mask_$pet");
+
+        String consequenceBlock = "(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Pet $pet, org.drools.modelcompiler.domain.Person $person) -> {{ ($person).setName(\"George\");drools.update($person, mask_$person); ($pet).setAge($pet.getAge() + 1); drools.update($pet, mask_$pet); }}";
+        CreatedClass aClass = new MaterializedLambdaConsequence("defaultpkg",
+                                                                "defaultpkg.RulesB45236F6195B110E0FA3A5447BC53274",
+                                                                Arrays.asList(bitMaskPerson, bitMaskPet))
+                .create(consequenceBlock, new ArrayList<>(), new ArrayList<>());
+
+        //language=JAVA
+        String expectedResult = "" +
+                "package defaultpkg;\n" +
+                "import static defaultpkg.RulesB45236F6195B110E0FA3A5447BC53274.*; " +
+                "import org.drools.modelcompiler.dsl.pattern.D; " +
+                "\n"+
+                "@org.drools.compiler.kie.builder.MaterializedLambda() " +
+                "public enum LambdaConsequence15D5E14C8AF75D1EE585FFA4A0764AEE implements org.drools.model.functions.Block3<org.drools.model.Drools, org.drools.modelcompiler.domain.Pet, org.drools.modelcompiler.domain.Person> {\n" +
+                "\n" +
+                "    INSTANCE;\n" +
+                "    public static final String EXPRESSION_HASH = \"2ABFB3D359AC0D0C1F6C1BAF91E05544\";\n" +
+                "    private final org.drools.model.BitMask mask_$person = org.drools.model.BitMask.getPatternMask(DomainClassesMetadataB45236F6195B110E0FA3A5447BC53274.org_drools_modelcompiler_domain_Person_Metadata_INSTANCE, \"name\");\n" +
+                "\n" +
+                "    private final org.drools.model.BitMask mask_$pet = org.drools.model.BitMask.getPatternMask(DomainClassesMetadataB45236F6195B110E0FA3A5447BC53274.org_drools_modelcompiler_domain_Pet_Metadata_INSTANCE, \"age\");\n" +
+                "\n" +
+                "    @Override()\n" +
+                "    public void execute(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Pet $pet, org.drools.modelcompiler.domain.Person $person) throws java.lang.Exception {\n" +
+                "        {\n" +
+                "            ($person).setName(\"George\");\n" +
+                "            drools.update($person, mask_$person);\n" +
+                "            ($pet).setAge($pet.getAge() + 1);\n" +
+                "            drools.update($pet, mask_$pet);\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+
+        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+    }
+
+    @Test
+    public void createConsequenceWithMultipleFieldUpdate() {
+        ArrayList<String> fields = new ArrayList<>();
+        fields.add("\"age\"");
+        fields.add("\"likes\"");
+        MaterializedLambda.BitMaskVariable bitMaskVariable = new MaterializedLambda.BitMaskVariableWithFields("DomainClassesMetadata53448E6B9A07CB05B976425EF329E308.org_drools_modelcompiler_domain_Person_Metadata_INSTANCE", fields, "mask_$p");
+
+        String consequenceBlock = "(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Person $p) -> {{ ($p).setAge($p.getAge() + 1); ($p).setLikes(\"Cheese\"); drools.update($p,mask_$p); }}";
+        CreatedClass aClass = new MaterializedLambdaConsequence("defaultpkg",
+                                                                "defaultpkg.Rules53448E6B9A07CB05B976425EF329E308",
+                                                                Arrays.asList(bitMaskVariable))
+                .create(consequenceBlock, new ArrayList<>(), new ArrayList<>());
+
+        //language=JAVA
+        String expectedResult = "" +
+                "package defaultpkg;\n" +
+                "\n" +
+                "import static defaultpkg.Rules53448E6B9A07CB05B976425EF329E308.*;\n" +
+                "import org.drools.modelcompiler.dsl.pattern.D;\n" +
+                "\n" +
+                "@org.drools.compiler.kie.builder.MaterializedLambda()\n" +
+                "public enum LambdaConsequenceC18D5E4E2DE9171EE73FFB2D81B29555 implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person> {\n" +
+                "\n" +
+                "    INSTANCE;\n" +
+                "    public static final String EXPRESSION_HASH = \"15102979E2E45F1A4617C12D3517D6B5\";\n" +
+                "    private final org.drools.model.BitMask mask_$p = org.drools.model.BitMask.getPatternMask(DomainClassesMetadata53448E6B9A07CB05B976425EF329E308.org_drools_modelcompiler_domain_Person_Metadata_INSTANCE, \"age\", \"likes\");\n" +
+                "\n" +
+                "    @Override()\n" +
+                "    public void execute(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Person $p) throws java.lang.Exception {\n" +
+                "        {\n" +
+                "            ($p).setAge($p.getAge() + 1);\n" +
+                "            ($p).setLikes(\"Cheese\");\n" +
+                "            drools.update($p, mask_$p);\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+
+        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
     }
 }


### PR DESCRIPTION
This is a draft PR to share my idea. Please let me know your thoughts.

Basically, it writes BitMask variables into the materialized LambdaConsequence as "private final" fields so execute() method can access them.

It passed all drools-model unit tests but I found that it fails with IncrementalCompilationCepTest#testIncrementalCompilationWithNewEvent in drools-test-coverage/test-compiler-integration. The failure is caused by duplication of LambdaConsequence class name during incremental compilation. I will look into it further.

One more point from code design aspect, I added "List<VariableDeclarator> bitMaskVariables" to MaterializedLambda. Actually, "bitMaskVariables" is required only by MaterializedLambdaConsequence. But if I add "List<VariableDeclarator> bitMaskVariables" to MaterializedLambdaConsequence, I would need more refactoring (e.g. MaterializedLambda.create() and ExecModelLambdaPostProcessor.extractLambdaFromMethodCall()). If you think it's worth refactoring, please let me know.

Thanks!
