### PR TITLE
Support for DecisionTable template configuration in SpringBoot

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -272,11 +272,11 @@ public abstract class AbstractKieModule
             ResourceType resourceType = conf instanceof ResourceConfigurationImpl && ((ResourceConfigurationImpl)conf).getResourceType() != null ?
                                         ((ResourceConfigurationImpl)conf).getResourceType() :
                                         ResourceType.determineResourceType(fileName);
-
+            
             if (resourceType == ResourceType.DTABLE && conf instanceof DecisionTableConfiguration) {
                 for (RuleTemplateModel template : kieBaseModel.getRuleTemplates()) {
-                    if (template.getDtable().equals( fileName )) {
-                        Resource templateResource = getResource( template.getTemplate() );
+                    if (fileName.endsWith( template.getDtable() )) {
+                        Resource templateResource = getResource( fileName.replace(template.getDtable(), "") + template.getTemplate() );
                         if ( templateResource != null ) {
                             ( (DecisionTableConfiguration) conf ).addRuleTemplateConfiguration( templateResource, template.getRow(), template.getCol() );
                         } else {


### PR DESCRIPTION
In SpringBoot application classes and resources are placed into BOOT-INF/classes/ subfolder of the assembled JAR file. That is why fileName (see updated code) starts with BOOT-INF/classes/ folder name. And template.getDtable() (taken from kmodule.xml) does not contain BOOT-INF/classes/ prefix. For this reason "if-condition" is changed to "fileName.endsWith( template.getDtable() )" - it will work both for SpringBoot and non-SpringBoot application.

As well, to get a template resource, a full path (with BOOT-INF/classes/ root subfolder) should be specified. That is why original code "getResource( template.getTemplate() );" will not work for SpringBoot application. Because of this, this code was replaced by "getResource( fileName.replace(template.getDtable(), "") + template.getTemplate() );". New code will work no matter which root folder is used inside JAR file - in SpringBoot application it will always prepend template.getTemplate() value with BOOT-INF/classes/ subfolder.