### PR TITLE
[NOISSUE] Fixed loading kjar files to modules

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java
@@ -159,7 +159,7 @@ public class KieRepositoryImpl
                                                        pomPropertiesUrl.getPath());
         if (pomReleaseId.equals(releaseId)) {
             String path = pomPropertiesUrl.getPath();
-            String pathToJar = path.substring( 0, path.indexOf( ".jar!" ) + 4 );
+            String pathToJar = path.substring( 0, Math.max(path.indexOf( ".jar!" ) + 4, path.indexOf( ".kjar!" ) + 5) );
 
             URL pathToKmodule;
             try {


### PR DESCRIPTION
If using busines central built files (DMN), which are packed into *.kjar, is not possible to load it into module, because path does contain ".jar!" sequence.