### PR TITLE
[DROOLS-5483] clear transactionResources ThreadLocal only when it is …

### DIFF
--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
@@ -248,9 +248,10 @@ public class JtaTransactionManager
                 logger.warn( "Unable to commit transaction", e);
                 throw new RuntimeException( "Unable to commit transaction",
                                             e );
+            } finally {
+                transactionResources.get().clear();
             }
         }
-        transactionResources.get().clear();
     }
     
     public void rollback(boolean transactionOwner) {


### PR DESCRIPTION
…the transaction owner