### PR TITLE
[DROOLS-5316] Test Scenario: wrong management of null values with simple types in DMN scenarios

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ConditionFilter.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/ConditionFilter.java
@@ -33,6 +33,6 @@ public class ConditionFilter implements ObjectFilter {
         return factToCheck.stream()
                 .allMatch(factCheckerHandle ->
                                   factCheckerHandle.getClazz().isAssignableFrom(object.getClass()) &&
-                                          factCheckerHandle.getCheckFuction().apply(object).isSatisfied());
+                                          factCheckerHandle.getCheckFuction().apply(object).isValid());
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/FactCheckerHandle.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/FactCheckerHandle.java
@@ -18,16 +18,16 @@ package org.drools.scenariosimulation.backend.fluent;
 
 import java.util.function.Function;
 
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 
 public class FactCheckerHandle {
 
     private final Class<?> clazz;
-    private final Function<Object, ResultWrapper> checkFuction;
+    private final Function<Object, ValueWrapper> checkFuction;
     private final ScenarioResult scenarioResult;
 
-    public FactCheckerHandle(Class<?> clazz, Function<Object, ResultWrapper> checkFuction, ScenarioResult scenarioResult) {
+    public FactCheckerHandle(Class<?> clazz, Function<Object, ValueWrapper> checkFuction, ScenarioResult scenarioResult) {
         this.clazz = clazz;
         this.checkFuction = checkFuction;
         this.scenarioResult = scenarioResult;
@@ -37,7 +37,7 @@ public class FactCheckerHandle {
         return clazz;
     }
 
-    public Function<Object, ResultWrapper> getCheckFuction() {
+    public Function<Object, ValueWrapper> getCheckFuction() {
         return checkFuction;
     }
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilder.java
@@ -22,8 +22,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.rule.Rule;
@@ -48,7 +48,7 @@ public interface RuleScenarioExecutableBuilder {
     }
 
     void addInternalCondition(Class<?> clazz,
-                              Function<Object, ResultWrapper> checkFunction,
+                              Function<Object, ValueWrapper> checkFunction,
                               ScenarioResult scenarioResult);
 
     void setActiveAgendaGroup(String agendaGroup);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatefulScenarioExecutableBuilder.java
@@ -26,8 +26,8 @@ import java.util.function.Function;
 
 import org.drools.scenariosimulation.api.model.FactIdentifier;
 import org.drools.scenariosimulation.backend.runner.ScenarioException;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
@@ -71,7 +71,7 @@ public class RuleStatefulScenarioExecutableBuilder implements RuleScenarioExecut
 
     @Override
     public void addInternalCondition(Class<?> clazz,
-                                     Function<Object, ResultWrapper> checkFunction,
+                                     Function<Object, ValueWrapper> checkFunction,
                                      ScenarioResult scenarioResult) {
         internalConditions.computeIfAbsent(scenarioResult.getFactIdentifier(), key -> new ArrayList<>())
                 .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/fluent/RuleStatelessScenarioExecutableBuilder.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.drools.scenariosimulation.api.model.FactIdentifier;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.kie.api.KieServices;
 import org.kie.api.command.Command;
 import org.kie.api.command.KieCommands;
@@ -49,7 +49,7 @@ public class RuleStatelessScenarioExecutableBuilder implements RuleScenarioExecu
 
     @Override
     public void addInternalCondition(Class<?> clazz,
-                                     Function<Object, ResultWrapper> checkFunction,
+                                     Function<Object, ValueWrapper> checkFunction,
                                      ScenarioResult scenarioResult) {
         internalConditions.computeIfAbsent(scenarioResult.getFactIdentifier(), key -> new ArrayList<>())
                 .add(new FactCheckerHandle(clazz, checkFunction, scenarioResult));

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelper.java
@@ -19,7 +19,6 @@ package org.drools.scenariosimulation.backend.runner;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.scenariosimulation.api.model.ExpressionElement;
@@ -35,18 +34,18 @@ import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
 import org.drools.scenariosimulation.backend.expression.ExpressionEvaluatorFactory;
 import org.drools.scenariosimulation.backend.fluent.DMNScenarioExecutableBuilder;
 import org.drools.scenariosimulation.backend.runner.model.InstanceGiven;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.kie.api.runtime.KieContainer;
 import org.kie.dmn.api.core.DMNDecisionResult;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.ast.DecisionNode;
 
-import static org.drools.scenariosimulation.backend.runner.model.ResultWrapper.createErrorResultWithErrorMessage;
+import static org.drools.scenariosimulation.backend.runner.model.ValueWrapper.errorWithMessage;
 import static org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus.SUCCEEDED;
 
 public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
@@ -132,14 +131,14 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
     }
 
     @SuppressWarnings("unchecked")
-    protected ResultWrapper getSingleFactValueResult(FactMapping factMapping,
-                                                     FactMappingValue expectedResult,
-                                                     DMNDecisionResult decisionResult,
-                                                     ExpressionEvaluator expressionEvaluator) {
+    protected ValueWrapper getSingleFactValueResult(FactMapping factMapping,
+                                                    FactMappingValue expectedResult,
+                                                    DMNDecisionResult decisionResult,
+                                                    ExpressionEvaluator expressionEvaluator) {
         Object resultRaw = decisionResult.getResult();
         final DMNDecisionResult.DecisionEvaluationStatus evaluationStatus = decisionResult.getEvaluationStatus();
         if (!SUCCEEDED.equals(evaluationStatus)) {
-            return createErrorResultWithErrorMessage("The decision " +
+            return errorWithMessage("The decision " +
                                                              decisionResult.getDecisionName() +
                                                              " has not been successfully evaluated: " +
                                                              evaluationStatus);
@@ -171,10 +170,10 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected Object createObject(Optional<Object> initialInstance, String className, Map<List<String>, Object> params, ClassLoader classLoader) {
+    protected Object createObject(ValueWrapper<Object> initialInstance, String className, Map<List<String>, Object> params, ClassLoader classLoader) {
         // simple types
-        if (initialInstance.isPresent() && !(initialInstance.get() instanceof Map)) {
-            return initialInstance.get();
+        if (initialInstance.isValid() && !(initialInstance.getValue() instanceof Map)) {
+            return initialInstance.getValue();
         }
         Map<String, Object> toReturn = (Map<String, Object>) initialInstance.orElseGet(HashMap::new);
         for (Map.Entry<List<String>, Object> listObjectEntry : params.entrySet()) {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelper.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -37,12 +36,12 @@ import org.drools.scenariosimulation.backend.expression.ExpressionEvaluator;
 import org.drools.scenariosimulation.backend.expression.ExpressionEvaluatorFactory;
 import org.drools.scenariosimulation.backend.fluent.CoverageAgendaListener;
 import org.drools.scenariosimulation.backend.fluent.RuleScenarioExecutableBuilder;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
 import org.drools.scenariosimulation.backend.runner.model.InstanceGiven;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.drools.scenariosimulation.backend.util.ScenarioBeanUtil;
 import org.drools.scenariosimulation.backend.util.ScenarioBeanWrapper;
 import org.kie.api.runtime.KieContainer;
@@ -152,9 +151,9 @@ public class RuleScenarioRunnerHelper extends AbstractRunnerHelper {
         return scenarioResults;
     }
 
-    protected Function<Object, ResultWrapper> createExtractorFunction(ExpressionEvaluator expressionEvaluator,
-                                                                      FactMappingValue expectedResult,
-                                                                      ScesimModelDescriptor scesimModelDescriptor) {
+    protected Function<Object, ValueWrapper> createExtractorFunction(ExpressionEvaluator expressionEvaluator,
+                                                                     FactMappingValue expectedResult,
+                                                                     ScesimModelDescriptor scesimModelDescriptor) {
         return objectToCheck -> {
 
             ExpressionIdentifier expressionIdentifier = expectedResult.getExpressionIdentifier();
@@ -183,7 +182,7 @@ public class RuleScenarioRunnerHelper extends AbstractRunnerHelper {
     }
 
     @Override
-    protected Object createObject(Optional<Object> initialInstance, String className, Map<List<String>, Object> params, ClassLoader classLoader) {
+    protected Object createObject(ValueWrapper<Object> initialInstance, String className, Map<List<String>, Object> params, ClassLoader classLoader) {
         return fillBean(initialInstance, className, params, classLoader);
     }
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 /**
  * Utility class to wrap a value with the possibility to specify error message or propose valid value.
- * Note: null can be used a value.
+ * Note: null can be used as value.
  * @param <T>
  */
 public class ValueWrapper<T> {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
@@ -20,7 +20,8 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
- * Utility class to wrap a value with the possibility to specify error message or propose valid value
+ * Utility class to wrap a value with the possibility to specify error message or propose valid value.
+ * Note: null can be used a value.
  * @param <T>
  */
 public class ValueWrapper<T> {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapper.java
@@ -20,42 +20,46 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
- * java.util.Optional clone to have the null result
+ * Utility class to wrap a value with the possibility to specify error message or propose valid value
  * @param <T>
  */
-public class ResultWrapper<T> {
+public class ValueWrapper<T> {
 
-    private final boolean satisfied;
+    private final boolean valid;
 
-    private final T result;
+    private final T value;
     private final T expected;
     private final String errorMessage;
 
-    private ResultWrapper(T result, T expected, boolean satisfied, String errorMessage) {
-        this.satisfied = satisfied;
-        this.result = result;
+    private ValueWrapper(T value, T expected, boolean valid, String errorMessage) {
+        this.valid = valid;
+        this.value = value;
         this.expected = expected;
         this.errorMessage = errorMessage;
     }
 
-    public static <T> ResultWrapper<T> createResult(T result) {
-        return new ResultWrapper<>(result, null, true, null);
+    public static <T> ValueWrapper<T> of(T value) {
+        return new ValueWrapper<>(value, null, true, null);
     }
 
-    public static <T> ResultWrapper<T> createErrorResult(T result, T expected) {
-        return new ResultWrapper<>(result, expected, false, null);
+    public static <T> ValueWrapper<T> errorWithValidValue(T value, T expected) {
+        return new ValueWrapper<>(value, expected, false, null);
     }
 
-    public static <T> ResultWrapper<T> createErrorResultWithErrorMessage(String errorMessage) {
-        return new ResultWrapper<>(null, null, false, errorMessage);
+    public static <T> ValueWrapper<T> errorWithMessage(String message) {
+        return new ValueWrapper<>(null, null, false, message);
     }
 
-    public boolean isSatisfied() {
-        return satisfied;
+    public static <T> ValueWrapper<T> errorEmptyMessage() {
+        return new ValueWrapper<>(null, null, false, null);
     }
 
-    public T getResult() {
-        return result;
+    public boolean isValid() {
+        return valid;
+    }
+
+    public T getValue() {
+        return value;
     }
 
     public T getExpected() {
@@ -67,14 +71,10 @@ public class ResultWrapper<T> {
     }
 
     public T orElse(T defaultValue) {
-        return satisfied ? result : defaultValue;
+        return valid ? value : defaultValue;
     }
 
     public T orElseGet(Supplier<T> defaultSupplier) {
-        return satisfied ? result : defaultSupplier.get();
-    }
-
-    public Optional<T> getOptional() {
-        return Optional.ofNullable( orElse(null));
+        return valid ? value : defaultSupplier.get();
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtil.java
@@ -16,15 +16,17 @@
 
 package org.drools.scenariosimulation.backend.util;
 
+import org.drools.scenariosimulation.backend.runner.ScenarioException;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
+
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import org.drools.scenariosimulation.backend.runner.ScenarioException;
+import static org.drools.scenariosimulation.backend.runner.model.ValueWrapper.errorEmptyMessage;
 
 public class ScenarioBeanUtil {
 
@@ -45,11 +47,11 @@ public class ScenarioBeanUtil {
     }
 
     public static <T> T fillBean(String className, Map<List<String>, Object> params, ClassLoader classLoader) {
-        return fillBean(Optional.empty(), className, params, classLoader);
+        return fillBean(errorEmptyMessage(), className, params, classLoader);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> T fillBean(Optional<Object> initialInstance, String className, Map<List<String>, Object> params, ClassLoader classLoader) {
+    public static <T> T fillBean(ValueWrapper<Object> initialInstance, String className, Map<List<String>, Object> params, ClassLoader classLoader) {
 
         T beanToFill = (T) initialInstance.orElseGet(() -> newInstance(loadClass(className, classLoader)));
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ConditionFilterTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ConditionFilterTest.java
@@ -21,27 +21,27 @@ import java.util.function.Function;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
 import org.drools.scenariosimulation.api.model.FactMappingValue;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public class ConditionFilterTest {
 
     @Test
     public void acceptTest() {
-        Function<Object, ResultWrapper> alwaysMatchFunction = ResultWrapper::createResult;
+        Function<Object, ValueWrapper> alwaysMatchFunction = ValueWrapper::of;
         FactMappingValue factMappingValue = new FactMappingValue(FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION, "Test");
         ScenarioResult scenarioResult = new ScenarioResult(factMappingValue);
-        ConditionFilter conditionFilter = new ConditionFilter(asList(new FactCheckerHandle(String.class, alwaysMatchFunction, scenarioResult)));
+        ConditionFilter conditionFilter = new ConditionFilter(singletonList(new FactCheckerHandle(String.class, alwaysMatchFunction, scenarioResult)));
 
         Assert.assertFalse(conditionFilter.accept(1));
         Assert.assertTrue(conditionFilter.accept("String"));
 
-        Function<Object, ResultWrapper> alwaysNotMatchFunction = object -> ResultWrapper.createErrorResult(null, null);
-        ConditionFilter conditionFilterFail = new ConditionFilter(asList(new FactCheckerHandle(String.class, alwaysNotMatchFunction, scenarioResult)));
+        Function<Object, ValueWrapper> alwaysNotMatchFunction = object -> ValueWrapper.errorWithValidValue(null, null);
+        ConditionFilter conditionFilterFail = new ConditionFilter(singletonList(new FactCheckerHandle(String.class, alwaysNotMatchFunction, scenarioResult)));
         Assert.assertFalse(conditionFilterFail.accept("String"));
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommandTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/ValidateFactCommandTest.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import org.drools.scenariosimulation.api.model.FactMappingValue;
 import org.drools.scenariosimulation.api.model.FactMappingValueStatus;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,7 +57,7 @@ public class ValidateFactCommandTest {
     @Test
     public void executeTest() {
         when(registryContext.lookup(KieSession.class)).thenReturn(kieSession);
-        Function<Object, ResultWrapper> alwaysMatchFunction = ResultWrapper::createResult;
+        Function<Object, ValueWrapper> alwaysMatchFunction = ValueWrapper::of;
 
         ValidateFactCommand validateFactCommand = new ValidateFactCommand(asList(new FactCheckerHandle(String.class, alwaysMatchFunction, scenarioResult)));
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -45,10 +44,10 @@ import org.drools.scenariosimulation.backend.fluent.DMNScenarioExecutableBuilder
 import org.drools.scenariosimulation.backend.model.Dispute;
 import org.drools.scenariosimulation.backend.model.Person;
 import org.drools.scenariosimulation.backend.runner.model.InstanceGiven;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,6 +71,7 @@ import static org.drools.scenariosimulation.backend.TestUtils.getRandomlyGenerat
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus;
 import static org.mockito.Matchers.any;
@@ -242,7 +242,7 @@ public class DMNScenarioRunnerHelperTest {
         params.put(asList("creator", "surname"), "TestSurname");
         params.put(singletonList("age"), BigDecimal.valueOf(10));
 
-        Optional<Object> initialInstance = runnerHelper.getDirectMapping(params).getOptional();
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
         Object objectRaw = runnerHelper.createObject(
                 initialInstance,
                 String.class.getCanonicalName(),
@@ -265,7 +265,7 @@ public class DMNScenarioRunnerHelperTest {
         String directMappingSimpleTypeValue = "TestName";
         params.put(emptyList(), directMappingSimpleTypeValue);
 
-        Optional<Object> initialInstance = runnerHelper.getDirectMapping(params).getOptional();
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
         Object objectRaw = runnerHelper.createObject(
                 initialInstance,
                 String.class.getCanonicalName(),
@@ -277,6 +277,21 @@ public class DMNScenarioRunnerHelperTest {
         assertEquals(directMappingSimpleTypeValue, objectRaw);
     }
 
+    @Test
+    public void createObjectDirectMappingSimpleTypeNull() {
+        Map<List<String>, Object> params = new HashMap<>();
+        params.put(emptyList(), null);
+
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
+        Object objectRaw = runnerHelper.createObject(
+                initialInstance,
+                String.class.getCanonicalName(),
+                params,
+                this.getClass().getClassLoader());
+
+        assertNull(objectRaw);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void createObjectDirectMappingComplexType() {
@@ -286,7 +301,7 @@ public class DMNScenarioRunnerHelperTest {
         params.put(emptyList(), directMappingComplexTypeValue);
         params.put(singletonList("key2"), "value2");
 
-        Optional<Object> initialInstance = runnerHelper.getDirectMapping(params).getOptional();
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
         Object objectRaw = runnerHelper.createObject(
                 initialInstance,
                 Map.class.getCanonicalName(),
@@ -315,11 +330,11 @@ public class DMNScenarioRunnerHelperTest {
     @Test
     public void getSingleFactValueResultFailDecision() {
         DMNDecisionResult failedDecision = createDecisionResultMock("Test", false, new ArrayList<>());
-        ResultWrapper<?> failedResult = runnerHelper.getSingleFactValueResult(null,
+        ValueWrapper<?> failedResult = runnerHelper.getSingleFactValueResult(null,
                                                                               null,
                                                                               failedDecision,
                                                                               expressionEvaluator);
-        assertFalse(failedResult.isSatisfied());
+        assertFalse(failedResult.isValid());
         assertEquals("The decision " +
                              failedDecision.getDecisionName() +
                              " has not been successfully evaluated: " +

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
@@ -489,6 +489,21 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         assertEquals(directMappingSimpleTypeValue, objectRaw);
     }
 
+    @Test
+    public void createObjectDirectMappingSimpleTypeNull() {
+        Map<List<String>, Object> params = new HashMap<>();
+        params.put(emptyList(), null);
+
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
+        Object objectRaw = runnerHelper.createObject(
+                initialInstance,
+                String.class.getCanonicalName(),
+                params,
+                this.getClass().getClassLoader());
+
+        assertNull(objectRaw);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void createObjectDirectMappingComplexType() {

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
@@ -51,11 +51,11 @@ import org.drools.scenariosimulation.backend.fluent.RuleScenarioExecutableBuilde
 import org.drools.scenariosimulation.backend.model.Dispute;
 import org.drools.scenariosimulation.backend.model.Person;
 import org.drools.scenariosimulation.backend.runner.model.InstanceGiven;
-import org.drools.scenariosimulation.backend.runner.model.ResultWrapper;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioExpect;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResult;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioResultMetadata;
 import org.drools.scenariosimulation.backend.runner.model.ScenarioRunnerData;
+import org.drools.scenariosimulation.backend.runner.model.ValueWrapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -387,23 +387,23 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
     public void createExtractorFunctionTest() {
         String personName = "Test";
         FactMappingValue factMappingValue = new FactMappingValue(personFactIdentifier, firstNameGivenExpressionIdentifier, personName);
-        Function<Object, ResultWrapper> extractorFunction = runnerHelper.createExtractorFunction(expressionEvaluator, factMappingValue, simulation.getScesimModelDescriptor());
+        Function<Object, ValueWrapper> extractorFunction = runnerHelper.createExtractorFunction(expressionEvaluator, factMappingValue, simulation.getScesimModelDescriptor());
         Person person = new Person();
 
         person.setFirstName(personName);
-        assertTrue(extractorFunction.apply(person).isSatisfied());
+        assertTrue(extractorFunction.apply(person).isValid());
 
         person.setFirstName("OtherString");
-        assertFalse(extractorFunction.apply(person).isSatisfied());
+        assertFalse(extractorFunction.apply(person).isValid());
 
-        Function<Object, ResultWrapper> extractorFunction1 = runnerHelper.createExtractorFunction(expressionEvaluator,
+        Function<Object, ValueWrapper> extractorFunction1 = runnerHelper.createExtractorFunction(expressionEvaluator,
                                                                                                   new FactMappingValue(personFactIdentifier,
                                                                                                                        firstNameGivenExpressionIdentifier,
                                                                                                                        null),
                                                                                                   simulation.getScesimModelDescriptor());
-        ResultWrapper nullValue = extractorFunction1.apply(new Person());
-        assertTrue(nullValue.isSatisfied());
-        assertNull(nullValue.getResult());
+        ValueWrapper nullValue = extractorFunction1.apply(new Person());
+        assertTrue(nullValue.isValid());
+        assertNull(nullValue.getValue());
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -433,22 +433,22 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         Map<List<String>, Object> paramsToSet = new HashMap<>();
         paramsToSet.put(emptyList(), "Test");
 
-        assertEquals("Test", runnerHelper.getDirectMapping(paramsToSet).getResult());
+        assertEquals("Test", runnerHelper.getDirectMapping(paramsToSet).getValue());
 
         paramsToSet.clear();
         paramsToSet.put(emptyList(), 1);
 
-        assertEquals(1, runnerHelper.getDirectMapping(paramsToSet).getResult());
+        assertEquals(1, runnerHelper.getDirectMapping(paramsToSet).getValue());
 
         paramsToSet.clear();
         paramsToSet.put(emptyList(), null);
 
-        assertNull(runnerHelper.getDirectMapping(paramsToSet).getResult());
+        assertNull(runnerHelper.getDirectMapping(paramsToSet).getValue());
 
         paramsToSet.clear();
 
-        ResultWrapper<Object> directMapping = runnerHelper.getDirectMapping(paramsToSet);
-        assertFalse(directMapping.isSatisfied());
+        ValueWrapper<Object> directMapping = runnerHelper.getDirectMapping(paramsToSet);
+        assertFalse(directMapping.isValid());
         assertEquals("No direct mapping available", directMapping.getErrorMessage().get());
     }
 
@@ -458,7 +458,7 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         params.put(singletonList("firstName"), "TestName");
         params.put(singletonList("age"), 10);
 
-        Optional<Object> initialInstance = runnerHelper.getDirectMapping(params).getOptional();
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
         Object objectRaw = runnerHelper.createObject(
                 initialInstance,
                 Person.class.getCanonicalName(),
@@ -477,7 +477,7 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         String directMappingSimpleTypeValue = "TestName";
         params.put(Collections.emptyList(), directMappingSimpleTypeValue);
 
-        Optional<Object> initialInstance = runnerHelper.getDirectMapping(params).getOptional();
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
         Object objectRaw = runnerHelper.createObject(
                 initialInstance,
                 String.class.getCanonicalName(),
@@ -498,7 +498,7 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         params.put(emptyList(), directMappingComplexTypeValue);
         params.put(singletonList("age"), 10);
 
-        Optional<Object> initialInstance = runnerHelper.getDirectMapping(params).getOptional();
+        ValueWrapper<Object> initialInstance = runnerHelper.getDirectMapping(params);
         Object objectRaw = runnerHelper.createObject(
                 initialInstance,
                 Map.class.getCanonicalName(),

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/model/ValueWrapperTest.java
@@ -21,19 +21,19 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class ResultWrapperTest {
+public class ValueWrapperTest {
 
     @Test
     public void orElse() {
-        assertEquals((Integer) 1, ResultWrapper.createResult(1).orElse(3));
-        assertEquals(3, ResultWrapper.createErrorResult(null, null).orElse(3));
-        assertNull(ResultWrapper.createResult(null).orElse(3));
+        assertEquals((Integer) 1, ValueWrapper.of(1).orElse(3));
+        assertEquals(3, ValueWrapper.errorWithValidValue(null, null).orElse(3));
+        assertNull(ValueWrapper.of(null).orElse(3));
     }
 
     @Test
     public void orElseGet() {
-        assertEquals((Integer) 1, ResultWrapper.createResult(1).orElseGet(() -> 3));
-        assertEquals(3, ResultWrapper.createErrorResult(null, null).orElseGet(() -> 3));
-        assertNull(ResultWrapper.createResult(null).orElseGet(() -> 3));
+        assertEquals((Integer) 1, ValueWrapper.of(1).orElseGet(() -> 3));
+        assertEquals(3, ValueWrapper.errorWithValidValue(null, null).orElseGet(() -> 3));
+        assertNull(ValueWrapper.of(null).orElseGet(() -> 3));
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.drools.scenariosimulation.backend.model.Dispute;
 import org.drools.scenariosimulation.backend.model.NotEmptyConstructor;
@@ -35,6 +34,8 @@ import org.junit.Test;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.drools.scenariosimulation.backend.runner.model.ValueWrapper.errorEmptyMessage;
+import static org.drools.scenariosimulation.backend.runner.model.ValueWrapper.of;
 import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.convertValue;
 import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.getField;
 import static org.drools.scenariosimulation.backend.util.ScenarioBeanUtil.loadClass;
@@ -57,7 +58,7 @@ public class ScenarioBeanUtilTest {
         paramsToSet.put(Arrays.asList("creator", "firstName"), FIRST_NAME);
         paramsToSet.put(Arrays.asList("creator", "age"), AGE);
 
-        Object result = ScenarioBeanUtil.fillBean(Optional.empty(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+        Object result = ScenarioBeanUtil.fillBean(errorEmptyMessage(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
 
         assertTrue(result instanceof Dispute);
 
@@ -74,7 +75,7 @@ public class ScenarioBeanUtilTest {
         paramsToSet.put(Arrays.asList("creator", "firstName"), FIRST_NAME);
         paramsToSet.put(Arrays.asList("creator", "age"), AGE);
 
-        Object result = ScenarioBeanUtil.fillBean(Optional.of(dispute), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+        Object result = ScenarioBeanUtil.fillBean(of(dispute), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
 
         assertTrue(result instanceof Dispute);
         assertSame(dispute, result);
@@ -85,7 +86,7 @@ public class ScenarioBeanUtilTest {
 
     @Test(expected = ScenarioException.class)
     public void fillBeanLoadClassTest() {
-        ScenarioBeanUtil.fillBean(Optional.empty(), "FakeCanonicalName", new HashMap<>(), classLoader);
+        ScenarioBeanUtil.fillBean(errorEmptyMessage(), "FakeCanonicalName", new HashMap<>(), classLoader);
     }
 
     @Test(expected = ScenarioException.class)
@@ -93,7 +94,7 @@ public class ScenarioBeanUtilTest {
         Map<List<String>, Object> paramsToSet = new HashMap<>();
         paramsToSet.put(singletonList("name"), null);
 
-        ScenarioBeanUtil.fillBean(Optional.empty(), NotEmptyConstructor.class.getCanonicalName(), paramsToSet, classLoader);
+        ScenarioBeanUtil.fillBean(errorEmptyMessage(), NotEmptyConstructor.class.getCanonicalName(), paramsToSet, classLoader);
     }
 
     @Test(expected = ScenarioException.class)
@@ -101,7 +102,7 @@ public class ScenarioBeanUtilTest {
         Map<List<String>, Object> paramsToSet = new HashMap<>();
         paramsToSet.put(singletonList("fakeField"), null);
 
-        ScenarioBeanUtil.fillBean(Optional.empty(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+        ScenarioBeanUtil.fillBean(errorEmptyMessage(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
     }
 
     @Test(expected = ScenarioException.class)
@@ -109,7 +110,7 @@ public class ScenarioBeanUtilTest {
         Map<List<String>, Object> paramsToSet = new HashMap<>();
         paramsToSet.put(singletonList("fakeField"), null);
 
-        ScenarioBeanUtil.fillBean(Optional.empty(), null, paramsToSet, classLoader);
+        ScenarioBeanUtil.fillBean(errorEmptyMessage(), null, paramsToSet, classLoader);
     }
 
     @Test(expected = ScenarioException.class)
@@ -117,7 +118,7 @@ public class ScenarioBeanUtilTest {
         Map<List<String>, Object> paramsToSet = new HashMap<>();
         paramsToSet.put(singletonList("description"), new ArrayList<>());
 
-        ScenarioBeanUtil.fillBean(Optional.empty(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+        ScenarioBeanUtil.fillBean(errorEmptyMessage(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
     }
 
     @Test

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -32,6 +32,7 @@ import org.drools.scenariosimulation.backend.runner.RuleScenarioRunnerHelperTest
 import org.drools.scenariosimulation.backend.runner.ScenarioException;
 import org.junit.Test;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.drools.scenariosimulation.backend.runner.model.ValueWrapper.errorEmptyMessage;
@@ -119,6 +120,14 @@ public class ScenarioBeanUtilTest {
         paramsToSet.put(singletonList("description"), new ArrayList<>());
 
         ScenarioBeanUtil.fillBean(errorEmptyMessage(), Dispute.class.getCanonicalName(), paramsToSet, classLoader);
+    }
+
+    @Test
+    public void fillBeanEmptyValueTest() {
+        Map<List<String>, Object> paramsToSet = new HashMap<>();
+        paramsToSet.put(emptyList(), null);
+
+        ScenarioBeanUtil.fillBean(of(null), String.class.getCanonicalName(), paramsToSet, classLoader);
     }
 
     @Test

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioBeanUtilTest.java
@@ -127,7 +127,7 @@ public class ScenarioBeanUtilTest {
         Map<List<String>, Object> paramsToSet = new HashMap<>();
         paramsToSet.put(emptyList(), null);
 
-        ScenarioBeanUtil.fillBean(of(null), String.class.getCanonicalName(), paramsToSet, classLoader);
+        assertNull(ScenarioBeanUtil.fillBean(of(null), String.class.getCanonicalName(), paramsToSet, classLoader));
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5316

Code changes:
- `AbstractScenarioRunnerHelper.createObject`: use `ValueWrapper` instead of `Optional` to distinguish `null` value and missing value (see `DMNScenarioRunnerHelper.createObject` impl)
- Refactor `ResultWrapper` to `ValueWrapper`: removed `getOptional` method (it was just wrong :) ) and renamed to be used as generic value wrapper
- Added additional tests to `DMNScenarioRunnerHelperTest`, `RuleScenarioRunnerHelperTest` and `ScenarioBeanUtilTest` to improve the coverage