### PR TITLE
DROOLS-4895 Backport RuleUnitComponentFactory#createRuleUnitDescription( KiePackage, String );

### DIFF
--- a/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitComponentFactoryImpl.java
+++ b/drools-ruleunit/src/main/java/org/drools/ruleunit/impl/RuleUnitComponentFactoryImpl.java
@@ -31,6 +31,16 @@ public class RuleUnitComponentFactoryImpl implements RuleUnitComponentFactory {
         return new RuleUnitDescriptionImpl( pkg, ruleUnitClass );
     }
 
+    /**
+     * Creates a rule unit description from the given qualified name.
+     * Optional operation (may be provided by alternative implementations)
+     * @return null: this is not a supported operation
+     */
+    @Override
+    public RuleUnitDescription createRuleUnitDescription( KiePackage pkg, String ruleUnitSimpleName ) {
+        return null;
+    }
+
     @Override
     public ApplyPmmlModelCommandExecutor newApplyPmmlModelCommandExecutor() {
         return new ApplyPmmlModelCommandExecutorImpl();

--- a/drools-ruleunit/src/test/java/org/drools/ruleunit/impl/RuleUnitComponentFactoryImplTest.java
+++ b/drools-ruleunit/src/test/java/org/drools/ruleunit/impl/RuleUnitComponentFactoryImplTest.java
@@ -1,0 +1,23 @@
+package org.drools.ruleunit.impl;
+
+import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RuleUnitComponentFactoryImplTest {
+
+    @Test
+    public void createRuleUnitDescriptionFromClass() {
+        RuleUnitComponentFactoryImpl r = new RuleUnitComponentFactoryImpl();
+        KnowledgePackageImpl fooBar = new KnowledgePackageImpl("org.drools.ruleunit");
+        assertNotNull(r.createRuleUnitDescription(fooBar, org.drools.ruleunit.TestRuleUnit.class));
+    }
+
+    @Test
+    public void createRuleUnitDescriptionFromString() {
+        RuleUnitComponentFactoryImpl r = new RuleUnitComponentFactoryImpl();
+        KnowledgePackageImpl fooBar = new KnowledgePackageImpl("org.drools.ruleunit");
+        assertNull(r.createRuleUnitDescription(fooBar, org.drools.ruleunit.TestRuleUnit.class));
+    }
+}

--- a/drools-ruleunit/src/test/java/org/drools/ruleunit/impl/RuleUnitComponentFactoryImplTest.java
+++ b/drools-ruleunit/src/test/java/org/drools/ruleunit/impl/RuleUnitComponentFactoryImplTest.java
@@ -18,6 +18,6 @@ public class RuleUnitComponentFactoryImplTest {
     public void createRuleUnitDescriptionFromString() {
         RuleUnitComponentFactoryImpl r = new RuleUnitComponentFactoryImpl();
         KnowledgePackageImpl fooBar = new KnowledgePackageImpl("org.drools.ruleunit");
-        assertNull(r.createRuleUnitDescription(fooBar, org.drools.ruleunit.TestRuleUnit.class));
+        assertNull(r.createRuleUnitDescription(fooBar, "org.drools.ruleunit.TestRuleUnit.class"));
     }
 }


### PR DESCRIPTION
add RuleUnitDescription createRuleUnitDescription( KiePackage pkg, String ruleUnitSimpleName ); implementation should be a no-op because it is only used in Kogito

requires API change https://github.com/kiegroup/droolsjbpm-knowledge/pull/419