### PR TITLE
[7.33.x] DROOLS-5263: Wrong test result status if rules have not been fired

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
@@ -180,6 +180,7 @@ public abstract class AbstractRunnerHelper {
 
         Set<FactIdentifier> inputFacts = factMappingValues.stream()
                 .filter(elem -> FactMappingType.GIVEN.equals(elem.getExpressionIdentifier().getType()))
+                .filter(elem -> !isFactMappingValueToSkip(elem))
                 .map(FactMappingValue::getFactIdentifier)
                 .collect(Collectors.toSet());
 
@@ -199,8 +200,7 @@ public abstract class AbstractRunnerHelper {
         for (FactMappingValue factMappingValue : factMappingValues) {
             FactIdentifier factIdentifier = factMappingValue.getFactIdentifier();
 
-            // null means skip
-            if (factMappingValue.getRawValue() == null) {
+            if (isFactMappingValueToSkip(factMappingValue)) {
                 continue;
             }
 
@@ -217,6 +217,10 @@ public abstract class AbstractRunnerHelper {
                     .add(factMappingValue);
         }
         return groupByFactIdentifier;
+    }
+
+    protected boolean isFactMappingValueToSkip(FactMappingValue factMappingValue) {
+        return factMappingValue.getRawValue() == null;
     }
 
     protected Map<List<String>, Object> getParamsForBean(ScesimModelDescriptor scesimModelDescriptor,

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelperTest.java
@@ -76,6 +76,18 @@ public class AbstractRunnerHelperTest {
     };
 
     @Test
+    public void isFactMappingValueToSkip() {
+        FactIdentifier factIdentifier = FactIdentifier.create("MyInstance", String.class.getCanonicalName());
+        ExpressionIdentifier expressionIdentifier = ExpressionIdentifier.create("MyProperty", FactMappingType.GIVEN);
+
+        FactMappingValue factMappingValueWithValidValue = new FactMappingValue(factIdentifier, expressionIdentifier, VALUE);
+        assertFalse(abstractRunnerHelper.isFactMappingValueToSkip(factMappingValueWithValidValue));
+
+        FactMappingValue factMappingValueWithoutValue = new FactMappingValue(factIdentifier, expressionIdentifier, null);
+        assertTrue(abstractRunnerHelper.isFactMappingValueToSkip(factMappingValueWithoutValue));
+    }
+
+    @Test
     public void fillResult() {
         FactIdentifier factIdentifier = FactIdentifier.create("MyInstance", String.class.getCanonicalName());
         ExpressionIdentifier expressionIdentifier = ExpressionIdentifier.create("MyProperty", FactMappingType.GIVEN);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
@@ -240,6 +240,14 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         List<ScenarioExpect> scenario2Outputs = runnerHelper.extractExpectedValues(scenario2.getUnmodifiableFactMappingValues());
         assertEquals(3, scenario2Outputs.size());
         assertEquals(1, scenario2Outputs.stream().filter(ScenarioExpect::isNewFact).count());
+
+        /* A Given "TEST" fact with null rawValue should works as the previous case, i.e. to not consider the GIVEN fact with empty data */
+        scenario2.addOrUpdateMappingValue(FactIdentifier.create("TEST", String.class.getCanonicalName()),
+                                          ExpressionIdentifier.create("TEST", FactMappingType.GIVEN),
+                                          null);
+        List<ScenarioExpect> scenario2aOutputs = runnerHelper.extractExpectedValues(scenario2.getUnmodifiableFactMappingValues());
+        assertEquals(3, scenario2aOutputs.size());
+        assertEquals(1, scenario2aOutputs.stream().filter(ScenarioExpect::isNewFact).count());
     }
 
     @Test


### PR DESCRIPTION
Backport of https://github.com/kiegroup/drools/commit/b6dfcf419fd09cb0336f298e0b76a0d2ad6e6bae

@danielezonca @dupliaka Can you please test and review it?

* DROOLS-5263: Filtering out facts with empty rawValues from inputFacts.

* DROOLS-5263: Tests
(cherry picked from commit b6dfcf419fd09cb0336f298e0b76a0d2ad6e6bae)

https://issues.redhat.com/browse/DROOLS-5263
https://issues.redhat.com/browse/RHDM-1330