### PR TITLE
[7.33.x] DROOLS-5249: do not store DateTimeFormatter as free form line

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -3100,7 +3100,9 @@ public class RuleModelDRLPersistenceImpl
                 if (eqPos > 0) {
                     String field = line.substring(0,
                                                   eqPos).trim();
-                    if ("java.text.SimpleDateFormat sdf".equals(field) || "org.drools.core.process.instance.WorkItemManager wim".equals(field)) {
+                    if ("java.text.SimpleDateFormat sdf".equals(field) ||
+                            "java.time.format.DateTimeFormatter dtf".equals(field) ||
+                            "org.drools.core.process.instance.WorkItemManager wim".equals(field)) {
                         addFreeFormLine = false;
                     }
                     String[] split = field.split(" ");


### PR DESCRIPTION
This is a cherry-pick of #2859 

We have two kinds of date boiler plate code snippets. For:
- java.util.Date: 'java.text.SimpleDateFormat sdf'
- java.time.LocalDate: 'java.time.format.DateTimeFormatter dtf'

If user set value either of 'Date' or 'LocalDate' field using 'Literal Value' guided editor action, the given date boiler plate is generated automatically behind the scene. This allows users to put in just value of date, e.g. "01-Jan-2000". User do not have to use parametric constructors, builders, parsers or factory methods. It is done behind the scene using 'sdf' or 'dtf' BoilerPlate.

If users set value either of 'Date' ot 'LocalDate' field using 'Formula' guided editor action, is their responsibility to construct 'Date' or 'LocalDate' instance.

For more details see https://issues.redhat.com/browse/DROOLS-5249