### PR TITLE
DROOLS-5507 : Converting excel spreadsheet to guided decision table causes an exception

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/GeneratorContextRuleModelVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/context/GeneratorContextRuleModelVisitor.java
@@ -133,45 +133,33 @@ public class GeneratorContextRuleModelVisitor {
     private void visitActionFieldList(final ActionInsertFact afl) {
         String factType = afl.getFactType();
         for (ActionFieldValue afv : afl.getFieldValues()) {
-            InterpolationVariable var = new InterpolationVariable(afv.getValue(),
-                                                                  afv.getType(),
-                                                                  factType,
-                                                                  afv.getField());
-            if (afv.getNature() == FieldNatureType.TYPE_TEMPLATE && !vars.contains(var)) {
-                vars.add(var);
-            } else {
-                hasNonTemplateOutput = true;
-            }
+            manageTemplateVariable(new InterpolationVariable(afv.getValue(),
+                                                             afv.getType(),
+                                                             factType,
+                                                             afv.getField()),
+                                   afv.getNature());
         }
     }
 
     private void visitActionFieldList(final ActionSetField afl) {
         String factType = model.getLHSBindingType(afl.getVariable());
         for (ActionFieldValue afv : afl.getFieldValues()) {
-            InterpolationVariable var = new InterpolationVariable(afv.getValue(),
-                                                                  afv.getType(),
-                                                                  factType,
-                                                                  afv.getField());
-            if (afv.getNature() == FieldNatureType.TYPE_TEMPLATE && !vars.contains(var)) {
-                vars.add(var);
-            } else {
-                hasNonTemplateOutput = true;
-            }
+            manageTemplateVariable(new InterpolationVariable(afv.getValue(),
+                                                             afv.getType(),
+                                                             factType,
+                                                             afv.getField()),
+                                   afv.getNature());
         }
     }
 
     private void visitActionFieldList(final ActionUpdateField afl) {
         String factType = model.getLHSBindingType(afl.getVariable());
         for (ActionFieldValue afv : afl.getFieldValues()) {
-            InterpolationVariable var = new InterpolationVariable(afv.getValue(),
-                                                                  afv.getType(),
-                                                                  factType,
-                                                                  afv.getField());
-            if (afv.getNature() == FieldNatureType.TYPE_TEMPLATE && !vars.contains(var)) {
-                vars.add(var);
-            } else {
-                hasNonTemplateOutput = true;
-            }
+            manageTemplateVariable(new InterpolationVariable(afv.getValue(),
+                                                             afv.getType(),
+                                                             factType,
+                                                             afv.getField()),
+                                   afv.getNature());
         }
     }
 
@@ -249,29 +237,26 @@ public class GeneratorContextRuleModelVisitor {
     }
 
     private void visitSingleFieldConstraint(final SingleFieldConstraint sfc) {
-        final InterpolationVariable var = new InterpolationVariable(sfc.getValue(),
-                                                                    sfc.getFieldType(),
-                                                                    (factPattern == null ? "" : factPattern.getFactType()),
-                                                                    sfc.getFieldName());
-        if (BaseSingleFieldConstraint.TYPE_TEMPLATE == sfc.getConstraintValueType() && !vars.contains(var)) {
-            vars.add(var);
-        } else {
-            hasNonTemplateOutput = true;
+        if (BaseSingleFieldConstraint.TYPE_PREDICATE == sfc.getConstraintValueType()) {
+            parseStringPattern(sfc.getValue());
+            return;
         }
+
+        manageTemplateVariable(new InterpolationVariable(sfc.getValue(),
+                                                         sfc.getFieldType(),
+                                                         (factPattern == null ? "" : factPattern.getFactType()),
+                                                         sfc.getFieldName()),
+                               sfc.getConstraintValueType());
 
         //Visit Connection constraints
         if (sfc.getConnectives() != null) {
             for (int i = 0; i < sfc.getConnectives().length; i++) {
                 final ConnectiveConstraint cc = sfc.getConnectives()[i];
-                InterpolationVariable ccVar = new InterpolationVariable(cc.getValue(),
-                                                                        cc.getFieldType(),
-                                                                        (factPattern == null ? "" : factPattern.getFactType()),
-                                                                        cc.getFieldName());
-                if (BaseSingleFieldConstraint.TYPE_TEMPLATE == cc.getConstraintValueType() && !vars.contains(ccVar)) {
-                    vars.add(ccVar);
-                } else {
-                    hasNonTemplateOutput = true;
-                }
+                manageTemplateVariable(new InterpolationVariable(cc.getValue(),
+                                                                 cc.getFieldType(),
+                                                                 (factPattern == null ? "" : factPattern.getFactType()),
+                                                                 cc.getFieldName()),
+                                       cc.getConstraintValueType());
             }
         }
     }
@@ -282,30 +267,31 @@ public class GeneratorContextRuleModelVisitor {
         if (factType == null) {
             factType = sfexp.getExpressionLeftSide().getClassType();
         }
-        final InterpolationVariable var = new InterpolationVariable(sfexp.getValue(),
-                                                                    genericType,
-                                                                    factType,
-                                                                    sfexp.getFieldName());
-        if (BaseSingleFieldConstraint.TYPE_TEMPLATE == sfexp.getConstraintValueType() && !vars.contains(var)) {
-            vars.add(var);
-        } else {
-            hasNonTemplateOutput = true;
-        }
+        manageTemplateVariable(new InterpolationVariable(sfexp.getValue(),
+                                                         genericType,
+                                                         factType,
+                                                         sfexp.getFieldName()),
+                               sfexp.getConstraintValueType());
 
         //Visit Connection constraints
         if (sfexp.getConnectives() != null) {
             for (int i = 0; i < sfexp.getConnectives().length; i++) {
                 final ConnectiveConstraint cc = sfexp.getConnectives()[i];
-                InterpolationVariable ccVar = new InterpolationVariable(cc.getValue(),
-                                                                        genericType,
-                                                                        factType,
-                                                                        cc.getFieldName());
-                if (BaseSingleFieldConstraint.TYPE_TEMPLATE == cc.getConstraintValueType() && !vars.contains(ccVar)) {
-                    vars.add(ccVar);
-                } else {
-                    hasNonTemplateOutput = true;
-                }
+                manageTemplateVariable(new InterpolationVariable(cc.getValue(),
+                                                                 genericType,
+                                                                 factType,
+                                                                 cc.getFieldName()),
+                                       cc.getConstraintValueType());
             }
+        }
+    }
+
+    private void manageTemplateVariable(final InterpolationVariable var,
+                                        final int constraintValueType) {
+        if (constraintValueType == BaseSingleFieldConstraint.TYPE_TEMPLATE && !vars.contains(var)) {
+            vars.add(var);
+        } else {
+            hasNonTemplateOutput = true;
         }
     }
 

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -5131,4 +5131,29 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
                 "end\n";
         assertEqualsIgnoreWhitespace(expectedDrl, resultDrl);
     }
+
+    @Test
+    public void testTwoPredicates() {
+
+        final String drl = "rule \"r0\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "Person( ( age != null ) == true, ( name == null ) == false )\n" +
+                "then\n" +
+                "end\n";
+
+        final PackageDataModelOracle dmo = mock(PackageDataModelOracle.class);
+        final RuleModel m = ruleModelPersistence.unmarshal(drl,
+                                                           Collections.EMPTY_LIST,
+                                                           dmo);
+        final String resultDrl = ruleModelPersistence.marshal(m);
+
+        final String expectedDrl = "rule \"r0\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "Person( eval( ( age != null ) == true ), eval( ( name == null ) == false ))\n" +
+                "then\n" +
+                "end\n";
+        assertEqualsIgnoreWhitespace(expectedDrl, resultDrl);
+    }
 }

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -5093,7 +5093,6 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
         final SingleFieldConstraint left = (SingleFieldConstraint) composite.getConstraint(0);
         final SingleFieldConstraint right = (SingleFieldConstraint) composite.getConstraint(1);
 
-
         assertEquals(factMvel, left.getFactType());
         assertEquals(symbol, left.getFieldName());
         assertEquals("!= null", left.getOperator());
@@ -5103,5 +5102,33 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
         assertEquals(symbol, right.getFieldName());
         assertEquals("matches", right.getOperator());
         assertEquals("P.*", right.getValue());
+    }
+
+    @Test
+    /**
+     * The GRE can not produce this, but the Persistence class is also used by XLS->GDST->XLS conversions.
+     */
+    public void testMoreComplexExpression() {
+
+        final String drl = "rule \"r0\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "Person( ( age != null ) == true )\n" +
+                "then\n" +
+                "end\n";
+
+        final PackageDataModelOracle dmo = mock(PackageDataModelOracle.class);
+        final RuleModel m = ruleModelPersistence.unmarshal(drl,
+                                                           Collections.EMPTY_LIST,
+                                                           dmo);
+        final String resultDrl = ruleModelPersistence.marshal(m);
+
+        final String expectedDrl = "rule \"r0\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "Person( eval( ( age != null ) == true ))\n" +
+                "then\n" +
+                "end\n";
+        assertEqualsIgnoreWhitespace(expectedDrl, resultDrl);
     }
 }

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitor.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/main/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitor.java
@@ -255,6 +255,11 @@ public class RuleModelVisitor {
     }
 
     private void visitSingleFieldConstraint(SingleFieldConstraint sfc) {
+        if (BaseSingleFieldConstraint.TYPE_PREDICATE == sfc.getConstraintValueType()){
+            parseStringPattern(sfc.getValue());
+            return;
+        }
+
         InterpolationVariable var = new InterpolationVariable(sfc.getValue(),
                                                               sfc.getFieldType(),
                                                               (factPattern == null ? "" : factPattern.getFactType()),

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitorTest.java
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/src/test/java/org/drools/workbench/models/datamodel/rule/visitors/RuleModelVisitorTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class RuleModelVisitorTest {
@@ -69,6 +70,27 @@ public class RuleModelVisitorTest {
         assertEquals("fieldName", interpolationVariable.getFactField());
         assertEquals("fieldType", interpolationVariable.getDataType());
         assertEquals("==", interpolationVariable.getOperator());
+    }
+
+    @Test
+    public void testSingleFieldConstraintPredicate() {
+
+        Map<InterpolationVariable, Integer> variableMap = new HashMap<>();
+        RuleModelVisitor visitor = new RuleModelVisitor(variableMap);
+
+        SingleFieldConstraint singleFieldConstraint = new SingleFieldConstraint();
+        singleFieldConstraint.setConstraintValueType(BaseSingleFieldConstraint.TYPE_PREDICATE);
+        singleFieldConstraint.setValue("(age != null) == \"@{param1}\"");
+
+        visitor.visit(singleFieldConstraint);
+
+        assertEquals(1, variableMap.keySet().size());
+
+        InterpolationVariable interpolationVariable = variableMap.keySet().iterator().next();
+        assertEquals("param1", interpolationVariable.getVarName());
+        assertEquals("Object", interpolationVariable.getDataType());
+        assertNull(interpolationVariable.getFactField());
+        assertNull(interpolationVariable.getOperator());
     }
 
     private static class TemplateAwareIAction implements IAction,

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTBRDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTBRDRLPersistenceTest.java
@@ -21,18 +21,50 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 
+import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.drools.workbench.models.datamodel.rule.PluggableIAction;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.TemplateAware;
 import org.drools.workbench.models.guided.dtable.backend.util.GuidedDTBRDRLPersistence;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class GuidedDTBRDRLPersistenceTest {
+
+    @Test
+    public void testSingleFieldConstraintPredicate() {
+        final GuidedDTBRDRLPersistence persistence = new GuidedDTBRDRLPersistence((key) -> "true");
+
+        final RuleModel ruleModel = new RuleModel();
+        ruleModel.name = "Template aware";
+
+        ruleModel.addRhsItem(new TemplateAwareIAction("initialValue"));
+        final FactPattern factPattern = new FactPattern("Person");
+        final SingleFieldConstraint constraint = new SingleFieldConstraint();
+        constraint.setConstraintValueType(BaseSingleFieldConstraint.TYPE_PREDICATE);
+        constraint.setValue("(age != null) == \"@{param1}\"");
+        factPattern.addConstraint(constraint);
+        ruleModel.addLhsItem(factPattern);
+
+        final String result = persistence.marshal(ruleModel);
+
+        final String expected = "rule \"Template aware\"\n" +
+                "\tdialect \"mvel\"\n" +
+                "\twhen\n" +
+                "\t\tPerson( eval( (age != null) == \"true\" ))\n" +
+                "\tthen\n" +
+                "\t\tsubstitutedValue;\n" +
+                "end\n";
+
+        assertEquals(expected,
+                     result);
+    }
 
     @Test
     public void testRHSWithTemplateAwareIAction() {


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5507

Failures that I ran into:
* `(age != null) == "@{param}" )` was not regognized as a predicate ( affects GRE, Templated rules and GDST BRL)
* Variables from single field predicate conditions were not found ( affects GRE, Templated rules and GDST BRL)