### PR TITLE
[DROOLS-4924] LambdaConsequence without bind variable is not material…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
@@ -248,7 +248,7 @@ public class Consequence {
 
 
         boolean requireDrools = rewriteRHS(ruleVariablesBlock, ruleConsequence);
-        MethodCallExpr executeCall = new MethodCallExpr(onCall, onCall == null ? "D." + EXECUTE_CALL : EXECUTE_CALL);
+        MethodCallExpr executeCall = new MethodCallExpr(onCall != null ? onCall : new NameExpr("D"), EXECUTE_CALL);
         LambdaExpr executeLambda = new LambdaExpr();
         executeCall.addArgument(executeLambda);
         executeLambda.setEnclosingParameters(true);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequence.java
@@ -49,7 +49,7 @@ public class MaterializedLambdaConsequence extends MaterializedLambda {
         }
 
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("execute", Modifier.Keyword.PUBLIC);
-        methodDeclaration.setThrownExceptions(NodeList.nodeList(parseClassOrInterfaceType("Exception")));
+        methodDeclaration.setThrownExceptions(NodeList.nodeList(parseClassOrInterfaceType("java.lang.Exception")));
         methodDeclaration.addAnnotation("Override");
         methodDeclaration.setType(new VoidType());
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
@@ -24,7 +24,7 @@ public class MaterializedLambdaConsequenceTest {
                 "public enum LambdaConsequence2FABA51719447471EAF65717A3CB3A94 implements org.drools.model.functions.Block2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>  {\n" +
                 "INSTANCE;\n" +
                 "        @Override()\n" +
-                "        public void execute(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) throws Exception {\n" +
+                "        public void execute(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) throws java.lang.Exception {\n" +
                 "            result.setValue(p1.getName() + \" is older than \" + p2.getName());\n" +
                 "        }\n" +
                 "    }\n";


### PR DESCRIPTION
…ized

In a failing case, the ancestor is "D.execute" instead of "execute". Thus, fixed like this.

Note: I also tried to add a unit test in ExecModelLambdaPostProcessorTest but I cannot reproduce the issue because ExecModelLambdaPostProcessorTest approach (simply using StaticJavaParser.parseResource()) doesn't reproduce the problem (= "D.execute").