### PR TITLE
[DROOLS-5326] Make LambdaIntrospector.methodFingerprintsMap cache siz…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/LambdaIntrospector.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/LambdaIntrospector.java
@@ -35,7 +35,9 @@ import org.mvel2.asm.Opcodes;
 
 public class LambdaIntrospector implements LambdaPrinter {
 
-    private static final int CACHE_SIZE = 32;
+    public static final String LAMBDA_INTROSPECTOR_CACHE_SIZE = "drools.lambda.introspector.cache.size";
+
+    private static final int CACHE_SIZE = Integer.parseInt(System.getProperty(LAMBDA_INTROSPECTOR_CACHE_SIZE, "32"));
 
     private static final Map<ClassIdentifier, Map<String, String>> methodFingerprintsMap = new LinkedHashMap() {
         @Override

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
@@ -50,13 +50,15 @@ public class LambdaIntrospectorTest {
         // System.setProperty(LambdaIntrospector.LAMBDA_INTROSPECTOR_CACHE_SIZE, "0");
 
         LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
-        Predicate1<Person> predicate1 = p -> p.getAge() > 35;
-        lambdaIntrospector.getLambdaFingerprint(predicate1);
 
         Field field = LambdaIntrospector.class.getDeclaredField("methodFingerprintsMap");
         field.setAccessible(true);
         // LambdaIntrospector.ClassIdentifier is not visible so the Map is not parameterized
         Map methodFingerprintsMap = (Map) field.get(lambdaIntrospector);
+        methodFingerprintsMap.clear();
+
+        Predicate1<Person> predicate1 = p -> p.getAge() > 35;
+        lambdaIntrospector.getLambdaFingerprint(predicate1);
 
         assertEquals(1, methodFingerprintsMap.size()); // 0 if you set the property to 0
     }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
@@ -1,0 +1,63 @@
+package org.drools.modelcompiler.util;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.drools.model.functions.Predicate1;
+import org.drools.modelcompiler.domain.Person;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class LambdaIntrospectorTest {
+
+    @Test
+    public void testLambdaFingerprint() {
+        LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
+        Predicate1<Person> predicate1 = p -> p.getAge() > 35;
+        String fingerprint = lambdaIntrospector.getLambdaFingerprint(predicate1);
+
+        assertThat(fingerprint, containsString("ALOAD 0"));
+        assertThat(fingerprint, containsString("INVOKEVIRTUAL org/drools/modelcompiler/domain/Person.getAge()I"));
+    }
+
+    @Test
+    public void testMaterializedLambdaFingerprint() {
+        LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
+        String fingerprint = lambdaIntrospector.getLambdaFingerprint(LambdaPredicate21D56248F6A2E8DA3990031D77D229DD.INSTANCE);
+
+        assertEquals("4DEB93975D9859892B1A5FD4B38E2155", fingerprint);
+    }
+
+    public enum LambdaPredicate21D56248F6A2E8DA3990031D77D229DD implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person> {
+
+        INSTANCE;
+
+        public static final String EXPRESSION_HASH = "4DEB93975D9859892B1A5FD4B38E2155";
+
+        @Override()
+        public boolean test(org.drools.modelcompiler.domain.Person p) {
+            return p.getAge() > 35;
+        }
+    }
+
+    @Test
+    public void testMethodFingerprintsMapCacheSize() throws Exception {
+        // Because methodFingerprintsMap is static, this property can be testable when you run this test method only
+        // (mvn test -Dtest=LambdaIntrospectorTest#testMethodFingerprintsMapCacheSize)
+        // System.setProperty(LambdaIntrospector.LAMBDA_INTROSPECTOR_CACHE_SIZE, "0");
+
+        LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
+        Predicate1<Person> predicate1 = p -> p.getAge() > 35;
+        lambdaIntrospector.getLambdaFingerprint(predicate1);
+
+        Field field = LambdaIntrospector.class.getDeclaredField("methodFingerprintsMap");
+        field.setAccessible(true);
+        // LambdaIntrospector.ClassIdentifier is not visible so the Map is not parameterized
+        Map methodFingerprintsMap = (Map) field.get(lambdaIntrospector);
+
+        assertEquals(1, methodFingerprintsMap.size()); // 0 if you set the property to 0
+    }
+}


### PR DESCRIPTION
…e configurable

Now you can set LambdaIntrospector.methodFingerprintsMap cache size with system property `drools.lambda.introspector.cache.size`:

for example)
`-Ddrools.lambda.introspector.cache.size=0`

Default size is 32.