### PR TITLE
[FAI-58] Extend DMNRuntimeEventListener

### DIFF
--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateAllEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateAllEvent.java
@@ -1,0 +1,9 @@
+package org.kie.dmn.api.core.event;
+
+public interface AfterEvaluateAllEvent extends DMNEvent {
+
+    String getModelNamespace();
+
+    String getModelName();
+
+}

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateAllEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/AfterEvaluateAllEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.api.core.event;
 
 public interface AfterEvaluateAllEvent extends DMNEvent {

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateAllEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateAllEvent.java
@@ -1,0 +1,9 @@
+package org.kie.dmn.api.core.event;
+
+public interface BeforeEvaluateAllEvent extends DMNEvent {
+
+    String getModelNamespace();
+
+    String getModelName();
+
+}

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateAllEvent.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/BeforeEvaluateAllEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.api.core.event;
 
 public interface BeforeEvaluateAllEvent extends DMNEvent {

--- a/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNRuntimeEventListener.java
+++ b/kie-dmn/kie-dmn-api/src/main/java/org/kie/dmn/api/core/event/DMNRuntimeEventListener.java
@@ -41,4 +41,8 @@ public interface DMNRuntimeEventListener {
     default void beforeInvokeBKM(BeforeInvokeBKMEvent event) {}
 
     default void afterInvokeBKM(AfterInvokeBKMEvent event) {}
+
+    default void beforeEvaluateAll(BeforeEvaluateAllEvent event) {}
+
+    default void afterEvaluateAll(AfterEvaluateAllEvent event) {}
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
@@ -1,0 +1,33 @@
+package org.kie.dmn.core.impl;
+
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.event.AfterEvaluateAllEvent;
+
+public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
+
+    private String modelNamespace;
+    private String modelName;
+    private DMNResult result;
+
+    public AfterEvaluateAllEventImpl(String modelNamespace, String modelName, DMNResult result) {
+        this.modelNamespace = modelNamespace;
+        this.modelName = modelName;
+        this.result = result;
+    }
+
+    @Override
+    public String getModelNamespace() {
+        return modelNamespace;
+    }
+
+    @Override
+    public String getModelName() {
+        return modelName;
+    }
+
+    @Override
+    public DMNResult getResult() {
+        return result;
+    }
+
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.impl;
 
 import org.kie.dmn.api.core.DMNResult;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
@@ -1,0 +1,33 @@
+package org.kie.dmn.core.impl;
+
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.event.BeforeEvaluateAllEvent;
+
+public class BeforeEvaluateAllEventImpl implements BeforeEvaluateAllEvent {
+
+    private String modelNamespace;
+    private String modelName;
+    private DMNResult result;
+
+    public BeforeEvaluateAllEventImpl(String modelNamespace, String modelName, DMNResult result) {
+        this.modelNamespace = modelNamespace;
+        this.modelName = modelName;
+        this.result = result;
+    }
+
+    @Override
+    public String getModelNamespace() {
+        return modelNamespace;
+    }
+
+    @Override
+    public String getModelName() {
+        return modelName;
+    }
+
+    @Override
+    public DMNResult getResult() {
+        return result;
+    }
+
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/BeforeEvaluateAllEventImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.core.impl;
 
 import org.kie.dmn.api.core.DMNResult;

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeEventManagerUtils.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeEventManagerUtils.java
@@ -19,11 +19,27 @@ package org.kie.dmn.core.impl;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.ast.BusinessKnowledgeModelNode;
 import org.kie.dmn.api.core.ast.DecisionNode;
 import org.kie.dmn.api.core.ast.DecisionServiceNode;
-import org.kie.dmn.api.core.event.*;
+import org.kie.dmn.api.core.event.AfterEvaluateAllEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateBKMEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateContextEntryEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionServiceEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionTableEvent;
+import org.kie.dmn.api.core.event.AfterInvokeBKMEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateAllEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateBKMEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateContextEntryEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateDecisionEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateDecisionServiceEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateDecisionTableEvent;
+import org.kie.dmn.api.core.event.BeforeInvokeBKMEvent;
+import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
+import org.kie.dmn.api.core.event.DMNRuntimeEventManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,9 +127,23 @@ public final class DMNRuntimeEventManagerUtils {
     }
 
     public static void fireAfterInvokeBKM( DMNRuntimeEventManager eventManager, BusinessKnowledgeModelNode bkm, DMNResult result) {
-        if( eventManager.hasListeners() ) {
+        if (eventManager.hasListeners()) {
             AfterInvokeBKMEvent event = new AfterInvokeBKMEventImpl(bkm, result);
             notifyListeners(eventManager, l -> l.afterInvokeBKM(event));
+        }
+    }
+
+    public static void fireBeforeEvaluateAll(DMNRuntimeEventManagerImpl eventManager, DMNModel model, DMNResultImpl result) {
+        if( eventManager.hasListeners() ) {
+            BeforeEvaluateAllEvent event = new BeforeEvaluateAllEventImpl(model.getNamespace(), model.getName(), result);
+            notifyListeners(eventManager, l -> l.beforeEvaluateAll(event));
+        }
+    }
+
+    public static void fireAfterEvaluateAll(DMNRuntimeEventManagerImpl eventManager, DMNModel model, DMNResultImpl result) {
+        if( eventManager.hasListeners() ) {
+            AfterEvaluateAllEvent event = new AfterEvaluateAllEventImpl(model.getNamespace(), model.getName(), result);
+            notifyListeners(eventManager, l -> l.afterEvaluateAll(event));
         }
     }
 
@@ -130,4 +160,5 @@ public final class DMNRuntimeEventManagerUtils {
     private DMNRuntimeEventManagerUtils() {
         // Constructing instances is not allowed for this class
     }
+
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
 import javax.xml.namespace.QName;
 
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
@@ -157,11 +156,13 @@ public class DMNRuntimeImpl
         Objects.requireNonNull(context, () -> MsgUtil.createMessage(Msg.PARAM_CANNOT_BE_NULL, "context"));
         boolean performRuntimeTypeCheck = performRuntimeTypeCheck(model);
         DMNResultImpl result = createResult( model, context );
+        DMNRuntimeEventManagerUtils.fireBeforeEvaluateAll( eventManager, model, result );
         // the engine should evaluate all Decisions belonging to the "local" model namespace, not imported decision explicitly.
         Set<DecisionNode> decisions = model.getDecisions().stream().filter(d -> d.getModelNamespace().equals(model.getNamespace())).collect(Collectors.toSet());
         for( DecisionNode decision : decisions ) {
             evaluateDecision(context, result, decision, performRuntimeTypeCheck);
         }
+        DMNRuntimeEventManagerUtils.fireAfterEvaluateAll( eventManager, model, result );
         return result;
     }
 


### PR DESCRIPTION
Add methods + events to DMNRuntimeEventListener to be able to monitor when API method calls are invoked on the DMNRuntime (evaluateAll, evaluateDS, etc.)