### PR TITLE
[DROOLS-5386] Accumulate with static method with pettern bind variable

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -2036,4 +2036,35 @@ public class AccumulateTest extends BaseModelTest {
         ksession.insert(new Person("Matteo", 38));
         ksession.fireAllRules();
     }
+
+    @Test
+    public void testAccumulateStaticMethodWithPatternBindVar() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + MyUtil.class.getCanonicalName() + ";\n" +
+                "rule R when\n" +
+                "  accumulate (\n" +
+                "       $p : Person(), $result : sum( MyUtil.add($p.getAge(), 10) ) "+
+                "         )" +
+                "then\n" +
+                "  insert($result);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert("x");
+        ksession.insert(new Person("Mark", 37));
+        ksession.insert(new Person("Edson", 35));
+        ksession.insert(new Person("Mario", 40));
+        ksession.fireAllRules();
+
+        List<Number> results = getObjectsIntoList(ksession, Number.class);
+        assertEquals(1, results.size());
+        assertEquals(142, results.get(0).intValue());
+    }
+
+    public static class MyUtil {
+        public static int add(int a, int b) {
+            return a + b;
+        }
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5386

This PR uses pattern input identifier ("$p") and its type (Person) when parsing the expression with drlxParse(). So $p is properly resolved as "_this" so it will not result in duplication.

I thought that this approach could be applied to all cases (not only static method) but if I applied, I got some failures in FLOW_DSL (I will file a JIRA and revisit). So I decided to apply only for a static method case to minimize the effect for now.