### PR TITLE
DROOLS-5351 - Allow to provide relative resource resolver for DMN runtime

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerConfigurationImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerConfigurationImpl.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
+
 package org.kie.dmn.core.compiler;
 
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import org.kie.api.conf.Option;
 import org.kie.dmn.api.core.AfterGeneratingSourcesListener;
@@ -40,7 +39,6 @@ public class DMNCompilerConfigurationImpl implements DMNCompilerConfiguration {
     private ClassLoader rootClassLoader = ClassLoaderUtil.findDefaultClassLoader();
     private List<AfterGeneratingSourcesListener> listeners = new ArrayList<>();
     private Boolean deferredCompilation = false;
-    private Function<String, Reader> relativeResolver;
 
     public void addExtensions(List<DMNExtensionRegister> extensionRegisters) {
         this.registeredExtensions.addAll(extensionRegisters);
@@ -121,13 +119,5 @@ public class DMNCompilerConfigurationImpl implements DMNCompilerConfiguration {
 
     public void setDeferredCompilation(Boolean deferredCompilation) {
         this.deferredCompilation = deferredCompilation;
-    }
-
-    public Function<String, Reader> getRelativeResolver() {
-        return relativeResolver;
-    }
-
-    public void setRelativeResolver(Function<String, Reader> relativeResolver) {
-        this.relativeResolver = relativeResolver;
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerConfigurationImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerConfigurationImpl.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-
 package org.kie.dmn.core.compiler;
 
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.kie.api.conf.Option;
 import org.kie.dmn.api.core.AfterGeneratingSourcesListener;
@@ -39,6 +40,7 @@ public class DMNCompilerConfigurationImpl implements DMNCompilerConfiguration {
     private ClassLoader rootClassLoader = ClassLoaderUtil.findDefaultClassLoader();
     private List<AfterGeneratingSourcesListener> listeners = new ArrayList<>();
     private Boolean deferredCompilation = false;
+    private Function<String, Reader> relativeResolver;
 
     public void addExtensions(List<DMNExtensionRegister> extensionRegisters) {
         this.registeredExtensions.addAll(extensionRegisters);
@@ -119,5 +121,13 @@ public class DMNCompilerConfigurationImpl implements DMNCompilerConfiguration {
 
     public void setDeferredCompilation(Boolean deferredCompilation) {
         this.deferredCompilation = deferredCompilation;
+    }
+
+    public Function<String, Reader> getRelativeResolver() {
+        return relativeResolver;
+    }
+
+    public void setRelativeResolver(Function<String, Reader> relativeResolver) {
+        this.relativeResolver = relativeResolver;
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -287,12 +287,12 @@ public class DMNCompilerImpl implements DMNCompiler {
     }
 
     protected static Resource resolveRelativeResource(ClassLoader classLoader, DMNModelImpl model, Import i, DMNModelInstrumentedBase node, Function<String, Reader> relativeResolver) {
-        if (model.getResource() != null) {
-            URL pmmlURL = pmmlImportURL(classLoader, model, i, node);
-            return ResourceFactory.newUrlResource(pmmlURL);
-        } else if (relativeResolver != null) {
+        if (relativeResolver != null) {
             Reader reader = relativeResolver.apply(i.getLocationURI());
             return ResourceFactory.newReaderResource(reader);
+        } else if (model.getResource() != null) {
+            URL pmmlURL = pmmlImportURL(classLoader, model, i, node);
+            return ResourceFactory.newUrlResource(pmmlURL);
         }
         throw new UnsupportedOperationException("Unable to determine relative Resource for import named: " + i.getName());
     }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -173,7 +173,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     @Override
     public DMNModel compile(Definitions dmndefs, Collection<DMNModel> dmnModels) {
         try {
-            return compile(dmndefs, dmnModels, null, ((DMNCompilerConfigurationImpl) dmnCompilerConfig).getRelativeResolver());
+            return compile(dmndefs, dmnModels, null, null);
         } catch (Exception e) {
             logger.error("Error compiling model from source.", e);
         }
@@ -183,7 +183,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     @Override
     public DMNModel compile(Definitions dmndefs, Resource resource, Collection<DMNModel> dmnModels) {
         try {
-            return compile(dmndefs, dmnModels, resource, ((DMNCompilerConfigurationImpl) dmnCompilerConfig).getRelativeResolver());
+            return compile(dmndefs, dmnModels, resource, null);
         } catch (Exception e) {
             logger.error("Error compiling model from source.", e);
         }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNCompilerImpl.java
@@ -173,7 +173,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     @Override
     public DMNModel compile(Definitions dmndefs, Collection<DMNModel> dmnModels) {
         try {
-            return compile(dmndefs, dmnModels, null, null);
+            return compile(dmndefs, dmnModels, null, ((DMNCompilerConfigurationImpl) dmnCompilerConfig).getRelativeResolver());
         } catch (Exception e) {
             logger.error("Error compiling model from source.", e);
         }
@@ -183,7 +183,7 @@ public class DMNCompilerImpl implements DMNCompiler {
     @Override
     public DMNModel compile(Definitions dmndefs, Resource resource, Collection<DMNModel> dmnModels) {
         try {
-            return compile(dmndefs, dmnModels, resource, null);
+            return compile(dmndefs, dmnModels, resource, ((DMNCompilerConfigurationImpl) dmnCompilerConfig).getRelativeResolver());
         } catch (Exception e) {
             logger.error("Error compiling model from source.", e);
         }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilder.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilder.java
@@ -17,6 +17,7 @@
 package org.kie.dmn.core.internal.utils;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -66,6 +67,7 @@ public class DMNRuntimeBuilder {
     private static class DMNRuntimeBuilderCtx {
 
         public final DMNCompilerConfigurationImpl cc;
+
         public final List<DMNProfile> dmnProfiles = new ArrayList<>();
 
         public DMNRuntimeBuilderCtx() {
@@ -101,6 +103,11 @@ public class DMNRuntimeBuilder {
         return this;
     }
 
+    public DMNRuntimeBuilder setRelativeResolver(Function<String, Reader> relativeResolver) {
+        ctx.cc.setRelativeResolver(relativeResolver);
+        return this;
+    }
+
     /**
      * Internal Utility class.
      */
@@ -124,6 +131,7 @@ public class DMNRuntimeBuilder {
         private static final Logger LOG = LoggerFactory.getLogger(DMNRuntimeBuilderConfigured.class);
 
         private final DMNRuntimeBuilderCtx ctx;
+
         private final DMNCompiler dmnCompiler;
 
         private DMNRuntimeBuilderConfigured(DMNRuntimeBuilderCtx ctx, DMNCompiler dmnCompiler) {
@@ -185,10 +193,10 @@ public class DMNRuntimeBuilder {
         }
     }
 
-
     private static class DMNRuntimeKBStatic implements DMNRuntimeKB {
 
         private final List<DMNProfile> dmnProfiles;
+
         private final List<DMNModel> models;
 
         private DMNRuntimeKBStatic(Collection<DMNModel> models, Collection<DMNProfile> dmnProfiles) {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilder.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/internal/utils/DMNRuntimeBuilder.java
@@ -192,7 +192,7 @@ public class DMNRuntimeBuilder {
                                                                                                                        dmnRes.getDefinitions().getName(),
                                                                                                                        relativeURI));
                     } else {
-                        LOG.error("specified a RelativeImportResolver but the compiler is not org.kie.dmn.core.compiler.DMNCompilerImpl");
+                        throw new IllegalStateException("specified a RelativeImportResolver but the compiler is not org.kie.dmn.core.compiler.DMNCompilerImpl");
                     }
                 } else {
                     dmnModel = dmnCompiler.compile(dmnRes.getDefinitions(), dmnRes.getResAndConfig().getResource(), dmnModels);

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/pmml/DMNRuntimePMMLTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/pmml/DMNRuntimePMMLTest.java
@@ -16,7 +16,9 @@
 
 package org.kie.dmn.core.pmml;
 
+import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.drools.compiler.kie.builder.impl.DrlProject;
@@ -39,10 +41,12 @@ import org.kie.dmn.core.assembler.DMNAssemblerService;
 import org.kie.dmn.core.impl.CompositeTypeImpl;
 import org.kie.dmn.core.impl.DMNModelImpl;
 import org.kie.dmn.core.impl.SimpleTypeImpl;
+import org.kie.dmn.core.internal.utils.DMNRuntimeBuilder;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.internal.builder.IncrementalResults;
 import org.kie.internal.builder.InternalKieBuilder;
+import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.services.KieAssemblersImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +84,16 @@ public class DMNRuntimePMMLTest {
                                                                                        DMNRuntimePMMLTest.class,
                                                                                        "test_scorecard.pmml");
         runDMNModelInvokingPMML(runtime);
+    }
+
+    @Test
+    public void testBasicNoKieAssembler() {
+        DMNRuntime dmnRuntime = DMNRuntimeBuilder.fromDefaults()
+                                                 .setRelativeImportResolver((ns, n, uri) -> new InputStreamReader(DMNRuntimePMMLTest.class.getResourceAsStream(uri)))
+                                                 .buildConfiguration()
+                                                 .fromResources(Arrays.asList(ResourceFactory.newClassPathResource("KiePMMLScoreCard.dmn", DMNRuntimePMMLTest.class)))
+                                                 .getOrElseThrow(e -> new RuntimeException("Error compiling DMN model(s)", e));
+        runDMNModelInvokingPMML(dmnRuntime);
     }
 
     static void runDMNModelInvokingPMML(final DMNRuntime runtime) {


### PR DESCRIPTION
@tarilabs could you please have a look and let me know if this has any side effects? We would like to pass resources not from the class loader so using relativeResolver seems to work.
In general it makes sense to have the resolver checked first before going via the resource which seems to always be there as it is the dmn resource if I got it right.

If this could be the way to go maybe we could expose the relative resolver as well via DMNRuntimeBuilder...