### PR TITLE
[DROOLS-5423] Declaring jaxb-runtime dependency for JDK >= 11

### DIFF
--- a/kie-pmml-new/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
+++ b/kie-pmml-new/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
@@ -33,4 +33,19 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>java11-pmml</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik 

See https://issues.redhat.com/browse/DROOLS-5423

In Java 11 JAXB implementation is not provided anymore. kie-pmml-compiler depends (indirectly) on it, for both execution and tests.
This PR is meant to include the required dependency *only* when executed in Java >= 11; a specifically-activated profile has been used for that.
Reason for such enforcement is that I think it is better to avoid polluting working setup (i.e execution on Java < 11) with solutions meant for different setup (Java >= 11).
The glassfish jaxb-runtime implementation has been choose because is the one that worked on my tests.
To verify that, I've the following setup

1. the drools project
2. an external "tester" project, that uses kie-pmml-new to run

The tests I've done are (all launched with mvn command line):

1. clean/test/install kie-pmml-new with Java 11
2. run tester project with Java 11
3. run tester project with Java 8
4. clean/test/install kie-pmml-new with Java 8
5. run tester project with Java 8
6. run tester project with Java 11
