### PR TITLE
[DROOLS-5271] RHS statements ordering changes with modify block in ex…

### DIFF
--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ModifyCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ModifyCompiler.java
@@ -31,12 +31,15 @@ public class ModifyCompiler {
                     usedBindings.addAll(invoke.getUsedBindings());
                     Optional<Node> parentNode = s.getParentNode();
                     parentNode.ifPresent(p -> {
-                        BlockStmt p1 = (BlockStmt) p;
-                        p1.getStatements().addAll(invoke.getNewObjectStatements());
-                        p1.getStatements().addAll(invoke.getOtherStatements());
-                        for (String modifiedProperty : invoke.getUsedBindings()) {
-                            p1.addStatement(new MethodCallExpr(null, "update", nodeList(new NameExpr(modifiedProperty))));
+                        BlockStmt replacementBlock = new BlockStmt();
+                        replacementBlock.getStatements().addAll(invoke.getNewObjectStatements());
+                        replacementBlock.getStatements().addAll(invoke.getOtherStatements());
+                        for (String modifiedFact : invoke.getUsedBindings()) {
+                            replacementBlock.addStatement(new MethodCallExpr(null, "update", nodeList(new NameExpr(modifiedFact))));
                         }
+                        BlockStmt p1 = (BlockStmt) p;
+                        int index = p1.getStatements().indexOf(s);
+                        p1.addStatement(index, replacementBlock);
                     });
                     s.remove();
                 });

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ModifyCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ModifyCompilerTest.java
@@ -17,7 +17,7 @@ public class ModifyCompilerTest implements CompilerTest {
     @Test
     public void testUncompiledMethod() {
         test("{modify( (List)$toEdit.get(0) ){ setEnabled( true ) }}",
-             "{ ((List) $toEdit.get(0)).setEnabled(true); }",
+             "{ { ((List) $toEdit.get(0)).setEnabled(true); } }",
              result -> assertThat(allUsedBindings(result), is(empty())));
     }
 
@@ -25,7 +25,7 @@ public class ModifyCompilerTest implements CompilerTest {
     public void testModify() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{  modify($p) { setCanDrink(true); } }",
-             "{ ($p).setCanDrink(true); update($p); }",
+             "{ { ($p).setCanDrink(true); update($p); } }",
              result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
     }
 
@@ -33,7 +33,7 @@ public class ModifyCompilerTest implements CompilerTest {
     public void testModifyWithLambda() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{  modify($p) {  setCanDrinkLambda(() -> true); } }",
-             "{ ($p).setCanDrinkLambda(() -> true); update($p); }",
+             "{ { ($p).setCanDrinkLambda(() -> true); update($p); } }",
              result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
     }
 
@@ -50,8 +50,10 @@ public class ModifyCompilerTest implements CompilerTest {
                      "if ($fact.getResult() != null) { " +
                      "  $fact.setResult(\"OK\"); " +
                      "} else { " +
-                         "($fact).setResult(\"FIRST\"); " +
-                         "update($fact); " +
+                         "{ " +
+                         "  ($fact).setResult(\"FIRST\"); " +
+                         "  update($fact); " +
+                         "} " +
                      "} " +
                      "} ",
              result -> assertThat(allUsedBindings(result), containsInAnyOrder("$fact")));


### PR DESCRIPTION
…ecutable model

https://issues.redhat.com/browse/DROOLS-5271

- Keep the statement order in RHS
- Add parentheses to surround the logic generated for the modify statement. This makes the result similar to standard-drl.