### PR TITLE
DROOLS-5291 & DROOLS-5223: Managing empty and invalid scesim file

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -129,7 +129,7 @@ public class ScenarioSimulationXMLPersistence {
 
     public ScenarioSimulationModel unmarshal(final String rawXml, boolean migrate) throws Exception {
         if (rawXml == null || rawXml.trim().equals("")) {
-            throw new IllegalArgumentException("File content is empty!");
+            throw new IllegalArgumentException("Malformed file, content is empty!");
         }
 
         String xml = migrate ? migrateIfNecessary(rawXml) : rawXml;

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistence.java
@@ -128,11 +128,8 @@ public class ScenarioSimulationXMLPersistence {
     }
 
     public ScenarioSimulationModel unmarshal(final String rawXml, boolean migrate) throws Exception {
-        if (rawXml == null) {
-            return new ScenarioSimulationModel();
-        }
-        if (rawXml.trim().equals("")) {
-            return new ScenarioSimulationModel();
+        if (rawXml == null || rawXml.trim().equals("")) {
+            throw new IllegalArgumentException("File content is empty!");
         }
 
         String xml = migrate ? migrateIfNecessary(rawXml) : rawXml;

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/util/ScenarioSimulationXMLPersistenceTest.java
@@ -305,6 +305,16 @@ public class ScenarioSimulationXMLPersistenceTest {
         assertEquals("1.0", version);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void unmarshalEmptyContent() throws Exception {
+        ScenarioSimulationXMLPersistence.getInstance().unmarshal("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unmarshalNullContent() throws Exception {
+        ScenarioSimulationXMLPersistence.getInstance().unmarshal(null);
+    }
+
     @Test
     public void unmarshalRULE() throws Exception {
         String toUnmarshal = getFileContent("scesim-rule.scesim");


### PR DESCRIPTION
@dupliaka @danielezonca can you please review and test?

Currently in case of loading an empty or `null` file content, a new empty model is created and returned. This cause a NPE in client side code. 
In my opinion, if the content is `null` or empty, an exception should be thrown.

Related PR Client Side: https://github.com/kiegroup/drools-wb/pull/1385