### PR TITLE
[PLANNER-1770] Replace jboss annotation api with jakarta for quarkus-optaplanner extension

### DIFF
--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -22,8 +22,8 @@
       <artifactId>javaparser-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/PLANNER-1770

Merge with https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1159

Fixes banned dependency by [Quarkus](https://github.com/quarkusio/quarkus/blob/master/core/creator/src/main/java/io/quarkus/creator/curator/Curator.java#L268) when creating the Quarkus-OptaPlanner extension.