### PR TITLE
[DROOLS-5261] Move shared code/classes to common modules/packages

### DIFF
--- a/kie-pmml-new/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/enums/BOOLEAN_OPERATOR.java
+++ b/kie-pmml-new/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/enums/BOOLEAN_OPERATOR.java
@@ -13,36 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.model.enums;
+package org.kie.pmml.commons.model.enums;
 
 import java.util.Arrays;
 
 import org.kie.pmml.commons.exceptions.KieEnumException;
 
 /**
- * @see <a href=http://dmg.org/pmml/v4-4/TreeModel.html#xsdGroup_PREDICATE>PREDICATE</a>
+ * @see <a href=http://dmg.org/pmml/v4-4/TreeModel.html#xsdElement_CompoundPredicate>CompoundPredicate</a>
  */
-public enum OPERATOR {
+public enum BOOLEAN_OPERATOR {
 
-    EQUAL("equal", "=="),
-    NOT_EQUAL("notEqual", "!="),
-    LESS_THAN("lessThan", "<"),
-    LESS_OR_EQUAL("lessOrEqual", "<="),
-    GREATER_THAN("greaterThan", ">"),
-    GREATER_OR_EQUAL("greaterOrEqual", ">="),
-    IS_MISSING("isMissing", ""),
-    IS_NOT_MISSING("isNotMissing", "");
+    OR("or", "||"),
+    AND("and", "&&"),
+    XOR("xor", "^"),
+    SURROGATE("surrogate", "surrogate");
 
-    private final String name;
-    private final String operator;
+    private String name;
+    private String customOperator;
 
-    OPERATOR(String name, String operator) {
+    BOOLEAN_OPERATOR(String name, String customOperator) {
         this.name = name;
-        this.operator = operator;
+        this.customOperator = customOperator;
     }
 
-    public static OPERATOR byName(String name) {
-        return Arrays.stream(OPERATOR.values())
+    public static BOOLEAN_OPERATOR byName(String name) {
+        return Arrays.stream(BOOLEAN_OPERATOR.values())
                 .filter(value -> name.equals(value.name))
                 .findFirst()
                 .orElseThrow(() -> new KieEnumException("Failed to find MODEL_TYPE with name: " + name));
@@ -52,7 +48,7 @@ public enum OPERATOR {
         return name;
     }
 
-    public String getOperator() {
-        return operator;
+    public String getCustomOperator() {
+        return customOperator;
     }
 }

--- a/kie-pmml-new/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/enums/OPERATOR.java
+++ b/kie-pmml-new/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/enums/OPERATOR.java
@@ -13,32 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.model.enums;
+package org.kie.pmml.commons.model.enums;
 
 import java.util.Arrays;
 
 import org.kie.pmml.commons.exceptions.KieEnumException;
 
 /**
- * @see <a href=http://dmg.org/pmml/v4-4/TreeModel.html#xsdElement_CompoundPredicate>CompoundPredicate</a>
+ * @see <a href=http://dmg.org/pmml/v4-4/TreeModel.html#xsdGroup_PREDICATE>PREDICATE</a>
  */
-public enum BOOLEAN_OPERATOR {
+public enum OPERATOR {
 
-    OR("or", "||"),
-    AND("and", "&&"),
-    XOR("xor", "^"),
-    SURROGATE("surrogate", "surrogate");
+    EQUAL("equal", "=="),
+    NOT_EQUAL("notEqual", "!="),
+    LESS_THAN("lessThan", "<"),
+    LESS_OR_EQUAL("lessOrEqual", "<="),
+    GREATER_THAN("greaterThan", ">"),
+    GREATER_OR_EQUAL("greaterOrEqual", ">="),
+    IS_MISSING("isMissing", ""),
+    IS_NOT_MISSING("isNotMissing", "");
 
-    private String name;
-    private String customOperator;
+    private final String name;
+    private final String operator;
 
-    BOOLEAN_OPERATOR(String name, String customOperator) {
+    OPERATOR(String name, String operator) {
         this.name = name;
-        this.customOperator = customOperator;
+        this.operator = operator;
     }
 
-    public static BOOLEAN_OPERATOR byName(String name) {
-        return Arrays.stream(BOOLEAN_OPERATOR.values())
+    public static OPERATOR byName(String name) {
+        return Arrays.stream(OPERATOR.values())
                 .filter(value -> name.equals(value.name))
                 .findFirst()
                 .orElseThrow(() -> new KieEnumException("Failed to find MODEL_TYPE with name: " + name));
@@ -48,7 +52,7 @@ public enum BOOLEAN_OPERATOR {
         return name;
     }
 
-    public String getCustomOperator() {
-        return customOperator;
+    public String getOperator() {
+        return operator;
     }
 }

--- a/kie-pmml-new/kie-pmml-models-archetype/pom.xml
+++ b/kie-pmml-new/kie-pmml-models-archetype/pom.xml
@@ -76,16 +76,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.kie</groupId>
-        <artifactId>blueprinter-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>skip-blueprinter</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
 
   </build>

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractModelASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractModelASTFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.models.drools.ast.factories;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class to be extended to generate a <code>KiePMMLDroolsAST</code> out of a <code>DataDictionary</code> and a <b>model</b>
+ */
+public abstract class KiePMMLAbstractModelASTFactory {
+
+    public static final String SURROGATE_RULENAME_PATTERN = "%s_surrogate_%s";
+    public static final String SURROGATE_GROUP_PATTERN = "%s_surrogate";
+    public static final String STATUS_NULL = "status == null";
+    public static final String STATUS_PATTERN = "status == \"%s\"";
+    public static final String PATH_PATTERN = "%s_%s";
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLAbstractModelASTFactory.class.getName());
+
+    protected KiePMMLAbstractModelASTFactory() {
+        // Avoid instantiation
+    }
+}

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractPredicateASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLAbstractPredicateASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.List;
 import java.util.Map;
@@ -25,13 +25,13 @@ import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 /**
  * Abstract class to be extended to generate <code>KiePMMLDroolsRule</code>s out of a <code>Predicate</code>s
  */
-public class KiePMMLTreeModelAbstractPredicateASTFactory {
+public class KiePMMLAbstractPredicateASTFactory {
 
     protected final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap;
     protected final List<KiePMMLOutputField> outputFields;
     protected final List<KiePMMLDroolsRule> rules;
 
-    protected KiePMMLTreeModelAbstractPredicateASTFactory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+    protected KiePMMLAbstractPredicateASTFactory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
         this.fieldTypeMap = fieldTypeMap;
         this.outputFields = outputFields;
         this.rules = rules;

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.List;
 import java.util.Map;
@@ -33,27 +33,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLASTFactoryUtils.getConstraintEntriesFromAndOrCompoundPredicate;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLASTFactoryUtils.getConstraintEntriesFromXOrCompoundPredicate;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_NULL;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_PATTERN;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.SURROGATE_GROUP_PATTERN;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTFactoryUtils.getConstraintEntriesFromAndOrCompoundPredicate;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTFactoryUtils.getConstraintEntriesFromXOrCompoundPredicate;
 
 /**
  * Class used to generate <code>KiePMMLDroolsRule</code>s out of a <code>CompoundPredicate</code>
  */
-public class KiePMMLTreeModelCompoundPredicateASTFactory extends KiePMMLTreeModelAbstractPredicateASTFactory {
+public class KiePMMLCompoundPredicateASTFactory extends KiePMMLAbstractPredicateASTFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelCompoundPredicateASTFactory.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLCompoundPredicateASTFactory.class.getName());
     private final CompoundPredicate compoundPredicate;
 
-    private KiePMMLTreeModelCompoundPredicateASTFactory(final CompoundPredicate compoundPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+    private KiePMMLCompoundPredicateASTFactory(final CompoundPredicate compoundPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
         super(fieldTypeMap, outputFields, rules);
         this.compoundPredicate = compoundPredicate;
     }
 
-    public static KiePMMLTreeModelCompoundPredicateASTFactory factory(final CompoundPredicate compoundPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
-        return new KiePMMLTreeModelCompoundPredicateASTFactory(compoundPredicate, fieldTypeMap, outputFields, rules);
+    public static KiePMMLCompoundPredicateASTFactory factory(final CompoundPredicate compoundPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+        return new KiePMMLCompoundPredicateASTFactory(compoundPredicate, fieldTypeMap, outputFields, rules);
     }
 
     public void declareRuleFromCompoundPredicate(final String parentPath,
@@ -97,7 +95,7 @@ public class KiePMMLTreeModelCompoundPredicateASTFactory extends KiePMMLTreeMode
                 !CompoundPredicate.BooleanOperator.XOR.equals((compoundPredicate.getBooleanOperator()))) {
             throw new KiePMMLException(String.format("getConstraintEntriesFromAndOrCompoundPredicate invoked with %s CompoundPredicate", compoundPredicate.getBooleanOperator()));
         }
-        String statusConstraint = StringUtils.isEmpty(parentPath) ? STATUS_NULL : String.format(STATUS_PATTERN, parentPath);
+        String statusConstraint = StringUtils.isEmpty(parentPath) ? KiePMMLAbstractModelASTFactory.STATUS_NULL : String.format(STATUS_PATTERN, parentPath);
         List<KiePMMLFieldOperatorValue> constraints;
         String statusToSet = isFinalLeaf ? DONE : currentRule;
         KiePMMLDroolsRule.Builder builder = KiePMMLDroolsRule.builder(currentRule, statusToSet, outputFields)
@@ -142,7 +140,7 @@ public class KiePMMLTreeModelCompoundPredicateASTFactory extends KiePMMLTreeMode
         if (!CompoundPredicate.BooleanOperator.SURROGATE.equals(compoundPredicate.getBooleanOperator())) {
             throw new KiePMMLException(String.format("declareRuleFromCompoundPredicateSurrogate invoked with %s CompoundPredicate", compoundPredicate.getBooleanOperator()));
         }
-        final String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
+        final String agendaActivationGroup = String.format(KiePMMLAbstractModelASTFactory.SURROGATE_GROUP_PATTERN, currentRule);
         KiePMMLDroolsRule.Builder builder = KiePMMLDroolsRule.builder(currentRule, null, outputFields)
                 .withStatusConstraint(String.format(STATUS_PATTERN, parentPath))
                 .withFocusedAgendaGroup(agendaActivationGroup);
@@ -151,7 +149,7 @@ public class KiePMMLTreeModelCompoundPredicateASTFactory extends KiePMMLTreeMode
         final List<Predicate> simplePredicates = compoundPredicate.getPredicates().stream().filter(predicate -> predicate instanceof SimplePredicate).collect(Collectors.toList());
         simplePredicates.forEach(predicate -> {
             SimplePredicate simplePredicate = (SimplePredicate) predicate;
-            KiePMMLTreeModelSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, outputFields, rules).declareRuleFromSimplePredicateSurrogate(parentPath, currentRule, agendaActivationGroup, result, isFinalLeaf);
+            KiePMMLSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, outputFields, rules).declareRuleFromSimplePredicateSurrogate(parentPath, currentRule, agendaActivationGroup, result, isFinalLeaf);
         });
     }
 }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.List;
 import java.util.Map;
@@ -30,11 +30,11 @@ import static org.kie.pmml.models.drools.commons.utils.KiePMMLDroolsModelUtils.g
 /**
  * Class used to generate <code>KiePMMLDroolsType</code>s out of a <code>DataDictionary</code>
  */
-public class KiePMMLTreeModelDataDictionaryASTFactory {
+public class KiePMMLDataDictionaryASTFactory {
 
     private final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap;
 
-    private KiePMMLTreeModelDataDictionaryASTFactory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    private KiePMMLDataDictionaryASTFactory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         this.fieldTypeMap = fieldTypeMap;
     }
 
@@ -42,8 +42,8 @@ public class KiePMMLTreeModelDataDictionaryASTFactory {
      * @param fieldTypeMap the <code>Map&lt;String, KiePMMLOriginalTypeGeneratedType&gt;</code> to be populated with mapping between original field' name and <b>original type/generated type</b> tupla
      * @return
      */
-    public static KiePMMLTreeModelDataDictionaryASTFactory factory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
-        return new KiePMMLTreeModelDataDictionaryASTFactory(fieldTypeMap);
+    public static KiePMMLDataDictionaryASTFactory factory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+        return new KiePMMLDataDictionaryASTFactory(fieldTypeMap);
     }
 
     /**

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLPredicateASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLPredicateASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.List;
 import java.util.Map;
@@ -32,16 +32,16 @@ import org.slf4j.LoggerFactory;
 /**
  * Class used to generate <code>KiePMMLDroolsRule</code>s out of a <code>Predicate</code>
  */
-public class KiePMMLTreeModelPredicateASTFactory extends KiePMMLTreeModelAbstractPredicateASTFactory {
+public class KiePMMLPredicateASTFactory extends KiePMMLAbstractPredicateASTFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelPredicateASTFactory.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLPredicateASTFactory.class.getName());
 
-    private KiePMMLTreeModelPredicateASTFactory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+    private KiePMMLPredicateASTFactory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
         super(fieldTypeMap, outputFields, rules);
     }
 
-    public static KiePMMLTreeModelPredicateASTFactory factory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
-        return new KiePMMLTreeModelPredicateASTFactory(fieldTypeMap, outputFields, rules);
+    public static KiePMMLPredicateASTFactory factory(final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+        return new KiePMMLPredicateASTFactory(fieldTypeMap, outputFields, rules);
     }
 
     /**
@@ -64,13 +64,13 @@ public class KiePMMLTreeModelPredicateASTFactory extends KiePMMLTreeModelAbstrac
                                          final boolean isFinalLeaf) {
         logger.trace("declareRuleFromPredicate {} {} {} {}", predicate, parentPath, currentRule, result);
         if (predicate instanceof True) {
-            KiePMMLTreeModelTruePredicateASTFactory.factory((True) predicate, outputFields, rules).declareRuleFromTruePredicate(parentPath, currentRule, result, isFinalLeaf);
+            KiePMMLTruePredicateASTFactory.factory((True) predicate, outputFields, rules).declareRuleFromTruePredicate(parentPath, currentRule, result, isFinalLeaf);
         } else if (predicate instanceof SimplePredicate) {
-            KiePMMLTreeModelSimplePredicateASTFactory.factory((SimplePredicate) predicate, fieldTypeMap, outputFields, rules).declareRuleFromSimplePredicate(parentPath, currentRule, result, isFinalLeaf);
+            KiePMMLSimplePredicateASTFactory.factory((SimplePredicate) predicate, fieldTypeMap, outputFields, rules).declareRuleFromSimplePredicate(parentPath, currentRule, result, isFinalLeaf);
         } else if (predicate instanceof SimpleSetPredicate) {
-            KiePMMLTreeModelSimpleSetPredicateASTFactory.factory((SimpleSetPredicate) predicate, fieldTypeMap, outputFields, rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, isFinalLeaf);
+            KiePMMLSimpleSetPredicateASTFactory.factory((SimpleSetPredicate) predicate, fieldTypeMap, outputFields, rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, isFinalLeaf);
         } else if (predicate instanceof CompoundPredicate) {
-            KiePMMLTreeModelCompoundPredicateASTFactory.factory((CompoundPredicate) predicate, fieldTypeMap, outputFields, rules).declareRuleFromCompoundPredicate(parentPath, currentRule, result, isFinalLeaf);
+            KiePMMLCompoundPredicateASTFactory.factory((CompoundPredicate) predicate, fieldTypeMap, outputFields, rules).declareRuleFromCompoundPredicate(parentPath, currentRule, result, isFinalLeaf);
         }
     }
 }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,35 +23,33 @@ import org.dmg.pmml.SimplePredicate;
 import org.drools.core.util.StringUtils;
 import org.kie.pmml.commons.enums.ResultCode;
 import org.kie.pmml.commons.model.KiePMMLOutputField;
+import org.kie.pmml.commons.model.enums.OPERATOR;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
 import org.kie.pmml.models.drools.ast.KiePMMLFieldOperatorValue;
 import org.kie.pmml.models.drools.tuples.KiePMMLOperatorValue;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
-import org.kie.pmml.models.drools.tree.model.enums.OPERATOR;
+import org.kie.pmml.models.drools.utils.KiePMMLASTFactoryUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_NULL;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_PATTERN;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.SURROGATE_RULENAME_PATTERN;
 
 /**
  * Class used to generate <code>KiePMMLDroolsRule</code> out of a <code>SimplePredicate</code>
  */
-public class KiePMMLTreeModelSimplePredicateASTFactory extends KiePMMLTreeModelAbstractPredicateASTFactory {
+public class KiePMMLSimplePredicateASTFactory extends KiePMMLAbstractPredicateASTFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelSimplePredicateASTFactory.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLSimplePredicateASTFactory.class.getName());
 
     private final SimplePredicate simplePredicate;
 
-    private KiePMMLTreeModelSimplePredicateASTFactory(final SimplePredicate simplePredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+    private KiePMMLSimplePredicateASTFactory(final SimplePredicate simplePredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
         super(fieldTypeMap, outputFields, rules);
         this.simplePredicate = simplePredicate;
     }
 
-    public static KiePMMLTreeModelSimplePredicateASTFactory factory(final SimplePredicate simplePredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
-        return new KiePMMLTreeModelSimplePredicateASTFactory(simplePredicate, fieldTypeMap, outputFields, rules);
+    public static KiePMMLSimplePredicateASTFactory factory(final SimplePredicate simplePredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+        return new KiePMMLSimplePredicateASTFactory(simplePredicate, fieldTypeMap, outputFields, rules);
     }
 
     public void declareRuleFromSimplePredicateSurrogate(
@@ -62,7 +60,7 @@ public class KiePMMLTreeModelSimplePredicateASTFactory extends KiePMMLTreeModelA
             boolean isFinalLeaf) {
         logger.trace("declareRuleFromSimplePredicateSurrogate {} {} {} {}", simplePredicate, currentRule, agendaActivationGroup, result);
         String fieldName = fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType();
-        String surrogateCurrentRule = String.format(SURROGATE_RULENAME_PATTERN, currentRule, fieldName);
+        String surrogateCurrentRule = String.format(KiePMMLAbstractModelASTFactory.SURROGATE_RULENAME_PATTERN, currentRule, fieldName);
         final List<KiePMMLFieldOperatorValue> constraints = Collections.singletonList(KiePMMLASTFactoryUtils.getConstraintEntryFromSimplePredicates(fieldName, "surrogate", Collections.singletonList(simplePredicate), fieldTypeMap));
         String statusToSet = isFinalLeaf ? DONE : currentRule;
         // Create "TRUE" matcher
@@ -88,7 +86,7 @@ public class KiePMMLTreeModelSimplePredicateASTFactory extends KiePMMLTreeModelA
                                                final Object result,
                                                boolean isFinalLeaf) {
         logger.trace("declareRuleFromSimplePredicate {} {} {}", simplePredicate, parentPath, currentRule);
-        String statusConstraint = StringUtils.isEmpty(parentPath) ? STATUS_NULL : String.format(STATUS_PATTERN, parentPath);
+        String statusConstraint = StringUtils.isEmpty(parentPath) ? KiePMMLAbstractModelASTFactory.STATUS_NULL : String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath);
         String key = fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType();
         String operator = OPERATOR.byName(simplePredicate.getOperator().value()).getOperator();
         Object value = KiePMMLASTFactoryUtils.getCorrectlyFormattedObject(simplePredicate, fieldTypeMap);

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,25 +31,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_NULL;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_PATTERN;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_NULL;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
 
 /**
  * Class used to generate <code>KiePMMLDroolsRule</code> out of a <code>SimpleSetPredicate</code>
  */
-public class KiePMMLTreeModelSimpleSetPredicateASTFactory extends KiePMMLTreeModelAbstractPredicateASTFactory {
+public class KiePMMLSimpleSetPredicateASTFactory extends KiePMMLAbstractPredicateASTFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelSimpleSetPredicateASTFactory.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLSimpleSetPredicateASTFactory.class.getName());
 
     private final SimpleSetPredicate simpleSetPredicate;
 
-    private KiePMMLTreeModelSimpleSetPredicateASTFactory(final SimpleSetPredicate simpleSetPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+    private KiePMMLSimpleSetPredicateASTFactory(final SimpleSetPredicate simpleSetPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
         super(fieldTypeMap, outputFields, rules);
         this.simpleSetPredicate = simpleSetPredicate;
     }
 
-    public static KiePMMLTreeModelSimpleSetPredicateASTFactory factory(final SimpleSetPredicate simpleSetPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
-        return new KiePMMLTreeModelSimpleSetPredicateASTFactory(simpleSetPredicate, fieldTypeMap, outputFields, rules);
+    public static KiePMMLSimpleSetPredicateASTFactory factory(final SimpleSetPredicate simpleSetPredicate, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+        return new KiePMMLSimpleSetPredicateASTFactory(simpleSetPredicate, fieldTypeMap, outputFields, rules);
     }
 
     public void declareRuleFromSimpleSetPredicate(final String parentPath,

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTruePredicateASTFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,25 +27,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_NULL;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_PATTERN;
 
 /**
  * Class used to generate a <code>KiePMMLDroolsRule</code> out of a <code>True</code> predicate
  */
-public class KiePMMLTreeModelTruePredicateASTFactory extends KiePMMLTreeModelAbstractPredicateASTFactory {
+public class KiePMMLTruePredicateASTFactory extends KiePMMLAbstractPredicateASTFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelTruePredicateASTFactory.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLTruePredicateASTFactory.class.getName());
 
     private final True truePredicate;
 
-    private KiePMMLTreeModelTruePredicateASTFactory(final True truePredicate, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+    private KiePMMLTruePredicateASTFactory(final True truePredicate, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
         super(Collections.emptyMap(), outputFields, rules);
         this.truePredicate = truePredicate;
     }
 
-    public static KiePMMLTreeModelTruePredicateASTFactory factory(final True truePredicate, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
-        return new KiePMMLTreeModelTruePredicateASTFactory(truePredicate, outputFields, rules);
+    public static KiePMMLTruePredicateASTFactory factory(final True truePredicate, final List<KiePMMLOutputField> outputFields, final List<KiePMMLDroolsRule> rules) {
+        return new KiePMMLTruePredicateASTFactory(truePredicate, outputFields, rules);
     }
 
     public void declareRuleFromTruePredicate(final String parentPath,
@@ -53,7 +51,7 @@ public class KiePMMLTreeModelTruePredicateASTFactory extends KiePMMLTreeModelAbs
                                              final Object result,
                                              boolean isFinalLeaf) {
         logger.trace("declareRuleFromTruePredicate {} {} {}", truePredicate, parentPath, currentRule);
-        String statusConstraint = StringUtils.isEmpty(parentPath) ? STATUS_NULL : String.format(STATUS_PATTERN, parentPath);
+        String statusConstraint = StringUtils.isEmpty(parentPath) ? KiePMMLAbstractModelASTFactory.STATUS_NULL : String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath);
         String statusToSet = isFinalLeaf ? DONE : currentRule;
         KiePMMLDroolsRule.Builder builder = KiePMMLDroolsRule.builder(currentRule, statusToSet, outputFields)
                 .withStatusConstraint(statusConstraint);

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtils.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.utils;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -25,12 +25,12 @@ import org.dmg.pmml.CompoundPredicate;
 import org.dmg.pmml.Predicate;
 import org.dmg.pmml.SimplePredicate;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
+import org.kie.pmml.commons.model.enums.BOOLEAN_OPERATOR;
 import org.kie.pmml.commons.model.enums.DATA_TYPE;
+import org.kie.pmml.commons.model.enums.OPERATOR;
 import org.kie.pmml.models.drools.ast.KiePMMLFieldOperatorValue;
 import org.kie.pmml.models.drools.tuples.KiePMMLOperatorValue;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
-import org.kie.pmml.models.drools.tree.model.enums.BOOLEAN_OPERATOR;
-import org.kie.pmml.models.drools.tree.model.enums.OPERATOR;
 
 import static java.util.stream.Collectors.groupingBy;
 import static org.kie.pmml.models.drools.commons.utils.KiePMMLDroolsModelUtils.getCorrectlyFormattedResult;

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLCompoundPredicateASTFactoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,9 +37,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTTestUtils.getSimplePredicate;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.SURROGATE_GROUP_PATTERN;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getSimplePredicate;
 
-public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
+public class KiePMMLCompoundPredicateASTFactoryTest {
 
     @Test
     public void declareRuleFromCompoundPredicateAndOrXorFinalLeaf() {
@@ -56,13 +58,13 @@ public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
             compoundPredicate.setBooleanOperator(operator);
             predicates.forEach(compoundPredicate::addPredicates);
             final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-            KiePMMLTreeModelCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateAndOrXor(parentPath, currentRule, result, true);
+            KiePMMLCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateAndOrXor(parentPath, currentRule, result, true);
             assertEquals(1, rules.size());
             final KiePMMLDroolsRule retrieved = rules.get(0);
             assertNotNull(retrieved);
             assertEquals(currentRule, retrieved.getName());
             assertEquals(DONE, retrieved.getStatusToSet());
-            assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+            assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
             assertEquals(result, retrieved.getResult());
             assertEquals(ResultCode.OK, retrieved.getResultCode());
             switch (compoundPredicate.getBooleanOperator()) {
@@ -96,13 +98,13 @@ public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
             compoundPredicate.setBooleanOperator(operator);
             predicates.forEach(compoundPredicate::addPredicates);
             final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-            KiePMMLTreeModelCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateAndOrXor(parentPath, currentRule, result, false);
+            KiePMMLCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateAndOrXor(parentPath, currentRule, result, false);
             assertEquals(1, rules.size());
             final KiePMMLDroolsRule retrieved = rules.get(0);
             assertNotNull(retrieved);
             assertEquals(currentRule, retrieved.getName());
             assertEquals(currentRule, retrieved.getStatusToSet());
-            assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+            assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
             switch (compoundPredicate.getBooleanOperator()) {
                 case AND:
                     assertNotNull(retrieved.getAndConstraints());
@@ -130,10 +132,10 @@ public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
         compoundPredicate.setBooleanOperator(CompoundPredicate.BooleanOperator.SURROGATE);
         predicates.forEach(compoundPredicate::addPredicates);
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateSurrogate(parentPath, currentRule, result, true);
+        KiePMMLCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateSurrogate(parentPath, currentRule, result, true);
         int expectedRules = (predicates.size() * 2) + 1; // For each "surrogate" predicate two rules -"TRUE" and "FALSE" - are generated; one more rule is generated for the Compound predicate itself
         assertEquals(expectedRules, rules.size());
-        String agendaActivationGroup = String.format(KiePMMLTreeModelASTFactory.SURROGATE_GROUP_PATTERN, currentRule);
+        String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
         for (KiePMMLDroolsRule retrieved : rules) {
             String ruleName = retrieved.getName();
             if (ruleName.contains("_surrogate_")) {
@@ -166,7 +168,7 @@ public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
                 }
             } else {
                 assertNotNull(retrieved.getStatusConstraint());
-                assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+                assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
                 assertEquals(agendaActivationGroup, retrieved.getFocusedAgendaGroup());
                 assertNull(retrieved.getStatusToSet());
                 assertNull(retrieved.getResult());
@@ -186,10 +188,10 @@ public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
         compoundPredicate.setBooleanOperator(CompoundPredicate.BooleanOperator.SURROGATE);
         predicates.forEach(compoundPredicate::addPredicates);
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateSurrogate(parentPath, currentRule, result, false);
+        KiePMMLCompoundPredicateASTFactory.factory(compoundPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromCompoundPredicateSurrogate(parentPath, currentRule, result, false);
         int expectedRules = (predicates.size() * 2) + 1; // For each "surrogate" predicate two rules -"TRUE" and "FALSE" - are generated; one more rule is generated for the Compound predicate itself
         assertEquals(expectedRules, rules.size());
-        String agendaActivationGroup = String.format(KiePMMLTreeModelASTFactory.SURROGATE_GROUP_PATTERN, currentRule);
+        String agendaActivationGroup = String.format(SURROGATE_GROUP_PATTERN, currentRule);
         for (KiePMMLDroolsRule retrieved : rules) {
             String ruleName = retrieved.getName();
             if (ruleName.contains("_surrogate_")) {
@@ -222,7 +224,7 @@ public class KiePMMLTreeModelCompoundPredicateASTFactoryTest {
                 }
             } else {
                 assertNotNull(retrieved.getStatusConstraint());
-                assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+                assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
                 assertEquals(agendaActivationGroup, retrieved.getFocusedAgendaGroup());
                 assertNull(retrieved.getStatusToSet());
                 assertNull(retrieved.getResult());

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLDataDictionaryASTFactoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,17 +33,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.models.drools.commons.utils.KiePMMLDroolsModelUtils.getSanitizedClassName;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTTestUtils.getDottedTypeDataField;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTTestUtils.getTypeDataField;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getDottedTypeDataField;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getTypeDataField;
 
-public class KiePMMLTreeModelDataDictionaryASTFactoryTest {
+public class KiePMMLDataDictionaryASTFactoryTest {
 
     @Test
     public void declareTypes() {
         List<DataField> dataFields = Arrays.asList(getTypeDataField(), getDottedTypeDataField(), getTypeDataField(), getDottedTypeDataField());
         DataDictionary dataDictionary = new DataDictionary(dataFields);
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
-        List<KiePMMLDroolsType> retrieved = KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(dataDictionary);
+        List<KiePMMLDroolsType> retrieved = KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(dataDictionary);
         assertNotNull(retrieved);
         assertEquals(dataFields.size(), retrieved.size());
         IntStream.range(0, dataFields.size()).forEach(i -> commonVerifyTypeDeclarationDescr(dataFields.get(i), fieldTypeMap, retrieved.get(i)));
@@ -53,7 +53,7 @@ public class KiePMMLTreeModelDataDictionaryASTFactoryTest {
     public void declareType() {
         DataField dataField = getTypeDataField();
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
-        KiePMMLDroolsType retrieved = KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareType(dataField);
+        KiePMMLDroolsType retrieved = KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareType(dataField);
         assertNotNull(retrieved);
         commonVerifyTypeDeclarationDescr(dataField, fieldTypeMap, retrieved);
     }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimplePredicateASTFactoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,11 +34,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.STATUS_PATTERN;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTFactory.SURROGATE_RULENAME_PATTERN;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTTestUtils.getSimplePredicate;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getSimplePredicate;
 
-public class KiePMMLTreeModelSimplePredicateASTFactoryTest {
+public class KiePMMLSimplePredicateASTFactoryTest {
 
     @Test
     public void declareRuleFromSimplePredicateSurrogateFinalLeaf() {
@@ -49,12 +47,12 @@ public class KiePMMLTreeModelSimplePredicateASTFactoryTest {
         String result = "RESULT";
         String parentPath = "parentPath";
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicateSurrogate(parentPath, currentRule, agendaActivationGroup, result, true);
+        KiePMMLSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicateSurrogate(parentPath, currentRule, agendaActivationGroup, result, true);
         assertEquals(2, rules.size());
         // This is the "TRUE" matching rule
         KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
-        String baseExpectedRule = String.format(SURROGATE_RULENAME_PATTERN, currentRule, fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType());
+        String baseExpectedRule = String.format(KiePMMLAbstractModelASTFactory.SURROGATE_RULENAME_PATTERN, currentRule, fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType());
         String expectedRule = baseExpectedRule + "_TRUE";
         assertEquals(expectedRule, retrieved.getName());
         assertEquals(DONE, retrieved.getStatusToSet());
@@ -105,12 +103,12 @@ public class KiePMMLTreeModelSimplePredicateASTFactoryTest {
         String result = "RESULT";
         String parentPath = "parentPath";
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicateSurrogate(parentPath, currentRule, agendaActivationGroup, result, false);
+        KiePMMLSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicateSurrogate(parentPath, currentRule, agendaActivationGroup, result, false);
         assertEquals(2, rules.size());
         // This is the "TRUE" matching rule
         KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
-        String baseExpectedRule = String.format(SURROGATE_RULENAME_PATTERN, currentRule, fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType());
+        String baseExpectedRule = String.format(KiePMMLAbstractModelASTFactory.SURROGATE_RULENAME_PATTERN, currentRule, fieldTypeMap.get(simplePredicate.getField().getValue()).getGeneratedType());
         String expectedRule = baseExpectedRule + "_TRUE";
         assertEquals(expectedRule, retrieved.getName());
         assertEquals(currentRule, retrieved.getStatusToSet());
@@ -160,13 +158,13 @@ public class KiePMMLTreeModelSimplePredicateASTFactoryTest {
         String declaredType = fieldTypeMap.get("outlook").getGeneratedType();
         String result = "RESULT";
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicate(parentPath, currentRule, result, true);
+        KiePMMLSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicate(parentPath, currentRule, result, true);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(DONE, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertEquals(ResultCode.OK, retrieved.getResultCode());
         assertEquals(result, retrieved.getResult());
         final List<KiePMMLFieldOperatorValue> andConstraints = retrieved.getAndConstraints();
@@ -188,13 +186,13 @@ public class KiePMMLTreeModelSimplePredicateASTFactoryTest {
         String declaredType = fieldTypeMap.get("outlook").getGeneratedType();
         String result = "RESULT";
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicate(parentPath, currentRule, result, false);
+        KiePMMLSimplePredicateASTFactory.factory(simplePredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimplePredicate(parentPath, currentRule, result, false);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(KiePMMLAbstractModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertEquals(currentRule, retrieved.getStatusToSet());
         final List<KiePMMLFieldOperatorValue> andConstraints = retrieved.getAndConstraints();
         assertNotNull(andConstraints);

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLSimpleSetPredicateASTFactoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,9 +35,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.commons.Constants.DONE;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTTestUtils.getSimpleSetPredicate;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
+import static org.kie.pmml.models.drools.utils.KiePMMLASTTestUtils.getSimpleSetPredicate;
 
-public class KiePMMLTreeModelSimpleSetPredicateASTFactoryTest {
+public class KiePMMLSimpleSetPredicateASTFactoryTest {
 
     @Test
     public void declareRuleFromSimpleSetPredicateIsInFinalLeaf() {
@@ -49,13 +50,13 @@ public class KiePMMLTreeModelSimpleSetPredicateASTFactoryTest {
         String result = "classB";
         String declaredType = fieldTypeMap.get("input1").getGeneratedType();
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, true);
+        KiePMMLSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, true);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(DONE, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertEquals(ResultCode.OK, retrieved.getResultCode());
         assertEquals(result, retrieved.getResult());
         assertNotNull(retrieved.getInConstraints());
@@ -80,13 +81,13 @@ public class KiePMMLTreeModelSimpleSetPredicateASTFactoryTest {
         String result = "classB";
         String declaredType = fieldTypeMap.get("input1").getGeneratedType();
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
-        KiePMMLTreeModelSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, false);
+        KiePMMLSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, false);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertNull(retrieved.getResultCode());
         assertNull(retrieved.getResult());
         assertNotNull(retrieved.getInConstraints());
@@ -112,13 +113,13 @@ public class KiePMMLTreeModelSimpleSetPredicateASTFactoryTest {
         String declaredType = fieldTypeMap.get("input2").getGeneratedType();
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         String statusToSet = DONE;
-        KiePMMLTreeModelSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, true);
+        KiePMMLSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, true);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(statusToSet, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertEquals(ResultCode.OK, retrieved.getResultCode());
         assertEquals(result, retrieved.getResult());
         assertNotNull(retrieved.getNotInConstraints());
@@ -144,13 +145,13 @@ public class KiePMMLTreeModelSimpleSetPredicateASTFactoryTest {
         String declaredType = fieldTypeMap.get("input2").getGeneratedType();
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         String statusToSet = DONE;
-        KiePMMLTreeModelSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, false);
+        KiePMMLSimpleSetPredicateASTFactory.factory(simpleSetPredicate, fieldTypeMap, Collections.emptyList(), rules).declareRuleFromSimpleSetPredicate(parentPath, currentRule, result, false);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertNull(retrieved.getResultCode());
         assertNull(retrieved.getResult());
         assertNotNull(retrieved.getNotInConstraints());

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTreeModelTruePredicateASTFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/ast/factories/KiePMMLTreeModelTruePredicateASTFactoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.ast.factories;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.Constants.DONE;
+import static org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory.STATUS_PATTERN;
 
 public class KiePMMLTreeModelTruePredicateASTFactoryTest {
 
@@ -38,13 +39,13 @@ public class KiePMMLTreeModelTruePredicateASTFactoryTest {
         String currentRule = "_will play_will play";
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         True truePredicate = new True();
-        KiePMMLTreeModelTruePredicateASTFactory.factory(truePredicate, Collections.emptyList(), rules).declareRuleFromTruePredicate(parentPath, currentRule, DONE, false);
+        KiePMMLTruePredicateASTFactory.factory(truePredicate, Collections.emptyList(), rules).declareRuleFromTruePredicate(parentPath, currentRule, DONE, false);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(currentRule, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertNull(retrieved.getAndConstraints());
         assertNull(retrieved.getResultCode());
     }
@@ -56,13 +57,13 @@ public class KiePMMLTreeModelTruePredicateASTFactoryTest {
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         String statusToSet = DONE;
         True truePredicate = new True();
-        KiePMMLTreeModelTruePredicateASTFactory.factory(truePredicate, Collections.emptyList(), rules).declareRuleFromTruePredicate(parentPath, currentRule, statusToSet, true);
+        KiePMMLTruePredicateASTFactory.factory(truePredicate, Collections.emptyList(), rules).declareRuleFromTruePredicate(parentPath, currentRule, statusToSet, true);
         assertEquals(1, rules.size());
         final KiePMMLDroolsRule retrieved = rules.get(0);
         assertNotNull(retrieved);
         assertEquals(currentRule, retrieved.getName());
         assertEquals(statusToSet, retrieved.getStatusToSet());
-        assertEquals(String.format(KiePMMLTreeModelASTFactory.STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
+        assertEquals(String.format(STATUS_PATTERN, parentPath), retrieved.getStatusConstraint());
         assertNull(retrieved.getAndConstraints());
         assertEquals(DONE, retrieved.getResult());
         assertEquals(ResultCode.OK, retrieved.getResultCode());

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtilsTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTFactoryUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.utils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +30,6 @@ import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelASTTestUtils.getSimplePredicate;
 
 public class KiePMMLASTFactoryUtilsTest {
 
@@ -39,7 +38,7 @@ public class KiePMMLASTFactoryUtilsTest {
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         String fieldName = "FIELD_NAME";
         List<SimplePredicate> simplePredicates = IntStream.range(0, 2)
-                .mapToObj(index -> getSimplePredicate(fieldName, DataType.STRING, "VALUE-" + index, fieldTypeMap)).collect(Collectors.toList());
+                .mapToObj(index -> KiePMMLASTTestUtils.getSimplePredicate(fieldName, DataType.STRING, "VALUE-" + index, fieldTypeMap)).collect(Collectors.toList());
         final KiePMMLFieldOperatorValue retrieved = KiePMMLASTFactoryUtils.getConstraintEntryFromSimplePredicates(fieldName, "or", simplePredicates, fieldTypeMap);
         assertEquals(fieldName, retrieved.getName());
         assertNotNull(retrieved.getConstraintsAsString());

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTTestUtils.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLASTTestUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.pmml.models.drools.tree.compiler.factories;
+package org.kie.pmml.models.drools.utils;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +29,10 @@ import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.kie.pmml.models.drools.commons.utils.KiePMMLDroolsModelUtils.getSanitizedClassName;
 
-public class KiePMMLTreeModelASTTestUtils {
+/**
+ * Utility methods for other <b>Test</b> classes
+ */
+public class KiePMMLASTTestUtils {
 
     public static DataField getTypeDataField() {
         DataField toReturn = new DataField();

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
@@ -38,6 +38,12 @@
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
+      <artifactId>kie-pmml-models-drools-common</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
       <artifactId>kie-test-util</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelASTFactory.java
@@ -25,6 +25,8 @@ import org.kie.pmml.commons.model.enums.DATA_TYPE;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsAST;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsType;
+import org.kie.pmml.models.drools.ast.factories.KiePMMLAbstractModelASTFactory;
+import org.kie.pmml.models.drools.ast.factories.KiePMMLDataDictionaryASTFactory;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,13 +37,8 @@ import static org.kie.pmml.compiler.commons.utils.ModelUtils.getTargetFieldType;
 /**
  * Class used to generate a <code>KiePMMLDroolsAST</code> out of a <code>DataDictionary</code> and a <code>TreeModel</code>
  */
-public class KiePMMLTreeModelASTFactory {
+public class KiePMMLTreeModelASTFactory extends KiePMMLAbstractModelASTFactory {
 
-    public static final String SURROGATE_RULENAME_PATTERN = "%s_surrogate_%s";
-    public static final String SURROGATE_GROUP_PATTERN = "%s_surrogate";
-    public static final String STATUS_NULL = "status == null";
-    public static final String STATUS_PATTERN = "status == \"%s\"";
-    public static final String PATH_PATTERN = "%s_%s";
     private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelASTFactory.class.getName());
 
     private KiePMMLTreeModelASTFactory() {
@@ -59,7 +56,7 @@ public class KiePMMLTreeModelASTFactory {
     public static KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         logger.trace("getKiePMMLDroolsAST {} {}", dataDictionary, model);
         DATA_TYPE targetType = getTargetFieldType(dataDictionary, model);
-        List<KiePMMLDroolsType> types = KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(dataDictionary);
+        List<KiePMMLDroolsType> types = KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(dataDictionary);
         final List<KiePMMLOutputField> outputFields = getOutputFields(model);
         List<KiePMMLDroolsRule> rules = KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, outputFields, model.getNoTrueChildStrategy(), targetType).declareRulesFromRootNode(model.getNode(), "");
         return new KiePMMLDroolsAST(types, rules);

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactory.java
@@ -28,6 +28,7 @@ import org.dmg.pmml.tree.TreeModel;
 import org.kie.pmml.commons.model.KiePMMLOutputField;
 import org.kie.pmml.commons.model.enums.DATA_TYPE;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
+import org.kie.pmml.models.drools.ast.factories.KiePMMLPredicateASTFactory;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,7 @@ public class KiePMMLTreeModelNodeASTFactory {
         }
         String currentRule = String.format(PATH_PATTERN, parentPath, node.getScore());
         if (!(predicate instanceof True)) {
-            KiePMMLTreeModelPredicateASTFactory.factory(fieldTypeMap, outputFields, rules).declareRuleFromPredicate(predicate, parentPath, currentRule, getCorrectlyFormattedResult(node.getScore(), targetType), true);
+            KiePMMLPredicateASTFactory.factory(fieldTypeMap, outputFields, rules).declareRuleFromPredicate(predicate, parentPath, currentRule, getCorrectlyFormattedResult(node.getScore(), targetType), true);
         }
     }
 
@@ -119,7 +120,7 @@ public class KiePMMLTreeModelNodeASTFactory {
             return;
         }
         String currentRule = String.format(PATH_PATTERN, parentPath, node.getScore());
-        KiePMMLTreeModelPredicateASTFactory.factory(fieldTypeMap, outputFields, rules).declareRuleFromPredicate(predicate, parentPath, currentRule, node.getScore(), false);
+        KiePMMLPredicateASTFactory.factory(fieldTypeMap, outputFields, rules).declareRuleFromPredicate(predicate, parentPath, currentRule, node.getScore(), false);
         node.getNodes().forEach(child -> declareRuleFromNode(child, currentRule, rules));
     }
 
@@ -136,7 +137,7 @@ public class KiePMMLTreeModelNodeASTFactory {
         logger.trace("declareDefaultRuleFromNode {} {}", node, parentPath);
         String originalRule = String.format(PATH_PATTERN, parentPath, node.getScore());
         String currentRule = String.format(PATH_PATTERN, "default", originalRule);
-        KiePMMLTreeModelPredicateASTFactory.factory(fieldTypeMap, outputFields, rules).declareRuleFromPredicate(new True(), originalRule, currentRule, getCorrectlyFormattedResult(node.getScore(), targetType), true);
+        KiePMMLPredicateASTFactory.factory(fieldTypeMap, outputFields, rules).declareRuleFromPredicate(new True(), originalRule, currentRule, getCorrectlyFormattedResult(node.getScore(), targetType), true);
     }
 
     protected boolean isFinalLeaf(final Node node) {

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelNodeASTFactoryTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.kie.pmml.commons.model.enums.DATA_TYPE;
 import org.kie.pmml.compiler.testutils.TestUtils;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsRule;
+import org.kie.pmml.models.drools.ast.factories.KiePMMLDataDictionaryASTFactory;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 
 import static org.junit.Assert.assertEquals;
@@ -69,7 +70,7 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
         assertEquals("will play", rootNode.getScore());
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         DATA_TYPE targetType = getTargetFieldType(golfingPmml.getDataDictionary(), golfingModel);
-        KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(golfingPmml.getDataDictionary());
+        KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(golfingPmml.getDataDictionary());
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareRulesFromRootNode(rootNode, "_will");
         assertFalse(fieldTypeMap.isEmpty());
     }
@@ -80,7 +81,7 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
         assertEquals("setosa", rootNode.getScore());
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         DATA_TYPE targetType = getTargetFieldType(irisPmml.getDataDictionary(), irisModel);
-        KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(irisPmml.getDataDictionary());
+        KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(irisPmml.getDataDictionary());
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareRulesFromRootNode(rootNode, "_setosa");
         assertFalse(fieldTypeMap.isEmpty());
     }
@@ -92,7 +93,7 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
         assertEquals("will play", finalNode.getScore());
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         DATA_TYPE targetType = getTargetFieldType(golfingPmml.getDataDictionary(), golfingModel);
-        KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(golfingPmml.getDataDictionary());
+        KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(golfingPmml.getDataDictionary());
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareIntermediateRuleFromNode(finalNode, "_will play", rules);
         assertFalse(rules.isEmpty());
@@ -105,7 +106,7 @@ public class KiePMMLTreeModelNodeASTFactoryTest {
         assertEquals("versicolor", finalNode.getScore());
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         DATA_TYPE targetType = getTargetFieldType(irisPmml.getDataDictionary(), irisModel);
-        KiePMMLTreeModelDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(irisPmml.getDataDictionary());
+        KiePMMLDataDictionaryASTFactory.factory(fieldTypeMap).declareTypes(irisPmml.getDataDictionary());
         final List<KiePMMLDroolsRule> rules = new ArrayList<>();
         KiePMMLTreeModelNodeASTFactory.factory(fieldTypeMap, Collections.emptyList(), TreeModel.NoTrueChildStrategy.RETURN_NULL_PREDICTION, targetType).declareIntermediateRuleFromNode(finalNode, "_setosa", rules);
         assertFalse(rules.isEmpty());

--- a/kie-pmml-new/pom.xml
+++ b/kie-pmml-new/pom.xml
@@ -155,6 +155,13 @@
         <classifier>tests</classifier>
         <version>${version.org.kie}</version>
       </dependency>
+      <!-- Drools -->
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-pmml-models-drools-common</artifactId>
+        <classifier>tests</classifier>
+        <version>${version.org.kie}</version>
+      </dependency>
       <!-- Tree -->
       <dependency>
         <groupId>org.kie</groupId>


### PR DESCRIPTION
@danielezonca @jiripetrlik 

Moved common classes (namely *ASTFactories) from TreeModel compiler to drools-common.

see https://issues.redhat.com/browse/DROOLS-5261