### PR TITLE
DROOLS-5421 DMN FEEL perf opt EvaluationContext.current()

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -64,9 +64,15 @@ public class EvaluationContextImpl implements EvaluationContext {
         this.dmnRuntime = dmnRuntime;
     }
 
+    private EvaluationContextImpl(FEELEventListenersManager eventsManager) {
+        this.eventsManager = eventsManager;
+    }
+
     @Override
     public EvaluationContext current() {
-        EvaluationContextImpl ec = new EvaluationContextImpl(rootClassLoader, eventsManager, new ArrayDeque<>(stack));
+        EvaluationContextImpl ec = new EvaluationContextImpl(eventsManager);
+        ec.stack = stack.clone();
+        ec.rootClassLoader = this.rootClassLoader;
         ec.dmnRuntime = this.dmnRuntime;
         ec.performRuntimeTypeCheck = this.performRuntimeTypeCheck;
         return ec;


### PR DESCRIPTION
This modification improves `EvaluationContext.current()` by a factor of ~2.5x times.

However, the magnitude of this change is in the 10s of ns.
```
BEFORE
Benchmark                                                Mode  Cnt   Score   Error  Units
EvaluationContextImplBenchmark.evaluationContextCurrent  avgt  100  38.393 ± 0.279  ns/op
AFTER
Benchmark                                                Mode  Cnt   Score   Error  Units
EvaluationContextImplBenchmark.evaluationContextCurrent  avgt  100  14.641 ± 0.085  ns/op
```

...so it's falling within the error range for the FEEL expressions _evaluation_ tests, e.g.:

```
BEFORE
Benchmark                                                                                                                    (expression)  Mode  Cnt  Score   Error  Units
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                       date("2016-07-29") + duration( "P3D" )  avgt  100  1.658 ± 0.010  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                       date("2016-07-29") - duration( "P3D" )  avgt  100  1.667 ± 0.009  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                      time("22:57:00") + duration( "PT1H1M" )  avgt  100  2.330 ± 0.024  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                      time("22:57:00") - duration( "PT1H1M" )  avgt  100  2.336 ± 0.013  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression  date and time("2016-07-29T05:48:23Z") + duration( "P1Y1M" )  avgt  100  5.660 ± 0.035  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression  date and time("2016-07-29T05:48:23Z") - duration( "P1Y1M" )  avgt  100  5.858 ± 0.070  us/op
AFTER
Benchmark                                                                                                                    (expression)  Mode  Cnt  Score   Error  Units
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                       date("2016-07-29") + duration( "P3D" )  avgt  100  1.673 ± 0.011  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                       date("2016-07-29") - duration( "P3D" )  avgt  100  1.690 ± 0.014  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                      time("22:57:00") + duration( "PT1H1M" )  avgt  100  2.277 ± 0.014  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression                      time("22:57:00") - duration( "PT1H1M" )  avgt  100  2.320 ± 0.032  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression  date and time("2016-07-29T05:48:23Z") + duration( "P1Y1M" )  avgt  100  5.865 ± 0.057  us/op
FEELDateTimeMathOperationsBenchmark.evaluateCompiledButInterpretedExpression  date and time("2016-07-29T05:48:23Z") - duration( "P1Y1M" )  avgt  100  5.791 ± 0.048  us/op
```

yet, I believe is a sensible modification for the reason explained above, proved by: https://github.com/kiegroup/kie-benchmarks/pull/86

let me know what you think @hellowdan 