### PR TITLE
DROOLS-5140: Throw exception when unit declaration is not present

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/errors/UnknownRuleUnitException.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/errors/UnknownRuleUnitException.java
@@ -16,30 +16,17 @@
 
 package org.drools.modelcompiler.builder.errors;
 
-import org.drools.compiler.compiler.DroolsError;
-import org.kie.internal.builder.ResultSeverity;
-
-public class UnknownRuleUnitError extends DroolsError {
+public class UnknownRuleUnitException extends RuntimeException {
 
     private String ruleUnitName;
 
-    public UnknownRuleUnitError( String ruleUnitName) {
+    public UnknownRuleUnitException(String ruleUnitName) {
         super();
         this.ruleUnitName = ruleUnitName;
     }
 
     @Override
-    public ResultSeverity getSeverity() {
-        return ResultSeverity.ERROR;
-    }
-
-    @Override
     public String getMessage() {
         return "Unknown rule unit: " + ruleUnitName;
-    }
-
-    @Override
-    public int[] getLines() {
-        return new int[0];
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -48,7 +48,7 @@ import org.drools.core.addon.TypeResolver;
 import org.drools.core.ruleunit.RuleUnitDescriptionLoader;
 import org.drools.core.util.Bag;
 import org.drools.modelcompiler.builder.PackageModel;
-import org.drools.modelcompiler.builder.errors.UnknownRuleUnitError;
+import org.drools.modelcompiler.builder.errors.UnknownRuleUnitException;
 import org.kie.api.definition.type.ClassReactive;
 import org.kie.api.definition.type.PropertyReactive;
 import org.kie.internal.builder.KnowledgeBuilderResult;
@@ -147,7 +147,7 @@ public class RuleContext {
         if (ruDescr.isPresent()) {
             ruleUnitDescr = ruDescr.get();
         } else if (!useNamingConvention) {
-            addCompilationError( new UnknownRuleUnitError( unitName ) );
+            throw new UnknownRuleUnitException( unitName );
         }
     }
 


### PR DESCRIPTION
returning an error won't stop compilation, but we actually want it to fail immediately