### PR TITLE
[DROOLS-5381] Implemented code-generation for TreeModel

### DIFF
--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
@@ -15,7 +15,6 @@
  */
 package org.kie.pmml.models.drools.utils;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.Model;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
@@ -63,7 +61,6 @@ public class KiePMMLDroolsModelFactoryUtils {
     }
 
     /**
-     *
      * @param dataDictionary
      * @param model
      * @param fieldTypeMap
@@ -86,7 +83,7 @@ public class KiePMMLDroolsModelFactoryUtils {
         CompilationUnit cloneCU = templateCU.clone();
         cloneCU.setPackageDeclaration(packageName);
         ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(modelClassName)
-                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND));
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + modelClassName));
         modelTemplate.setName(className);
         MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(model.getMiningFunction().value());
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
@@ -153,7 +150,6 @@ public class KiePMMLDroolsModelFactoryUtils {
 
     /**
      * Populate the <b>fieldTypeMap</b> <code>Map&lt;String, KiePMMLOriginalTypeGeneratedType&gt;</code>
-     *
      * @param body
      * @param fieldTypeMap
      */

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
@@ -56,7 +56,7 @@ public class KiePMMLDroolsModelFactoryUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(KiePMMLDroolsModelFactoryUtils.class.getName());
 
-    public KiePMMLDroolsModelFactoryUtils() {
+    private KiePMMLDroolsModelFactoryUtils() {
         // Avoid instantiation
     }
 

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtils.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.models.drools.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
+import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.Model;
+import org.kie.pmml.commons.exceptions.KiePMMLException;
+import org.kie.pmml.commons.exceptions.KiePMMLInternalException;
+import org.kie.pmml.commons.model.KiePMMLOutputField;
+import org.kie.pmml.commons.model.enums.MINING_FUNCTION;
+import org.kie.pmml.commons.model.enums.PMML_MODEL;
+import org.kie.pmml.commons.model.enums.RESULT_FEATURE;
+import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
+import static org.kie.pmml.compiler.commons.factories.KiePMMLOutputFieldFactory.getOutputFields;
+import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.MAIN_CLASS_NOT_FOUND;
+import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFromFileName;
+import static org.kie.pmml.compiler.commons.utils.ModelUtils.getTargetFieldName;
+
+/**
+ * Utility class to provide common methods for KiePMMLDroolsModel-specific <b>factories</b>
+ */
+public class KiePMMLDroolsModelFactoryUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLDroolsModelFactoryUtils.class.getName());
+
+    public KiePMMLDroolsModelFactoryUtils() {
+        // Avoid instantiation
+    }
+
+    /**
+     *
+     * @param dataDictionary
+     * @param model
+     * @param fieldTypeMap
+     * @param packageName
+     * @param javaTemplate the name of the <b>file</b> to be used as template source
+     * @param modelClassName the name of the class used in the provided template
+     * @return
+     */
+    public static CompilationUnit getKiePMMLModelCompilationUnit(final DataDictionary dataDictionary,
+                                                                 final Model model,
+                                                                 final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap,
+                                                                 final String packageName,
+                                                                 final String javaTemplate,
+                                                                 final String modelClassName) {
+        logger.trace("getKiePMMLModelCompilationUnit {} {} {}", dataDictionary, model, packageName);
+        String className = getSanitizedClassName(model.getModelName());
+        String targetField = getTargetFieldName(dataDictionary, model).orElse(null);
+        List<KiePMMLOutputField> outputFields = getOutputFields(model);
+        CompilationUnit templateCU = getFromFileName(javaTemplate);
+        CompilationUnit cloneCU = templateCU.clone();
+        cloneCU.setPackageDeclaration(packageName);
+        ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(modelClassName)
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND));
+        modelTemplate.setName(className);
+        MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(model.getMiningFunction().value());
+        final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
+        setConstructor(model, constructorDeclaration, modelTemplate.getName(), targetField, miningFunction);
+        addOutputFieldsPopulation(constructorDeclaration.getBody(), outputFields);
+        addFieldTypeMapPopulation(constructorDeclaration.getBody(), fieldTypeMap);
+        return cloneCU;
+    }
+
+    /**
+     * Define the <b>targetField</b>, the <b>miningFunction</b> and the <b>pmmlMODEL</b> inside the constructor
+     * @param model
+     * @param constructorDeclaration
+     * @param tableName
+     * @param targetField
+     * @param miningFunction
+     */
+    static void setConstructor(final Model model, final ConstructorDeclaration constructorDeclaration, final SimpleName tableName, final String targetField, MINING_FUNCTION miningFunction) {
+        constructorDeclaration.setName(tableName);
+        final BlockStmt body = constructorDeclaration.getBody();
+        final List<AssignExpr> assignExprs = body.findAll(AssignExpr.class);
+        assignExprs.forEach(assignExpr -> {
+            if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("targetField")) {
+                assignExpr.setValue(new StringLiteralExpr(targetField));
+            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("miningFunction")) {
+                assignExpr.setValue(new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
+            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("pmmlMODEL")) {
+                PMML_MODEL pmmlModel = PMML_MODEL.byName(model.getClass().getSimpleName());
+                assignExpr.setValue(new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
+            }
+        });
+    }
+
+    /**
+     * Populate the <b>outputFields</b> <code>List&lt;KiePMMLOutputField&gt;</code>
+     * @param body
+     * @param outputFields
+     */
+    static void addOutputFieldsPopulation(final BlockStmt body, final List<KiePMMLOutputField> outputFields) {
+        for (KiePMMLOutputField outputField : outputFields) {
+            NodeList<Expression> expressions = NodeList.nodeList(new StringLiteralExpr(outputField.getName()), new NameExpr("Collections.emptyList()"));
+            MethodCallExpr builder = new MethodCallExpr(new NameExpr("KiePMMLOutputField"), "builder", expressions);
+            if (outputField.getRank() != null) {
+                expressions = NodeList.nodeList(new IntegerLiteralExpr(outputField.getRank()));
+                builder = new MethodCallExpr(builder, "withRank", expressions);
+            }
+            if (outputField.getValue() != null) {
+                expressions = NodeList.nodeList(new StringLiteralExpr(outputField.getValue().toString()));
+                builder = new MethodCallExpr(builder, "withValue", expressions);
+            }
+            if (outputField.getTargetField().isPresent()) {
+                expressions = NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().get()));
+                builder = new MethodCallExpr(builder, "withTargetField", expressions);
+            }
+            if (outputField.getResultFeature() != null) {
+                expressions = NodeList.nodeList(new NameExpr(RESULT_FEATURE.class.getName() + "." + outputField.getResultFeature().toString()));
+                builder = new MethodCallExpr(builder, "withResultFeature", expressions);
+            }
+            Expression newOutputField = new MethodCallExpr(builder, "build");
+            expressions = NodeList.nodeList(newOutputField);
+            body.addStatement(new MethodCallExpr(new NameExpr("outputFields"), "add", expressions));
+        }
+    }
+
+    /**
+     * Populate the <b>fieldTypeMap</b> <code>Map&lt;String, KiePMMLOriginalTypeGeneratedType&gt;</code>
+     *
+     * @param body
+     * @param fieldTypeMap
+     */
+    static void addFieldTypeMapPopulation(BlockStmt body, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+        for (Map.Entry<String, KiePMMLOriginalTypeGeneratedType> entry : fieldTypeMap.entrySet()) {
+            KiePMMLOriginalTypeGeneratedType kiePMMLOriginalTypeGeneratedType = entry.getValue();
+            NodeList<Expression> expressions = NodeList.nodeList(new StringLiteralExpr(kiePMMLOriginalTypeGeneratedType.getOriginalType()), new StringLiteralExpr(kiePMMLOriginalTypeGeneratedType.getGeneratedType()));
+            ObjectCreationExpr objectCreationExpr = new ObjectCreationExpr();
+            objectCreationExpr.setType(KiePMMLOriginalTypeGeneratedType.class.getName());
+            objectCreationExpr.setArguments(expressions);
+            expressions = NodeList.nodeList(new StringLiteralExpr(entry.getKey()), objectCreationExpr);
+            body.addStatement(new MethodCallExpr(new NameExpr("fieldTypeMap"), "put", expressions));
+        }
+    }
+}

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtilsTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/utils/KiePMMLDroolsModelFactoryUtilsTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.models.drools.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.DataField;
+import org.dmg.pmml.DataType;
+import org.dmg.pmml.FieldName;
+import org.dmg.pmml.MiningField;
+import org.dmg.pmml.MiningFunction;
+import org.dmg.pmml.MiningSchema;
+import org.dmg.pmml.Model;
+import org.dmg.pmml.OpType;
+import org.dmg.pmml.tree.TreeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.pmml.commons.model.KiePMMLOutputField;
+import org.kie.pmml.commons.model.enums.MINING_FUNCTION;
+import org.kie.pmml.commons.model.enums.PMML_MODEL;
+import org.kie.pmml.commons.model.enums.RESULT_FEATURE;
+import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
+import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFromFileName;
+
+public class KiePMMLDroolsModelFactoryUtilsTest {
+
+    private static final String TEMPLATE_SOURCE = "Template.tmpl";
+    private static final String TEMPLATE_CLASS_NAME = "Template";
+
+    private static CompilationUnit COMPILATION_UNIT;
+    private static ClassOrInterfaceDeclaration MODEL_TEMPLATE;
+
+    @BeforeClass
+    public static void setup() {
+        COMPILATION_UNIT = getFromFileName(TEMPLATE_SOURCE);
+        MODEL_TEMPLATE = COMPILATION_UNIT.getClassByName(TEMPLATE_CLASS_NAME).get();
+    }
+
+    @Test
+    public void getKiePMMLModelCompilationUnit() {
+        DataDictionary dataDictionary = new DataDictionary();
+        String targetFieldString = "target.field";
+        FieldName targetFieldName = FieldName.create(targetFieldString);
+        dataDictionary.addDataFields(new DataField(targetFieldName, OpType.CONTINUOUS, DataType.DOUBLE));
+        String modelName = "ModelName";
+        Model model = new TreeModel();
+        model.setModelName(modelName);
+        model.setMiningFunction(MiningFunction.CLASSIFICATION);
+        MiningField targetMiningField = new MiningField(targetFieldName);
+        targetMiningField.setUsageType(MiningField.UsageType.TARGET);
+        MiningSchema miningSchema = new MiningSchema();
+        miningSchema.addMiningFields(targetMiningField);
+        model.setMiningSchema(miningSchema);
+        Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
+        fieldTypeMap.put(targetFieldString, new KiePMMLOriginalTypeGeneratedType(targetFieldString, getSanitizedClassName(targetFieldString)));
+        String packageName = "net.test";
+        CompilationUnit retrieved = KiePMMLDroolsModelFactoryUtils.getKiePMMLModelCompilationUnit(dataDictionary, model, fieldTypeMap, packageName, TEMPLATE_SOURCE, TEMPLATE_CLASS_NAME);
+        assertEquals(packageName, retrieved.getPackageDeclaration().get().getNameAsString());
+        ConstructorDeclaration constructorDeclaration = retrieved.getClassByName(modelName).get().getDefaultConstructor().get();
+        MINING_FUNCTION miningFunction = MINING_FUNCTION.CLASSIFICATION;
+        PMML_MODEL pmmlModel = PMML_MODEL.byName(model.getClass().getSimpleName());
+        Map<String, Expression> assignExpressionMap = new HashMap<>();
+        assignExpressionMap.put("targetField", new StringLiteralExpr(targetFieldString));
+        assignExpressionMap.put("miningFunction", new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
+        assignExpressionMap.put("pmmlMODEL", new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
+        commonEvaluateAssignExpr(constructorDeclaration.getBody(), assignExpressionMap);
+        int expectedMethodCallExprs = assignExpressionMap.size() + fieldTypeMap.size() + 1; // The last "1" is for the super invocation
+        commonEvaluateFieldTypeMap(constructorDeclaration.getBody(), fieldTypeMap, expectedMethodCallExprs);
+    }
+
+    @Test
+    public void setConstructor() {
+        Model model = new TreeModel();
+        PMML_MODEL pmmlModel = PMML_MODEL.byName(model.getClass().getSimpleName());
+        ConstructorDeclaration constructorDeclaration = MODEL_TEMPLATE.getDefaultConstructor().get();
+        SimpleName tableName = new SimpleName("TABLE_NAME");
+        String targetField = "TARGET_FIELD";
+        MINING_FUNCTION miningFunction = MINING_FUNCTION.CLASSIFICATION;
+        KiePMMLDroolsModelFactoryUtils.setConstructor(model, constructorDeclaration, tableName, targetField, miningFunction);
+        assertEquals(tableName, constructorDeclaration.getName());
+        Map<String, Expression> assignExpressionMap = new HashMap<>();
+        assignExpressionMap.put("targetField", new StringLiteralExpr(targetField));
+        assignExpressionMap.put("miningFunction", new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
+        assignExpressionMap.put("pmmlMODEL", new NameExpr(pmmlModel.getClass().getName() + "." + pmmlModel.name()));
+        commonEvaluateAssignExpr(constructorDeclaration.getBody(), assignExpressionMap);
+    }
+
+    @Test
+    public void addOutputFieldsPopulation() {
+        BlockStmt blockStmt = new BlockStmt();
+        List<KiePMMLOutputField> outputFields = IntStream.range(0, 3)
+                .mapToObj(index -> KiePMMLOutputField.builder("OUTPUTFIELD-" + index, Collections.emptyList())
+                        .withRank(new Random().nextInt(3))
+                        .withValue("VALUE-" + index)
+                        .withTargetField("TARGETFIELD-" + index)
+                        .build())
+                .collect(Collectors.toList());
+        KiePMMLDroolsModelFactoryUtils.addOutputFieldsPopulation(blockStmt, outputFields);
+        List<MethodCallExpr> retrieved = getMethodCallExprList(blockStmt, outputFields.size(), "outputFields", "add");
+        for (KiePMMLOutputField outputField : outputFields) {
+            assertTrue(retrieved.stream()
+                               .filter(methodCallExpr -> methodCallExpr.getArguments().size() == 1)
+                               .map(methodCallExpr -> methodCallExpr.getArgument(0))
+                               .filter(Expression::isMethodCallExpr)
+                               .map(expressionArgument -> (MethodCallExpr) expressionArgument)
+                               .anyMatch(methodCallExpr -> {
+                                   boolean toReturn = commonEvaluateMethodCallExpr(methodCallExpr, "build", new NodeList<>(), MethodCallExpr.class);
+                                   MethodCallExpr resultFeatureScopeExpr = (MethodCallExpr) methodCallExpr.getScope().get();
+                                   NodeList<Expression> expectedArguments = NodeList.nodeList(new NameExpr(RESULT_FEATURE.class.getName() + "." + outputField.getResultFeature().toString()));
+                                   toReturn &= commonEvaluateMethodCallExpr(resultFeatureScopeExpr, "withResultFeature", expectedArguments, MethodCallExpr.class);
+                                   MethodCallExpr targetFieldScopeExpr = (MethodCallExpr) resultFeatureScopeExpr.getScope().get();
+                                   expectedArguments = NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().get()));
+                                   toReturn &= commonEvaluateMethodCallExpr(targetFieldScopeExpr, "withTargetField", expectedArguments, MethodCallExpr.class);
+                                   MethodCallExpr valueScopeExpr = (MethodCallExpr) targetFieldScopeExpr.getScope().get();
+                                   expectedArguments = NodeList.nodeList(new StringLiteralExpr(outputField.getValue().toString()));
+                                   toReturn &= commonEvaluateMethodCallExpr(valueScopeExpr, "withValue", expectedArguments, MethodCallExpr.class);
+                                   MethodCallExpr rankScopeExpr = (MethodCallExpr) valueScopeExpr.getScope().get();
+                                   expectedArguments = NodeList.nodeList(new IntegerLiteralExpr(outputField.getRank()));
+                                   toReturn &= commonEvaluateMethodCallExpr(rankScopeExpr, "withRank", expectedArguments, MethodCallExpr.class);
+                                   MethodCallExpr builderScopeExpr = (MethodCallExpr) rankScopeExpr.getScope().get();
+                                   expectedArguments = NodeList.nodeList(new StringLiteralExpr(outputField.getName()), new NameExpr("Collections.emptyList()"));
+                                   toReturn &= commonEvaluateMethodCallExpr(builderScopeExpr, "builder", expectedArguments, NameExpr.class);
+                                   toReturn &= builderScopeExpr.getName().equals(new SimpleName("builder"));
+                                   toReturn &= builderScopeExpr.getScope().get().equals(new NameExpr("KiePMMLOutputField"));
+                                   return toReturn;
+                               }));
+        }
+    }
+
+    @Test
+    public void addFieldTypeMapPopulation() {
+        BlockStmt blockStmt = new BlockStmt();
+        Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
+        IntStream.range(0, 3).forEach(index -> {
+            String key = "KEY-" + index;
+            KiePMMLOriginalTypeGeneratedType value = new KiePMMLOriginalTypeGeneratedType("ORIGINALTYPE-" + index, "GENERATEDTYPE-" + index);
+            fieldTypeMap.put(key, value);
+        });
+        KiePMMLDroolsModelFactoryUtils.addFieldTypeMapPopulation(blockStmt, fieldTypeMap);
+        commonEvaluateFieldTypeMap(blockStmt, fieldTypeMap, fieldTypeMap.size());
+    }
+
+    private void commonEvaluateAssignExpr(BlockStmt blockStmt, Map<String, Expression> assignExpressionMap) {
+        List<AssignExpr> retrieved = blockStmt.findAll(AssignExpr.class);
+        for (Map.Entry<String, Expression> entry : assignExpressionMap.entrySet()) {
+            assertTrue(retrieved.stream()
+                               .filter(assignExpr -> assignExpr.getTarget().asNameExpr().equals(new NameExpr(entry.getKey())))
+                               .anyMatch(assignExpr -> assignExpr.getValue().equals(entry.getValue())));
+        }
+    }
+
+    private void commonEvaluateFieldTypeMap(BlockStmt blockStmt, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, int expectedMethodCallSize) {
+        List<MethodCallExpr> retrieved = getMethodCallExprList(blockStmt, expectedMethodCallSize, "fieldTypeMap", "put");
+        for (Map.Entry<String, KiePMMLOriginalTypeGeneratedType> entry : fieldTypeMap.entrySet()) {
+            assertTrue(retrieved.stream()
+                               .map(MethodCallExpr::getArguments)
+                               .anyMatch(arguments -> {
+                                   boolean toReturn = arguments.size() == 2;
+                                   Expression firstArgument = arguments.get(0);
+                                   Expression secondArgument = arguments.get(1);
+                                   toReturn &= firstArgument.isStringLiteralExpr() && ((StringLiteralExpr) firstArgument).getValue().equals(entry.getKey());
+                                   toReturn &= secondArgument.isObjectCreationExpr() &&
+                                           ((ObjectCreationExpr) secondArgument).getArgument(0).isStringLiteralExpr() &&
+                                           ((StringLiteralExpr) ((ObjectCreationExpr) secondArgument).getArgument(0)).getValue().equals(entry.getValue().getOriginalType()) &&
+                                           ((ObjectCreationExpr) secondArgument).getArgument(1).isStringLiteralExpr() &&
+                                           ((StringLiteralExpr) ((ObjectCreationExpr) secondArgument).getArgument(1)).getValue().equals(entry.getValue().getGeneratedType());
+                                   return toReturn;
+                               }));
+        }
+    }
+
+    private boolean commonEvaluateMethodCallExpr(MethodCallExpr toEvaluate, String name, NodeList<Expression> expectedArguments, Class<? extends Expression> expectedScopeType) {
+        boolean toReturn = Objects.equals(new SimpleName(name), toEvaluate.getName());
+        toReturn &= expectedArguments.size() == toEvaluate.getArguments().size();
+        for (int i = 0; i < expectedArguments.size(); i++) {
+            toReturn &= expectedArguments.get(i).equals(toEvaluate.getArgument(i));
+        }
+        if (expectedScopeType != null) {
+            toReturn &= toEvaluate.getScope().isPresent() && toEvaluate.getScope().get().getClass().equals(expectedScopeType);
+        }
+        return toReturn;
+    }
+
+    private List<MethodCallExpr> getMethodCallExprList(BlockStmt blockStmt, int expectedSize, String scope, String method) {
+        Stream<Statement> statementStream = getStatementStream(blockStmt, expectedSize);
+        return statementStream
+                .filter(Statement::isExpressionStmt)
+                .map(expressionStmt -> ((ExpressionStmt) expressionStmt).getExpression())
+                .filter(expression -> expression instanceof MethodCallExpr)
+                .map(expression -> (MethodCallExpr) expression)
+                .filter(methodCallExpr ->
+                                methodCallExpr.getScope().isPresent() &&
+                                        methodCallExpr.getScope().get().isNameExpr() &&
+                                        ((NameExpr) methodCallExpr.getScope().get()).getName().asString().equals(scope) &&
+                                        methodCallExpr.getName().asString().equals(method))
+                .collect(Collectors.toList());
+    }
+
+    private Stream<Statement> getStatementStream(BlockStmt blockStmt, int expectedSize) {
+        final NodeList<Statement> statements = blockStmt.getStatements();
+        assertEquals(expectedSize, statements.size());
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                        statements.iterator(),
+                        Spliterator.ORDERED), false);
+    }
+}

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/resources/Template.tmpl
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/resources/Template.tmpl
@@ -1,0 +1,11 @@
+public class Template {
+
+
+    public Template() {
+        super(modelName, Collections.emptyList());
+        targetField = targetField;
+        miningFunction = miningFunction;
+        pmmlMODEL = null;
+    }
+
+}

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
@@ -44,7 +44,7 @@ public class ScorecardModelImplementationProvider extends DroolsModelProvider<Sc
     public KiePMMLScorecardModel getKiePMMLDroolsModel(DataDictionary dataDictionary, Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         try {
             return KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(dataDictionary, model, fieldTypeMap);
-        } catch (IOException | IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException e) {
             throw new KiePMMLException(e.getMessage(), e);
         }
     }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -70,7 +70,7 @@ public class KiePMMLScorecardModelFactory {
         CompilationUnit cloneCU = getKiePMMLModelCompilationUnit(dataDictionary, model, fieldTypeMap, packageName, KIE_PMML_SCORECARD_MODEL_TEMPLATE_JAVA, KIE_PMML_SCORECARD_MODEL_TEMPLATE);
         String className = getSanitizedClassName(model.getModelName());
         ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
-                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND));
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + className));
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
         setSuperInvocation(model, constructorDeclaration, modelTemplate.getName());
         Map<String, String> toReturn = new HashMap<>();

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -15,33 +15,21 @@
  */
 package org.kie.pmml.models.drools.scorecard.compiler.factories;
 
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.scorecard.Scorecard;
 import org.kie.memorycompiler.KieMemoryCompiler;
+import org.kie.pmml.commons.exceptions.KiePMMLException;
 import org.kie.pmml.commons.exceptions.KiePMMLInternalException;
-import org.kie.pmml.commons.model.KiePMMLOutputField;
-import org.kie.pmml.commons.model.enums.MINING_FUNCTION;
-import org.kie.pmml.commons.model.enums.PMML_MODEL;
-import org.kie.pmml.commons.model.enums.RESULT_FEATURE;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsAST;
 import org.kie.pmml.models.drools.scorecard.model.KiePMMLScorecardModel;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
@@ -50,10 +38,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageName;
-import static org.kie.pmml.compiler.commons.factories.KiePMMLOutputFieldFactory.getOutputFields;
 import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.MAIN_CLASS_NOT_FOUND;
-import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFromFileName;
-import static org.kie.pmml.compiler.commons.utils.ModelUtils.getTargetFieldName;
+import static org.kie.pmml.models.drools.utils.KiePMMLDroolsModelFactoryUtils.getKiePMMLModelCompilationUnit;
 
 /**
  * Class used to generate <code>KiePMMLScorecard</code> out of a <code>DataDictionary</code> and a <code>ScorecardModel</code>
@@ -69,7 +55,7 @@ public class KiePMMLScorecardModelFactory {
         // Avoid instantiation
     }
 
-    public static KiePMMLScorecardModel getKiePMMLScorecardModel(DataDictionary dataDictionary, Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IOException, IllegalAccessException, InstantiationException {
+    public static KiePMMLScorecardModel getKiePMMLScorecardModel(DataDictionary dataDictionary, Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IllegalAccessException, InstantiationException {
         logger.trace("getKiePMMLScorecardModel {}", model);
         String className = getSanitizedClassName(model.getModelName());
         String packageName = getSanitizedPackageName(className);
@@ -79,22 +65,14 @@ public class KiePMMLScorecardModelFactory {
         return (KiePMMLScorecardModel) compiledClasses.get(fullClassName).newInstance();
     }
 
-    public static Map<String, String> getKiePMMLScorecardModelSourcesMap(final DataDictionary dataDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final String packageName) throws IOException {
+    public static Map<String, String> getKiePMMLScorecardModelSourcesMap(final DataDictionary dataDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final String packageName) {
         logger.trace("getKiePMMLScorecardModelSourcesMap {} {} {}", dataDictionary, model, packageName);
+        CompilationUnit cloneCU = getKiePMMLModelCompilationUnit(dataDictionary, model, fieldTypeMap, packageName, KIE_PMML_SCORECARD_MODEL_TEMPLATE_JAVA, KIE_PMML_SCORECARD_MODEL_TEMPLATE);
         String className = getSanitizedClassName(model.getModelName());
-        String targetField = getTargetFieldName(dataDictionary, model).orElse(null);
-        List<KiePMMLOutputField> outputFields = getOutputFields(model);
-        CompilationUnit templateCU = getFromFileName(KIE_PMML_SCORECARD_MODEL_TEMPLATE_JAVA);
-        CompilationUnit cloneCU = templateCU.clone();
-        cloneCU.setPackageDeclaration(packageName);
-        ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(KIE_PMML_SCORECARD_MODEL_TEMPLATE)
-                .orElseThrow(() -> new RuntimeException(MAIN_CLASS_NOT_FOUND));
-        modelTemplate.setName(className);
-        MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(model.getMiningFunction().value());
+        ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND));
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
-        setConstructor(model, constructorDeclaration, modelTemplate.getName(), targetField, miningFunction);
-        addOutputFieldsPopulation(constructorDeclaration.getBody(), outputFields);
-        addFieldTypeMapPopulation(constructorDeclaration.getBody(), fieldTypeMap);
+        setSuperInvocation(model, constructorDeclaration, modelTemplate.getName());
         Map<String, String> toReturn = new HashMap<>();
         String fullClassName = packageName + "." + className;
         toReturn.put(fullClassName, cloneCU.toString());
@@ -114,45 +92,7 @@ public class KiePMMLScorecardModelFactory {
         return KiePMMLScorecardModelASTFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
     }
 
-    private static void addFieldTypeMapPopulation(BlockStmt body, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
-        for (Map.Entry<String, KiePMMLOriginalTypeGeneratedType> entry : fieldTypeMap.entrySet()) {
-            KiePMMLOriginalTypeGeneratedType kiePMMLOriginalTypeGeneratedType = entry.getValue();
-            NodeList<Expression> expressions = NodeList.nodeList(new StringLiteralExpr(kiePMMLOriginalTypeGeneratedType.getOriginalType()), new StringLiteralExpr(kiePMMLOriginalTypeGeneratedType.getGeneratedType()));
-            ObjectCreationExpr objectCreationExpr = new ObjectCreationExpr();
-            objectCreationExpr.setType(KiePMMLOriginalTypeGeneratedType.class.getName());
-            objectCreationExpr.setArguments(expressions);
-            expressions = NodeList.nodeList(new StringLiteralExpr(entry.getKey()), objectCreationExpr);
-            body.addStatement(new MethodCallExpr(new NameExpr("fieldTypeMap"), "put", expressions));
-        }
-    }
-
-    private static void addOutputFieldsPopulation(final BlockStmt body, final List<KiePMMLOutputField> outputFields) {
-        for (KiePMMLOutputField outputField : outputFields) {
-            NodeList<Expression> expressions = NodeList.nodeList(new StringLiteralExpr(outputField.getName()), new NameExpr("Collections.emptyList()"));
-            MethodCallExpr builder = new MethodCallExpr(new NameExpr("KiePMMLOutputField"), "builder", expressions);
-            if (outputField.getRank() != null) {
-                expressions = NodeList.nodeList(new IntegerLiteralExpr(outputField.getRank()));
-                builder = new MethodCallExpr(builder, "withRank", expressions);
-            }
-            if (outputField.getValue() != null) {
-                expressions = NodeList.nodeList(new NameExpr(outputField.getValue().toString()));
-                builder = new MethodCallExpr(builder, "withValue", expressions);
-            }
-            if (outputField.getTargetField().isPresent()) {
-                expressions = NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().get()));
-                builder = new MethodCallExpr(builder, "withTargetField", expressions);
-            }
-            if (outputField.getResultFeature() != null) {
-                expressions = NodeList.nodeList(new NameExpr(RESULT_FEATURE.class.getName() + "." + outputField.getResultFeature().toString()));
-                builder = new MethodCallExpr(builder, "withResultFeature", expressions);
-            }
-            Expression newOutputField = new MethodCallExpr(builder, "build");
-            expressions = NodeList.nodeList(newOutputField);
-            body.addStatement(new MethodCallExpr(new NameExpr("outputFields"), "add", expressions));
-        }
-    }
-
-    private static void setConstructor(final Scorecard scorecard, final ConstructorDeclaration constructorDeclaration, final SimpleName tableName, final String targetField, MINING_FUNCTION miningFunction) {
+    private static void setSuperInvocation(final Scorecard scorecard, final ConstructorDeclaration constructorDeclaration, final SimpleName tableName) {
         constructorDeclaration.setName(tableName);
         final BlockStmt body = constructorDeclaration.getBody();
         body.getStatements().iterator().forEachRemaining(statement -> {
@@ -160,16 +100,6 @@ public class KiePMMLScorecardModelFactory {
                 ExplicitConstructorInvocationStmt superStatement = (ExplicitConstructorInvocationStmt) statement;
                 NameExpr modelNameExpr = (NameExpr) superStatement.getArgument(0);
                 modelNameExpr.setName(String.format("\"%s\"", scorecard.getModelName()));
-            }
-        });
-        final List<AssignExpr> assignExprs = body.findAll(AssignExpr.class);
-        assignExprs.forEach(assignExpr -> {
-            if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("targetField")) {
-                assignExpr.setValue(new StringLiteralExpr(targetField));
-            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("miningFunction")) {
-                assignExpr.setValue(new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
-            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("pmmlMODEL")) {
-                assignExpr.setValue(new NameExpr(PMML_MODEL.SCORECARD_MODEL.getClass().getName() + "." + PMML_MODEL.SCORECARD_MODEL.name()));
             }
         });
     }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/main/resources/META-INF/services/org.kie.pmml.evaluator.core.executor.PMMLModelExecutor
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/main/resources/META-INF/services/org.kie.pmml.evaluator.core.executor.PMMLModelExecutor
@@ -1,2 +1,0 @@
-# SPI implementation
-org.kie.pmml.models.drools.scorecard.evaluator.PMMLScorecardModelEvaluator

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
@@ -23,6 +23,10 @@
       <artifactId>kie-pmml-models-drools-tree-model</artifactId>
     </dependency>
     <!-- EXTERNAL -->
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-memory-compiler</artifactId>
+    </dependency>
     <!-- TEST -->
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
@@ -19,14 +19,13 @@ import java.util.Map;
 
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.tree.TreeModel;
+import org.kie.pmml.commons.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsAST;
 import org.kie.pmml.models.drools.provider.DroolsModelProvider;
 import org.kie.pmml.models.drools.tree.compiler.factories.KiePMMLTreeModelFactory;
 import org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel.PMML_MODEL_TYPE;
 
@@ -35,29 +34,27 @@ import static org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel.PMML_MODEL_
  */
 public class TreeModelImplementationProvider extends DroolsModelProvider<TreeModel, KiePMMLTreeModel> {
 
-    private static final Logger logger = LoggerFactory.getLogger(TreeModelImplementationProvider.class.getName());
-
     @Override
     public PMML_MODEL getPMMLModelType() {
-        logger.trace("getPMMLModelType");
         return PMML_MODEL_TYPE;
     }
 
     @Override
     public KiePMMLTreeModel getKiePMMLDroolsModel(DataDictionary dataDictionary, TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
-        logger.trace("getKiePMMLDroolsModel {} {} {}", dataDictionary, model, fieldTypeMap);
-        return KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, model, fieldTypeMap);
+        try {
+            return KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, model, fieldTypeMap);
+        } catch (IllegalAccessException | InstantiationException e) {
+            throw new KiePMMLException(e.getMessage(), e);
+        }
     }
 
     @Override
     public KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
-        logger.trace("getKiePMMLDroolsAST {} {} {}", dataDictionary, model, fieldTypeMap);
         return KiePMMLTreeModelFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
     }
 
     @Override
     public Map<String, String> getKiePMMLDroolsModelSourcesMap(DataDictionary dataDictionary, TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) {
-        // TODO {gcardosi} to implement
-        throw new RuntimeException("Not implemented, yet");
+        return KiePMMLTreeModelFactory.getKiePMMLTreeModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
     }
 }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -15,23 +15,31 @@
  */
 package org.kie.pmml.models.drools.tree.compiler.factories;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.tree.TreeModel;
-import org.kie.pmml.commons.model.KiePMMLOutputField;
-import org.kie.pmml.commons.model.enums.MINING_FUNCTION;
+import org.kie.memorycompiler.KieMemoryCompiler;
+import org.kie.pmml.commons.exceptions.KiePMMLException;
+import org.kie.pmml.commons.exceptions.KiePMMLInternalException;
 import org.kie.pmml.models.drools.ast.KiePMMLDroolsAST;
 import org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel;
 import org.kie.pmml.models.drools.tuples.KiePMMLOriginalTypeGeneratedType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.kie.pmml.compiler.commons.factories.KiePMMLOutputFieldFactory.getOutputFields;
-import static org.kie.pmml.compiler.commons.utils.ModelUtils.getTargetFieldName;
+import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
+import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageName;
+import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.MAIN_CLASS_NOT_FOUND;
+import static org.kie.pmml.models.drools.utils.KiePMMLDroolsModelFactoryUtils.getKiePMMLModelCompilationUnit;
 
 /**
  * Class used to generate <code>KiePMMLTreeModel</code> out of a <code>DataDictionary</code> and a <code>TreeModel</code>
@@ -40,19 +48,38 @@ public class KiePMMLTreeModelFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(KiePMMLTreeModelFactory.class.getName());
 
+    private static final String KIE_PMML_TREE_MODEL_TEMPLATE_JAVA = "KiePMMLTreeModelTemplate.tmpl";
+    private static final String KIE_PMML_TREE_MODEL_TEMPLATE = "KiePMMLTreeModelTemplate";
+
     private KiePMMLTreeModelFactory() {
+        // Avoid instantiation
     }
 
-    public static KiePMMLTreeModel getKiePMMLTreeModel(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public static KiePMMLTreeModel getKiePMMLTreeModel(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IllegalAccessException, InstantiationException {
         logger.trace("getKiePMMLTreeModel {}", model);
-        String name = model.getModelName();
-        Optional<String> targetFieldName = getTargetFieldName(dataDictionary, model);
-        final List<KiePMMLOutputField> outputFields = getOutputFields(model);
-        return KiePMMLTreeModel.builder(name, Collections.emptyList(), MINING_FUNCTION.byName(model.getMiningFunction().value()), model.getAlgorithmName())
-                .withOutputFields(outputFields)
-                .withFieldTypeMap(fieldTypeMap)
-                .withTargetField(targetFieldName.orElse(null))
-                .build();
+        String className = getSanitizedClassName(model.getModelName());
+        String packageName = getSanitizedPackageName(className);
+        Map<String, String> sourcesMap = getKiePMMLTreeModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
+        String fullClassName = packageName + "." + className;
+        final Map<String, Class<?>> compiledClasses = KieMemoryCompiler.compile(sourcesMap, Thread.currentThread().getContextClassLoader());
+        return (KiePMMLTreeModel) compiledClasses.get(fullClassName).newInstance();
+    }
+
+    public static Map<String, String> getKiePMMLTreeModelSourcesMap(final DataDictionary dataDictionary,
+                                                                    final TreeModel model,
+                                                                    final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap,
+                                                                    final String packageName) {
+        logger.trace("getKiePMMLTreeModelSourcesMap {} {} {}", dataDictionary, model, packageName);
+        CompilationUnit cloneCU = getKiePMMLModelCompilationUnit(dataDictionary, model, fieldTypeMap, packageName, KIE_PMML_TREE_MODEL_TEMPLATE_JAVA, KIE_PMML_TREE_MODEL_TEMPLATE);
+        String className = getSanitizedClassName(model.getModelName());
+        ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND));
+        final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
+        setSuperInvocation(model, constructorDeclaration, modelTemplate.getName());
+        Map<String, String> toReturn = new HashMap<>();
+        String fullClassName = packageName + "." + className;
+        toReturn.put(fullClassName, cloneCU.toString());
+        return toReturn;
     }
 
     /**
@@ -66,5 +93,19 @@ public class KiePMMLTreeModelFactory {
     public static KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         logger.trace("getKiePMMLDroolsAST {}", model);
         return KiePMMLTreeModelASTFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
+    }
+
+    private static void setSuperInvocation(final TreeModel treeModel, final ConstructorDeclaration constructorDeclaration, final SimpleName tableName) {
+        constructorDeclaration.setName(tableName);
+        final BlockStmt body = constructorDeclaration.getBody();
+        body.getStatements().iterator().forEachRemaining(statement -> {
+            if (statement instanceof ExplicitConstructorInvocationStmt) {
+                ExplicitConstructorInvocationStmt superStatement = (ExplicitConstructorInvocationStmt) statement;
+                NameExpr modelNameExpr = (NameExpr) superStatement.getArgument(0);
+                modelNameExpr.setName(String.format("\"%s\"", treeModel.getModelName()));
+                NameExpr algorithmNameExpr = (NameExpr) superStatement.getArgument(2);
+                algorithmNameExpr.setName(String.format("\"%s\"", treeModel.getAlgorithmName()));
+            }
+        });
     }
 }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -73,7 +73,7 @@ public class KiePMMLTreeModelFactory {
         CompilationUnit cloneCU = getKiePMMLModelCompilationUnit(dataDictionary, model, fieldTypeMap, packageName, KIE_PMML_TREE_MODEL_TEMPLATE_JAVA, KIE_PMML_TREE_MODEL_TEMPLATE);
         String className = getSanitizedClassName(model.getModelName());
         ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
-                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND));
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + className));
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
         setSuperInvocation(model, constructorDeclaration, modelTemplate.getName());
         Map<String, String> toReturn = new HashMap<>();

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -57,7 +57,7 @@ public class KiePMMLTreeModelFactoryTest {
     }
 
     @Test
-    public void getKiePMMLTreeModel() {
+    public void getKiePMMLTreeModel() throws InstantiationException, IllegalAccessException {
         final DataDictionary dataDictionary = pmml.getDataDictionary();
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         KiePMMLTreeModel retrieved = KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, treeModel, fieldTypeMap);

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/java/org/kie/pmml/models/drools/tree/model/KiePMMLTreeModel.java
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/java/org/kie/pmml/models/drools/tree/model/KiePMMLTreeModel.java
@@ -29,7 +29,7 @@ public class KiePMMLTreeModel extends KiePMMLDroolsModel {
 
     private final String algorithmName;
 
-    private KiePMMLTreeModel(String name, List<KiePMMLExtension> extensions, String algorithmName) {
+    protected KiePMMLTreeModel(String name, List<KiePMMLExtension> extensions, String algorithmName) {
         super(name, extensions);
         this.algorithmName = algorithmName;
     }

--- a/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/resources/KiePMMLTreeModelTemplate.tmpl
+++ b/kie-pmml-new/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/resources/KiePMMLTreeModelTemplate.tmpl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.models.drools.tree.model;
+
+import java.util.Collections;
+
+import org.kie.pmml.commons.model.KiePMMLOutputField;
+import org.kie.pmml.commons.model.enums.PMML_MODEL;
+import org.kie.pmml.models.drools.tree.model.KiePMMLTreeModel;
+
+
+public class KiePMMLTreeModelTemplate extends KiePMMLTreeModel {
+
+    public KiePMMLTreeModelTemplate() {
+        super(modelName, Collections.emptyList(), algorithmName);
+        targetField = targetField;
+        pmmlMODEL = null;
+    }
+}


### PR DESCRIPTION
@danielezonca @jiripetrlik @mariofusco 
See https://issues.redhat.com/browse/DROOLS-5381

1) `KiePMMLDroolsModel` returned by  `DroolsModelProvider` are code-generated
2) Concrete _DroolsModelProviders_ (e.g. `TreeModelImplementationProvider`) have to implement 
`Map<String, String> getKiePMMLDroolsModelSourcesMap(....)`
3) Most code for code-generation is shared for different `KiePMMLDroolsModel`s, so it has been put inside `KiePMMLDroolsModelFactoryUtils.getKiePMMLModelCompilationUnit(...)`
4) differences between constructors (e.g. super invocation) are managed locally by every implementation
