### PR TITLE
[RHPAM-2877] Drools Canonical Model causes infinite loop firing of rules

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
@@ -655,6 +655,14 @@ public final class ClassUtils {
         return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
     }
 
+    public static boolean isGetter(String methodName) {
+        return (methodName.startsWith("get") && methodName.length() > 3) || (methodName.startsWith("is") && methodName.length() > 2);
+    }
+
+    public static boolean isSetter(String methodName) {
+        return (methodName.startsWith("set") && methodName.length() > 3);
+    }
+
     public static <T extends Externalizable> T deepClone(T origin) {
         return origin == null ? null : deepClone(origin, origin.getClass().getClassLoader());
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
@@ -66,6 +66,8 @@ import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static java.util.stream.Collectors.toSet;
+import static org.drools.core.util.ClassUtils.isGetter;
+import static org.drools.core.util.ClassUtils.isSetter;
 import static org.drools.core.util.ClassUtils.getter2property;
 import static org.drools.core.util.ClassUtils.setter2property;
 import static org.drools.modelcompiler.builder.PackageModel.DOMAIN_CLASSESS_METADATA_FILE_NAME;
@@ -394,28 +396,32 @@ public class Consequence {
             Optional<Expression> root = removeRootNodeViaScope.getRootNode()
                     .filter(s -> isNameExprWithName(s, updatedVar));
             if (methodCall.getScope().isPresent() && root.isPresent()) {
-                String propName = methodToProperty(methodCall, removeRootNodeViaScope.getFirstChild());
+                boolean isDirectMethod = removeRootNodeViaScope.getFirstChild().equals(removeRootNodeViaScope.getWithoutRootNode());
+                String propName = null;
+                if (isDirectMethod && isSetter(methodCall.getNameAsString())) {
+                    // direct setter of the updated fact
+                    propName = setter2property(methodCall.getNameAsString());
+                } else if (!isDirectMethod && !isGetter(methodCall.getNameAsString())) {
+                    // indirect setter so the prop of the first getter is modified
+                    // using "!isGetter()" instead of "isSetter()" because we want the behavior similar to standard-drl (DialectUtil.parseModifiedProperties)
+                    Expression firstExpr = removeRootNodeViaScope.getFirstChild();
+                    if (firstExpr.isMethodCallExpr()) {
+                        propName = getter2property(firstExpr.asMethodCallExpr().getNameAsString());
+                    }
+                } else {
+                    // e.g. only getter
+                    continue;
+                }
                 if (propName != null) {
+                    // TODO: also register additional property in case the invoked method is annotated with @Modifies
                     modifiedProps.add(propName);
                 } else {
                     // if we were unable to detect the property the mask has to be all set, so avoid the rest of the cycle
-                    return null;
+                    return new HashSet<>();
                 }
             }
         }
         return modifiedProps;
-    }
-
-    private String methodToProperty(MethodCallExpr mce, Expression getter) {
-        String propertyName = setter2property(mce.getNameAsString());
-
-        if (propertyName == null && getter.isMethodCallExpr()) {
-            propertyName = getter2property(getter.asMethodCallExpr().getNameAsString());
-        }
-
-        // TODO also register additional property in case the invoked method is annotated with @Modifies
-
-        return propertyName;
     }
 
     private static boolean isDroolsMethod(MethodCallExpr mce) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
@@ -392,6 +392,9 @@ public class Consequence {
     private Set<String> findModifiedProperties( List<MethodCallExpr> methodCallExprs, MethodCallExpr updateExpr, String updatedVar ) {
         Set<String> modifiedProps = new HashSet<>();
         for (MethodCallExpr methodCall : methodCallExprs.subList(0, methodCallExprs.indexOf(updateExpr))) {
+            if (!isDirectExpression(methodCall)) {
+                continue; // don't evaluate a method which is a part of other expression
+            }
             DrlxParseUtil.RemoveRootNodeResult removeRootNodeViaScope = DrlxParseUtil.findRemoveRootNodeViaScope(methodCall);
             Optional<Expression> root = removeRootNodeViaScope.getRootNode()
                     .filter(s -> isNameExprWithName(s, updatedVar));
@@ -422,6 +425,10 @@ public class Consequence {
             }
         }
         return modifiedProps;
+    }
+
+    private boolean isDirectExpression(MethodCallExpr methodCall) {
+        return methodCall.getParentNode().map(parent -> parent instanceof ExpressionStmt).orElse(false);
     }
 
     private static boolean isDroolsMethod(MethodCallExpr mce) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -23,8 +23,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -47,6 +49,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessContext;
 import org.kie.api.runtime.rule.FactHandle;
@@ -2041,5 +2044,38 @@ public class CompilerTest extends BaseModelTest {
 
         KieSession ksession = getKieSession( str );
         assertNotNull( ksession);
+    }
+
+    @Test
+    public void testHashSet() throws Exception {
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + HashSet.class.getCanonicalName() + ";\n" +
+                           "import " + Set.class.getCanonicalName() + ";\n" +
+                           "declare Application\n" +
+                           "    categories : Set = new HashSet()" +
+                           "end\n" +
+                           "rule R1\n" +
+                           "no-loop true\n" +
+                           "when \n" +
+                           "  $a : Application()\n" +
+                           "then\n" +
+                           "  modify ($a) { getCategories().add(\"hello\") };\n" +
+                           "end\n" +
+                           "rule R2\n" +
+                           "when \n" +
+                           "  $a : Application(categories contains \"hello\")\n" +
+                           "then\n" +
+                           "end";
+
+        final KieSession ksession = getKieSession(str);
+
+        FactType appType = ksession.getKieBase().getFactType("org.drools.test", "Application");
+        Object appObj = appType.newInstance();
+        Set<String> categories = new HashSet<>();
+        appType.set(appObj, "categories", categories);
+
+        ksession.insert(appObj);
+        assertEquals(2, ksession.fireAllRules());
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.Person;
+import org.drools.modelcompiler.domain.Pet;
 import org.drools.modelcompiler.domain.Result;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
@@ -549,5 +550,113 @@ public class PropertyReactivityTest extends BaseModelTest {
         KieSession ksession = getKieSession( str );
 
         assertEquals( 2, ksession.fireAllRules(5) );
+    }
+
+    @Test
+    public void testMultipleFieldUpdate() {
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "rule R1 when\n" +
+                "    $p : Person( name == \"Mario\" )\n" +
+                "then\n" +
+                "    modify($p) { setAge( $p.getAge()+1 ), setLikes(\"Cheese\") };\n" +
+                "end\n" +
+                "rule R2 when\n" +
+                "    $p : Person( name == \"Mario\", likes == \"Cheese\" )\n" +
+                "then\n" +
+                "    modify($p) { setAge( $p.getAge()+1 ) };\n" +
+                "end\n";
+
+        KieSession ksession = getKieSession( str );
+
+        Person p = new Person("Mario", 40);
+        p.setLikes("Beer");
+        ksession.insert( p );
+        ksession.fireAllRules();
+
+        assertEquals(42, p.getAge());
+    }
+
+    @Test
+    public void testComplexSetterArgument() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "rule R \n" +
+                "when\n" +
+                "    $p: Person(address.street == \"street1\")\n" +
+                "then\n" +
+                "    modify($p) { setLikes( String.valueOf(($p.getAddress().getStreet() + $p.getAddress().getCity()))) };\n" +
+                "end";
+
+        KieSession ksession = getKieSession( str );
+
+        Person me = new Person( "Mario", 40 );
+        me.setAddress(new Address("street1", 2, "city1"));
+        ksession.insert( me );
+
+        assertEquals(1, ksession.fireAllRules(10));
+
+        assertEquals( "street1city1", me.getLikes() );
+    }
+
+    @Test
+    public void testNestedPropInRHS() throws Exception {
+        // Property Reactivity for "owner"
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + Pet.class.getCanonicalName() + ";\n" +
+                           "rule R1\n" +
+                           "when \n" +
+                           "  $pet : Pet(age == 3)\n" +
+                           "then\n" +
+                           "  modify ($pet) { getOwner().setLikes(\"Cookie\") };\n" +
+                           "end\n" +
+                           "rule R2\n" +
+                           "when \n" +
+                           "  Pet(owner.likes == \"Cookie\")\n" +
+                           "then\n" +
+                           "end";
+
+        final KieSession ksession = getKieSession(str);
+
+        Pet pet = new Pet(Pet.PetType.cat);
+        Person person = new Person("John");
+        person.setLikes("Meat");
+        pet.setOwner(person);
+        pet.setAge(3);
+
+        ksession.insert(pet);
+        assertEquals(2, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testDeeplyNestedPropInRHS() throws Exception {
+        // Property Reactivity for "owner"
+        final String str =
+                "package org.drools.test;\n" +
+                           "import " + Pet.class.getCanonicalName() + ";\n" +
+                           "rule R1\n" +
+                           "when \n" +
+                           "  $pet : Pet(age == 3)\n" +
+                           "then\n" +
+                           "  modify ($pet) { getOwner().getAddress().setStreet(\"XYZ street\") };\n" +
+                           "end\n" +
+                           "rule R2\n" +
+                           "when \n" +
+                           "  Pet(owner.address.street == \"XYZ street\")\n" +
+                           "then\n" +
+                           "end";
+
+        final KieSession ksession = getKieSession(str);
+
+        Pet pet = new Pet(Pet.PetType.cat);
+        Person person = new Person("John");
+        person.setAddress(new Address("ABC street"));
+        pet.setOwner(person);
+        pet.setAge(3);
+
+        ksession.insert(pet);
+        assertEquals(2, ksession.fireAllRules());
     }
 }


### PR DESCRIPTION
for 7.33.x.

cherry picked
https://github.com/kiegroup/drools/commit/fc924465437919d5b6bd99849ee595e6e7ebf957
 -> The main commit to fix the issue in RHPAM-2877
https://github.com/kiegroup/drools/commit/574b8e09eceb68c7e48a600b3d18fee7c491cfb0
 -> Required to pass the unit tests in the above commit. Actually it's also a notable fix so good to backport.