### PR TITLE
DROOLS-4917: Multistatement support for MVEL Expressions

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluator.java
@@ -16,7 +16,6 @@
 
 package org.drools.scenariosimulation.backend.expression;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,7 @@ public class MVELExpressionEvaluator implements ExpressionEvaluator {
 
     @Override
     public Object evaluateLiteralExpression(String rawExpression, String className, List<String> genericClasses) {
-        Object expressionResult = compileAndExecute(rawExpression, Collections.emptyMap());
+        Object expressionResult = compileAndExecute(rawExpression, new HashMap<>());
         Class<Object> requiredClass = loadClass(className, classLoader);
         if (expressionResult != null && !requiredClass.isAssignableFrom(expressionResult.getClass())) {
             throw new IllegalArgumentException("Cannot assign a '" + expressionResult.getClass().getCanonicalName() +

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluatorTest.java
@@ -104,6 +104,10 @@ public class MVELExpressionEvaluatorTest {
 
         assertEquals("Value", evaluator.evaluateLiteralExpression("# \"Value\"", String.class.getCanonicalName(), Collections.emptyList()));
 
+        assertEquals(3, evaluator.evaluateLiteralExpression("# a = 1; b = 2; a+b;", Integer.class.getCanonicalName(), Collections.emptyList()));
+
+        assertEquals("Test", evaluator.evaluateLiteralExpression("# a = \"Te\"; b = \"st\"; a+b;", String.class.getCanonicalName(), Collections.emptyList()));
+
         assertThatThrownBy(() -> evaluator.evaluateLiteralExpression("1+", String.class.getCanonicalName(), Collections.emptyList()))
                 .isInstanceOf(RuntimeException.class);
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/MVELExpressionEvaluatorTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mvel2.CompileException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -107,6 +108,12 @@ public class MVELExpressionEvaluatorTest {
         assertEquals(3, evaluator.evaluateLiteralExpression("# a = 1; b = 2; a+b;", Integer.class.getCanonicalName(), Collections.emptyList()));
 
         assertEquals("Test", evaluator.evaluateLiteralExpression("# a = \"Te\"; b = \"st\"; a+b;", String.class.getCanonicalName(), Collections.emptyList()));
+
+        assertThatThrownBy(() -> evaluator.evaluateLiteralExpression("# a = 1 b = 2 a+b;", Integer.class.getCanonicalName(), Collections.emptyList()))
+                .isInstanceOf(CompileException.class);
+
+        assertThatThrownBy(() -> evaluator.evaluateLiteralExpression("# a = 1; a+b;", Integer.class.getCanonicalName(), Collections.emptyList()))
+                .isInstanceOf(CompileException.class);
 
         assertThatThrownBy(() -> evaluator.evaluateLiteralExpression("1+", String.class.getCanonicalName(), Collections.emptyList()))
                 .isInstanceOf(RuntimeException.class);


### PR DESCRIPTION
@jomarko  @danielezonca can you please review and test?

Very simply, now it's possible to define variables in MVEL expressions, in order to support multistatement expressions. 
The change is to substitute `Collection.emptyMap`, which is immutable, with a `new HashMap<>()`, which represents the collection where variables are stored.