### PR TITLE
[DROOLS-5325] Make DMN use dmn-bom and remove duplicated dependency declaration

### DIFF
--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -33,33 +33,10 @@
 
       <dependency>
         <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-api</artifactId>
+        <artifactId>kie-dmn-bom</artifactId>
         <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-model</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-feel</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-backend</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-core</artifactId>   
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.xmlunit</groupId>
-        <artifactId>xmlunit-core</artifactId>
-        <version>2.2.1</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5325

Use inherited version of `org.xmlunit:xmlunit-core` and import `kie-dmn-bom` to remove explicit module declaration