### PR TITLE
[DROOLS-5346] Enhance unit test to detect non-externalized lambda widely

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
@@ -22,16 +22,21 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.printer.PrettyPrinter;
-import org.drools.modelcompiler.util.lambdareplace.DoNotConvertLambdaException;
 import org.drools.modelcompiler.util.lambdareplace.ExecModelLambdaPostProcessor;
+import org.drools.modelcompiler.util.lambdareplace.NonExternalisedLambdaFoundException;
 
 import static org.drools.modelcompiler.builder.JavaParserCompiler.getPrettyPrinter;
 
 public class RuleWriter {
+
+    public static final String DROOLS_CHECK_NON_EXTERNALISED_LAMBDA = "drools.check.nonExternalisedLambda";
+    private static final boolean CHECK_NON_EXTERNALISED_LAMBDA = Boolean.parseBoolean(System.getProperty(DROOLS_CHECK_NON_EXTERNALISED_LAMBDA, "false"));
 
     private final PrettyPrinter prettyPrinter = getPrettyPrinter();
 
@@ -82,6 +87,9 @@ public class RuleWriter {
                                 pkgModel.getStaticImports(),
                                 postProcessedCU
                         ).convertLambdas();
+                        if (CHECK_NON_EXTERNALISED_LAMBDA) {
+                            checkNonExternalisedLambda(postProcessedCU);
+                        }
                     }
                     rules.add(new RuleFileSource(addFileName, postProcessedCU));
                 } else {
@@ -90,6 +98,16 @@ public class RuleWriter {
             }
         }
         return rules;
+    }
+
+    private void checkNonExternalisedLambda(CompilationUnit postProcessedCU) {
+        List<LambdaExpr> lambdaExprs = postProcessedCU.findAll(LambdaExpr.class).stream().collect(Collectors.toList());
+        if (lambdaExprs.isEmpty()) {
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        lambdaExprs.stream().forEach(lExpr -> sb.append(lExpr.toString() + "\n"));
+        throw new NonExternalisedLambdaFoundException("Non externalised lambda found in " + rulesFileName + "\n" + sb.toString());
     }
 
     public class RuleFileSource {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/NonExternalisedLambdaFoundException.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/NonExternalisedLambdaFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.util.lambdareplace;
+
+public class NonExternalisedLambdaFoundException extends RuntimeException {
+
+    public NonExternalisedLambdaFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This commit doesn't affect runtime or unit tests by default. If you enable both of 2 properties to 'true',
- drools.externaliseCanonicalModelLambda
- drools.check.nonExternalisedLambda

executable model throws NonExternalisedLambdaFoundException when generated source codes contain non-externalized lambdas.
 
For example, if you add the following code to BaseModelTest, you can easily check if unit tests generate non-externalized lambda or not.

```
public abstract class BaseModelTest {
    
    static {
        System.setProperty("drools.externaliseCanonicalModelLambda", "true");
        System.setProperty("drools.check.nonExternalisedLambda", "true");
    }
```
