### PR TITLE
[DROOLS-4956] Normarize rule constraints for property reactivity and …

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/PatternBuilder.java
@@ -61,6 +61,7 @@ import org.drools.compiler.rule.builder.dialect.DialectUtil;
 import org.drools.compiler.rule.builder.dialect.java.JavaDialect;
 import org.drools.compiler.rule.builder.dialect.mvel.MVELAnalysisResult;
 import org.drools.compiler.rule.builder.dialect.mvel.MVELDialect;
+import org.drools.compiler.rule.builder.util.ConstraintUtils;
 import org.drools.compiler.builder.DroolsAssemblerContext;
 import org.drools.core.base.ClassFieldReader;
 import org.drools.core.base.ClassObjectType;
@@ -604,6 +605,8 @@ public class PatternBuilder
             } else {
                 expression = b.getText();
             }
+
+            expression = ConstraintUtils.normalizeConstraintExpression(expression, pattern.getObjectType().getClassType());
 
             ConstraintConnectiveDescr result = parseExpression(context,
                                                                patternDescr,

--- a/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/ConstraintUtils.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/ConstraintUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.rule.builder.util;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ConstraintUtils {
+
+    private static final Pattern RELATIONAL_CONSTRAINT = Pattern.compile("^([\\S&&[^&|\\(\\)=!><]]*)\\s*(==|!=|<=|>=|<|>)\\s*([\\S&&[^&|\\(\\)=!><]]*)$");
+
+    public static final String DROOLS_NORMALIZE_CONSTRAINT = "drools.normalize.constraint";
+
+    private static boolean ENABLE_NORMALIZE = Boolean.valueOf(System.getProperty(DROOLS_NORMALIZE_CONSTRAINT, "true"));
+
+    private ConstraintUtils() {}
+
+    public static String normalizeConstraintExpression(String expression, Class<?> clazz) {
+
+        if (!ENABLE_NORMALIZE) {
+            return expression;
+        }
+        String trimmedExpression = expression.trim();
+
+        Matcher m = RELATIONAL_CONSTRAINT.matcher(trimmedExpression);
+        boolean isFound = m.find();
+        if (!isFound || m.groupCount() != 3) {
+            return expression; // cannot normalize
+        }
+        String left = m.group(1).trim();
+        String operator = m.group(2);
+        String right = m.group(3).trim();
+
+        Set<String> propertyNames;
+        try {
+            propertyNames = getPropertyNames(clazz);
+        } catch (IntrospectionException | RuntimeException e) {
+            return expression; // cannot normalize
+        }
+
+        if (!propertyNames.contains(left) && propertyNames.contains(right)) {
+            operator = inverseOperator(operator);
+            return new StringBuilder().append(right).append(operator).append(left).toString();
+        } else {
+            return expression;
+        }
+    }
+
+    private static String inverseOperator(String operator) {
+        switch (operator) {
+            case ">":
+                return "<";
+            case "<":
+                return ">";
+            case ">=":
+                return "<=";
+            case "<=":
+                return ">=";
+            default:
+                return operator;
+        }
+    }
+
+    private static Set<String> getPropertyNames(Class<?> clazz) throws IntrospectionException {
+        PropertyDescriptor[] propDescrs = Introspector.getBeanInfo(clazz).getPropertyDescriptors();
+        Set<String> propertyNames = new HashSet<>();
+        for (PropertyDescriptor pd : propDescrs) {
+            propertyNames.add(pd.getName());
+        }
+        return propertyNames;
+    }
+}

--- a/drools-compiler/src/test/java/org/drools/compiler/rule/builder/util/ConstraintUtilsTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/rule/builder/util/ConstraintUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.rule.builder.util;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.drools.compiler.Person;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.drools.compiler.rule.builder.util.ConstraintUtils.normalizeConstraintExpression;
+
+public class ConstraintUtilsTest {
+
+    @Test
+    public void testNormalizeConstraintExpression() {
+        String[][] testExpressions = {
+                                      {"name==\"Toshiya\"", "\"Toshiya\" == name"},
+                                      {"name == \"Toshiya\"", "name == \"Toshiya\""},
+                                      {"name!=\"Toshiya\"", "\"Toshiya\" != name"},
+                                      {"name==$customerName", "$customerName == name"},
+                                      {"age==10", "10 == age"},
+                                      {"age<10", "10 > age"}, // inverse operator
+                                      {"age>10", "10 < age"}, // inverse operator
+                                      {"age<=10", "10 >= age"}, // inverse operator
+                                      {"age>=10", "10 <= age"}, // inverse operator
+                                      {"10==age || 20==age", "10==age || 20==age"}, // don't normalize
+                                      {"10==age||20==age", "10==age||20==age"}, // don't normalize
+                                      {"10<age && 20>age", "10<age && 20>age"}, // don't normalize
+                                      {"10<age&&20>age", "10<age&&20>age"}, // don't normalize
+                                      {"10<age&&alive", "10<age&&alive"}, // don't normalize
+                                      {"alive||10 < age", "alive||10 < age"}, // don't normalize
+                                      {"eval(20 == age)", "eval(20 == age)"}, // don't normalize
+                                      {"(20 == age)", "(20 == age)"}, // don't normalize
+                                      {"true == (age > 20)", "true == (age > 20)"}, // don't normalize
+
+        };
+
+        Arrays.stream(testExpressions).forEach(expr -> {
+            assertEquals(expr[0], normalizeConstraintExpression(expr[1], Person.class));
+        });
+    }
+
+    @Test
+    public void testDisableNormalization() throws Exception {
+        Field field = ConstraintUtils.class.getDeclaredField( "ENABLE_NORMALIZE" );
+        field.setAccessible(true);
+        field.set(null, false);
+        try {
+            assertEquals("\"Toshiya\" == name", normalizeConstraintExpression("\"Toshiya\" == name", Person.class));
+        } finally {
+            field.set(null, true);
+        }
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintExpression.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 
 import org.drools.compiler.lang.descr.BaseDescr;
 import org.drools.compiler.lang.descr.ExprConstraintDescr;
+import org.drools.compiler.rule.builder.util.ConstraintUtils;
 import org.kie.api.definition.type.Position;
 
 public class ConstraintExpression {
@@ -50,6 +51,8 @@ public class ConstraintExpression {
 
         // I really hope we won't be comparing Strings with newline here.
         String expressionWithoutNewLines = expression.replace("\n", "");
+
+        expressionWithoutNewLines = ConstraintUtils.normalizeConstraintExpression(expressionWithoutNewLines, patternType);
 
         return new ConstraintExpression( expressionWithoutNewLines );
     }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ConstraintNormalizationTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ConstraintNormalizationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler;
+
+import org.drools.core.common.NamedEntryPoint;
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.CompositeObjectSinkAdapter;
+import org.drools.core.reteoo.ObjectTypeNode;
+import org.drools.modelcompiler.domain.Person;
+import org.drools.modelcompiler.domain.Toy;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ConstraintNormalizationTest extends BaseModelTest {
+
+    public ConstraintNormalizationTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Test
+    public void testNormalizationForPropertyReactivity() {
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + Toy.class.getCanonicalName() + ";\n" +
+                           "rule R1 when \n" +
+                           " $t : Toy($owner : owner)\n" +
+                           " $p : Person($owner == name)\n" +
+                           "then\n" +
+                           "  $p.setAge(20);" +
+                           "  update($p);" +
+                           "end\n" +
+                           "rule R2 when \n" +
+                           "  $p : Person(age == 20)\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieSession ksession = getKieSession(str);
+
+        final Toy t = new Toy("Ball");
+        t.setOwner("Toshiya");
+        final Person p = new Person("Toshiya", 45);
+        ksession.insert(t);
+        ksession.insert(p);
+        assertEquals(2, ksession.fireAllRules(10)); // no infinite loop
+    }
+
+    @Test
+    public void testNormalizationForPropertyReactivity2() {
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R1 when \n" +
+                           " $i : Integer()\n" +
+                           " $p : Person($i < age)\n" +
+                           "then\n" +
+                           "  $p.setName(\"Blaa\");" +
+                           "  update($p);" +
+                           "end\n" +
+                           "rule R2 when \n" +
+                           " $p : Person(name == \"Blaa\")\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieSession ksession = getKieSession(str);
+
+        final Person p = new Person("Toshiya", 45);
+        ksession.insert(new Integer(30));
+        ksession.insert(p);
+        assertEquals(2, ksession.fireAllRules(10)); // no infinite loop
+    }
+
+    @Test
+    public void testNormalizationForAlphaIndexing() {
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R1 when \n" +
+                           " $p : Person(\"Toshiya\" == name)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when \n" +
+                           " $p : Person(\"Mario\" == name)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R3 when \n" +
+                           " $p : Person(\"Luca\" == name)\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieSession ksession = getKieSession(str);
+
+        ObjectTypeNode otn = ((NamedEntryPoint) ksession.getEntryPoint("DEFAULT")).getEntryPointNode().getObjectTypeNodes().entrySet()
+                                                                                  .stream()
+                                                                                  .filter(e -> e.getKey().getClassName().equals(Person.class.getCanonicalName()))
+                                                                                  .map(e -> e.getValue())
+                                                                                  .findFirst()
+                                                                                  .get();
+        CompositeObjectSinkAdapter sinkAdaptor = (CompositeObjectSinkAdapter) otn.getObjectSinkPropagator();
+
+        assertNotNull(sinkAdaptor.getHashedSinkMap());
+        assertEquals(3, sinkAdaptor.getHashedSinkMap().size());
+
+        final Person p = new Person("Toshiya", 45);
+        ksession.insert(p);
+        assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testNormalizationForNodeSharing() {
+
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R1 when \n" +
+                           " $p : Person(\"Toshiya\" == name)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when \n" +
+                           // Note: Trimmed white spaces around '=='. If DROOLS-5023 is resolved, we can also test with spaces
+                           " $p : Person(name==\"Toshiya\")\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieSession ksession = getKieSession(str);
+
+        assertEquals(1, ReteDumper.collectNodes(ksession).stream().filter(AlphaNode.class::isInstance).count());
+
+        final Person p = new Person("Toshiya", 45);
+        ksession.insert(p);
+        assertEquals(2, ksession.fireAllRules());
+    }
+}


### PR DESCRIPTION
…indexing

WIP implementation. Please give a quick review before going too far. Thanks!

Limitation:

- Cannot parse constrains with "&&" (e.g. "10<age && 20>age") so the constraint will be left without normalization. I may add a specific logic for "&&" case but it may have a little performance degration. If you think it's worth trying, let me know.
- Cannot parse constrains which are surrounded by parentheses (e.g. "(10 == age)") so the constraint will be left without normalization. Similarly, I may add a specific logic for that but it may have a little performance degration.

Remaining work:

- I will add more unit tests because this change would affect widely.
- I will do some performance test and I may consider tuning if it's slow
