### PR TITLE
RHDM-1283 Exclude transitive plexus-utils versions.

### DIFF
--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -93,6 +93,12 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
@@ -130,6 +136,10 @@
           <groupId>javax.el</groupId>
           <artifactId>javax.el-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -140,6 +150,10 @@
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHDM-1283
Related PR: https://github.com/kiegroup/kie-soup/pull/141