### PR TITLE
Fix typo in pom scm developer connection field.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <scm>
     <connection>scm:git:https://github.com:kiegroup/drools.git</connection>
-    <developerConnection>scm:git:git@github.com:kirgroup/drools.git</developerConnection>
+    <developerConnection>scm:git:git@github.com:kiegroup/drools.git</developerConnection>
     <url>https://github.com/kiegroup/drools</url>
   </scm>
 


### PR DESCRIPTION
One of the url's in the scm section says `kirgroup` instead of `kiegroup`, leading to a 404 when trying to follow up on GitHub.