### PR TITLE
[DROOLS-5448] Add TransformationDictionary to "compiler" stack method

### DIFF
--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
@@ -19,11 +19,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.kie.pmml.commons.model.abstracts.AbstractKiePMMLBase;
 import org.kie.pmml.commons.model.enums.MINING_FUNCTION;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
+import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
 
 /**
  * KIE representation of PMML model
@@ -35,6 +37,8 @@ public abstract class KiePMMLModel extends AbstractKiePMMLBase {
     protected String targetField;
     protected Map<String, Object> outputFieldsMap = new HashMap<>();
     protected Map<String, Object> missingValueReplacementMap = new HashMap<>();
+    protected Map<String, Function<List<KiePMMLNameValue>, Object>> commonTransformationsMap = new HashMap<>();
+    protected Map<String, Function<List<KiePMMLNameValue>, Object>> localTransformationsMap = new HashMap<>();
 
     protected KiePMMLModel(String name, List<KiePMMLExtension> extensions) {
         super(name, extensions);
@@ -60,6 +64,14 @@ public abstract class KiePMMLModel extends AbstractKiePMMLBase {
         return Collections.unmodifiableMap(missingValueReplacementMap);
     }
 
+    public Map<String, Function<List<KiePMMLNameValue>, Object>> getCommonTransformationsMap() {
+        return Collections.unmodifiableMap(commonTransformationsMap);
+    }
+
+    public Map<String, Function<List<KiePMMLNameValue>, Object>> getLocalTransformationsMap() {
+        return Collections.unmodifiableMap(localTransformationsMap);
+    }
+
     /**
      * Method to retrieve the <b>package</b> name to be used inside kiebase/package attribute of
      * kmodule.xml and to use for package creation inside PMMLAssemblerService
@@ -79,6 +91,7 @@ public abstract class KiePMMLModel extends AbstractKiePMMLBase {
      * @return
      */
     public abstract Object evaluate(final Object knowledgeBase, Map<String, Object> requestData);
+
 
     public abstract static class Builder<T extends KiePMMLModel> extends AbstractKiePMMLBase.Builder<T> {
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProvider.java
@@ -38,7 +38,7 @@ public interface ModelImplementationProvider<T extends Model, E extends KiePMMLM
      * @return
      * @throws KiePMMLInternalException
      */
-    E getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder);
+    E getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, final Object kBuilder);
 
     /**
      * Method to be called following a <b>kie-maven-plugin</b> invocation
@@ -51,5 +51,5 @@ public interface ModelImplementationProvider<T extends Model, E extends KiePMMLM
      * @return
      * @throws KiePMMLInternalException
      */
-    E getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder);
+    E getKiePMMLModelFromPlugin(final String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, final Object kBuilder);
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/src/main/java/org/kie/pmml/compiler/api/provider/ModelImplementationProvider.java
@@ -17,6 +17,7 @@ package org.kie.pmml.compiler.api.provider;
 
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.Model;
+import org.dmg.pmml.TransformationDictionary;
 import org.kie.pmml.commons.exceptions.KiePMMLInternalException;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
@@ -29,24 +30,26 @@ public interface ModelImplementationProvider<T extends Model, E extends KiePMMLM
     PMML_MODEL getPMMLModelType();
 
     /**
+     *
      * @param dataDictionary
+     * @param transformationDictionary
      * @param model
      * @param kBuilder Using <code>Object</code> to avoid coupling with drools
      * @return
      * @throws KiePMMLInternalException
      */
-    E getKiePMMLModel(DataDictionary dataDictionary, T model, Object kBuilder);
+    E getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder);
 
     /**
      * Method to be called following a <b>kie-maven-plugin</b> invocation
      *
      * @param packageName the package into which put all the generated classes out of the given <code>Model</code>
-     *
      * @param dataDictionary
+     * @param transformationDictionary
      * @param model
      * @param kBuilder Using <code>Object</code> to avoid coupling with drools
      * @return
      * @throws KiePMMLInternalException
      */
-    E getKiePMMLModelFromPlugin(String packageName, DataDictionary dataDictionary, T model, Object kBuilder);
+    E getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder);
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -86,7 +86,7 @@ public class KiePMMLModelRetriever {
      * @param model
      * @return
      */
-    private static Stream<ModelImplementationProvider<Model, KiePMMLModel>> getModelImplementationProviderStream(Model model) {
+    private static Stream<ModelImplementationProvider<Model, KiePMMLModel>> getModelImplementationProviderStream(final Model model) {
         final PMML_MODEL pmmlMODEL = PMML_MODEL.byName(model.getClass().getSimpleName());
         return modelImplementationProviderFinder.getImplementations(false)
                 .stream()

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.Model;
+import org.dmg.pmml.TransformationDictionary;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
@@ -39,36 +40,44 @@ public class KiePMMLModelRetriever {
     /**
      * Read the given <code>DataDictionary</code> and <code>Model</code>> to return an <code>Optional&lt;KiePMMLModel&gt;</code>
      * @param dataDictionary
+     * @param transformationDictionary
      * @param model
      * @param kBuilder Using <code>Object</code> to avoid coupling with drools
      * @return
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      */
-    public static Optional<KiePMMLModel> getFromDataDictionaryAndModel(DataDictionary dataDictionary, Model model, Object kBuilder) {
+    public static Optional<KiePMMLModel> getFromCommonDataAndModel(final DataDictionary dataDictionary,
+                                                                   final TransformationDictionary transformationDictionary,
+                                                                   final Model model,
+                                                                   final Object kBuilder) {
         logger.trace("getFromDataDictionaryAndModel {}", model);
         final PMML_MODEL pmmlMODEL = PMML_MODEL.byName(model.getClass().getSimpleName());
         logger.debug("pmmlModelType {}", pmmlMODEL);
         return getModelImplementationProviderStream(model)
-                .map(implementation -> implementation.getKiePMMLModel(dataDictionary, model, kBuilder))
+                .map(implementation -> implementation.getKiePMMLModel(dataDictionary, transformationDictionary, model, kBuilder))
                 .findFirst();
     }
 
     /**
      * Read the given <code>DataDictionary</code> and <code>Model</code>> to return an <code>Optional&lt;KiePMMLModel&gt;</code>
-     *
      * @param packageName the package into which put all the generated classes out of the given <code>InputStream</code>
      * @param dataDictionary
+     * @param transformationDictionary
      * @param model
      * @param kBuilder Using <code>Object</code> to avoid coupling with drools
      * @return
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      */
-    public static Optional<KiePMMLModel> getFromDataDictionaryAndModelFromPlugin(String packageName, DataDictionary dataDictionary, Model model, Object kBuilder) {
+    public static Optional<KiePMMLModel> getFromCommonDataAndModelFromPlugin(final String packageName,
+                                                                             final DataDictionary dataDictionary,
+                                                                             final TransformationDictionary transformationDictionary,
+                                                                             final Model model,
+                                                                             final Object kBuilder) {
         logger.trace("getFromDataDictionaryAndModel {}", model);
         final PMML_MODEL pmmlMODEL = PMML_MODEL.byName(model.getClass().getSimpleName());
         logger.debug("pmmlModelType {}", pmmlMODEL);
         return getModelImplementationProviderStream(model)
-                .map(implementation -> implementation.getKiePMMLModelFromPlugin(packageName, dataDictionary, model, kBuilder))
+                .map(implementation -> implementation.getKiePMMLModelFromPlugin(packageName, dataDictionary, transformationDictionary, model, kBuilder))
                 .findFirst();
     }
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
@@ -27,7 +27,7 @@ import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromDataDictionaryAndModel;
+import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndModel;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
 
 public class KiePMMLModelRetrieverTest {
@@ -39,7 +39,7 @@ public class KiePMMLModelRetrieverTest {
     @Test
     public void getFromDataDictionaryAndModelWithProvider() throws Exception {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(MULTIPLE_TARGETS_SOURCE));
-        final Optional<KiePMMLModel> retrieved = getFromDataDictionaryAndModel(pmmlModel.getDataDictionary(), pmmlModel.getModels().get(0), null);
+        final Optional<KiePMMLModel> retrieved = getFromCommonDataAndModel(pmmlModel.getDataDictionary(), pmmlModel.getTransformationDictionary(), pmmlModel.getModels().get(0), null);
         assertNotNull(retrieved);
         assertTrue(retrieved.isPresent());
         assertTrue(retrieved.get() instanceof KiePMMLTestingModel);
@@ -48,7 +48,7 @@ public class KiePMMLModelRetrieverTest {
     @Test
     public void getFromDataDictionaryAndModelWithoutProvider() throws Exception {
         pmmlModel = KiePMMLUtil.load(getFileInputStream(ONE_MINING_TARGET_SOURCE));
-        final Optional<KiePMMLModel> retrieved = getFromDataDictionaryAndModel(pmmlModel.getDataDictionary(), pmmlModel.getModels().get(0), null);
+        final Optional<KiePMMLModel> retrieved = getFromCommonDataAndModel(pmmlModel.getDataDictionary(), pmmlModel.getTransformationDictionary(), pmmlModel.getModels().get(0), null);
         assertNotNull(retrieved);
         assertFalse(retrieved.isPresent());
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/TestingModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/mocks/TestingModelImplementationProvider.java
@@ -16,8 +16,11 @@
 package org.kie.pmml.compiler.commons.mocks;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
 
 import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.regression.RegressionModel;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
 import org.kie.pmml.compiler.api.provider.ModelImplementationProvider;
@@ -35,12 +38,12 @@ public class TestingModelImplementationProvider implements ModelImplementationPr
     }
 
     @Override
-    public KiePMMLTestingModel getKiePMMLModel(DataDictionary dataDictionary, RegressionModel model, Object kBuilder) {
+    public KiePMMLTestingModel getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, Object kBuilder) {
         return new KiePMMLTestingModel("TEST_MODEL", Collections.emptyList());
     }
 
     @Override
-    public KiePMMLTestingModel getKiePMMLModelFromPlugin(String packageName, DataDictionary dataDictionary, RegressionModel model, Object kBuilder) {
-        return getKiePMMLModel(dataDictionary, model, kBuilder);
+    public KiePMMLTestingModel getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, Object kBuilder) {
+        return getKiePMMLModel(dataDictionary, transformationDictionary, model, kBuilder);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompiler.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompiler.java
@@ -36,7 +36,7 @@ public interface PMMLCompiler {
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      * @throws ExternalException if any other kind of <code>Exception</code> has been thrown during execution
      */
-    List<KiePMMLModel> getModels(InputStream inputStream, Object kbuilder);
+    List<KiePMMLModel> getModels(final InputStream inputStream, final Object kbuilder);
 
     /**
      * Read the given <code>InputStream</code> to return a <code>List&lt;KiePMMLModel&gt;</code> following a
@@ -49,5 +49,5 @@ public interface PMMLCompiler {
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      * @throws ExternalException if any other kind of <code>Exception</code> has been thrown during execution
      */
-    List<KiePMMLModel> getModelsFromPlugin(String factoryClassName, String packageName, InputStream inputStream, Object kbuilder);
+    List<KiePMMLModel> getModelsFromPlugin(final String factoryClassName, final String packageName, final InputStream inputStream, final Object kbuilder);
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.PMML;
 import org.kie.pmml.commons.exceptions.ExternalException;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
@@ -37,8 +36,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.commons.factories.KiePMMLFactoryFactory.getFactorySourceCode;
-import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromDataDictionaryAndModel;
-import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromDataDictionaryAndModelFromPlugin;
+import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndModel;
+import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndModelFromPlugin;
 
 /**
  * <code>PMMLCompiler</code> default implementation
@@ -107,11 +106,10 @@ public class PMMLCompilerImpl implements PMMLCompiler {
      */
     private List<KiePMMLModel> getModels(PMML pmml, Object kbuilder) {
         logger.trace("getModels {}", pmml);
-        DataDictionary dataDictionary = pmml.getDataDictionary();
         return pmml
                 .getModels()
                 .stream()
-                .map(model -> getFromDataDictionaryAndModel(dataDictionary, model, kbuilder))
+                .map(model -> getFromCommonDataAndModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), model, kbuilder))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
@@ -126,12 +124,10 @@ public class PMMLCompilerImpl implements PMMLCompiler {
      */
     private List<KiePMMLModel> getModelsFromPlugin(String packageName, PMML pmml, Object kbuilder) {
         logger.trace("getModels {}", pmml);
-        DataDictionary dataDictionary = pmml.getDataDictionary();
-
         return pmml
                 .getModels()
                 .stream()
-                .map(model -> getFromDataDictionaryAndModelFromPlugin(packageName, dataDictionary, model, kbuilder))
+                .map(model -> getFromCommonDataAndModelFromPlugin(packageName, pmml.getDataDictionary(), pmml.getTransformationDictionary(), model, kbuilder))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
@@ -47,7 +47,7 @@ public class PMMLCompilerImpl implements PMMLCompiler {
     private static final Logger logger = LoggerFactory.getLogger(PMMLCompilerImpl.class.getName());
 
     @Override
-    public List<KiePMMLModel> getModels(InputStream inputStream, Object kbuilder) {
+    public List<KiePMMLModel> getModels(final InputStream inputStream, final Object kbuilder) {
         logger.trace("getModels {} {}", inputStream, kbuilder);
         try {
             PMML commonPMMLModel = KiePMMLUtil.load(inputStream);
@@ -62,7 +62,7 @@ public class PMMLCompilerImpl implements PMMLCompiler {
     }
 
     @Override
-    public List<KiePMMLModel> getModelsFromPlugin(String factoryClassName, String packageName, InputStream inputStream, Object kbuilder) {
+    public List<KiePMMLModel> getModelsFromPlugin(final String factoryClassName, final String packageName, final InputStream inputStream, final Object kbuilder) {
         logger.trace("getModels {} {}", inputStream, kbuilder);
         try {
             PMML commonPMMLModel = KiePMMLUtil.load(inputStream);
@@ -104,7 +104,7 @@ public class PMMLCompilerImpl implements PMMLCompiler {
      * @return
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      */
-    private List<KiePMMLModel> getModels(PMML pmml, Object kbuilder) {
+    private List<KiePMMLModel> getModels(final PMML pmml, final Object kbuilder) {
         logger.trace("getModels {}", pmml);
         return pmml
                 .getModels()
@@ -122,7 +122,7 @@ public class PMMLCompilerImpl implements PMMLCompiler {
      * @return
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      */
-    private List<KiePMMLModel> getModelsFromPlugin(String packageName, PMML pmml, Object kbuilder) {
+    private List<KiePMMLModel> getModelsFromPlugin(final String packageName, final PMML pmml, final Object kbuilder) {
         logger.trace("getModels {}", pmml);
         return pmml
                 .getModels()

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/executor/PMMLContext.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/executor/PMMLContext.java
@@ -26,5 +26,13 @@ public interface PMMLContext extends Context {
 
     void addMissingValueReplaced(String fieldName, Object missingValueReplaced);
 
+    void addCommonTranformation(String fieldName, Object commonTranformation);
+
+    void addLocalTranformation(String fieldName, Object commonTranformation);
+
     Map<String, Object> getMissingValueReplacedMap();
+
+    Map<String, Object> getCommonTransformationMap();
+
+    Map<String, Object> getLocalTransformationMap();
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/executor/PMMLContext.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/executor/PMMLContext.java
@@ -24,11 +24,11 @@ public interface PMMLContext extends Context {
 
     PMMLRequestData getRequestData();
 
-    void addMissingValueReplaced(String fieldName, Object missingValueReplaced);
+    void addMissingValueReplaced(final String fieldName, final Object missingValueReplaced);
 
-    void addCommonTranformation(String fieldName, Object commonTranformation);
+    void addCommonTranformation(final String fieldName, final Object commonTranformation);
 
-    void addLocalTranformation(String fieldName, Object commonTranformation);
+    void addLocalTranformation(final String fieldName, final Object commonTranformation);
 
     Map<String, Object> getMissingValueReplacedMap();
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/executor/PMMLRuntime.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/src/main/java/org/kie/pmml/evaluator/api/executor/PMMLRuntime.java
@@ -38,7 +38,7 @@ public interface PMMLRuntime {
      * the <code>KiePMMLModel</code> retrieved, or an <b>empty</b> one if none
      * is registered with the given name.
      */
-    Optional<KiePMMLModel> getModel(String modelName);
+    Optional<KiePMMLModel> getModel(final String modelName);
 
     /**
      * Evaluate the model, given the context
@@ -46,5 +46,5 @@ public interface PMMLRuntime {
      * @param context the context with all the input variables
      * @return the result of the evaluation
      */
-    PMML4Result evaluate(String modelName, PMMLContext context);
+    PMML4Result evaluate(final String modelName, final PMMLContext context);
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
@@ -26,12 +26,13 @@ import org.kie.pmml.evaluator.api.executor.PMMLContext;
 public class PMMLContextImpl extends ContextImpl implements PMMLContext {
 
     private static final String PMML_REQUEST_DATA = "PMML_REQUEST_DATA";
-    final Map<String, Object> missingValueReplacedMap;
+    private final Map<String, Object> missingValueReplacedMap = new HashMap<>();
+    private final Map<String, Object> commonTransformationMap = new HashMap<>();
+    private final Map<String, Object> localTransformationMap = new HashMap<>();
 
     public PMMLContextImpl(PMMLRequestData pmmlRequestData) {
         super();
         set(PMML_REQUEST_DATA, pmmlRequestData);
-        missingValueReplacedMap = new HashMap<>();
     }
 
     @Override
@@ -45,7 +46,27 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
     }
 
     @Override
+    public void addCommonTranformation(String fieldName, Object commonTranformation) {
+        localTransformationMap.put(fieldName, commonTranformation);
+    }
+
+    @Override
+    public void addLocalTranformation(String fieldName, Object commonTranformation) {
+        commonTransformationMap.put(fieldName, commonTranformation);
+    }
+
+    @Override
     public Map<String, Object> getMissingValueReplacedMap() {
         return Collections.unmodifiableMap(missingValueReplacedMap);
+    }
+
+    @Override
+    public Map<String, Object> getCommonTransformationMap() {
+        return commonTransformationMap;
+    }
+
+    @Override
+    public Map<String, Object> getLocalTransformationMap() {
+        return localTransformationMap;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
@@ -30,7 +30,7 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
     private final Map<String, Object> commonTransformationMap = new HashMap<>();
     private final Map<String, Object> localTransformationMap = new HashMap<>();
 
-    public PMMLContextImpl(PMMLRequestData pmmlRequestData) {
+    public PMMLContextImpl(final PMMLRequestData pmmlRequestData) {
         super();
         set(PMML_REQUEST_DATA, pmmlRequestData);
     }
@@ -41,17 +41,17 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
     }
 
     @Override
-    public void addMissingValueReplaced(String fieldName, Object missingValueReplaced) {
+    public void addMissingValueReplaced(final String fieldName, final Object missingValueReplaced) {
         missingValueReplacedMap.put(fieldName, missingValueReplaced);
     }
 
     @Override
-    public void addCommonTranformation(String fieldName, Object commonTranformation) {
+    public void addCommonTranformation(final String fieldName, final Object commonTranformation) {
         localTransformationMap.put(fieldName, commonTranformation);
     }
 
     @Override
-    public void addLocalTranformation(String fieldName, Object commonTranformation) {
+    public void addLocalTranformation(final String fieldName, final Object commonTranformation) {
         commonTransformationMap.put(fieldName, commonTranformation);
     }
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/PMMLContextImpl.java
@@ -62,11 +62,11 @@ public class PMMLContextImpl extends ContextImpl implements PMMLContext {
 
     @Override
     public Map<String, Object> getCommonTransformationMap() {
-        return commonTransformationMap;
+        return Collections.unmodifiableMap(commonTransformationMap);
     }
 
     @Override
     public Map<String, Object> getLocalTransformationMap() {
-        return localTransformationMap;
+        return Collections.unmodifiableMap(localTransformationMap);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
@@ -44,7 +44,7 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
     private static final Logger logger = LoggerFactory.getLogger(DroolsModelProvider.class.getName());
 
     @Override
-    public E getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder) {
+    public E getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, final Object kBuilder) {
         logger.trace("getKiePMMLModel {} {} {}", dataDictionary, transformationDictionary, model);
         if (!(kBuilder instanceof KnowledgeBuilder)) {
             throw new KiePMMLException(String.format("Expecting KnowledgeBuilder, received %s", kBuilder.getClass().getName()));
@@ -58,7 +58,7 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
     }
 
     @Override
-    public E getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder) {
+    public E getKiePMMLModelFromPlugin(final String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, final Object kBuilder) {
         logger.trace("getKiePMMLModelFromPlugin {} {} {}", dataDictionary, model, kBuilder);
         if (!(kBuilder instanceof KnowledgeBuilder)) {
             throw new KiePMMLException(String.format("Expecting KnowledgeBuilder, received %s", kBuilder.getClass().getName()));
@@ -76,7 +76,7 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
         }
     }
 
-    public abstract E getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
+    public abstract E getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
 
     public abstract KiePMMLDroolsAST getKiePMMLDroolsAST(final DataDictionary dataDictionary, final T model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
 
@@ -86,7 +86,7 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
                                                                         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap,
                                                                         final String packageName) throws IOException;
 
-    public PackageDescr getPackageDescr(KiePMMLDroolsAST kiePMMLDroolsAST, String packageName) {
+    public PackageDescr getPackageDescr(final KiePMMLDroolsAST kiePMMLDroolsAST, final String packageName) {
         return getBaseDescr(kiePMMLDroolsAST, packageName);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
@@ -21,8 +21,8 @@ import java.util.Map;
 
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.Model;
+import org.dmg.pmml.TransformationDictionary;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
-import org.drools.compiler.lang.DrlDumper;
 import org.drools.compiler.lang.descr.PackageDescr;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
@@ -44,29 +44,29 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
     private static final Logger logger = LoggerFactory.getLogger(DroolsModelProvider.class.getName());
 
     @Override
-    public E getKiePMMLModel(DataDictionary dataDictionary, T model, Object kBuilder) {
-        logger.trace("getKiePMMLModel {} {}", dataDictionary, model);
+    public E getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder) {
+        logger.trace("getKiePMMLModel {} {} {}", dataDictionary, transformationDictionary, model);
         if (!(kBuilder instanceof KnowledgeBuilder)) {
             throw new KiePMMLException(String.format("Expecting KnowledgeBuilder, received %s", kBuilder.getClass().getName()));
         }
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
         KiePMMLDroolsAST kiePMMLDroolsAST = getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
-        E toReturn = getKiePMMLDroolsModel(dataDictionary, model, fieldTypeMap);
+        E toReturn = getKiePMMLDroolsModel(dataDictionary, transformationDictionary, model, fieldTypeMap);
         PackageDescr packageDescr = getPackageDescr(kiePMMLDroolsAST, toReturn.getKModulePackageName());
         ((KnowledgeBuilderImpl) kBuilder).addPackage(packageDescr);
         return toReturn;
     }
 
     @Override
-    public E getKiePMMLModelFromPlugin(String packageName, DataDictionary dataDictionary, T model, Object kBuilder) {
+    public E getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Object kBuilder) {
         logger.trace("getKiePMMLModelFromPlugin {} {} {}", dataDictionary, model, kBuilder);
         if (!(kBuilder instanceof KnowledgeBuilder)) {
             throw new KiePMMLException(String.format("Expecting KnowledgeBuilder, received %s", kBuilder.getClass().getName()));
         }
         try {
             final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
-            KiePMMLDroolsAST kiePMMLDroolsAST =  getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
-            Map<String, String> sourcesMap = getKiePMMLDroolsModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
+            KiePMMLDroolsAST kiePMMLDroolsAST = getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
+            Map<String, String> sourcesMap = getKiePMMLDroolsModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
             E toReturn = (E) new KiePMMLDroolsModelWithSources(model.getModelName(), packageName, sourcesMap);
             PackageDescr packageDescr = getPackageDescr(kiePMMLDroolsAST, packageName);
             ((KnowledgeBuilderImpl) kBuilder).addPackage(packageDescr);
@@ -76,11 +76,12 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
         }
     }
 
-    public abstract E getKiePMMLDroolsModel(DataDictionary dataDictionary, T model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
+    public abstract E getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final T model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
 
-    public abstract KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, T model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
+    public abstract KiePMMLDroolsAST getKiePMMLDroolsAST(final DataDictionary dataDictionary, final T model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap);
 
     public abstract Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary,
+                                                                        final TransformationDictionary transformationDictionary,
                                                                         final T model,
                                                                         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap,
                                                                         final String packageName) throws IOException;

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.scorecard.Scorecard;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
@@ -41,21 +42,21 @@ public class ScorecardModelImplementationProvider extends DroolsModelProvider<Sc
     }
 
     @Override
-    public KiePMMLScorecardModel getKiePMMLDroolsModel(DataDictionary dataDictionary, Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public KiePMMLScorecardModel getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         try {
-            return KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(dataDictionary, model, fieldTypeMap);
+            return KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(dataDictionary, transformationDictionary, model, fieldTypeMap);
         } catch (IllegalAccessException | InstantiationException e) {
             throw new KiePMMLException(e.getMessage(), e);
         }
     }
 
     @Override
-    public KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public KiePMMLDroolsAST getKiePMMLDroolsAST(final DataDictionary dataDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         return KiePMMLScorecardModelFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
     }
 
     @Override
-    public Map<String, String> getKiePMMLDroolsModelSourcesMap(DataDictionary dataDictionary, Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) throws IOException {
-        return KiePMMLScorecardModelFactory.getKiePMMLScorecardModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
+    public Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) throws IOException {
+        return KiePMMLScorecardModelFactory.getKiePMMLScorecardModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProvider.java
@@ -15,7 +15,6 @@
  */
 package org.kie.pmml.models.drools.scorecard.compiler.executor;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.dmg.pmml.DataDictionary;
@@ -42,7 +41,7 @@ public class ScorecardModelImplementationProvider extends DroolsModelProvider<Sc
     }
 
     @Override
-    public KiePMMLScorecardModel getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public KiePMMLScorecardModel getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         try {
             return KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(dataDictionary, transformationDictionary, model, fieldTypeMap);
         } catch (IllegalAccessException | InstantiationException e) {
@@ -56,7 +55,7 @@ public class ScorecardModelImplementationProvider extends DroolsModelProvider<Sc
     }
 
     @Override
-    public Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) throws IOException {
+    public Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final String packageName) {
         return KiePMMLScorecardModelFactory.getKiePMMLScorecardModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -88,7 +88,7 @@ public class KiePMMLScorecardModelFactory {
      * @param fieldTypeMap
      * @return
      */
-    public static KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public static KiePMMLDroolsAST getKiePMMLDroolsAST(final DataDictionary dataDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         logger.trace("getKiePMMLDroolsAST {}", model);
         return KiePMMLScorecardModelASTFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.scorecard.Scorecard;
 import org.kie.memorycompiler.KieMemoryCompiler;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
@@ -55,17 +56,17 @@ public class KiePMMLScorecardModelFactory {
         // Avoid instantiation
     }
 
-    public static KiePMMLScorecardModel getKiePMMLScorecardModel(DataDictionary dataDictionary, Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IllegalAccessException, InstantiationException {
+    public static KiePMMLScorecardModel getKiePMMLScorecardModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IllegalAccessException, InstantiationException {
         logger.trace("getKiePMMLScorecardModel {}", model);
         String className = getSanitizedClassName(model.getModelName());
         String packageName = getSanitizedPackageName(className);
-        Map<String, String> sourcesMap = getKiePMMLScorecardModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
+        Map<String, String> sourcesMap = getKiePMMLScorecardModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
         String fullClassName = packageName + "." + className;
         final Map<String, Class<?>> compiledClasses = KieMemoryCompiler.compile(sourcesMap, Thread.currentThread().getContextClassLoader());
         return (KiePMMLScorecardModel) compiledClasses.get(fullClassName).newInstance();
     }
 
-    public static Map<String, String> getKiePMMLScorecardModelSourcesMap(final DataDictionary dataDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final String packageName) {
+    public static Map<String, String> getKiePMMLScorecardModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final Scorecard model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final String packageName) {
         logger.trace("getKiePMMLScorecardModelSourcesMap {} {} {}", dataDictionary, model, packageName);
         CompilationUnit cloneCU = getKiePMMLModelCompilationUnit(dataDictionary, model, fieldTypeMap, packageName, KIE_PMML_SCORECARD_MODEL_TEMPLATE_JAVA, KIE_PMML_SCORECARD_MODEL_TEMPLATE);
         String className = getSanitizedClassName(model.getModelName());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/executor/ScorecardModelImplementationProviderTest.java
@@ -45,7 +45,7 @@ public class ScorecardModelImplementationProviderTest {
         assertNotNull(pmml);
         assertEquals(1, pmml.getModels().size());
         assertTrue(pmml.getModels().get(0) instanceof Scorecard);
-        final KiePMMLScorecardModel kiePMMLModel = PROVIDER.getKiePMMLModel(pmml.getDataDictionary(), (Scorecard) pmml.getModels().get(0), KNOWLEDGE_BUILDER);
+        final KiePMMLScorecardModel kiePMMLModel = PROVIDER.getKiePMMLModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), (Scorecard) pmml.getModels().get(0), KNOWLEDGE_BUILDER);
         assertNotNull(kiePMMLModel);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -19,8 +19,6 @@ package org.kie.pmml.models.drools.scorecard.compiler.factories;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.dmg.pmml.DataDictionary;
@@ -61,12 +59,11 @@ public class KiePMMLScorecardModelFactoryTest {
 
     @Test
     public void getKiePMMLScorecardModel() throws Exception {
-        final DataDictionary dataDictionary = pmml.getDataDictionary();
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
-        IntStream.range(0,3).forEach(index -> {
-            fieldTypeMap.put("TYPE-"+ index, new KiePMMLOriginalTypeGeneratedType("Original-"+ index, "Generated-"+ index));
+        IntStream.range(0, 3).forEach(index -> {
+            fieldTypeMap.put("TYPE-" + index, new KiePMMLOriginalTypeGeneratedType("Original-" + index, "Generated-" + index));
         });
-        KiePMMLScorecardModel retrieved = KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(dataDictionary, scorecardModel, fieldTypeMap);
+        KiePMMLScorecardModel retrieved = KiePMMLScorecardModelFactory.getKiePMMLScorecardModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), scorecardModel, fieldTypeMap);
         assertNotNull(retrieved);
         assertEquals(scorecardModel.getModelName(), retrieved.getName());
         assertEquals(TARGET_FIELD, retrieved.getTargetField());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/test/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/src/test/java/org/kie/pmml/models/drools/scorecard/evaluator/PMMLScorecardModelEvaluatorTest.java
@@ -88,7 +88,7 @@ public class PMMLScorecardModelEvaluatorTest {
         assertEquals(1, pmml.getModels().size());
         assertTrue(pmml.getModels().get(0) instanceof Scorecard);
         KnowledgeBuilderImpl knowledgeBuilder = new KnowledgeBuilderImpl();
-        kiePMMLModel = provider.getKiePMMLModel(pmml.getDataDictionary(), (Scorecard) pmml.getModels().get(0), knowledgeBuilder);
+        kiePMMLModel = provider.getKiePMMLModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), (Scorecard) pmml.getModels().get(0), knowledgeBuilder);
         kieBase = new KieHelper()
                 .addContent(knowledgeBuilder.getPackageDescrs(kiePMMLModel.getKModulePackageName()).get(0))
                 .setReleaseId(RELEASE_ID)

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
@@ -41,7 +41,7 @@ public class TreeModelImplementationProvider extends DroolsModelProvider<TreeMod
     }
 
     @Override
-    public KiePMMLTreeModel getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public KiePMMLTreeModel getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         try {
             return KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, transformationDictionary, model, fieldTypeMap);
         } catch (IllegalAccessException | InstantiationException e) {
@@ -55,7 +55,7 @@ public class TreeModelImplementationProvider extends DroolsModelProvider<TreeMod
     }
 
     @Override
-    public Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) {
+    public Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, final String packageName) {
         return KiePMMLTreeModelFactory.getKiePMMLTreeModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProvider.java
@@ -18,6 +18,7 @@ package org.kie.pmml.models.drools.tree.compiler.executor;
 import java.util.Map;
 
 import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.tree.TreeModel;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
@@ -40,21 +41,21 @@ public class TreeModelImplementationProvider extends DroolsModelProvider<TreeMod
     }
 
     @Override
-    public KiePMMLTreeModel getKiePMMLDroolsModel(DataDictionary dataDictionary, TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public KiePMMLTreeModel getKiePMMLDroolsModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         try {
-            return KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, model, fieldTypeMap);
+            return KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, transformationDictionary, model, fieldTypeMap);
         } catch (IllegalAccessException | InstantiationException e) {
             throw new KiePMMLException(e.getMessage(), e);
         }
     }
 
     @Override
-    public KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public KiePMMLDroolsAST getKiePMMLDroolsAST(final DataDictionary dataDictionary, final TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         return KiePMMLTreeModelFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
     }
 
     @Override
-    public Map<String, String> getKiePMMLDroolsModelSourcesMap(DataDictionary dataDictionary, TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) {
-        return KiePMMLTreeModelFactory.getKiePMMLTreeModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
+    public Map<String, String> getKiePMMLDroolsModelSourcesMap(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap, String packageName) {
+        return KiePMMLTreeModelFactory.getKiePMMLTreeModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.tree.TreeModel;
 import org.kie.memorycompiler.KieMemoryCompiler;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
@@ -55,17 +56,18 @@ public class KiePMMLTreeModelFactory {
         // Avoid instantiation
     }
 
-    public static KiePMMLTreeModel getKiePMMLTreeModel(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IllegalAccessException, InstantiationException {
+    public static KiePMMLTreeModel getKiePMMLTreeModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) throws IllegalAccessException, InstantiationException {
         logger.trace("getKiePMMLTreeModel {}", model);
         String className = getSanitizedClassName(model.getModelName());
         String packageName = getSanitizedPackageName(className);
-        Map<String, String> sourcesMap = getKiePMMLTreeModelSourcesMap(dataDictionary, model, fieldTypeMap, packageName);
+        Map<String, String> sourcesMap = getKiePMMLTreeModelSourcesMap(dataDictionary, transformationDictionary, model, fieldTypeMap, packageName);
         String fullClassName = packageName + "." + className;
         final Map<String, Class<?>> compiledClasses = KieMemoryCompiler.compile(sourcesMap, Thread.currentThread().getContextClassLoader());
         return (KiePMMLTreeModel) compiledClasses.get(fullClassName).newInstance();
     }
 
     public static Map<String, String> getKiePMMLTreeModelSourcesMap(final DataDictionary dataDictionary,
+                                                                    final TransformationDictionary transformationDictionary,
                                                                     final TreeModel model,
                                                                     final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap,
                                                                     final String packageName) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -92,7 +92,7 @@ public class KiePMMLTreeModelFactory {
      * @param fieldTypeMap
      * @return
      */
-    public static KiePMMLDroolsAST getKiePMMLDroolsAST(DataDictionary dataDictionary, TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
+    public static KiePMMLDroolsAST getKiePMMLDroolsAST(final DataDictionary dataDictionary, final TreeModel model, final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap) {
         logger.trace("getKiePMMLDroolsAST {}", model);
         return KiePMMLTreeModelASTFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap);
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/executor/TreeModelImplementationProviderTest.java
@@ -45,7 +45,7 @@ public class TreeModelImplementationProviderTest {
         assertNotNull(pmml);
         assertEquals(1, pmml.getModels().size());
         assertTrue(pmml.getModels().get(0) instanceof TreeModel);
-        final KiePMMLTreeModel kiePMMLModel = PROVIDER.getKiePMMLModel(pmml.getDataDictionary(), (TreeModel) pmml.getModels().get(0), KNOWLEDGE_BUILDER);
+        final KiePMMLTreeModel kiePMMLModel = PROVIDER.getKiePMMLModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), (TreeModel) pmml.getModels().get(0), KNOWLEDGE_BUILDER);
         assertNotNull(kiePMMLModel);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -58,9 +58,8 @@ public class KiePMMLTreeModelFactoryTest {
 
     @Test
     public void getKiePMMLTreeModel() throws InstantiationException, IllegalAccessException {
-        final DataDictionary dataDictionary = pmml.getDataDictionary();
         final Map<String, KiePMMLOriginalTypeGeneratedType> fieldTypeMap = new HashMap<>();
-        KiePMMLTreeModel retrieved = KiePMMLTreeModelFactory.getKiePMMLTreeModel(dataDictionary, treeModel, fieldTypeMap);
+        KiePMMLTreeModel retrieved = KiePMMLTreeModelFactory.getKiePMMLTreeModel(pmml.getDataDictionary(),pmml.getTransformationDictionary(), treeModel, fieldTypeMap);
         assertNotNull(retrieved);
         assertEquals(treeModel.getModelName(), retrieved.getName());
         assertEquals(TARGET_FIELD, retrieved.getTargetField());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluatorTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/src/test/java/org/kie/pmml/models/drools/tree/evaluator/PMMLTreeModelEvaluatorTest.java
@@ -77,7 +77,7 @@ public class PMMLTreeModelEvaluatorTest {
         assertEquals(1, pmml.getModels().size());
         assertTrue(pmml.getModels().get(0) instanceof TreeModel);
         KnowledgeBuilderImpl knowledgeBuilder = new KnowledgeBuilderImpl();
-        kiePMMLModel = provider.getKiePMMLModel(pmml.getDataDictionary(), (TreeModel) pmml.getModels().get(0), knowledgeBuilder);
+        kiePMMLModel = provider.getKiePMMLModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), (TreeModel) pmml.getModels().get(0), knowledgeBuilder);
         kieBase = new KieHelper()
                 .addContent(knowledgeBuilder.getPackageDescrs(kiePMMLModel.getKModulePackageName()).get(0))
                 .setReleaseId(RELEASE_ID)

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProvider.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.MiningFunction;
 import org.dmg.pmml.OpType;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.regression.RegressionModel;
 import org.kie.pmml.commons.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.enums.OP_TYPE;
@@ -54,21 +55,21 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
     }
 
     @Override
-    public KiePMMLRegressionModel getKiePMMLModel(DataDictionary dataDictionary, RegressionModel model, Object kBuilder) {
+    public KiePMMLRegressionModel getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, Object kBuilder) {
         logger.trace("getKiePMMLModel {} {} {}", dataDictionary, model, kBuilder);
         validate(dataDictionary, model);
         try {
-            return KiePMMLRegressionModelFactory.getKiePMMLRegressionModelClasses(dataDictionary, model);
+            return KiePMMLRegressionModelFactory.getKiePMMLRegressionModelClasses(dataDictionary, transformationDictionary, model);
         } catch (IOException | IllegalAccessException | InstantiationException e) {
             throw new KiePMMLException(e.getMessage(), e);
         }
     }
 
     @Override
-    public KiePMMLRegressionModel getKiePMMLModelFromPlugin(String packageName, DataDictionary dataDictionary, RegressionModel model, Object kBuilder) {
+    public KiePMMLRegressionModel getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, Object kBuilder) {
         logger.trace("getKiePMMLModelFromPlugin {} {} {}", dataDictionary, model, kBuilder);
         try {
-            final Map<String, String> sourcesMap = KiePMMLRegressionModelFactory.getKiePMMLRegressionModelSourcesMap(dataDictionary, model, packageName);
+            final Map<String, String> sourcesMap = KiePMMLRegressionModelFactory.getKiePMMLRegressionModelSourcesMap(dataDictionary, transformationDictionary, model, packageName);
             return new KiePMMLRegressionModelWithSources(model.getModelName(), packageName, sourcesMap);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProvider.java
@@ -55,7 +55,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
     }
 
     @Override
-    public KiePMMLRegressionModel getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, Object kBuilder) {
+    public KiePMMLRegressionModel getKiePMMLModel(final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, final Object kBuilder) {
         logger.trace("getKiePMMLModel {} {} {}", dataDictionary, model, kBuilder);
         validate(dataDictionary, model);
         try {
@@ -66,7 +66,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
     }
 
     @Override
-    public KiePMMLRegressionModel getKiePMMLModelFromPlugin(String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, Object kBuilder) {
+    public KiePMMLRegressionModel getKiePMMLModelFromPlugin(final String packageName, final DataDictionary dataDictionary, final TransformationDictionary transformationDictionary, final RegressionModel model, final Object kBuilder) {
         logger.trace("getKiePMMLModelFromPlugin {} {} {}", dataDictionary, model, kBuilder);
         try {
             final Map<String, String> sourcesMap = KiePMMLRegressionModelFactory.getKiePMMLRegressionModelSourcesMap(dataDictionary, transformationDictionary, model, packageName);
@@ -76,7 +76,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    protected void validate(DataDictionary dataDictionary, RegressionModel toValidate) {
+    protected void validate(final DataDictionary dataDictionary, final RegressionModel toValidate) {
         if (toValidate.getRegressionTables() == null || toValidate.getRegressionTables().isEmpty()) {
             throw new KiePMMLException("At least one RegressionTable required");
         }
@@ -88,7 +88,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateRegression(List<KiePMMLNameOpType> targetFields, RegressionModel toValidate) {
+    private void validateRegression(final List<KiePMMLNameOpType> targetFields, final RegressionModel toValidate) {
         validateRegressionTargetField(targetFields, toValidate);
         if (toValidate.getRegressionTables().size() != 1) {
             throw new KiePMMLException("Expected one RegressionTable, retrieved " + toValidate.getRegressionTables().size());
@@ -108,7 +108,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateClassification(DataDictionary dataDictionary, RegressionModel toValidate) {
+    private void validateClassification(final DataDictionary dataDictionary, final RegressionModel toValidate) {
         final String categoricalTargeName = getCategoricalTargetName(dataDictionary, toValidate);
         final OP_TYPE opType = getOpType(dataDictionary, toValidate, categoricalTargeName);
         switch (opType) {
@@ -123,7 +123,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateClassificationCategorical(DataDictionary dataDictionary, RegressionModel toValidate, String categoricalFieldName) {
+    private void validateClassificationCategorical(final DataDictionary dataDictionary, final RegressionModel toValidate, final String categoricalFieldName) {
         if (isBinary(dataDictionary, categoricalFieldName)) {
             validateClassificationCategoricalBinary(toValidate);
         } else {
@@ -131,7 +131,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateClassificationCategoricalBinary(RegressionModel toValidate) {
+    private void validateClassificationCategoricalBinary(final RegressionModel toValidate) {
         switch (toValidate.getNormalizationMethod()) {
             case LOGIT:
             case PROBIT:
@@ -148,7 +148,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateClassificationCategoricalNotBinary(RegressionModel toValidate) {
+    private void validateClassificationCategoricalNotBinary(final RegressionModel toValidate) {
         switch (toValidate.getNormalizationMethod()) {
             case SOFTMAX:
             case SIMPLEMAX:
@@ -166,7 +166,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateClassificationOrdinal(RegressionModel toValidate) {
+    private void validateClassificationOrdinal(final RegressionModel toValidate) {
         switch (toValidate.getNormalizationMethod()) {
             case LOGIT:
             case PROBIT:
@@ -183,7 +183,7 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private void validateRegressionTargetField(List<KiePMMLNameOpType> targetFields, RegressionModel toValidate) {
+    private void validateRegressionTargetField(final List<KiePMMLNameOpType> targetFields, final RegressionModel toValidate) {
         if (targetFields.size() != 1) {
             throw new KiePMMLException("Expected one target field, retrieved " + targetFields.size());
         }
@@ -192,17 +192,17 @@ public class RegressionModelImplementationProvider implements ModelImplementatio
         }
     }
 
-    private boolean isRegression(RegressionModel toValidate) {
+    private boolean isRegression(final RegressionModel toValidate) {
         return Objects.equals(MiningFunction.REGRESSION, toValidate.getMiningFunction());
     }
 
-    private boolean isBinary(DataDictionary dataDictionary, String categoricalFieldName) {
+    private boolean isBinary(final DataDictionary dataDictionary, final String categoricalFieldName) {
         return dataDictionary.getDataFields().stream()
                 .filter(dataField -> Objects.equals(dataField.getName().getValue(), categoricalFieldName)).mapToDouble(dataField -> dataField.getValues().size())
                 .findFirst().orElse(0) == 2;
     }
 
-    private String getCategoricalTargetName(DataDictionary dataDictionary, RegressionModel toValidate) {
+    private String getCategoricalTargetName(final DataDictionary dataDictionary, final RegressionModel toValidate) {
         List<KiePMMLNameOpType> targetFields = getTargetFields(dataDictionary, toValidate);
         final List<String> categoricalFields = dataDictionary.getDataFields().stream()
                 .filter(dataField -> OpType.CATEGORICAL.equals(dataField.getOpType()))

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
@@ -34,8 +35,10 @@ import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.DataField;
 import org.dmg.pmml.MiningFunction;
 import org.dmg.pmml.OpType;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.regression.RegressionModel;
 import org.kie.memorycompiler.KieMemoryCompiler;
+import org.kie.pmml.commons.exceptions.KiePMMLInternalException;
 import org.kie.pmml.commons.model.KiePMMLOutputField;
 import org.kie.pmml.commons.model.enums.MINING_FUNCTION;
 import org.kie.pmml.commons.model.enums.PMML_MODEL;
@@ -60,17 +63,22 @@ public class KiePMMLRegressionModelFactory {
     private KiePMMLRegressionModelFactory() {
     }
 
-    public static KiePMMLRegressionModel getKiePMMLRegressionModelClasses(DataDictionary dataDictionary, RegressionModel model) throws IOException, IllegalAccessException, InstantiationException {
+    public static KiePMMLRegressionModel getKiePMMLRegressionModelClasses(final DataDictionary dataDictionary,
+                                                                          final TransformationDictionary transformationDictionary,
+                                                                          final RegressionModel model) throws IOException, IllegalAccessException, InstantiationException {
         logger.trace("getKiePMMLRegressionModelClasses {} {}", dataDictionary, model);
         String className = getSanitizedClassName(model.getModelName());
         String packageName = getSanitizedPackageName(model.getModelName());
-        Map<String, String> sourcesMap = getKiePMMLRegressionModelSourcesMap(dataDictionary, model, packageName);
+        Map<String, String> sourcesMap = getKiePMMLRegressionModelSourcesMap(dataDictionary, transformationDictionary, model, packageName);
         String fullClassName = packageName + "." + className;
         final Map<String, Class<?>> compiledClasses = KieMemoryCompiler.compile(sourcesMap, Thread.currentThread().getContextClassLoader());
         return (KiePMMLRegressionModel) compiledClasses.get(fullClassName).newInstance();
     }
 
-    public static Map<String, String> getKiePMMLRegressionModelSourcesMap(DataDictionary dataDictionary, RegressionModel model, String packageName) throws IOException {
+    public static Map<String, String> getKiePMMLRegressionModelSourcesMap(final DataDictionary dataDictionary,
+                                                                          final TransformationDictionary transformationDictionary,
+                                                                          final RegressionModel model,
+                                                                          final String packageName) throws IOException {
         logger.trace("getKiePMMLRegressionModelSourcesMap {} {} {}", dataDictionary, model, packageName);
         String className = getSanitizedClassName(model.getModelName());
         String modelName = model.getModelName();
@@ -86,7 +94,8 @@ public class KiePMMLRegressionModelFactory {
         String nestedTable = tablesSourceMap.size() == 1 ? tablesSourceMap.keySet().iterator().next() :
                 tablesSourceMap.keySet().stream().filter(tableName -> tableName.startsWith("KiePMMLRegressionTableClassification"))
                         .findFirst().orElseThrow(() -> new RuntimeException("Failed to find expected KiePMMLRegressionTableClassification"));
-        setConstructor(className, nestedTable, modelTemplate, targetFieldName, MINING_FUNCTION.byName(model.getMiningFunction().value()), modelName);
+        final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format("Missing default constructor in ClassOrInterfaceDeclaration %s ", modelTemplate.getName())));
+        populateConstructor(className, nestedTable, constructorDeclaration, targetFieldName, MINING_FUNCTION.byName(model.getMiningFunction().value()), modelName);
         Map<String, String> toReturn = tablesSourceMap.entrySet().stream().collect(Collectors.toMap(entry -> packageName + "." + entry.getKey(), entry -> entry.getValue().getSource()));
         String fullClassName = packageName + "." + className;
         toReturn.put(fullClassName, cloneCU.toString());
@@ -107,31 +116,29 @@ public class KiePMMLRegressionModelFactory {
         return toReturn;
     }
 
-    private static void setConstructor(String generatedClassName, String nestedTable, ClassOrInterfaceDeclaration modelTemplate, String targetField, MINING_FUNCTION miningFunction, String modelName) {
+    private static void populateConstructor(String generatedClassName, String nestedTable, final ConstructorDeclaration constructorDeclaration, String targetField, MINING_FUNCTION miningFunction, String modelName) {
         ObjectCreationExpr objectCreationExpr = new ObjectCreationExpr();
         objectCreationExpr.setType(nestedTable);
-        modelTemplate.getDefaultConstructor().ifPresent(constructor -> {
-            constructor.setName(generatedClassName);
-            final BlockStmt body = constructor.getBody();
-            body.getStatements().iterator().forEachRemaining(statement -> {
-                if (statement instanceof ExplicitConstructorInvocationStmt) {
-                    ExplicitConstructorInvocationStmt superStatement = (ExplicitConstructorInvocationStmt) statement;
-                    NameExpr modelNameExpr = (NameExpr) superStatement.getArgument(0);
-                    modelNameExpr.setName(String.format("\"%s\"", modelName));
-                }
-            });
-            final List<AssignExpr> assignExprs = body.findAll(AssignExpr.class);
-            assignExprs.forEach(assignExpr -> {
-                if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("regressionTable")) {
-                    assignExpr.setValue(objectCreationExpr);
-                } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("targetField")) {
-                    assignExpr.setValue(new StringLiteralExpr(targetField));
-                } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("miningFunction")) {
-                    assignExpr.setValue(new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
-                } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("pmmlMODEL")) {
-                    assignExpr.setValue(new NameExpr(PMML_MODEL.REGRESSION_MODEL.getClass().getName() + "." + PMML_MODEL.REGRESSION_MODEL.name()));
-                }
-            });
+        constructorDeclaration.setName(generatedClassName);
+        final BlockStmt body = constructorDeclaration.getBody();
+        body.getStatements().iterator().forEachRemaining(statement -> {
+            if (statement instanceof ExplicitConstructorInvocationStmt) {
+                ExplicitConstructorInvocationStmt superStatement = (ExplicitConstructorInvocationStmt) statement;
+                NameExpr modelNameExpr = (NameExpr) superStatement.getArgument(0);
+                modelNameExpr.setName(String.format("\"%s\"", modelName));
+            }
+        });
+        final List<AssignExpr> assignExprs = body.findAll(AssignExpr.class);
+        assignExprs.forEach(assignExpr -> {
+            if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("regressionTable")) {
+                assignExpr.setValue(objectCreationExpr);
+            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("targetField")) {
+                assignExpr.setValue(new StringLiteralExpr(targetField));
+            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("miningFunction")) {
+                assignExpr.setValue(new NameExpr(miningFunction.getClass().getName() + "." + miningFunction.name()));
+            } else if (assignExpr.getTarget().asNameExpr().getNameAsString().equals("pmmlMODEL")) {
+                assignExpr.setValue(new NameExpr(PMML_MODEL.REGRESSION_MODEL.getClass().getName() + "." + PMML_MODEL.REGRESSION_MODEL.name()));
+            }
         });
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
@@ -102,7 +102,11 @@ public class KiePMMLRegressionModelFactory {
         return toReturn;
     }
 
-    private static Map<String, KiePMMLTableSourceCategory> getRegressionTablesMap(DataDictionary dataDictionary, RegressionModel model, String targetFieldName, List<KiePMMLOutputField> outputFields, String packageName) throws IOException {
+    private static Map<String, KiePMMLTableSourceCategory> getRegressionTablesMap(final DataDictionary dataDictionary,
+                                                                                  final RegressionModel model,
+                                                                                  final String targetFieldName,
+                                                                                  final List<KiePMMLOutputField> outputFields,
+                                                                                  final String packageName) throws IOException {
         final DataField targetDataField = dataDictionary.getDataFields().stream()
                 .filter(field -> Objects.equals(targetFieldName, field.getName().getValue()))
                 .findFirst().orElse(null);
@@ -116,7 +120,12 @@ public class KiePMMLRegressionModelFactory {
         return toReturn;
     }
 
-    private static void populateConstructor(String generatedClassName, String nestedTable, final ConstructorDeclaration constructorDeclaration, String targetField, MINING_FUNCTION miningFunction, String modelName) {
+    private static void populateConstructor(final String generatedClassName,
+                                            final String nestedTable,
+                                            final ConstructorDeclaration constructorDeclaration,
+                                            final String targetField,
+                                            final MINING_FUNCTION miningFunction,
+                                            final String modelName) {
         ObjectCreationExpr objectCreationExpr = new ObjectCreationExpr();
         objectCreationExpr.setType(nestedTable);
         constructorDeclaration.setName(generatedClassName);
@@ -142,7 +151,7 @@ public class KiePMMLRegressionModelFactory {
         });
     }
 
-    private static boolean isRegression(MiningFunction miningFunction, String targetField, OpType targetOpType) {
+    private static boolean isRegression(final MiningFunction miningFunction, final String targetField, final OpType targetOpType) {
         return Objects.equals(MiningFunction.REGRESSION, miningFunction) && (targetField == null || Objects.equals(OpType.CONTINUOUS, targetOpType));
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/executor/RegressionModelImplementationProviderTest.java
@@ -46,7 +46,7 @@ public class RegressionModelImplementationProviderTest {
         assertNotNull(pmml);
         assertEquals(1, pmml.getModels().size());
         assertTrue(pmml.getModels().get(0) instanceof RegressionModel);
-        final KiePMMLRegressionModel kiePMMLModel = PROVIDER.getKiePMMLModel(pmml.getDataDictionary(), (RegressionModel) pmml.getModels().get(0), RELEASE_ID);
+        final KiePMMLRegressionModel kiePMMLModel = PROVIDER.getKiePMMLModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), (RegressionModel) pmml.getModels().get(0), RELEASE_ID);
         assertNotNull(kiePMMLModel);
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
@@ -35,6 +35,7 @@ import org.dmg.pmml.MiningField;
 import org.dmg.pmml.MiningFunction;
 import org.dmg.pmml.MiningSchema;
 import org.dmg.pmml.OpType;
+import org.dmg.pmml.TransformationDictionary;
 import org.dmg.pmml.regression.CategoricalPredictor;
 import org.dmg.pmml.regression.NumericPredictor;
 import org.dmg.pmml.regression.PredictorTerm;
@@ -72,6 +73,7 @@ public class KiePMMLRegressionModelFactoryTest {
     private List<MiningField> miningFields;
     private MiningField targetMiningField;
     private DataDictionary dataDictionary;
+    private TransformationDictionary transformationDictionary;
     private MiningSchema miningSchema;
     private RegressionModel regressionModel;
 
@@ -103,6 +105,7 @@ public class KiePMMLRegressionModelFactoryTest {
         targetMiningField = miningFields.get(0);
         targetMiningField.setUsageType(MiningField.UsageType.TARGET);
         dataDictionary = getDataDictionary(dataFields);
+        transformationDictionary = new TransformationDictionary();
         miningSchema = getMiningSchema(miningFields);
         regressionModel = getRegressionModel(modelName, MiningFunction.REGRESSION, miningSchema, regressionTables);
     }
@@ -117,7 +120,7 @@ public class KiePMMLRegressionModelFactoryTest {
 
     @Test
     public void getKiePMMLRegressionModelTest() throws IOException, IllegalAccessException, InstantiationException {
-        KiePMMLRegressionModel retrieved = getKiePMMLRegressionModelClasses(dataDictionary, regressionModel);
+        KiePMMLRegressionModel retrieved = getKiePMMLRegressionModelClasses(dataDictionary, transformationDictionary, regressionModel);
         assertNotNull(retrieved);
         assertEquals(regressionModel.getModelName(), retrieved.getName());
         assertEquals(MINING_FUNCTION.byName(regressionModel.getMiningFunction().value()), retrieved.getMiningFunction());
@@ -148,7 +151,7 @@ public class KiePMMLRegressionModelFactoryTest {
         for (CategoricalPredictor categoricalPredictor : originalRegressionTable.getCategoricalPredictors()) {
             assertTrue(categoricalFunctionMap.containsKey(categoricalPredictor.getName().getValue()));
         }
-        final  Map<String, Function<Map<String, Object>, Double>>  predictorTermsFunctionMap = regressionTable.getPredictorTermsFunctionMap();
+        final Map<String, Function<Map<String, Object>, Double>> predictorTermsFunctionMap = regressionTable.getPredictorTermsFunctionMap();
         for (PredictorTerm predictorTerm : originalRegressionTable.getPredictorTerms()) {
             assertTrue(predictorTermsFunctionMap.containsKey(predictorTerm.getName().getValue()));
         }


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik
See https://issues.redhat.com/browse/DROOLS-5448

This PR is meant to split the parent one.
Basically, it
1) add TransformationDictionary to signatures of methods involved in PMML compilation
2) define the actual transformations inside PMMLRuntime (currently required maps are not populated)
3) updates tests to match modifications
