### PR TITLE
BAQE-1425 - Remove DummyProcessRuntime from session benchmarks

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -2204,7 +2204,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         @Override
         public ProcessInstance getProcessInstance( long processInstanceId ) {
-            throw new UnsupportedOperationException( );
+            return null;
         }
 
         @Override


### PR DESCRIPTION
On Drools benchmarks, the DummyProcessRuntime class is being used only on org.drools.benchmarks.session.sessionpool.DisposeSessionWithProcessRuntimeBenchmark and it is being affected by changes in the Interface InternalProcessRuntime (which is implemented by DummyProcessRuntime).