### PR TITLE
[DROOLS-5378] Alpha Node ordering

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -244,6 +244,7 @@ public abstract class AbstractKieModule
         kbConf.setOption(kBaseModel.getDeclarativeAgenda());
         kbConf.setOption(kBaseModel.getSequential());
         kbConf.setOption(kBaseModel.getSessionsPool());
+        kbConf.setOption(kBaseModel.getAlphaNodeOrdering());
         return kbConf;
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
@@ -59,7 +59,7 @@ public class KieBaseModelImpl
 
     private EqualityBehaviorOption       equalsBehavior = EqualityBehaviorOption.IDENTITY;
 
-    private AlphaNodeOrderingOption      alphaNodeOrdering = AlphaNodeOrderingOption.COUNT;
+    private AlphaNodeOrderingOption      alphaNodeOrdering = AlphaNodeOrderingOption.NONE;
 
     private EventProcessingOption        eventProcessingMode = EventProcessingOption.CLOUD;
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieBaseModelImpl.java
@@ -36,6 +36,7 @@ import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.builder.model.RuleTemplateModel;
+import org.kie.api.conf.AlphaNodeOrderingOption;
 import org.kie.api.conf.DeclarativeAgendaOption;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
@@ -57,6 +58,8 @@ public class KieBaseModelImpl
     private List<String>                 packages;
 
     private EqualityBehaviorOption       equalsBehavior = EqualityBehaviorOption.IDENTITY;
+
+    private AlphaNodeOrderingOption      alphaNodeOrdering = AlphaNodeOrderingOption.COUNT;
 
     private EventProcessingOption        eventProcessingMode = EventProcessingOption.CLOUD;
 
@@ -243,6 +246,15 @@ public class KieBaseModelImpl
         return this;
     }
 
+    public AlphaNodeOrderingOption getAlphaNodeOrdering() {
+        return alphaNodeOrdering;
+    }
+
+    public KieBaseModel setAlphaNodeOrdering(AlphaNodeOrderingOption alphaNodeOrdering) {
+        this.alphaNodeOrdering = alphaNodeOrdering;
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.kie.kproject.KieBaseModel#getEventProcessingMode()
      */
@@ -343,6 +355,9 @@ public class KieBaseModelImpl
             if ( kBase.getEqualsBehavior() != null ) {
                 writer.addAttribute( "equalsBehavior", kBase.getEqualsBehavior().toString().toLowerCase() );
             }
+            if ( kBase.getAlphaNodeOrdering() != null ) {
+                writer.addAttribute( "alphaNodeOrdering", kBase.getAlphaNodeOrdering().toString().toLowerCase() );
+            }
             if ( kBase.getDeclarativeAgenda() != null ) {
                 writer.addAttribute( "declarativeAgenda", kBase.getDeclarativeAgenda().toString().toLowerCase() );
             }
@@ -411,6 +426,11 @@ public class KieBaseModelImpl
             String equalsBehavior = reader.getAttribute( "equalsBehavior" );
             if ( equalsBehavior != null ) {
                 kBase.setEqualsBehavior( EqualityBehaviorOption.determineEqualityBehavior( equalsBehavior ) );
+            }
+
+            String alphaNodeOrdering = reader.getAttribute( "alphaNodeOrdering" );
+            if ( alphaNodeOrdering != null ) {
+                kBase.setAlphaNodeOrdering( AlphaNodeOrderingOption.determineAlphaNodeOrdering( alphaNodeOrdering ) );
             }
 
             String declarativeAgenda = reader.getAttribute( "declarativeAgenda" );

--- a/drools-compiler/src/test/java/org/drools/compiler/conf/KnowledgeBaseConfigurationTest.java
+++ b/drools-compiler/src/test/java/org/drools/compiler/conf/KnowledgeBaseConfigurationTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
+import org.kie.api.conf.AlphaNodeOrderingOption;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.conf.RemoveIdentitiesOption;
@@ -391,7 +392,31 @@ public class KnowledgeBaseConfigurationTest {
         assertEquals( "cloud",
                       config.getProperty( EventProcessingOption.PROPERTY_NAME ) );
     }
-    
+
+    @Test
+    public void testAlphaNodeOrderingConfiguration() {
+        // setting the option using the type safe method
+        config.setOption(AlphaNodeOrderingOption.COUNT);
+
+        // checking the type safe getOption() method
+        assertEquals(AlphaNodeOrderingOption.COUNT,
+                     config.getOption(AlphaNodeOrderingOption.class));
+        // checking the string based getProperty() method
+        assertEquals("count",
+                     config.getProperty(AlphaNodeOrderingOption.PROPERTY_NAME));
+
+        // setting the options using the string based setProperty() method
+        config.setProperty(AlphaNodeOrderingOption.PROPERTY_NAME,
+                           "none");
+
+        // checking the type safe getOption() method
+        assertEquals(AlphaNodeOrderingOption.NONE,
+                     config.getOption(AlphaNodeOrderingOption.class));
+        // checking the string based getProperty() method
+        assertEquals("none",
+                     config.getProperty(AlphaNodeOrderingOption.PROPERTY_NAME));
+    }
+
     @Test
     public void testMaxThreadsConfiguration() {
         // setting the option using the type safe method

--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -635,7 +635,7 @@ public class RuleBaseConfiguration
     }
 
     public void setAlphaNodeOrderingOption(final AlphaNodeOrderingOption option) {
-        checkCanChange(); // throws an exception if a change isn't possible;
+        checkCanChange();
         this.alphaNodeOrderingOption = option;
     }
 

--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -36,6 +36,7 @@ import org.drools.core.util.MVELSafeHelper;
 import org.drools.core.util.StringUtils;
 import org.drools.reflective.classloader.ProjectClassLoader;
 import org.kie.api.KieBaseConfiguration;
+import org.kie.api.conf.AlphaNodeOrderingOption;
 import org.kie.api.conf.DeclarativeAgendaOption;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
@@ -153,6 +154,8 @@ public class RuleBaseConfiguration
 
     private IndexPrecedenceOption indexPrecedenceOption;
 
+    private AlphaNodeOrderingOption alphaNodeOrderingOption;
+
     // if "true", rulebase builder will try to split
     // the rulebase into multiple partitions that can be evaluated
     // in parallel by using multiple internal threads
@@ -212,6 +215,7 @@ public class RuleBaseConfiguration
         out.writeBoolean(declarativeAgenda);
         out.writeObject(componentFactory);
         out.writeInt(sessionPoolSize);
+        out.writeObject(alphaNodeOrderingOption);
     }
 
     public void readExternal(ObjectInput in) throws IOException,
@@ -244,6 +248,7 @@ public class RuleBaseConfiguration
         declarativeAgenda = in.readBoolean();
         componentFactory = (KieComponentFactory) in.readObject();
         sessionPoolSize = in.readInt();
+        alphaNodeOrderingOption = (AlphaNodeOrderingOption) in.readObject();
     }
 
     /**
@@ -337,6 +342,8 @@ public class RuleBaseConfiguration
             setMBeansEnabled( MBeansOption.isEnabled(value));
         } else if ( name.equals( ClassLoaderCacheOption.PROPERTY_NAME ) ) {
             setClassLoaderCacheEnabled( StringUtils.isEmpty( value ) ? true : Boolean.valueOf(value));
+        } else if ( name.equals( AlphaNodeOrderingOption.PROPERTY_NAME ) ) {
+            setAlphaNodeOrderingOption( AlphaNodeOrderingOption.determineAlphaNodeOrdering( StringUtils.isEmpty( value ) ? "count" : value));
         }
     }
 
@@ -392,6 +399,8 @@ public class RuleBaseConfiguration
             return isMBeansEnabled() ? "enabled" : "disabled";
         } else if ( name.equals( ClassLoaderCacheOption.PROPERTY_NAME ) ) {
             return Boolean.toString( isClassLoaderCacheEnabled() );
+        } else if ( name.equals( AlphaNodeOrderingOption.PROPERTY_NAME ) ) {
+            return getAlphaNodeOrderingOption().getValue();
         }
 
         return null;
@@ -484,6 +493,9 @@ public class RuleBaseConfiguration
         
         setDeclarativeAgendaEnabled( Boolean.valueOf( this.chainedProperties.getProperty( DeclarativeAgendaOption.PROPERTY_NAME,
                                                                                           "false" ) ) );
+
+        setAlphaNodeOrderingOption(AlphaNodeOrderingOption.determineAlphaNodeOrdering(this.chainedProperties.getProperty(AlphaNodeOrderingOption.PROPERTY_NAME,
+                                                                                                                         "count")));
     }
 
     /**
@@ -616,6 +628,15 @@ public class RuleBaseConfiguration
     public void setEventProcessingMode(final EventProcessingOption mode) {
         checkCanChange(); // throws an exception if a change isn't possible;
         this.eventProcessingMode = mode;
+    }
+
+    public AlphaNodeOrderingOption getAlphaNodeOrderingOption() {
+        return this.alphaNodeOrderingOption;
+    }
+
+    public void setAlphaNodeOrderingOption(final AlphaNodeOrderingOption option) {
+        checkCanChange(); // throws an exception if a change isn't possible;
+        this.alphaNodeOrderingOption = option;
     }
 
     public int getCompositeKeyDepth() {
@@ -1163,6 +1184,8 @@ public class RuleBaseConfiguration
             return (T) (this.isClassLoaderCacheEnabled() ? ClassLoaderCacheOption.ENABLED : ClassLoaderCacheOption.DISABLED);
         } else if (DeclarativeAgendaOption.class.equals(option)) {
             return (T) (this.isDeclarativeAgenda() ? DeclarativeAgendaOption.ENABLED : DeclarativeAgendaOption.DISABLED);
+        } else if (AlphaNodeOrderingOption.class.equals(option)) {
+            return (T) getAlphaNodeOrderingOption();
         }
         return null;
 
@@ -1211,6 +1234,8 @@ public class RuleBaseConfiguration
             setClassLoaderCacheEnabled( ( (ClassLoaderCacheOption) option ).isClassLoaderCacheEnabled());
         } else if (option instanceof DeclarativeAgendaOption) {
             setDeclarativeAgendaEnabled(((DeclarativeAgendaOption) option).isDeclarativeAgendaEnabled());
+        } else if (option instanceof AlphaNodeOrderingOption) {
+            setAlphaNodeOrderingOption( (AlphaNodeOrderingOption) option);
         }
 
     }

--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -343,7 +343,7 @@ public class RuleBaseConfiguration
         } else if ( name.equals( ClassLoaderCacheOption.PROPERTY_NAME ) ) {
             setClassLoaderCacheEnabled( StringUtils.isEmpty( value ) ? true : Boolean.valueOf(value));
         } else if ( name.equals( AlphaNodeOrderingOption.PROPERTY_NAME ) ) {
-            setAlphaNodeOrderingOption( AlphaNodeOrderingOption.determineAlphaNodeOrdering( StringUtils.isEmpty( value ) ? "count" : value));
+            setAlphaNodeOrderingOption( AlphaNodeOrderingOption.determineAlphaNodeOrdering( StringUtils.isEmpty( value ) ? "none" : value));
         }
     }
 
@@ -495,7 +495,7 @@ public class RuleBaseConfiguration
                                                                                           "false" ) ) );
 
         setAlphaNodeOrderingOption(AlphaNodeOrderingOption.determineAlphaNodeOrdering(this.chainedProperties.getProperty(AlphaNodeOrderingOption.PROPERTY_NAME,
-                                                                                                                         "count")));
+                                                                                                                         "none")));
     }
 
     /**

--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -110,6 +110,7 @@ import static org.drools.core.util.MemoryUtil.hasPermGen;
  * drools.declarativeAgendaEnabled =  &lt;true|false&gt; 
  * drools.permgenThreshold = &lt;1...n&gt;
  * drools.jittingThreshold = &lt;1...n&gt;
+ * drools.alphaNodeOrdering = &lt;count|custom|none&gt; (custom is experimental)
  * </pre>
  */
 public class RuleBaseConfiguration

--- a/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
@@ -15,13 +15,14 @@
 
 package org.drools.core.addon;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
+import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.spi.AlphaNodeFieldConstraint;
 import org.drools.core.spi.ObjectType;
 import org.kie.api.conf.AlphaNodeOrderingOption;
-import org.kie.api.definition.rule.Rule;
 
 /**
  * 
@@ -31,7 +32,7 @@ import org.kie.api.definition.rule.Rule;
  */
 public interface AlphaNodeOrderingStrategy {
 
-    void analyzeAlphaConstraints(Set<Rule> ruleSet);
+    void analyzeAlphaConstraints(Map<String, InternalKnowledgePackage> pkgs, Collection<InternalKnowledgePackage> newPkgs);
 
     void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints, ObjectType objectType);
 

--- a/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.drools.core.spi.ObjectType;
 import org.kie.api.conf.AlphaNodeOrderingOption;
 import org.kie.api.definition.rule.Rule;
 
@@ -32,7 +33,7 @@ public interface AlphaNodeOrderingStrategy {
 
     void analyzeAlphaConstraints(Set<Rule> ruleSet);
 
-    void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints);
+    void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints, ObjectType objectType);
 
     static AlphaNodeOrderingStrategy createAlphaNodeOrderingStrategy(AlphaNodeOrderingOption option) {
         if (AlphaNodeOrderingOption.COUNT.equals(option)) {

--- a/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.core.addon;
+
+import java.util.List;
+import java.util.Set;
+
+import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.kie.api.conf.AlphaNodeOrderingOption;
+import org.kie.api.definition.rule.Rule;
+
+/**
+ * 
+ * Interface for alpha node ordering. Implement methods to analyze rules and reorder alpha constraints
+ * in order to maximize alpha node sharing and minimize the number of evaluations.
+ *
+ */
+public interface AlphaNodeOrderingStrategy {
+
+    void analyzeAlphaConstraints(Set<Rule> ruleSet);
+
+    void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints);
+
+    static AlphaNodeOrderingStrategy createAlphaNodeOrderingStrategy(AlphaNodeOrderingOption option) {
+        if (AlphaNodeOrderingOption.COUNT.equals(option)) {
+            return new CountBasedOrderingStrategy();
+        } else {
+            return new NoopOrderingStrategy();
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
@@ -37,8 +37,10 @@ public interface AlphaNodeOrderingStrategy {
     static AlphaNodeOrderingStrategy createAlphaNodeOrderingStrategy(AlphaNodeOrderingOption option) {
         if (AlphaNodeOrderingOption.COUNT.equals(option)) {
             return new CountBasedOrderingStrategy();
-        } else {
+        } else if (AlphaNodeOrderingOption.NONE.equals(option)) {
             return new NoopOrderingStrategy();
+        } else {
+            throw new IllegalArgumentException("No implementation found for AlphaNodeOrderingOption [" + option + "]");
         }
     }
 }

--- a/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/AlphaNodeOrderingStrategy.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.spi.AlphaNodeFieldConstraint;
 import org.drools.core.spi.ObjectType;
+import org.drools.core.util.ClassUtils;
 import org.kie.api.conf.AlphaNodeOrderingOption;
 
 /**
@@ -39,6 +40,13 @@ public interface AlphaNodeOrderingStrategy {
     static AlphaNodeOrderingStrategy createAlphaNodeOrderingStrategy(AlphaNodeOrderingOption option) {
         if (AlphaNodeOrderingOption.COUNT.equals(option)) {
             return new CountBasedOrderingStrategy();
+        } else if (AlphaNodeOrderingOption.CUSTOM.equals(option)) {
+            String customStrategyClassName = System.getProperty(AlphaNodeOrderingOption.CUSTOM_CLASS_PROPERTY_NAME);
+            if (customStrategyClassName == null || customStrategyClassName.trim().isEmpty()) {
+                throw new RuntimeException("Configure system property " + AlphaNodeOrderingOption.CUSTOM_CLASS_PROPERTY_NAME + " with custom strategy implementation FQCN when you use AlphaNodeOrderingOption.CUSTOM");
+            } else {
+                return (AlphaNodeOrderingStrategy) ClassUtils.instantiateObject(customStrategyClassName);
+            }
         } else if (AlphaNodeOrderingOption.NONE.equals(option)) {
             return new NoopOrderingStrategy();
         } else {

--- a/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.core.addon;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.core.rule.Accumulate;
+import org.drools.core.rule.Pattern;
+import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.kie.api.definition.rule.Rule;
+
+/**
+ * 
+ * Reorder based on usage count of alpha constraints
+ *
+ */
+public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
+
+    private Map<AlphaNodeFieldConstraint, Integer> analyzedAlphaConstraints = new HashMap<>();
+
+    @Override
+    public void analyzeAlphaConstraints(Set<Rule> ruleSet) {
+        // Pattern
+        ruleSet.stream()
+               .flatMap(rule -> ((RuleImpl) rule).getLhs().getChildren().stream())
+               .filter(Pattern.class::isInstance)
+               .map(Pattern.class::cast)
+               .flatMap(pattern -> pattern.getConstraints().stream())
+               .filter(AlphaNodeFieldConstraint.class::isInstance)
+               .map(AlphaNodeFieldConstraint.class::cast)
+               .forEach(constraint -> analyzedAlphaConstraints.merge(constraint, 1, (count, newValue) -> count + 1));
+
+        // Accumulate
+        ruleSet.stream()
+               .flatMap(rule -> ((RuleImpl) rule).getLhs().getChildren().stream())
+               .filter(Pattern.class::isInstance)
+               .map(Pattern.class::cast)
+               .map(Pattern::getSource)
+               .filter(Accumulate.class::isInstance)
+               .map(Accumulate.class::cast)
+               .map(Accumulate::getSource)
+               .filter(Pattern.class::isInstance)
+               .map(Pattern.class::cast)
+               .flatMap(pattern -> pattern.getConstraints().stream())
+               .filter(AlphaNodeFieldConstraint.class::isInstance)
+               .map(AlphaNodeFieldConstraint.class::cast)
+               .forEach(constraint -> analyzedAlphaConstraints.merge(constraint, 1, (count, newValue) -> count + 1));
+
+        // TODO: Other cases
+
+        //        System.out.println("analyzedAlphaConstraints : " + analyzedAlphaConstraints);
+    }
+
+    @Override
+    public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints) {
+        // greater usage count is earlier
+        //        System.out.println("alphaConstraints : " + alphaConstraints);
+        alphaConstraints.sort((constraint1, constraint2) -> {
+            Integer count1 = analyzedAlphaConstraints.getOrDefault(constraint1, 1);
+            Integer count2 = analyzedAlphaConstraints.getOrDefault(constraint2, 1);
+            return count2.compareTo(count1);
+        });
+        //        System.out.println("reordered alphaConstraints : " + alphaConstraints);
+    }
+
+}

--- a/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
@@ -19,11 +19,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.rule.Accumulate;
 import org.drools.core.rule.Pattern;
 import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.drools.core.spi.ObjectType;
 import org.kie.api.definition.rule.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,48 +39,57 @@ public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
 
     private static final Logger logger = LoggerFactory.getLogger(CountBasedOrderingStrategy.class);
 
-    private Map<AlphaNodeFieldConstraint, Integer> analyzedAlphaConstraints = new HashMap<>();
+    private Map<ObjectType, Map<AlphaNodeFieldConstraint, Integer>> analyzedAlphaConstraints = new HashMap<>();
 
     @Override
     public void analyzeAlphaConstraints(Set<Rule> ruleSet) {
-        // Pattern
-        ruleSet.stream()
-               .flatMap(rule -> ((RuleImpl) rule).getLhs().getChildren().stream())
-               .filter(Pattern.class::isInstance)
-               .map(Pattern.class::cast)
-               .flatMap(pattern -> pattern.getConstraints().stream())
-               .filter(AlphaNodeFieldConstraint.class::isInstance)
-               .map(AlphaNodeFieldConstraint.class::cast)
-               .forEach(constraint -> analyzedAlphaConstraints.merge(constraint, 1, (count, newValue) -> count + 1));
+        // Direct Pattern
+        List<Pattern> patternList = ruleSet.stream()
+                                           .flatMap(rule -> ((RuleImpl) rule).getLhs().getChildren().stream())
+                                           .filter(Pattern.class::isInstance)
+                                           .map(Pattern.class::cast)
+                                           .collect(Collectors.toList());
 
         // Accumulate
-        ruleSet.stream()
-               .flatMap(rule -> ((RuleImpl) rule).getLhs().getChildren().stream())
-               .filter(Pattern.class::isInstance)
-               .map(Pattern.class::cast)
-               .map(Pattern::getSource)
-               .filter(Accumulate.class::isInstance)
-               .map(Accumulate.class::cast)
-               .map(Accumulate::getSource)
-               .filter(Pattern.class::isInstance)
-               .map(Pattern.class::cast)
-               .flatMap(pattern -> pattern.getConstraints().stream())
-               .filter(AlphaNodeFieldConstraint.class::isInstance)
-               .map(AlphaNodeFieldConstraint.class::cast)
-               .forEach(constraint -> analyzedAlphaConstraints.merge(constraint, 1, (count, newValue) -> count + 1));
+        patternList.addAll(ruleSet.stream()
+                                  .flatMap(rule -> ((RuleImpl) rule).getLhs().getChildren().stream())
+                                  .filter(Pattern.class::isInstance)
+                                  .map(Pattern.class::cast)
+                                  .map(Pattern::getSource)
+                                  .filter(Accumulate.class::isInstance)
+                                  .map(Accumulate.class::cast)
+                                  .map(Accumulate::getSource)
+                                  .filter(Pattern.class::isInstance)
+                                  .map(Pattern.class::cast)
+                                  .collect(Collectors.toList()));
 
         // TODO: Other cases
+
+        for (Pattern pattern : patternList) {
+            ObjectType objectType = pattern.getObjectType();
+            Map<AlphaNodeFieldConstraint, Integer> analyzedAlphaConstraintsPerObjectType = analyzedAlphaConstraints.computeIfAbsent(objectType, key -> new HashMap<AlphaNodeFieldConstraint, Integer>());
+            pattern.getConstraints()
+                   .stream()
+                   .filter(AlphaNodeFieldConstraint.class::isInstance)
+                   .map(AlphaNodeFieldConstraint.class::cast)
+                   .forEach(constraint -> analyzedAlphaConstraintsPerObjectType.merge(constraint, 1, (count, newValue) -> count + 1));
+        }
 
         logger.trace("analyzedAlphaConstraints : {}", analyzedAlphaConstraints);
     }
 
     @Override
-    public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints) {
+    public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints, ObjectType objectType) {
         // greater usage count is earlier
         logger.trace("** before alphaConstraints : {}", alphaConstraints);
+        Map<AlphaNodeFieldConstraint, Integer> analyzedAlphaConstraintsPerObjectType = analyzedAlphaConstraints.get(objectType);
+        if (analyzedAlphaConstraintsPerObjectType == null) {
+            logger.trace(" ** after alphaConstraints : {}", alphaConstraints);
+            return;
+        }
         alphaConstraints.sort((constraint1, constraint2) -> {
-            Integer count1 = analyzedAlphaConstraints.getOrDefault(constraint1, 1);
-            Integer count2 = analyzedAlphaConstraints.getOrDefault(constraint2, 1);
+            Integer count1 = analyzedAlphaConstraintsPerObjectType.getOrDefault(constraint1, 1);
+            Integer count2 = analyzedAlphaConstraintsPerObjectType.getOrDefault(constraint2, 1);
             return count2.compareTo(count1);
         });
         logger.trace(" ** after alphaConstraints : {}", alphaConstraints);

--- a/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
@@ -65,19 +65,19 @@ public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
 
         // TODO: Other cases
 
-        //        System.out.println("analyzedAlphaConstraints : " + analyzedAlphaConstraints);
+        System.out.println("analyzedAlphaConstraints : " + analyzedAlphaConstraints);
     }
 
     @Override
     public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints) {
         // greater usage count is earlier
-        //        System.out.println("alphaConstraints : " + alphaConstraints);
+        System.out.println("** before alphaConstraints : " + alphaConstraints);
         alphaConstraints.sort((constraint1, constraint2) -> {
             Integer count1 = analyzedAlphaConstraints.getOrDefault(constraint1, 1);
             Integer count2 = analyzedAlphaConstraints.getOrDefault(constraint2, 1);
             return count2.compareTo(count1);
         });
-        //        System.out.println("reordered alphaConstraints : " + alphaConstraints);
+        System.out.println(" ** after alphaConstraints : " + alphaConstraints);
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
@@ -16,12 +16,15 @@
 package org.drools.core.addon;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.rule.Accumulate;
 import org.drools.core.rule.Collect;
@@ -48,7 +51,9 @@ public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
     private Map<ObjectType, Map<AlphaNodeFieldConstraint, Integer>> analyzedAlphaConstraints = new HashMap<>();
 
     @Override
-    public void analyzeAlphaConstraints(Set<Rule> ruleSet) {
+    public void analyzeAlphaConstraints(Map<String, InternalKnowledgePackage> pkgs, Collection<InternalKnowledgePackage> newPkgs) {
+
+        Set<Rule> ruleSet = collectRules(pkgs, newPkgs);
 
         List<Pattern> patternList = new ArrayList<>();
         ruleSet.stream()
@@ -66,6 +71,13 @@ public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
         }
 
         logger.trace("analyzedAlphaConstraints : {}", analyzedAlphaConstraints);
+    }
+
+    private Set<Rule> collectRules(Map<String, InternalKnowledgePackage> pkgs, Collection<InternalKnowledgePackage> newPkgs) {
+        Set<Rule> ruleSet = new HashSet<>();
+        pkgs.forEach((pkgName, pkg) -> ruleSet.addAll(pkg.getRules()));
+        newPkgs.forEach(pkg -> ruleSet.addAll(pkg.getRules())); // okay to overwrite
+        return ruleSet;
     }
 
     private void collectPatterns(GroupElement ge, List<Pattern> patternList) {

--- a/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/CountBasedOrderingStrategy.java
@@ -25,6 +25,8 @@ import org.drools.core.rule.Accumulate;
 import org.drools.core.rule.Pattern;
 import org.drools.core.spi.AlphaNodeFieldConstraint;
 import org.kie.api.definition.rule.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 
@@ -32,6 +34,8 @@ import org.kie.api.definition.rule.Rule;
  *
  */
 public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
+
+    private static final Logger logger = LoggerFactory.getLogger(CountBasedOrderingStrategy.class);
 
     private Map<AlphaNodeFieldConstraint, Integer> analyzedAlphaConstraints = new HashMap<>();
 
@@ -65,19 +69,19 @@ public class CountBasedOrderingStrategy implements AlphaNodeOrderingStrategy {
 
         // TODO: Other cases
 
-        System.out.println("analyzedAlphaConstraints : " + analyzedAlphaConstraints);
+        logger.trace("analyzedAlphaConstraints : {}", analyzedAlphaConstraints);
     }
 
     @Override
     public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints) {
         // greater usage count is earlier
-        System.out.println("** before alphaConstraints : " + alphaConstraints);
+        logger.trace("** before alphaConstraints : {}", alphaConstraints);
         alphaConstraints.sort((constraint1, constraint2) -> {
             Integer count1 = analyzedAlphaConstraints.getOrDefault(constraint1, 1);
             Integer count2 = analyzedAlphaConstraints.getOrDefault(constraint2, 1);
             return count2.compareTo(count1);
         });
-        System.out.println(" ** after alphaConstraints : " + alphaConstraints);
+        logger.trace(" ** after alphaConstraints : {}", alphaConstraints);
     }
 
 }

--- a/drools-core/src/main/java/org/drools/core/addon/NoopOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/NoopOrderingStrategy.java
@@ -15,17 +15,18 @@
 
 package org.drools.core.addon;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
+import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.spi.AlphaNodeFieldConstraint;
 import org.drools.core.spi.ObjectType;
-import org.kie.api.definition.rule.Rule;
 
 public class NoopOrderingStrategy implements AlphaNodeOrderingStrategy {
 
     @Override
-    public void analyzeAlphaConstraints(Set<Rule> ruleSet) {
+    public void analyzeAlphaConstraints(Map<String, InternalKnowledgePackage> pkgs, Collection<InternalKnowledgePackage> newPkgs) {
         // no op
     }
 

--- a/drools-core/src/main/java/org/drools/core/addon/NoopOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/NoopOrderingStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.core.addon;
+
+import java.util.List;
+import java.util.Set;
+
+import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.kie.api.definition.rule.Rule;
+
+public class NoopOrderingStrategy implements AlphaNodeOrderingStrategy {
+
+    @Override
+    public void analyzeAlphaConstraints(Set<Rule> ruleSet) {
+        // no op
+    }
+
+    @Override
+    public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints) {
+        // no op
+    }
+
+}

--- a/drools-core/src/main/java/org/drools/core/addon/NoopOrderingStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/addon/NoopOrderingStrategy.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.drools.core.spi.ObjectType;
 import org.kie.api.definition.rule.Rule;
 
 public class NoopOrderingStrategy implements AlphaNodeOrderingStrategy {
@@ -29,8 +30,7 @@ public class NoopOrderingStrategy implements AlphaNodeOrderingStrategy {
     }
 
     @Override
-    public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints) {
+    public void reorderAlphaConstraints(List<AlphaNodeFieldConstraint> alphaConstraints, ObjectType objectType) {
         // no op
     }
-
 }

--- a/drools-core/src/main/java/org/drools/core/impl/InternalKnowledgeBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalKnowledgeBase.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.SessionConfiguration;
+import org.drools.core.addon.AlphaNodeOrderingStrategy;
 import org.drools.core.base.ClassFieldAccessorCache;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
@@ -150,4 +151,6 @@ public interface InternalKnowledgeBase extends KieBase {
 
     List<AsyncReceiveNode> getReceiveNodes();
     void addReceiveNode(AsyncReceiveNode node);
+
+    AlphaNodeOrderingStrategy getAlphaNodeOrderingStrategy();
 }

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -193,7 +193,7 @@ public class KnowledgeBaseImpl
 
     private KieSessionsPool sessionPool;
 
-    private AlphaNodeOrderingStrategy alphaNodeOrderingStrategy = new CountBasedOrderingStrategy();
+    private transient AlphaNodeOrderingStrategy alphaNodeOrderingStrategy = new CountBasedOrderingStrategy();
 
     public KnowledgeBaseImpl() { }
 
@@ -506,6 +506,8 @@ public class KnowledgeBaseImpl
         }
 
         this.getConfiguration().getComponentFactory().initTraitFactory(this);
+
+        this.alphaNodeOrderingStrategy = AlphaNodeOrderingStrategy.createAlphaNodeOrderingStrategy(this.config.getAlphaNodeOrderingOption());
 
         rewireReteAfterDeserialization();
     }

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -44,7 +44,7 @@ import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.SessionConfiguration;
 import org.drools.core.SessionConfigurationImpl;
 import org.drools.core.addon.AlphaNodeOrderingStrategy;
-import org.drools.core.addon.CountBasedOrderingStrategy;
+import org.drools.core.addon.NoopOrderingStrategy;
 import org.drools.core.base.ClassFieldAccessorCache;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.common.BaseNode;
@@ -193,7 +193,7 @@ public class KnowledgeBaseImpl
 
     private KieSessionsPool sessionPool;
 
-    private transient AlphaNodeOrderingStrategy alphaNodeOrderingStrategy = new CountBasedOrderingStrategy();
+    private transient AlphaNodeOrderingStrategy alphaNodeOrderingStrategy = new NoopOrderingStrategy();
 
     public KnowledgeBaseImpl() { }
 

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -55,7 +55,6 @@ import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.RuleBasePartitionId;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.event.KieBaseEventSupport;
 import org.drools.core.factmodel.ClassDefinition;
@@ -850,7 +849,7 @@ public class KnowledgeBaseImpl
             wm.flushPropagations();
         }
 
-        alphaNodeOrderingStrategy.analyzeAlphaConstraints(collectRules(pkgs, clonedPkgs));
+        alphaNodeOrderingStrategy.analyzeAlphaConstraints(pkgs, clonedPkgs);
 
         // we need to merge all byte[] first, so that the root classloader can resolve classes
         for (InternalKnowledgePackage newPkg : clonedPkgs) {
@@ -959,13 +958,6 @@ public class KnowledgeBaseImpl
         if (config.isMultithreadEvaluation() && !hasMultiplePartitions()) {
             disableMultithreadEvaluation("The rete network cannot be partitioned: disabling multithread evaluation");
         }
-    }
-
-    private Set<Rule> collectRules(Map<String, InternalKnowledgePackage> pkgs, Collection<InternalKnowledgePackage> newPkgs) {
-        Set<Rule> ruleSet = new HashSet<>();
-        pkgs.forEach((pkgName, pkg) -> ruleSet.addAll(pkg.getRules()));
-        newPkgs.forEach(pkg -> ruleSet.addAll(pkg.getRules())); // okay to overwrite
-        return ruleSet;
     }
 
     public void processAllTypesDeclaration( Collection<InternalKnowledgePackage> pkgs ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
@@ -105,7 +105,7 @@ public class PatternBuilder
 
         Constraints constraints = createConstraints(context, pattern);
 
-        context.getKnowledgeBase().getAlphaNodeOrderingStrategy().reorderAlphaConstraints(constraints.alphaConstraints);
+        context.getKnowledgeBase().getAlphaNodeOrderingStrategy().reorderAlphaConstraints(constraints.alphaConstraints, pattern.getObjectType());
 
         // Create BetaConstraints object
         context.setBetaconstraints( constraints.betaConstraints );

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PatternBuilder.java
@@ -105,6 +105,8 @@ public class PatternBuilder
 
         Constraints constraints = createConstraints(context, pattern);
 
+        context.getKnowledgeBase().getAlphaNodeOrderingStrategy().reorderAlphaConstraints(constraints.alphaConstraints);
+
         // Create BetaConstraints object
         context.setBetaconstraints( constraints.betaConstraints );
 

--- a/drools-core/src/main/java/org/drools/core/rule/Declaration.java
+++ b/drools-core/src/main/java/org/drools/core/rule/Declaration.java
@@ -328,7 +328,11 @@ public class Declaration
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     public String toString() {
-        return "(" + this.readAccessor.getValueType() + ") " + this.identifier;
+        if (readAccessor instanceof ClassFieldReader && !((ClassFieldReader) readAccessor).hasReadAccessor()) {
+            return "(null) " + this.identifier;
+        } else {
+            return "(" + this.readAccessor.getValueType() + ") " + this.identifier;
+        }
     }
 
     public int hashCode() {

--- a/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
+++ b/drools-core/src/main/java/org/drools/core/rule/PredicateConstraint.java
@@ -223,6 +223,9 @@ public class PredicateConstraint extends MutableTypeConstraint
             }
         }
 
+        if (this.expression == null) {
+            return other.expression == null;
+        }
         return this.expression.equals( other.expression );
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
@@ -184,6 +184,8 @@ public class CanonicalKieModule implements InternalKieModule {
             kbConf.setOption(kBaseModel.getEventProcessingMode());
             kbConf.setOption(kBaseModel.getDeclarativeAgenda());
             kbConf.setOption(kBaseModel.getSequential());
+            kbConf.setOption(kBaseModel.getSessionsPool());
+            kbConf.setOption(kBaseModel.getAlphaNodeOrdering());
         }
         return kbConf;
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
@@ -250,6 +251,7 @@ public abstract class AccumulateVisitor {
 
         Optional<DeclarationSpec> decl = context.getDeclarationById(rootNodeName);
 
+/*
         Class<?> clazz = decl.map(DeclarationSpec::getDeclarationClass)
                 .orElseGet( () -> {
                     try {
@@ -258,6 +260,18 @@ public abstract class AccumulateVisitor {
                         throw new RuntimeException( e );
                     }
                 } );
+*/
+        Optional<?> optClass = decl.map(DeclarationSpec::getDeclarationClass);
+        Class<?> clazz;
+        if (optClass.isPresent()) {
+            clazz = (Class<?>) optClass.get();
+        } else {
+            try {
+                clazz =  context.getTypeResolver().resolveType(rootNodeName);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException( e );
+            }
+        }
 
         final TypedExpression typedExpression = new ToMethodCall(context).toMethodCallWithClassCheck(methodCallWithoutRootNode.getWithoutRootNode(), null, clazz);
         final Class<?> methodCallExprType = typedExpression.getRawClass();

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
@@ -251,7 +250,6 @@ public abstract class AccumulateVisitor {
 
         Optional<DeclarationSpec> decl = context.getDeclarationById(rootNodeName);
 
-/*
         Class<?> clazz = decl.map(DeclarationSpec::getDeclarationClass)
                 .orElseGet( () -> {
                     try {
@@ -260,18 +258,6 @@ public abstract class AccumulateVisitor {
                         throw new RuntimeException( e );
                     }
                 } );
-*/
-        Optional<?> optClass = decl.map(DeclarationSpec::getDeclarationClass);
-        Class<?> clazz;
-        if (optClass.isPresent()) {
-            clazz = (Class<?>) optClass.get();
-        } else {
-            try {
-                clazz =  context.getTypeResolver().resolveType(rootNodeName);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException( e );
-            }
-        }
 
         final TypedExpression typedExpression = new ToMethodCall(context).toMethodCallWithClassCheck(methodCallWithoutRootNode.getWithoutRootNode(), null, clazz);
         final Class<?> methodCallExprType = typedExpression.getRawClass();

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AlphaNodeOrderingTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AlphaNodeOrderingTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2005 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.rule.constraint.MvelConstraint;
+import org.drools.modelcompiler.domain.Person;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.conf.AlphaNodeOrderingOption;
+import org.kie.api.runtime.KieSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AlphaNodeOrderingTest extends BaseModelTest {
+
+    public AlphaNodeOrderingTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Test
+    public void testCountBasedAlphaNodeOrdering() {
+        String str =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                     "rule R1 when\n" +
+                     "  $p : Person(age != 0, age != 1, age != 2, age != 3)\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $p : Person(age != 1, age != 2, age != 3)\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R3 when\n" +
+                     "  $p : Person(age != 2, age != 3)\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R4 when\n" +
+                     "  $p : Person(age != 3)\n" +
+                     "then\n" +
+                     "end\n";
+
+        KieModuleModel model = KieServices.get().newKieModuleModel();
+        model.newKieBaseModel("kb")
+             .setDefault(true)
+             .setAlphaNodeOrdering(AlphaNodeOrderingOption.COUNT)
+             .newKieSessionModel("ks")
+             .setDefault(true);
+
+        KieSession ksession = getKieSession(model, str);
+
+//        ReteDumper.dumpRete(ksession);
+        List<AlphaNode> alphaNodes = ReteDumper.collectNodes(ksession)
+                                               .stream()
+                                               .filter(AlphaNode.class::isInstance)
+                                               .map(node -> (AlphaNode) node)
+                                               .collect(Collectors.toList());
+        assertEquals(4, alphaNodes.size());
+
+        if (testRunType == RUN_TYPE.STANDARD_FROM_DRL) {
+            // Not found a good way to assert constraints in case of externalized LambdaConstraint
+            // Anyway alphaNodes.size() == 4 means that alpha nodes are reordered so effectively shared
+            Optional<AlphaNode> optAlphaNot3 = alphaNodes.stream()
+                                                         .filter(node -> ((MvelConstraint)node.getConstraint()).getExpression().equals("age != 3"))
+                                                         .findFirst();
+            assertTrue(optAlphaNot3.isPresent());
+
+            AlphaNode alphaNot3 = optAlphaNot3.get();
+
+            AlphaNode alphaNot2 = getNextAlphaNode(alphaNot3);
+            assertEquals("age != 2", ((MvelConstraint)alphaNot2.getConstraint()).getExpression());
+
+            AlphaNode alphaNot1 = getNextAlphaNode(alphaNot2);
+            assertEquals("age != 1", ((MvelConstraint)alphaNot1.getConstraint()).getExpression());
+
+            AlphaNode alphaNot0 = getNextAlphaNode(alphaNot1);
+            assertEquals("age != 0", ((MvelConstraint)alphaNot0.getConstraint()).getExpression());
+        }
+
+        ksession.insert(new Person("Mario", 1));
+        assertEquals(2, ksession.fireAllRules());
+    }
+
+    private AlphaNode getNextAlphaNode(AlphaNode current) {
+        Optional<AlphaNode> optNextAlpha = Arrays.stream(current.getSinks())
+                                                 .filter(AlphaNode.class::isInstance)
+                                                 .map(AlphaNode.class::cast)
+                                                 .findFirst();
+        assertTrue(optNextAlpha.isPresent());
+        AlphaNode nextAlpha = optNextAlpha.get();
+        return nextAlpha;
+    }
+
+    @Test
+    public void testNoopAlphaNodeOrdering() {
+        String str =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                     "rule R1 when\n" +
+                     "  $p : Person(age != 0, age != 1, age != 2, age != 3)\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $p : Person(age != 1, age != 2, age != 3)\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R3 when\n" +
+                     "  $p : Person(age != 2, age != 3)\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R4 when\n" +
+                     "  $p : Person(age != 3)\n" +
+                     "then\n" +
+                     "end\n";
+
+        KieModuleModel model = KieServices.get().newKieModuleModel();
+        model.newKieBaseModel("kb")
+             .setDefault(true)
+             .setAlphaNodeOrdering(AlphaNodeOrderingOption.NONE)
+             .newKieSessionModel("ks")
+             .setDefault(true);
+
+        KieSession ksession = getKieSession(model, str);
+
+        ReteDumper.dumpRete(ksession);
+        List<AlphaNode> alphaNodes = ReteDumper.collectNodes(ksession)
+                                               .stream()
+                                               .filter(AlphaNode.class::isInstance)
+                                               .map(node -> (AlphaNode) node)
+                                               .collect(Collectors.toList());
+        assertEquals(10, alphaNodes.size());
+
+        ksession.insert(new Person("Mario", 1));
+        assertEquals(2, ksession.fireAllRules());
+    }
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AlphaNodeOrderingTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AlphaNodeOrderingTest.java
@@ -145,7 +145,7 @@ public class AlphaNodeOrderingTest extends BaseModelTest {
 
         KieSession ksession = getKieSession(model, str);
 
-        ReteDumper.dumpRete(ksession);
+//        ReteDumper.dumpRete(ksession);
         List<AlphaNode> alphaNodes = ReteDumper.collectNodes(ksession)
                                                .stream()
                                                .filter(AlphaNode.class::isInstance)
@@ -178,15 +178,17 @@ public class AlphaNodeOrderingTest extends BaseModelTest {
                      "end\n";
 
         KieModuleModel model = KieServices.get().newKieModuleModel();
-        model.newKieBaseModel("kb")
+        model
+//             .setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.FALSE.toString())
+             .newKieBaseModel("kb")
              .setDefault(true)
-             .setAlphaNodeOrdering(AlphaNodeOrderingOption.COUNT)
+             .setAlphaNodeOrdering(AlphaNodeOrderingOption.COUNT) // Fails with COUNT
              .newKieSessionModel("ks")
              .setDefault(true);
 
         KieSession ksession = getKieSession(model, str);
 
-                ReteDumper.dumpRete(ksession);
+//                ReteDumper.dumpRete(ksession);
         List<AlphaNode> alphaNodes = ReteDumper.collectNodes(ksession)
                                                .stream()
                                                .filter(AlphaNode.class::isInstance)
@@ -201,9 +203,9 @@ public class AlphaNodeOrderingTest extends BaseModelTest {
     @Test
     public void testInstanceof() {
 
-        // address.street == "ABC street" has larger usage count.
-        // So reordering results in [address.street == "ABC street", address != null] for R1
-        //   -> NullPointerException
+        // name != "Paul" has larger usage count.
+        // So reordering results in [name != "Paul", this instanceof FactBSub] for R1
+        //   -> FactASuper.getName() throws UnsupportedOperationException 
 
         String str =
                 "import " + FactASuper.class.getCanonicalName() + "\n" +
@@ -219,15 +221,17 @@ public class AlphaNodeOrderingTest extends BaseModelTest {
                      "end\n";
 
         KieModuleModel model = KieServices.get().newKieModuleModel();
-        model.newKieBaseModel("kb")
+        model
+//             .setConfigurationProperty("drools.externaliseCanonicalModelLambda", Boolean.FALSE.toString())
+             .newKieBaseModel("kb")
              .setDefault(true)
-             .setAlphaNodeOrdering(AlphaNodeOrderingOption.COUNT)
+             .setAlphaNodeOrdering(AlphaNodeOrderingOption.COUNT) // Fails with COUNT
              .newKieSessionModel("ks")
              .setDefault(true);
 
         KieSession ksession = getKieSession(model, str);
 
-                ReteDumper.dumpRete(ksession);
+//                ReteDumper.dumpRete(ksession);
         List<AlphaNode> alphaNodes = ReteDumper.collectNodes(ksession)
                                                .stream()
                                                .filter(AlphaNode.class::isInstance)

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactASuper.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactASuper.java
@@ -1,0 +1,14 @@
+package org.drools.modelcompiler.domain;
+
+public class FactASuper {
+
+    public FactASuper() {}
+
+    public String getName() {
+        throw new UnsupportedOperationException("getName is not supported on FactASuper");
+    }
+
+    public void setName(String name) {
+        throw new UnsupportedOperationException("setName is not supported on FactASuper");
+    }
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactASuper.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactASuper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.modelcompiler.domain;
 
 public class FactASuper {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactBSub.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactBSub.java
@@ -1,0 +1,22 @@
+package org.drools.modelcompiler.domain;
+
+public class FactBSub extends FactASuper {
+
+    private String name;
+
+    public FactBSub() {}
+
+    public FactBSub(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactBSub.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactBSub.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.modelcompiler.domain;
 
 public class FactBSub extends FactASuper {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactCSub.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactCSub.java
@@ -1,0 +1,22 @@
+package org.drools.modelcompiler.domain;
+
+public class FactCSub extends FactASuper {
+
+    private String name;
+
+    public FactCSub() {}
+
+    public FactCSub(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactCSub.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/FactCSub.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.modelcompiler.domain;
 
 public class FactCSub extends FactASuper {


### PR DESCRIPTION
Added Alpha Node Ordering. By default, alpha nodes are reordered based on usage count (AlphaNodeOrderingOption.COUNT). If you set AlphaNodeOrderingOption.NONE as KieBaseOption, alpha nodes will not be reordered (= The order will be the same as written in rules).

CountBasedOrderingStrategy.analyzeAlphaConstraints() : Counts usage count of alpha constraints in all rules
CountBasedOrderingStrategy.reorderAlphaConstraints() : Reorder alpha constraints right before creating AlphaNodes.

See https://github.com/kiegroup/droolsjbpm-knowledge/pull/446

This is a draft implementation. I will need to do some more work in analyzeAlphaConstraints() and add more unit tests. But a basic use case (= alpha constraints inside Pattern) works fine.
