### PR TITLE
[DROOLS-5348] Lambda predicate is not externalized when a binding var…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/RuleWriter.java
@@ -36,7 +36,7 @@ import static org.drools.modelcompiler.builder.JavaParserCompiler.getPrettyPrint
 public class RuleWriter {
 
     public static final String DROOLS_CHECK_NON_EXTERNALISED_LAMBDA = "drools.check.nonExternalisedLambda";
-    private static final boolean CHECK_NON_EXTERNALISED_LAMBDA = Boolean.parseBoolean(System.getProperty(DROOLS_CHECK_NON_EXTERNALISED_LAMBDA, "false"));
+    private static boolean checkNonExternalisedLambda = Boolean.parseBoolean(System.getProperty(DROOLS_CHECK_NON_EXTERNALISED_LAMBDA, "false"));
 
     private final PrettyPrinter prettyPrinter = getPrettyPrinter();
 
@@ -87,7 +87,7 @@ public class RuleWriter {
                                 pkgModel.getStaticImports(),
                                 postProcessedCU
                         ).convertLambdas();
-                        if (CHECK_NON_EXTERNALISED_LAMBDA) {
+                        if (checkNonExternalisedLambda) {
                             checkNonExternalisedLambda(postProcessedCU);
                         }
                     }
@@ -108,6 +108,12 @@ public class RuleWriter {
         StringBuilder sb = new StringBuilder();
         lambdaExprs.stream().forEach(lExpr -> sb.append(lExpr.toString() + "\n"));
         throw new NonExternalisedLambdaFoundException("Non externalised lambda found in " + rulesFileName + "\n" + sb.toString());
+    }
+    public static boolean isCheckNonExternalisedLambda() {
+        return checkNonExternalisedLambda;
+    }
+    public static void setCheckNonExternalisedLambda(boolean checkNonExternalisedLambda) {
+        RuleWriter.checkNonExternalisedLambda = checkNonExternalisedLambda;
     }
 
     public class RuleFileSource {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -517,7 +517,7 @@ public class DrlxParseUtil {
     }
 
     private static boolean canResolveAllParameterTypes(Collection<String> usedDeclarations, boolean skipFirstParamAsThis, Optional<Class<?>> patternClass, RuleContext ruleContext) {
-        if (!skipFirstParamAsThis && (!patternClass.isPresent() || patternClass.get().equals(Object.class))) {
+        if (!skipFirstParamAsThis && !patternClass.isPresent()) {
             return false;
         }
         if (usedDeclarations.isEmpty()) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -477,24 +477,62 @@ public class DrlxParseUtil {
                                                              Expression expr,
                                                              boolean skipFirstParamAsThis,
                                                              Optional<Class<?>> patternClass) {
+        return generateLambdaWithoutParameters(usedDeclarations, expr, skipFirstParamAsThis, patternClass, null);
+    }
+    public static Expression generateLambdaWithoutParameters(Collection<String> usedDeclarations,
+                                                             Expression expr,
+                                                             boolean skipFirstParamAsThis,
+                                                             Optional<Class<?>> patternClass,
+                                                             RuleContext ruleContext) {
         DrlxParseUtil.transformDrlNameExprToNameExpr(expr);
         if (skipFirstParamAsThis && usedDeclarations.isEmpty()) {
             return expr;
         }
         LambdaExpr lambdaExpr = new LambdaExpr();
-        lambdaExpr.setEnclosingParameters( true );
+        lambdaExpr.setEnclosingParameters(true);
+
+        // Only when we can resolve all parameter types, do it
+        boolean canResolve = canResolveAllParameterTypes(usedDeclarations, skipFirstParamAsThis, patternClass, ruleContext);
         if (!skipFirstParamAsThis) {
             Type type;
-            if(patternClass.isPresent() && usedDeclarations.isEmpty() && patternClass.filter(c -> !Object.class.equals(c)).isPresent()) {
+            if (canResolve) {
                 type = StaticJavaParser.parseClassOrInterfaceType(patternClass.get().getCanonicalName());
             } else {
                 type = new UnknownType();
             }
             lambdaExpr.addParameter(new Parameter(type, THIS_PLACEHOLDER));
         }
-        usedDeclarations.stream().map( s -> new Parameter( new UnknownType(), s ) ).forEach( lambdaExpr::addParameter );
-        lambdaExpr.setBody( new ExpressionStmt(expr) );
+        usedDeclarations.stream()
+                        .map(s -> {
+                            if (canResolve) {
+                                return new Parameter(getDelarationType(ruleContext, s), s);
+                            } else {
+                                return new Parameter(new UnknownType(), s);
+                            }
+                        })
+                        .forEach(lambdaExpr::addParameter);
+
+        lambdaExpr.setBody(new ExpressionStmt(expr));
         return lambdaExpr;
+    }
+
+    private static boolean canResolveAllParameterTypes(Collection<String> usedDeclarations, boolean skipFirstParamAsThis, Optional<Class<?>> patternClass, RuleContext ruleContext) {
+        if (!skipFirstParamAsThis && (!patternClass.isPresent() || patternClass.get().equals(Object.class))) {
+            return false;
+        }
+        if (usedDeclarations.isEmpty()) {
+            return true;
+        }
+        return usedDeclarations.stream().map(decl -> getDelarationType(ruleContext, decl)).noneMatch(type -> type instanceof UnknownType);
+    }
+
+    private static Type getDelarationType(RuleContext ruleContext, String variableName) {
+        if (ruleContext == null) {
+            return new UnknownType();
+        }
+        return ruleContext.getDeclarationById(variableName)
+                          .map(DeclarationSpec::getBoxedType)
+                          .orElseGet(UnknownType::new);
     }
 
     public static TypedExpression toMethodCallWithClassCheck(RuleContext context, Expression expr, String bindingId, Class<?> clazz, TypeResolver typeResolver) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -153,7 +153,7 @@ public abstract class AbstractExpressionBuilder {
         return drlxParseResult.isStatic() ? expr :
                 generateLambdaWithoutParameters(usedDeclarations,
                                                 expr,
-                                                drlxParseResult.isSkipThisAsParam(), ofNullable(drlxParseResult.getPatternType()));
+                                                drlxParseResult.isSkipThisAsParam(), ofNullable(drlxParseResult.getPatternType()), context);
     }
 
     boolean hasIndex( SingleDrlxParseSuccess drlxParseResult ) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -278,6 +278,7 @@ public abstract class AccumulateVisitor {
             Optional<DeclarationSpec> accumulateClassDeclOpt = context.getDeclarationById(inputId);
             if (!decl.isPresent() && accumulateClassDeclOpt.isPresent()) {
                 // when static method is used in accumulate function, "_this" is a pattern input
+                // Note that DrlxParseUtil.generateLambdaWithoutParameters() takes the patternType as a class of "_this"
                 paramExprBindingId = inputId;
                 patternType = accumulateClassDeclOpt.get().getDeclarationClass();
             }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -46,6 +46,7 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
     @Override
     void createMethodDeclaration(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("test", Modifier.Keyword.PUBLIC);
+        methodDeclaration.setThrownExceptions(NodeList.nodeList(parseClassOrInterfaceType("java.lang.Exception")));
         methodDeclaration.addAnnotation("Override");
         methodDeclaration.setType(new PrimitiveType(PrimitiveType.Primitive.BOOLEAN));
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ExternalisedLambdaTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ExternalisedLambdaTest.java
@@ -62,7 +62,6 @@ public class ExternalisedLambdaTest extends BaseModelTest {
                      "end";
 
         KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
-        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
         KieSession ksession = null;
         try {
             ksession = getKieSession(kieModuleModel, str);
@@ -89,7 +88,6 @@ public class ExternalisedLambdaTest extends BaseModelTest {
                      "end";
 
         KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
-        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
         KieSession ksession = null;
         try {
             ksession = getKieSession(kieModuleModel, str);
@@ -120,7 +118,6 @@ public class ExternalisedLambdaTest extends BaseModelTest {
                      "end";
 
         KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
-        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
         KieSession ksession = null;
         try {
             ksession = getKieSession(kieModuleModel, str);
@@ -152,7 +149,6 @@ public class ExternalisedLambdaTest extends BaseModelTest {
                      "end";
 
         KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
-        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
         KieSession ksession = null;
         try {
             ksession = getKieSession(kieModuleModel, str);

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ExternalisedLambdaTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ExternalisedLambdaTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.drools.modelcompiler.builder.RuleWriter;
+import org.drools.modelcompiler.domain.Person;
+import org.drools.modelcompiler.util.lambdareplace.NonExternalisedLambdaFoundException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ExternalisedLambdaTest extends BaseModelTest {
+
+    public ExternalisedLambdaTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Before
+    public void init() {
+        RuleWriter.setCheckNonExternalisedLambda(true);
+    }
+
+    @After
+    public void clear() {
+        RuleWriter.setCheckNonExternalisedLambda(false);
+    }
+
+    @Test
+    public void testConsequenceNoVariable() throws Exception {
+        // DROOLS-4924
+        String str =
+                "package defaultpkg;\n" +
+                     "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "  $p : Person(name == \"Mario\")\n" +
+                     "then\n" +
+                     "  System.out.println(\"Hello\");\n" +
+                     "end";
+
+        KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
+        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
+        KieSession ksession = null;
+        try {
+            ksession = getKieSession(kieModuleModel, str);
+        } catch (NonExternalisedLambdaFoundException e) {
+            fail(e.getMessage());
+        }
+
+        Person me = new Person("Mario", 40);
+        ksession.insert(me);
+
+        assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testExternalizeBindingVariableLambda() throws Exception {
+        String str =
+                "package defaultpkg;\n" +
+                     "import " + Person.class.getCanonicalName() + ";" +
+                     "global java.util.List list;\n" +
+                     "rule R when\n" +
+                     "  $p : Person($n : name == \"Mario\")\n" +
+                     "then\n" +
+                     "  list.add($n);\n" +
+                     "end";
+
+        KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
+        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
+        KieSession ksession = null;
+        try {
+            ksession = getKieSession(kieModuleModel, str);
+        } catch (NonExternalisedLambdaFoundException e) {
+            fail(e.getMessage());
+        }
+
+        final List<String> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+
+        Person me = new Person("Mario", 40);
+        ksession.insert(me);
+        ksession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Mario");
+    }
+
+    @Test
+    public void testExternalizeLambdaPredicate() throws Exception {
+        String str =
+                "package defaultpkg;\n" +
+                     "import " + Person.class.getCanonicalName() + ";" +
+                     "global java.util.List list;\n" +
+                     "rule R when\n" +
+                     "  $p : Person(name == \"Mario\")\n" +
+                     "then\n" +
+                     "  list.add($p.getName());\n" +
+                     "end";
+
+        KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
+        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
+        KieSession ksession = null;
+        try {
+            ksession = getKieSession(kieModuleModel, str);
+        } catch (NonExternalisedLambdaFoundException e) {
+            fail(e.getMessage());
+        }
+
+        final List<String> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+
+        Person me = new Person("Mario", 40);
+        ksession.insert(me);
+        ksession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder("Mario");
+    }
+
+    @Test
+    public void testExternalizeLambdaUsingVariable() throws Exception {
+        String str =
+                "package defaultpkg;\n" +
+                     "import " + Person.class.getCanonicalName() + ";\n" +
+                     "global java.util.List list;\n" +
+                     "rule R when\n" +
+                     "  Integer( $i : intValue )\n" +
+                     "  Person( age > $i )\n" +
+                     "then\n" +
+                     "  list.add($i);\n" +
+                     "end";
+
+        KieModuleModel kieModuleModel = KieServices.get().newKieModuleModel();
+        kieModuleModel.setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.TRUE.toString());
+        KieSession ksession = null;
+        try {
+            ksession = getKieSession(kieModuleModel, str);
+        } catch (NonExternalisedLambdaFoundException e) {
+            fail(e.getMessage());
+        }
+
+        final List<Integer> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+
+        ksession.insert(43);
+        ksession.insert(new Person("John", 44));
+        ksession.fireAllRules();
+
+        Assertions.assertThat(list).containsExactlyInAnyOrder(43);
+    }
+
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
@@ -17,16 +17,16 @@ public class MaterializedLambdaPredicateTest {
 
         //language=JAVA
         String expectedResult = "" +
-                "package org.drools.modelcompiler.util.lambdareplace.P21;\n" +
+                "package org.drools.modelcompiler.util.lambdareplace.P76;\n" +
                 "import static rulename.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "" +
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaPredicate21D56248F6A2E8DA3990031D77D229DD implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person> {\n" +
+                "public enum LambdaPredicate76225D48A900C3A3B5A4F199EDD5E88A implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person> {\n" +
                 " INSTANCE; \n" +
                 "public static final String EXPRESSION_HASH = \"4DEB93975D9859892B1A5FD4B38E2155\";" +
                 "        @Override()\n" +
-                "        public boolean test(org.drools.modelcompiler.domain.Person p) {\n" +
+                "        public boolean test(org.drools.modelcompiler.domain.Person p) throws java.lang.Exception {\n" +
                 "            return p.getAge() > 35;\n" +
                 "        }\n" +
                 "    }\n";
@@ -42,16 +42,16 @@ public class MaterializedLambdaPredicateTest {
 
         //language=JAVA
         String expectedResult = "" +
-                "package org.drools.modelcompiler.util.lambdareplace.PAA;\n" +
+                "package org.drools.modelcompiler.util.lambdareplace.PF5;\n" +
                 "import static rulename.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "" +
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaPredicateAA9C2A9BA1F03DB5742F8AC4FBFAABD9 implements org.drools.model.functions.Predicate2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>  {\n" +
+                "public enum LambdaPredicateF51471B33192ACC0504CA26C719BFCB7 implements org.drools.model.functions.Predicate2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>  {\n" +
                 " INSTANCE; \n" +
                 "public static final String EXPRESSION_HASH = \"DC57C20B4AF3C2BFEB2552943994B6F7\";" +
                 "        @Override()\n" +
-                "        public boolean test(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) {\n" +
+                "        public boolean test(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) throws java.lang.Exception {\n" +
                 "            return p1.getAge() > p2.getAge();\n" +
                 "        }\n" +
                 "    }\n";

--- a/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
+++ b/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
@@ -46,14 +46,14 @@ class PatternTestHarness {
         Rule rule = rule("beta")
                 .build(
                         pattern(markV)
-                                .expr("exprA", mypackage.P69.LambdaPredicate692822A3ABA827C58CD70BCCDF6B142C.INSTANCE,
+                                .expr("exprA", mypackage.PB4.LambdaPredicateB4BD3C13169578B6FA8E952113BF43FE.INSTANCE,
                                       alphaIndexedBy(String.class, Index.ConstraintType.EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name", "age")),
                         pattern(olderV)
-                                .expr("exprB", mypackage.PE3.LambdaPredicateE31E97736774182C8A51C4478B600F6F.INSTANCE,
+                                .expr("exprB", mypackage.PAA.LambdaPredicateAA0174191F4A6806B804030B95638BF9.INSTANCE,
                                       alphaIndexedBy(String.class, Index.ConstraintType.NOT_EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name"))
-                                .expr("exprC", markV,  mypackage.P75.LambdaPredicate750358A2A9F1C9B968C6288BBE7E0F71.INSTANCE,
+                                .expr("exprC", markV,  mypackage.PC0.LambdaPredicateC06E24C125614C09F9319B8C2B0D7A08.INSTANCE,
                                       betaIndexedBy(int.class, Index.ConstraintType.GREATER_THAN, 0, mypackage.P6F.LambdaExtractor6F66D90C869211C6AEC2E67F99D874D8.INSTANCE, mypackage.P6F.LambdaExtractor6F66D90C869211C6AEC2E67F99D874D8.INSTANCE),
                                       reactOn("age")),
                         on(olderV, markV).execute(mypackage.P73.LambdaConsequence73B957CDB8CD5D5A17BDA94A7D62ED86.INSTANCE)


### PR DESCRIPTION
…iable is involved

https://issues.redhat.com/browse/DROOLS-5348

The main fix is to add Types to lambda parameters because these Types are required for lambda externalization.

I also moved some tests from CompilerTest to ExternalisedLambdaTest for easier maintenance.