### PR TITLE
[DROOLS-4611] Fix support for double (infinity and NaN) in test scenario

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -201,7 +201,7 @@ public class ScenarioBeanUtil {
         } else if (clazz.isAssignableFrom(Long.class) || clazz.isAssignableFrom(long.class)) {
             return Long.toString((Long) cleanValue);
         } else if (clazz.isAssignableFrom(Double.class) || clazz.isAssignableFrom(double.class)) {
-            return cleanValue + "d";
+            return revertDouble((Double) cleanValue);
         } else if (clazz.isAssignableFrom(Float.class) || clazz.isAssignableFrom(float.class)) {
             return cleanValue + "f";
         } else if (clazz.isAssignableFrom(Character.class) || clazz.isAssignableFrom(char.class)) {
@@ -276,5 +276,12 @@ public class ScenarioBeanUtil {
 
     private static String cleanStringForNumberParsing(String rawValue) {
         return rawValue.replaceAll("(-)\\s*([0-9])", "$1$2");
+    }
+
+    private static String revertDouble(Double doubleValue) {
+        if(Double.isInfinite(doubleValue) || Double.isNaN(doubleValue)) {
+            return String.valueOf(doubleValue);
+        }
+        return doubleValue + "d";
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -56,7 +56,7 @@ public class ScenarioBeanUtil {
         for (Map.Entry<List<String>, Object> param : params.entrySet()) {
 
             // direct mapping already considered
-            if(param.getKey().isEmpty()) {
+            if (param.getKey().isEmpty()) {
                 continue;
             }
 
@@ -279,7 +279,7 @@ public class ScenarioBeanUtil {
     }
 
     private static String revertDouble(Double doubleValue) {
-        if(Double.isInfinite(doubleValue) || Double.isNaN(doubleValue)) {
+        if (Double.isInfinite(doubleValue) || Double.isNaN(doubleValue)) {
             return String.valueOf(doubleValue);
         }
         return doubleValue + "d";

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -201,6 +201,9 @@ public class ScenarioBeanUtilTest {
         assertEquals("1", revertValue(1));
         assertEquals("1", revertValue(1L));
         assertEquals("1.0d", revertValue(1.0d));
+        assertEquals("NaN", revertValue(Double.NaN));
+        assertEquals("Infinity", revertValue(Double.POSITIVE_INFINITY));
+        assertEquals("-Infinity", revertValue(Double.NEGATIVE_INFINITY));
         assertEquals("1.0f", revertValue(1.0f));
         assertEquals("a", revertValue('a'));
         assertEquals("1", revertValue((short) 1));
@@ -220,6 +223,12 @@ public class ScenarioBeanUtilTest {
         assertEquals("1", revertValue(convertValue(Long.class.getCanonicalName(), "1", classLoader)));
         assertEquals("1.0d", revertValue(convertValue(double.class.getCanonicalName(), "1", classLoader)));
         assertEquals("1.0d", revertValue(convertValue(Double.class.getCanonicalName(), "1", classLoader)));
+        assertEquals("NaN", revertValue(convertValue(double.class.getCanonicalName(), "NaN", classLoader)));
+        assertEquals("NaN", revertValue(convertValue(Double.class.getCanonicalName(), "NaN", classLoader)));
+        assertEquals("Infinity", revertValue(convertValue(double.class.getCanonicalName(), "Infinity", classLoader)));
+        assertEquals("Infinity", revertValue(convertValue(Double.class.getCanonicalName(), "Infinity", classLoader)));
+        assertEquals("-Infinity", revertValue(convertValue(double.class.getCanonicalName(), "-Infinity", classLoader)));
+        assertEquals("-Infinity", revertValue(convertValue(Double.class.getCanonicalName(), "-Infinity", classLoader)));
         assertEquals("1.0f", revertValue(convertValue(float.class.getCanonicalName(), "1", classLoader)));
         assertEquals("1.0f", revertValue(convertValue(Float.class.getCanonicalName(), "1", classLoader)));
         assertEquals("1.0d", revertValue(convertValue(double.class.getCanonicalName(), "1.0", classLoader)));


### PR DESCRIPTION
This PR fix revert function for double values to support `NaN`, `Infinity` and `-Infinity`

@yesamer @dupliaka @jomarko 

https://issues.redhat.com/browse/DROOLS-4611