### PR TITLE
[DROOLS-5353] Avoid ClassLoader retention in LambdaIntrospector

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/LambdaIntrospector.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/LambdaIntrospector.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 import org.drools.core.util.asm.DumpMethodVisitor;
 import org.drools.model.functions.IntrospectableLambda;
@@ -36,15 +37,9 @@ import org.mvel2.asm.Opcodes;
 public class LambdaIntrospector implements LambdaPrinter {
 
     public static final String LAMBDA_INTROSPECTOR_CACHE_SIZE = "drools.lambda.introspector.cache.size";
-
     private static final int CACHE_SIZE = Integer.parseInt(System.getProperty(LAMBDA_INTROSPECTOR_CACHE_SIZE, "32"));
 
-    private static final Map<ClassIdentifier, Map<String, String>> methodFingerprintsMap = new LinkedHashMap() {
-        @Override
-        protected boolean removeEldestEntry( Map.Entry eldest) {
-            return (size() > CACHE_SIZE);
-        }
-    };
+    private static final Map<ClassLoader, Map<String, Map<String, String>>> methodFingerprintsMapPerClassLoader = new WeakHashMap<>();
 
     @Override
     public String getLambdaFingerprint(Object lambda) {
@@ -88,49 +83,33 @@ public class LambdaIntrospector implements LambdaPrinter {
         }
     }
 
-    private static Map<String, String> getFingerprintsForClass( Object lambda, SerializedLambda extracted) {
+    private static Map<String, String> getFingerprintsForClass(Object lambda, SerializedLambda extracted) {
         ClassLoader lambdaClassLoader = lambda.getClass().getClassLoader();
         String className = extracted.getCapturingClass();
-        ClassIdentifier id = new ClassIdentifier( lambdaClassLoader, className );
-        Map<String, String> fingerprints = methodFingerprintsMap.get( id );
-
-        if (fingerprints == null) {
-            LambdaIntrospector.LambdaClassVisitor visitor = new LambdaIntrospector.LambdaClassVisitor();
-            try (InputStream classStream = lambdaClassLoader.getResourceAsStream( className.replace( '.', '/' ) + ".class" )) {
-                ClassReader reader = new ClassReader( classStream);
-                reader.accept(visitor, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
-            } catch (Exception e) {
-                throw new RuntimeException( e );
-            }
-            fingerprints = visitor.getMethodsMap();
-            methodFingerprintsMap.put( id, fingerprints );
+        if (CACHE_SIZE <= 0) {
+            return getFingerPrints(lambdaClassLoader, className); // don't even create an entry
         }
-        return fingerprints;
+        Map<String, Map<String, String>> methodFingerprintsMap = methodFingerprintsMapPerClassLoader.computeIfAbsent(lambdaClassLoader, k -> new LinkedHashMap<String, Map<String, String>>() {
+
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, Map<String, String>> eldest) {
+                return (size() > CACHE_SIZE);
+            }
+        });
+        return methodFingerprintsMap.computeIfAbsent(className, k -> getFingerPrints(lambdaClassLoader, className));
     }
 
-    private static class ClassIdentifier {
-        private final ClassLoader classLoader;
-        private final String className;
-
-        private ClassIdentifier( ClassLoader classLoader, String className ) {
-            this.classLoader = classLoader;
-            this.className = className;
+    private static Map<String, String> getFingerPrints(ClassLoader lambdaClassLoader, String className) {
+        Map<String, String> fingerprints;
+        LambdaIntrospector.LambdaClassVisitor visitor = new LambdaIntrospector.LambdaClassVisitor();
+        try (InputStream classStream = lambdaClassLoader.getResourceAsStream( className.replace( '.', '/' ) + ".class" )) {
+            ClassReader reader = new ClassReader( classStream);
+            reader.accept(visitor, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+        } catch (Exception e) {
+            throw new RuntimeException( e );
         }
-
-        @Override
-        public boolean equals( Object o ) {
-            if (o instanceof ClassIdentifier) {
-                ClassIdentifier that = ( ClassIdentifier ) o;
-                return className.equals( that.className ) && classLoader == that.classLoader;
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return 31 * className.hashCode() + classLoader.hashCode();
-        }
+        fingerprints = visitor.getMethodsMap();
+        return fingerprints;
     }
 
     private static class LambdaClassVisitor extends ClassVisitor {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/LambdaIntrospector.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/LambdaIntrospector.java
@@ -41,6 +41,10 @@ public class LambdaIntrospector implements LambdaPrinter {
 
     private static final Map<ClassLoader, Map<String, Map<String, String>>> methodFingerprintsMapPerClassLoader = new WeakHashMap<>();
 
+    static Map<ClassLoader, Map<String, Map<String, String>>> getMethodFingerprintsMapPerClassLoader() {
+        return methodFingerprintsMapPerClassLoader;
+    }
+
     @Override
     public String getLambdaFingerprint(Object lambda) {
         if(lambda.toString().equals("INSTANCE")) { // Materialized lambda

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
@@ -49,13 +49,10 @@ public class LambdaIntrospectorTest {
         // (mvn test -Dtest=LambdaIntrospectorTest#testMethodFingerprintsMapCacheSize)
         // System.setProperty(LambdaIntrospector.LAMBDA_INTROSPECTOR_CACHE_SIZE, "0");
 
-        LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
-
-        Field field = LambdaIntrospector.class.getDeclaredField("methodFingerprintsMapPerClassLoader");
-        field.setAccessible(true);
-        // LambdaIntrospector.ClassIdentifier is not visible so the Map is not parameterized
-        Map<ClassLoader, Map<String, Map<String, String>>> methodFingerprintsMapPerClassLoader = (Map<ClassLoader, Map<String, Map<String, String>>>) field.get(lambdaIntrospector);
+        Map<ClassLoader, Map<String, Map<String, String>>> methodFingerprintsMapPerClassLoader = LambdaIntrospector.getMethodFingerprintsMapPerClassLoader();
         methodFingerprintsMapPerClassLoader.clear();
+
+        LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
 
         Predicate1<Person> predicate1 = p -> p.getAge() > 35;
         lambdaIntrospector.getLambdaFingerprint(predicate1);

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/LambdaIntrospectorTest.java
@@ -45,21 +45,23 @@ public class LambdaIntrospectorTest {
 
     @Test
     public void testMethodFingerprintsMapCacheSize() throws Exception {
-        // Because methodFingerprintsMap is static, this property can be testable when you run this test method only
+        // To test system property, you need to run this test method only.
         // (mvn test -Dtest=LambdaIntrospectorTest#testMethodFingerprintsMapCacheSize)
         // System.setProperty(LambdaIntrospector.LAMBDA_INTROSPECTOR_CACHE_SIZE, "0");
 
         LambdaIntrospector lambdaIntrospector = new LambdaIntrospector();
 
-        Field field = LambdaIntrospector.class.getDeclaredField("methodFingerprintsMap");
+        Field field = LambdaIntrospector.class.getDeclaredField("methodFingerprintsMapPerClassLoader");
         field.setAccessible(true);
         // LambdaIntrospector.ClassIdentifier is not visible so the Map is not parameterized
-        Map methodFingerprintsMap = (Map) field.get(lambdaIntrospector);
-        methodFingerprintsMap.clear();
+        Map<ClassLoader, Map<String, Map<String, String>>> methodFingerprintsMapPerClassLoader = (Map<ClassLoader, Map<String, Map<String, String>>>) field.get(lambdaIntrospector);
+        methodFingerprintsMapPerClassLoader.clear();
 
         Predicate1<Person> predicate1 = p -> p.getAge() > 35;
         lambdaIntrospector.getLambdaFingerprint(predicate1);
 
-        assertEquals(1, methodFingerprintsMap.size()); // 0 if you set the property to 0
+        Map<String, Map<String, String>> methodFingerprintsMap = methodFingerprintsMapPerClassLoader.get(predicate1.getClass().getClassLoader());
+
+        assertEquals(1, methodFingerprintsMap.size()); // methodFingerprintsMap is null if cache size is 0.
     }
 }


### PR DESCRIPTION
In order to avoid ClassLoader retention, this PR changes the cache to use WeakHashMap where a ClassLoader is a weak key. So if the ClassLoader is no longer used, the entry will be removed (= WeakHashMap doesn't prevent ClassLoader from being garbage-collected).

ClassIdentifier is split into ClassLoader and className so the Map structure is also split. In the WeakHashMap, methodFingerprintsMap is put as a value per className. So the methodFingerprintsMap itself isn't changed by this PR.

Now ClassLoader wouldn't leak regardless of externaliseCanonicalModelLambda is enabled or not. Btw, the cache size doesn't matter much now. Even if externaliseCanonicalModelLambda is enabled, the default value '32' wouldn't be a problem because ClassLoarders will be garbage-collected.
