### PR TITLE
RHDM-1159: Exception while coverting spreedsheet decision table to guided decision table

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2753,7 +2754,7 @@ public class RuleModelDRLPersistenceImpl
             }
             int opPos = expr.indexOf(opString);
             if (opPos >= 0 &&
-                    isNotMethodName(expr, opPos) &&
+                    isNotMethodName(expr, opString, opPos) &&
                     !isInQuote(expr, opPos) &&
                     !(Character.isLetter(opString.charAt(0)) &&
                             (expr.length() == opPos + opString.length() || Character.isLetter(expr.charAt(opPos + opString.length())) ||
@@ -2783,7 +2784,16 @@ public class RuleModelDRLPersistenceImpl
     }
 
     private static boolean isNotMethodName(final String expression,
+                                           final String potentialOperator,
                                            final int operatorPosition) {
+        if (Objects.equals(potentialOperator, Operator.EQUAL.getOperatorString()) ||
+                Objects.equals(potentialOperator, Operator.NOT_EQUAL.getOperatorString()) ||
+                Objects.equals(potentialOperator, Operator.LESS.getOperatorString()) ||
+                Objects.equals(potentialOperator, Operator.LESS_OR_EQUAL.getOperatorString()) ||
+                Objects.equals(potentialOperator, Operator.GREATER.getOperatorString()) ||
+                Objects.equals(potentialOperator, Operator.GREATER_OR_EQUAL.getOperatorString())) {
+            return true;
+        }
         return operatorPosition == 0 || expression.charAt(operatorPosition - 1) == ' ';
     }
 
@@ -4225,7 +4235,6 @@ public class RuleModelDRLPersistenceImpl
             return value.substring(0, value.length() - 1);
         }
     }
-
 
     /**
      * If the bound type is not in the DMO it probably hasn't been imported.

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -32,6 +32,7 @@ import org.drools.compiler.lang.Expander;
 import org.drools.compiler.lang.dsl.DSLMappingFile;
 import org.drools.compiler.lang.dsl.DSLTokenizedMappingFile;
 import org.drools.compiler.lang.dsl.DefaultExpander;
+import org.drools.core.base.evaluators.Operator;
 import org.drools.workbench.models.datamodel.rule.ActionCallMethod;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
 import org.drools.workbench.models.datamodel.rule.ActionGlobalCollectionAdd;
@@ -69,7 +70,6 @@ import org.drools.workbench.models.datamodel.rule.RuleAttribute;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraintEBLeftSide;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.MethodInfo;
@@ -9644,5 +9644,56 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
         assertEquals("a, \"b, something\", c()", fieldConstraint.getValue());
         assertEqualsIgnoreWhitespace(drl,
                                      RuleModelDRLPersistenceImpl.getInstance().marshal(model));
+    }
+
+    @Test
+    public void testSingleFieldConstraintOperatorWithoutSpace() {
+        assertSingleFieldConstraintOperatorNoSpace(Operator.EQUAL.getOperatorString());
+        assertSingleFieldConstraintOperatorNoSpace(Operator.NOT_EQUAL.getOperatorString());
+        assertSingleFieldConstraintOperatorNoSpace(Operator.LESS.getOperatorString());
+        assertSingleFieldConstraintOperatorNoSpace(Operator.LESS_OR_EQUAL.getOperatorString());
+        assertSingleFieldConstraintOperatorNoSpace(Operator.GREATER.getOperatorString());
+        assertSingleFieldConstraintOperatorNoSpace(Operator.GREATER_OR_EQUAL.getOperatorString());
+    }
+
+    private void assertSingleFieldConstraintOperatorNoSpace(final String operator) {
+        String drl = "rule \"rule1\"\n"
+                + "when\n"
+                + "Applicant( age" + operator + "55 )\n"
+                + "then\n"
+                + "end";
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                          Collections.emptyList(),
+                                                                          dmo);
+
+        assertNotNull(m);
+        assertEquals("rule1",
+                     m.name);
+
+        assertEquals(1,
+                     m.lhs.length);
+        IPattern p = m.lhs[0];
+        assertTrue(p instanceof FactPattern);
+
+        FactPattern fp = (FactPattern) p;
+        assertEquals("Applicant",
+                     fp.getFactType());
+
+        assertEquals(1,
+                     fp.getConstraintList().getConstraints().length);
+        assertTrue(fp.getConstraint(0) instanceof SingleFieldConstraint);
+
+        SingleFieldConstraint sfp = (SingleFieldConstraint) fp.getConstraint(0);
+        assertEquals("Applicant",
+                     sfp.getFactType());
+        assertEquals("age",
+                     sfp.getFieldName());
+        assertEquals(operator,
+                     sfp.getOperator());
+        assertEquals("55",
+                     sfp.getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_LITERAL,
+                     sfp.getConstraintValueType());
     }
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/RHDM-1159

The XLS attached to the JIRA now converts correctly (and the User can view _source_).

Part of an ensemble:
- https://github.com/kiegroup/drools/pull/2723
- https://github.com/kiegroup/drools-wb/pull/1282