### PR TITLE
[DROOLS-5502] DMN Generate Strongly Typed Output Set

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/declaredtype/api/FieldDefinition.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/declaredtype/api/FieldDefinition.java
@@ -49,4 +49,8 @@ public interface FieldDefinition {
     default Optional<String> overriddenSetterName() {
         return Optional.empty();
     }
+
+    default Optional<String> getJavadocComment() {
+        return Optional.empty();
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/declaredtype/generator/GeneratedClassDeclaration.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/declaredtype/generator/GeneratedClassDeclaration.java
@@ -177,6 +177,8 @@ public class GeneratedClassDeclaration {
             field = generatedClass.addFieldWithInitializer(returnType, fieldName, parseExpression(fieldDefinition.getInitExpr()), modifiers);
         }
 
+        fieldDefinition.getJavadocComment().ifPresent(field::setJavadocComment);
+
         if (fieldDefinition.createAccessors()) {
             MethodDeclaration setter = field.createSetter();
             fieldDefinition.overriddenSetterName().ifPresent(setter::setName);

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.typesafe;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.drools.modelcompiler.builder.generator.declaredtype.api.AnnotationDefinition;
+import org.drools.modelcompiler.builder.generator.declaredtype.api.FieldDefinition;
+import org.drools.modelcompiler.builder.generator.declaredtype.api.MethodDefinition;
+import org.drools.modelcompiler.builder.generator.declaredtype.api.TypeDefinition;
+import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
+
+abstract class AbstractDMNSetType implements TypeDefinition {
+
+    List<DMNDeclaredField> fields = new ArrayList<>();
+
+    Map<String, DMNType> fieldsKey = new HashMap<>();
+
+    List<AnnotationDefinition> annotations = new ArrayList<>();
+    private DMNAllTypesIndex index;
+    private String javadoc;
+
+    private DMNStronglyCodeGenConfig codeGenConfig;
+
+    AbstractDMNSetType(DMNAllTypesIndex index, DMNStronglyCodeGenConfig codeGenConfig) {
+        this.index = index;
+        this.codeGenConfig = codeGenConfig;
+    }
+
+    public void addField(String key, DMNType type) {
+        fieldsKey.put(key, type);
+    }
+
+    @Override
+    public List<? extends FieldDefinition> getFields() {
+        return fields;
+    }
+
+    public void initFields() {
+        for (Map.Entry<String, DMNType> f : fieldsKey.entrySet()) {
+            DMNDeclaredField dmnDeclaredField = new DMNDeclaredField(index, f, codeGenConfig);
+            fields.add(dmnDeclaredField);
+        }
+    }
+
+    @Override
+    public List<FieldDefinition> getKeyFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<String> getSuperTypeName() {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> getInterfacesNames() {
+        return Collections.singletonList(FEELPropertyAccessible.class.getCanonicalName());
+    }
+
+    @Override
+    public List<MethodDefinition> getMethods() {
+        return new FEELPropertyAccessibleImplementation(fields).getMethods();
+    }
+
+    @Override
+    public List<AnnotationDefinition> getAnnotationsToBeAdded() {
+        return annotations;
+    }
+
+    @Override
+    public List<FieldDefinition> findInheritedDeclaredFields() {
+        return Collections.emptyList();
+    }
+
+    public void setJavadoc(String javadoc) {
+        this.javadoc = javadoc;
+    }
+
+    @Override
+    public Optional<String> getJavadoc() {
+        return Optional.of(this.javadoc);
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNAllTypesIndex.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNAllTypesIndex.java
@@ -16,11 +16,8 @@
 
 package org.kie.dmn.typesafe;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Period;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,11 +102,11 @@ public class DMNAllTypesIndex {
             case UNKNOWN:
                 return Object.class;
             case DATE:
-                return LocalDate.class;
+                return Temporal.class;
             case TIME:
-                return LocalTime.class;
+                return Temporal.class;
             case DATE_TIME:
-                return LocalDateTime.class;
+                return Temporal.class;
             case BOOLEAN:
                 return Boolean.class;
             case NUMBER:
@@ -126,10 +123,10 @@ public class DMNAllTypesIndex {
         switch (expectedFEELType.getName()) {
             case SimpleType.YEARS_AND_MONTHS_DURATION:
             case "yearMonthDuration":
-                return Period.class;
+                return TemporalAmount.class;
             case SimpleType.DAYS_AND_TIME_DURATION:
             case "dayTimeDuration":
-                return Duration.class;
+                return TemporalAmount.class;
             default:
                 throw new IllegalArgumentException();
         }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredField.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredField.java
@@ -200,4 +200,8 @@ public class DMNDeclaredField implements FieldDefinition {
         return Optional.of("set" + CodegenStringUtil.escapeIdentifier(ucFirst(originalMapKey)));
     }
 
+    @Override
+    public Optional<String> getJavadocComment() {
+        return Optional.of(fieldDMNType.toString());
+    }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNOutputSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNOutputSetType.java
@@ -16,14 +16,14 @@
 
 package org.kie.dmn.typesafe;
 
-class DMNInputSetType extends AbstractDMNSetType {
+class DMNOutputSetType extends AbstractDMNSetType {
 
-    DMNInputSetType(DMNAllTypesIndex index, DMNStronglyCodeGenConfig codeGenConfig) {
+    DMNOutputSetType(DMNAllTypesIndex index, DMNStronglyCodeGenConfig codeGenConfig) {
         super(index, codeGenConfig);
     }
 
     @Override
     public String getTypeName() {
-        return "InputSet";
+        return "OutputSet";
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/FEELPropertyAccessibleImplementation.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/FEELPropertyAccessibleImplementation.java
@@ -186,6 +186,8 @@ public class FEELPropertyAccessibleImplementation {
         MethodWithStringBody setFeelProperty = new MethodWithStringBody("fromMap", "void", body.toString());
         setFeelProperty.addParameter("java.util.Map<String, Object>", "values");
 
+        addOverrideAnnotation(setFeelProperty);
+
         return setFeelProperty;
     }
 

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/impl/DMNTypeSafeTypeTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/impl/DMNTypeSafeTypeTemplate.java
@@ -43,8 +43,12 @@ public interface DMNTypeSafeTypeTemplate {
         {
             Object propertyValues = values.get("$property$");
             if(propertyValues != null) {
-                $property$ = new PropertyType();
-                $property$.fromMap((java.util.Map<String, Object>) propertyValues);
+                if (propertyValues instanceof PropertyType) {
+                    $property$ = (PropertyType) propertyValues;
+                } else {
+                    $property$ = new PropertyType();
+                    $property$.fromMap((java.util.Map<String, Object>) propertyValues);
+                }
             }
         }
 
@@ -53,13 +57,18 @@ public interface DMNTypeSafeTypeTemplate {
             Object propertyValues = values.get("$property$");
             if(propertyValues != null) {
                 $property$ = new java.util.ArrayList<>();
-                for (java.util.Map<String, Object> v : (java.util.Collection<java.util.Map<String, Object>>) propertyValues) {
-                    PropertyType item = new PropertyType();
-                    item.fromMap(v);
-                    $property$.add(item);
+                for (Object v : (java.util.Collection<Object>) propertyValues) {
+                    if (v instanceof PropertyType) {
+                        $property$.add((PropertyType)v);
+                    } else {
+                        PropertyType item = new PropertyType();
+                        item.fromMap((java.util.Map<String, Object>)v);
+                        $property$.add(item);
+                    }
                 }
             }
         }
+
         // Collections of basic fields
         {
             Object propertyValues = values.get("$property$");
@@ -71,4 +80,5 @@ public interface DMNTypeSafeTypeTemplate {
             }
         }
     }
+
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
@@ -186,13 +186,15 @@ public abstract class BaseVariantTest {
 
     protected Map<String, Class<?>> allCompiledClasses;
 
+    protected Map<String, String> allSources;
+
     protected String testName = "";
 
     private void createTypeSafeInput(DMNRuntime runtime) {
         String prefix = String.format("%s%s", testName, testConfig.name());
         factory = new DMNTypeSafePackageName.ModelFactory(prefix);
         DMNAllTypesIndex index = new DMNAllTypesIndex(factory, runtime.getModels().toArray(new DMNModel[]{}));
-        Map<String, String> allSources = new HashMap<>();
+        allSources = new HashMap<>();
 
         for (DMNModel m : runtime.getModels()) {
             Map<String, String> allTypesSourceCode = new DMNTypeSafeTypeGenerator(m, index, factory)
@@ -235,14 +237,6 @@ public abstract class BaseVariantTest {
         }
     }
 
-    /**
-     * Utility test method, for class inspection.
-     */
-    protected Class<?> getStronglyClassByName(DMNModel dmnModel, String className) {
-        String fqn = factory.create(dmnModel).appendPackage(className);
-        return allCompiledClasses.get(fqn);
-    }
-
     private DMNResult evaluateDecisionServiceTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String decisionServiceName) {
         Map<String, Object> inputMap = context.getAll();
         FEELPropertyAccessible inputSet;
@@ -265,6 +259,14 @@ public abstract class BaseVariantTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Utility test method, for class inspection.
+     */
+    protected Class<?> getStronglyClassByName(DMNModel dmnModel, String className) {
+        String fqn = factory.create(dmnModel).appendPackage(className);
+        return allCompiledClasses.get(fqn);
     }
 
     protected FEELPropertyAccessible createInstanceFromCompiledClasses(Map<String, Class<?>> compile, DMNTypeSafePackageName packageName, String className) throws Exception {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
@@ -17,6 +17,7 @@
 package org.kie.dmn.core;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.api.core.ast.ItemDefNode;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.compiler.DMNTypeRegistry;
@@ -266,6 +268,12 @@ public class DMNCompilerTest extends BaseVariantTest {
         }
         LOG.debug("{}", evaluateAll);
         assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult(), is("Hello John!"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, evaluateAll);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Greeting"), is("Hello John!"));
+        }
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNRuntimeTest.java
@@ -665,7 +665,7 @@ public class DMNRuntimeTest extends BaseInterpretedVsCompiledTest {
         assertThat( ctx.get("cSecond"), is( BigDecimal.valueOf( 1 ) ) );
         assertThat( ctx.get("cTimezone"), is( "GMT-01:00" ) );
         assertThat( ctx.get("years"), is( BigDecimal.valueOf( 1 ) ) );
-        assertThat( ctx.get("seconds"), is( BigDecimal.valueOf( 14 ) ) );
+        assertThat( ctx.get("d1seconds"), is( BigDecimal.valueOf( 14 ) ) );
 
     }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
@@ -23,28 +23,40 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.core.BaseVariantTest;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.util.EvalHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
+import static org.kie.dmn.core.util.DynamicTypeUtils.prototype;
 
 public class DMNRuntimeTypesTest extends BaseVariantTest {
 
@@ -82,6 +94,19 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("DecisionDateAndTime").getResult(), is(LocalDateTime.of(2020, 4, 2, 10, 0)));
         assertThat(dmnResult.getDecisionResultByName("DecisionDate").getResult(), is(LocalDate.of(2020, 4, 3)));
         assertThat(dmnResult.getDecisionResultByName("DecisionTime").getResult(), is(LocalTime.of(10, 0)));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("DecisionString"), is("Hello, John Doe"));
+            assertThat(allProperties.get("DecisionNumber"), is(new BigDecimal(2)));
+            assertThat(allProperties.get("DecisionBoolean"), is(false));
+            assertThat(allProperties.get("DecisionDTDuration"), is(Duration.parse("P2D")));
+            assertThat(allProperties.get("DecisionYMDuration"), is(ComparablePeriod.parse("P2M")));
+            assertThat(allProperties.get("DecisionDateAndTime"), is(LocalDateTime.of(2020, 4, 2, 10, 0)));
+            assertThat(allProperties.get("DecisionDate"), is(LocalDate.of(2020, 4, 3)));
+            assertThat(allProperties.get("DecisionTime"), is(LocalTime.of(10, 0)));
+        }
     }
 
     @Test
@@ -101,6 +126,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("nameconstclass"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Decision-1"), is("nameconstclass"));
+        }
     }
 
     @Test
@@ -127,6 +158,13 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("Decision Yearly").getResult(), is("Total Yearly 10"));
         assertThat(dmnResult.getDecisionResultByName("Decision Employee").getResult(), is("For John Doe total: 3"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Decision Yearly"), is("Total Yearly 10"));
+            assertThat(allProperties.get("Decision Employee"), is("For John Doe total: 3"));
+        }
     }
 
     @Test
@@ -145,6 +183,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("John Doe is S"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Decision-1"), is("John Doe is S"));
+        }
     }
 
     @Test
@@ -166,6 +210,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("John Doe has 3 pairs."));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Decision-1"), is("John Doe has 3 pairs."));
+        }
     }
 
     @Test
@@ -182,6 +232,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("Decision: John Doe"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Decision-1"), is("Decision: John Doe"));
+        }
     }
 
     @Test
@@ -216,6 +272,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("highlights").getResult(), is("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("highlights"), is("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]"));
+        }
     }
 
     @Test
@@ -240,6 +302,16 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("DecisionListVowel").getResult(), is(new BigDecimal(2)));
         assertThat(dmnResult.getDecisionResultByName("DecisionJustA").getResult(), is("the a"));
         assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getResult(), is(new BigDecimal(1)));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("DecisionListNumber"), is(new BigDecimal(3)));
+            assertThat(allProperties.get("DecisionVowel"), is("the e"));
+            assertThat(allProperties.get("DecisionListVowel"), is(new BigDecimal(2)));
+            assertThat(allProperties.get("DecisionJustA"), is("the a"));
+            assertThat(allProperties.get("DecisionListOfA"), is(new BigDecimal(1)));
+        }
     }
 
     @Test
@@ -264,6 +336,16 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("DecisionListVowel").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
         assertThat(dmnResult.getDecisionResultByName("DecisionJustA").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
         assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("DecisionListNumber"), is(new BigDecimal(3)));
+            assertThat(allProperties.get("DecisionVowel"), nullValue());
+            assertThat(allProperties.get("DecisionListVowel"), nullValue());
+            assertThat(allProperties.get("DecisionJustA"), nullValue());
+            assertThat(allProperties.get("DecisionListOfA"), nullValue());
+        }
     }
 
     @Test
@@ -288,6 +370,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("decision1").getResult(), is("L1nameL2namename"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("decision1"), is("L1nameL2namename"));
+        }
     }
 
     @Test
@@ -318,6 +406,358 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         LOG.debug("{}", dmnResult);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
         assertThat(dmnResult.getDecisionResultByName("Should the driver be suspended?").getResult(), is("Yes"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            FEELPropertyAccessible driver = (FEELPropertyAccessible)allProperties.get("Driver");
+            assertThat(driver.getClass().getSimpleName(), is("TDriver"));
+            assertThat(driver.getFEELProperty("Name").toOptional().get(), is("Luca"));
+            assertThat(driver.getFEELProperty("Age").toOptional().get(), is(35));
+            assertThat(driver.getFEELProperty("State").toOptional().get(), is("Italy"));
+            assertThat(driver.getFEELProperty("City").toOptional().get(), is("Milan"));
+            assertThat(driver.getFEELProperty("Points").toOptional().get(), is(2000));
+
+            FEELPropertyAccessible violation = (FEELPropertyAccessible)allProperties.get("Violation");
+            assertThat(violation.getClass().getSimpleName(), is("TViolation"));
+            assertThat(violation.getFEELProperty("Code").toOptional().get(), is("s"));
+            assertThat(violation.getFEELProperty("Date").toOptional().get(), is(LocalDate.of(1984, 11, 6)));
+            assertThat(violation.getFEELProperty("Type").toOptional().get(), is("speed"));
+            assertThat(violation.getFEELProperty("Actual Speed").toOptional().get(), is(120));
+            assertThat(violation.getFEELProperty("Speed Limit").toOptional().get(), is(100));
+
+            FEELPropertyAccessible fine = (FEELPropertyAccessible)allProperties.get("Fine");
+            assertThat(fine.getClass().getSimpleName(), is("TFine"));
+            assertThat(fine.getFEELProperty("Amount").toOptional().get(), is(new BigDecimal("500")));
+            assertThat(fine.getFEELProperty("Points").toOptional().get(), is(new BigDecimal("3")));
+
+            Object suspended = allProperties.get("Should the driver be suspended?");
+            assertThat(suspended, instanceOf(String.class));
+            assertThat(suspended, is("Yes"));
+        }
+    }
+
+    @Test
+    public void testDecisionService() {
+        final DMNRuntime runtime = createRuntime("DecisionServiceABC_DMN12.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60", "Drawing 1");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        // DecisionService only
+        final DMNContext context = DMNFactory.newContext();
+
+        final DMNResult dmnResult1 = evaluateDecisionService(runtime, dmnModel, context, "Decision Service ABC");
+        LOG.debug("{}", dmnResult1);
+        assertThat(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages()), dmnResult1.hasErrors(), is(false));
+
+        final DMNContext result = dmnResult1.getContext();
+        assertThat(result.getAll(), not(hasEntry(is("Invoking Decision"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
+        assertThat(result.get("ABC"), is("abc"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult1);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Invoking Decision"), nullValue());
+            Object abc = allProperties.get("ABC");
+            assertThat(abc, instanceOf(String.class));
+            assertThat(abc, is("abc"));
+        }
+
+        // evaluateAll
+        final DMNContext context2 = DMNFactory.newContext();
+
+        final DMNResult dmnResult2 = runtime.evaluateAll(dmnModel, context2);
+        LOG.debug("{}", dmnResult2);
+        dmnResult2.getDecisionResults().forEach(x -> LOG.debug("{}", x));
+        assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(false));
+
+        final DMNContext result2 = dmnResult2.getContext();
+        assertThat(result2.get("ABC"), is("abc"));
+        assertThat(result2.get("Invoking Decision"), is("abc"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult2);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            Object decisionService = allProperties.get("Decision Service ABC");
+            assertThat(decisionService, instanceOf(FEELFunction.class));
+            assertThat(((FEELFunction)decisionService).getName(), is("Decision Service ABC"));
+            Object invokingDecision = allProperties.get("Invoking Decision");
+            assertThat(invokingDecision, instanceOf(String.class));
+            assertThat(invokingDecision, is("abc"));
+            Object abc = allProperties.get("ABC");
+            assertThat(abc, instanceOf(String.class));
+            assertThat(abc, is("abc"));
+        }
+    }
+
+    @Test
+    public void testBKM() {
+        final DMNRuntime runtime = createRuntime("0009-invocation-arithmetic.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11", "literal invocation1");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final Map<String, Object> loan = new HashMap<>();
+        loan.put("amount", BigDecimal.valueOf(600000));
+        loan.put("rate", new BigDecimal("0.0375"));
+        loan.put("term", BigDecimal.valueOf(360));
+        final DMNContext context = DMNFactory.newContext();
+        context.set("fee", 100);
+        context.set("Loan", loan);
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(
+                   ((BigDecimal) dmnResult.getContext().get("MonthlyPayment")).setScale(8, BigDecimal.ROUND_DOWN),
+                   is(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN)));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            Object fee = allProperties.get("fee");
+            assertThat(fee, is(100));
+            FEELPropertyAccessible loanOut = (FEELPropertyAccessible)allProperties.get("Loan");
+            assertThat(loanOut.getClass().getSimpleName(), is("TLoan"));
+            assertThat(loanOut.getFEELProperty("amount").toOptional().get(), is(BigDecimal.valueOf(600000)));
+            assertThat(loanOut.getFEELProperty("rate").toOptional().get(), is(new BigDecimal("0.0375")));
+            assertThat(loanOut.getFEELProperty("term").toOptional().get(), is(BigDecimal.valueOf(360)));
+            Object bkm = allProperties.get("PMT");
+            assertThat(bkm, instanceOf(FEELFunction.class));
+            assertThat(((FEELFunction)bkm).getName(), is("PMT"));
+            Object monthlyPayment = allProperties.get("MonthlyPayment");
+            assertThat(((BigDecimal) monthlyPayment).setScale(8, BigDecimal.ROUND_DOWN),
+                       is(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN)));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testCapitalLetterConflict() {
+        // To be fixed by DROOLS-5518
+        final DMNRuntime runtime = createRuntime("capitalLetterConflict.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_B321C9B1-856E-45DE-B05D-5B4D4D301D37", "capitalLetterConflict");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final Map<String, Object> myPerson = new HashMap<>();
+        myPerson.put("name", "John");
+        myPerson.put("age", 28);
+        final Map<String, Object> myPersonCapital = new HashMap<>();
+        myPersonCapital.put("name", "Paul");
+        myPersonCapital.put("age", 26);
+
+        final DMNContext context = DMNFactory.newContext();
+        context.set("myPerson", myPerson);
+        context.set("MyPerson", myPersonCapital);
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.getContext().get("myDecision"), is("myDecision is John"));
+        assertThat(dmnResult.getContext().get("MyDecision"), is("MyDecision is Paul"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("myPerson");
+            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("John"));
+            assertThat(myPersonOut.getFEELProperty("age").toOptional().get(), is(28));
+            FEELPropertyAccessible myPersonCapitalOut = (FEELPropertyAccessible) allProperties.get("MyPerson");
+            assertThat(myPersonCapitalOut.getClass().getSimpleName(), is("TPerson"));
+            assertThat(myPersonCapitalOut.getFEELProperty("name").toOptional().get(), is("Paul"));
+            assertThat(myPersonCapitalOut.getFEELProperty("age").toOptional().get(), is(26));
+            Object myDecision = (String) allProperties.get("myDecision");
+            assertThat(myDecision, is("myDecision is John"));
+            Object myDecisionCapital = (String) allProperties.get("MyDecision");
+            assertThat(myDecisionCapital, is("MyDecision is Paul"));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testCapitalLetterConflictWithInputAndDecision() {
+        // To be fixed by DROOLS-5518
+        final DMNRuntime runtime = createRuntime("capitalLetterConflictWithInputAndDecision.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_EE9DAFC0-D50D-4D23-8676-FF8A40E02919", "capitalLetterConflictWithInputAndDecision");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final Map<String, Object> person = new HashMap<>();
+        person.put("name", "John");
+        person.put("age", 28);
+
+        final DMNContext context = DMNFactory.newContext();
+        context.set("myNode", person);
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+        assertThat(dmnResult.getContext().get("MyNode"), is("MyNode is John"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("myNode");
+            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("John"));
+            assertThat(myPersonOut.getFEELProperty("age").toOptional().get(), is(28));
+            Object myDecision = (String) allProperties.get("MyNode");
+            assertThat(myDecision, is("MyNode is John"));
+        }
+    }
+
+    @Test
+    public void testShareTypeForInputAndOutput() {
+        final DMNRuntime runtime = createRuntime("shareTypeForInputAndOutput.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_DBEFBA7B-C568-4631-A89E-AA31F7C6564B", "shareTypeForInputAndOutput");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final Map<String, Object> person = new HashMap<>();
+        person.put("name", "John");
+        person.put("age", 28);
+        person.put("employmentPeriod", Period.of(1, 2, 1));
+
+        final DMNContext context = DMNFactory.newContext();
+        context.set("inputPerson", person);
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+
+        Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
+        assertThat(outputPerson.get("name"), is("Paul"));
+        assertThat(outputPerson.get("age"), is(new BigDecimal(20)));
+        assertThat(outputPerson.get("employmentPeriod"), is(ComparablePeriod.of(1, 3, 1)));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("outputPerson");
+            assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
+            assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("Paul"));
+            assertThat(myPersonOut.getFEELProperty("age").toOptional().get(), is(new BigDecimal(20)));
+            assertThat(myPersonOut.getFEELProperty("employmentPeriod").toOptional().get(), is(ComparablePeriod.of(1, 3, 1)));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testCollectionType() {
+        // To be fixed by DROOLS-5538
+        final DMNRuntime runtime = createRuntime("PersonListHelloBKM2.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel(
+                "http://www.trisotech.com/definitions/_7e41a76e-2df6-4899-bf81-ae098757a3b6", "PersonListHelloBKM2");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final DMNContext context = DMNFactory.newContext();
+
+        final Map<String, Object> p1 = prototype(entry("Full Name", "John Doe"), entry("Age", 33));
+        final Map<String, Object> p2 = prototype(entry("Full Name", "47"), entry("Age", 47));
+
+        context.set("My Input Data", Arrays.asList(p1, p2));
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+
+        assertThat((List<?>) dmnResult.getContext().get("My Decision"),
+                contains(prototype(entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33))),
+                         prototype(entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47)))));
+
+        // Add typeSafe assertion
+    }
+
+    @Test
+    public void testComponentCollection() {
+        final DMNRuntime runtime = createRuntime("collections.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_2A93F258-EF3B-4150-A202-1D02A893DF2B", "collections");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final DMNContext context = DMNFactory.newContext();
+
+        final Map<String, Object> addr1 = prototype(entry("city", "city1"), entry("street", "street1"));
+        final Map<String, Object> addr2 = prototype(entry("city", "city2"), entry("street", "street2"));
+
+        final Map<String, Object> person = prototype(entry("name", "John"), entry("addressList", Arrays.asList(addr1, addr2)));
+
+        context.set("inputPerson", person);
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+
+        Map<String, Object> outputPerson = (Map<String, Object>)dmnResult.getContext().get("outputPerson");
+
+        assertThat(outputPerson.get("name"), is("Paul"));
+        Map<String, Object> outputAddr1 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(0);
+        Map<String, Object> outputAddr2 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(1);
+
+        assertThat(outputAddr1.get("city"), anyOf(is("cityA"), is("cityB")));
+        assertThat(outputAddr1.get("street"), anyOf(is("streetA"), is("streetB")));
+        assertThat(outputAddr2.get("city"), anyOf(is("cityA"), is("cityB")));
+        assertThat(outputAddr2.get("street"), anyOf(is("streetA"), is("streetB")));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            FEELPropertyAccessible typedOutputPerson = (FEELPropertyAccessible) allProperties.get("outputPerson");
+            assertThat(typedOutputPerson.getClass().getSimpleName(), is("TPerson"));
+            assertThat(typedOutputPerson.getFEELProperty("name").toOptional().get(), is("Paul"));
+            List<FEELPropertyAccessible> addressList = (List<FEELPropertyAccessible>)typedOutputPerson.getFEELProperty("addressList").toOptional().get();
+            FEELPropertyAccessible typedOutputAddr1 = addressList.get(0);
+            FEELPropertyAccessible typedOutputAddr2 = addressList.get(1);
+            assertThat(typedOutputAddr1.getFEELProperty("city").toOptional().get(), anyOf(is("cityA"), is("cityB")));
+            assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get(), anyOf(is("streetA"), is("streetB")));
+            assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get(), anyOf(is("cityA"), is("cityB")));
+            assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get(), anyOf(is("streetA"), is("streetB")));
+        }
+    }
+
+    @Test
+    public void testComponentCollectionPassTypedObject() {
+        final DMNRuntime runtime = createRuntime("collectionsPassTypedObject.dmn", this.getClass());
+        final DMNModel dmnModel = runtime.getModel("https://kiegroup.org/dmn/_10C4DB2B-1DCA-4B4F-A994-FA046AE5C7B0", "collectionsPassTypedObject");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        final DMNContext context = DMNFactory.newContext();
+
+        final Map<String, Object> addr1 = prototype(entry("city", "city1"), entry("street", "street1"));
+        final Map<String, Object> addr2 = prototype(entry("city", "city2"), entry("street", "street2"));
+
+        final Map<String, Object> person = prototype(entry("name", "John"), entry("addressList", Arrays.asList(addr1, addr2)));
+
+        context.set("inputPerson", person);
+
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
+        assertThat(dmnResult.hasErrors(), is(false));
+
+        Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
+
+        assertThat(outputPerson.get("name"), is("Paul"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            FEELPropertyAccessible typedOutputPerson = (FEELPropertyAccessible) allProperties.get("outputPerson");
+            assertThat(typedOutputPerson.getClass().getSimpleName(), is("TPerson"));
+            assertThat(typedOutputPerson.getFEELProperty("name").toOptional().get(), is("Paul"));
+            List<FEELPropertyAccessible> addressList = (List<FEELPropertyAccessible>) typedOutputPerson.getFEELProperty("addressList").toOptional().get();
+            FEELPropertyAccessible typedOutputAddr1 = addressList.get(0);
+            FEELPropertyAccessible typedOutputAddr2 = addressList.get(1);
+            assertThat(typedOutputAddr1.getFEELProperty("city").toOptional().get(), anyOf(is("city1"), is("city2")));
+            assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get(), anyOf(is("street1"), is("street2")));
+            assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get(), anyOf(is("city1"), is("city2")));
+            assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get(), anyOf(is("street1"), is("street2")));
+        } else {
+            // if TypeSafe, ((List) outputPerson.get("addressList")).get(0) returns TAddress
+            Map<String, Object> outputAddr1 = (Map<String, Object>) ((List) outputPerson.get("addressList")).get(0);
+            Map<String, Object> outputAddr2 = (Map<String, Object>) ((List) outputPerson.get("addressList")).get(1);
+
+            assertThat(outputAddr1.get("city"), anyOf(is("city1"), is("city2")));
+            assertThat(outputAddr1.get("street"), anyOf(is("street1"), is("street2")));
+            assertThat(outputAddr2.get("city"), anyOf(is("city1"), is("city2")));
+            assertThat(outputAddr2.get("street"), anyOf(is("street1"), is("street2")));
+        }
     }
 }
-

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -103,6 +104,14 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         DMNContext result = evaluateAll.getContext();
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
+
+        FEELPropertyAccessible outputSet = createInstanceFromCompiledClasses(compiledClasses, packageName, "OutputSet");
+        outputSet.fromMap(result.getAll());
+
+        assertThat(outputSet.getFEELProperty("p").toOptional().get(), equalTo(tPersonInstance));
+        Map<String, Object> dContext = (Map<String, Object>)outputSet.getFEELProperty("d").toOptional().get();
+        assertThat(dContext.get("Hello"), is("Hello Mr. x"));
+        assertThat(dContext.get("the person"), equalTo(tPersonInstance));
     }
 
     private FEELPropertyAccessible tAddress(Map<String, Class<?>> compile, String streetName, int streetNumber) throws Exception {
@@ -156,6 +165,14 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         DMNContext result = evaluateAll.getContext();
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
+
+        FEELPropertyAccessible outputSet = createInstanceFromCompiledClasses(classes, packageName, "OutputSet");
+        outputSet.fromMap(result.getAll());
+
+        assertThat(outputSet.getFEELProperty("p").toOptional().get(), equalTo(context.getFEELProperty("p").toOptional().get()));
+        Map<String, Object> dContext = (Map<String, Object>)outputSet.getFEELProperty("d").toOptional().get();
+        assertThat(dContext.get("Hello"), is("Hello Mr. x"));
+        assertThat(dContext.get("the person"), equalTo(context.getFEELProperty("p").toOptional().get()));
     }
 
     private static DMNResult evaluateTyped(FEELPropertyAccessible context, DMNRuntime runtime, DMNModel dmnModel) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/JavadocTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.core.stronglytyped;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.comments.JavadocComment;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.core.BaseVariantTest;
+import org.kie.dmn.core.util.DMNRuntimeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE;
+import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK_TYPESAFE;
+
+public class JavadocTest extends BaseVariantTest {
+
+    public static final Logger LOG = LoggerFactory.getLogger(JavadocTest.class);
+
+    public JavadocTest(VariantTestConf testConfig) {
+        super(testConfig);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[] params() {
+        return new Object[]{BUILDER_DEFAULT_NOCL_TYPECHECK_TYPESAFE, KIE_API_TYPECHECK_TYPESAFE};
+    }
+
+    @Test
+    public void testDateAndTime() throws Exception {
+        final DMNRuntime runtime = createRuntime("0007-date-time.dmn", getClass());
+        runtime.addListener(DMNRuntimeUtil.createListener());
+
+        final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9", "dateTime Table 58");
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+        // Typesafe only test
+        Map<String, String> sourceMap = new HashMap<>();
+        allSources.forEach((k, v) -> sourceMap.put(k.substring(k.lastIndexOf(".") + 1), v));
+
+        String inputSet = sourceMap.get("InputSet");
+        CompilationUnit cu = StaticJavaParser.parse(inputSet);
+        assertJavadoc(cu, "dateTimeString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "timezone", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "oneHour", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : days and time duration }");
+        assertJavadoc(cu, "month", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "year", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "hours", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "timeString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "dateString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "seconds", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "day", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "minutes", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "durationString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+
+        String outputSet = sourceMap.get("OutputSet");
+        cu = StaticJavaParser.parse(outputSet);
+        assertJavadoc(cu, "timezone", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "date_45Time", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : date and time }");
+        assertJavadoc(cu, "hours", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "time", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : time }");
+        assertJavadoc(cu, "minutes", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "date_45Time2", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : date and time }");
+        assertJavadoc(cu, "years", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "dateTimeString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "oneHour", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : days and time duration }");
+        assertJavadoc(cu, "d1seconds", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "month", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "cDay", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "sumDurations", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : days and time duration }");
+        assertJavadoc(cu, "cYear", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "cSecond", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "dateString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "cTimezone", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "durationString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "cHour", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "year", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "time2", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : time }");
+        assertJavadoc(cu, "timeString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : string }");
+        assertJavadoc(cu, "time3", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : time }");
+        assertJavadoc(cu, "hoursInDuration", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "dtDuration1", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : days and time duration }");
+        assertJavadoc(cu, "seconds", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "dtDuration2", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : days and time duration }");
+        assertJavadoc(cu, "day", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "cMonth", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "cMinute", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "ymDuration2", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : days and time duration }");
+
+        String tDateVariants = sourceMap.get("TDateVariants");
+        cu = StaticJavaParser.parse(tDateVariants);
+        assertJavadoc(cu, "fromString", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : date }");
+        assertJavadoc(cu, "fromDateTime", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : date }");
+        assertJavadoc(cu, "fromYearMonthDay", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : date }");
+
+        String tDateTimeComponents = sourceMap.get("TDateTimeComponents");
+        cu = StaticJavaParser.parse(tDateTimeComponents);
+        assertJavadoc(cu, "year", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "month", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "day", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "hour", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "minute", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+        assertJavadoc(cu, "second", "DMNType{ http://www.omg.org/spec/FEEL/20140401 : number }");
+    }
+
+    private void assertJavadoc(CompilationUnit cu, String field, String expectedJavadocComment) {
+        Optional<FieldDeclaration> opt = cu.findFirst(FieldDeclaration.class, fd -> fd.asFieldDeclaration().getVariable(0).getNameAsString().equals(field));
+        assertTrue(opt.isPresent());
+        Optional<JavadocComment> actual = opt.get().getJavadocComment();
+        assertTrue(actual.isPresent());
+        assertThat(actual.get().getContent(), containsString(expectedJavadocComment));
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
@@ -17,12 +17,14 @@
 package org.kie.dmn.core.v1_3;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.core.BaseVariantTest;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
@@ -59,6 +61,12 @@ public class DMN13specificTest extends BaseVariantTest {
 
         final DMNContext result = dmnResult.getContext();
         assertThat(result.get("salutation"), is("Hello, John"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("salutation"), is("Hello, John"));
+        }
     }
 
     @Test
@@ -92,6 +100,13 @@ public class DMN13specificTest extends BaseVariantTest {
         final DMNContext result = dmnResult.getContext();
         assertThat(result.get("Strategy"), is("THROUGH"));
         assertThat(result.get("Routing"), is("ACCEPT"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Strategy"), is("THROUGH"));
+            assertThat(allProperties.get("Routing"), is("ACCEPT"));
+        }
     }
 
     @Test
@@ -124,5 +139,12 @@ public class DMN13specificTest extends BaseVariantTest {
         final DMNContext result = dmnResult.getContext();
         assertThat(result.get("Strategy"), is("THROUGH"));
         assertThat(result.get("Routing"), is("ACCEPT"));
+
+        if (isTypeSafe()) {
+            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            Map<String, Object> allProperties = outputSet.allFEELProperties();
+            assertThat(allProperties.get("Strategy"), is("THROUGH"));
+            assertThat(allProperties.get("Routing"), is("ACCEPT"));
+        }
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0007-date-time.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/0007-date-time.dmn
@@ -291,8 +291,8 @@
       <text>ymDuration2.years</text>
     </literalExpression>
   </decision>
-  <decision id="_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" name="seconds">
-    <variable name="seconds" typeRef="feel:number"/>
+  <decision id="_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" name="d1seconds">
+    <variable name="d1seconds" typeRef="feel:number"/>
     <informationRequirement>
       <requiredDecision href="#_972ecd98-1c70-4f0c-909c-786f23c61dbb"/>
     </informationRequirement>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/0007-date-time.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/0007-date-time.dmn
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tns="http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="_69430b3e-17b8-430d-b760-c505bf6469f9" namespace="http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9" exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.33.1; 1.0" name="dateTime Table 58" triso:logoChoice="Default">
+  <itemDefinition id="tDateTimeComponents" name="tDateTimeComponents">
+    <itemComponent id="_df05a420-dbc5-48cf-be85-4b41702c4f33" name="Year">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent id="_3e119228-7599-47e5-aa96-182e5ff66034" name="Month">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent id="_d5d22cac-3276-4dfd-9aee-353aa47bf2d4" name="Day">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent id="_63defe21-0369-438e-b879-27df2bcf475e" name="Hour">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent id="_1ebad337-b2da-49ed-8ab2-b308d78e1b2f" name="Minute">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent id="_4666a2d0-63b2-4822-b5b4-e266f4cca3d1" name="Second">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+  </itemDefinition>
+  <itemDefinition id="tDateVariants" name="tDateVariants">
+    <itemComponent id="_02d44cc2-24ac-4f64-a61f-7044684dc438" name="fromString">
+      <typeRef>feel:date</typeRef>
+    </itemComponent>
+    <itemComponent id="_13da5f5e-8fdd-4a33-9500-ceeaaeaccc91" name="fromDateTime">
+      <typeRef>feel:date</typeRef>
+    </itemComponent>
+    <itemComponent id="_c4e03aa1-d8f3-4ffa-aab2-42a17a4fb707" name="fromYearMonthDay">
+      <typeRef>feel:date</typeRef>
+    </itemComponent>
+  </itemDefinition>
+  <inputData id="_74a9c3ad-a813-444e-88ee-8a91096ee233" name="dateString">
+    <variable name="dateString" typeRef="feel:string"/>
+  </inputData>
+  <inputData id="_e5705a69-0114-4f64-8aca-22500a533a51" name="timeString">
+    <variable name="timeString" typeRef="feel:string"/>
+  </inputData>
+  <decision id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" name="Date">
+    <variable name="Date" typeRef="tns:tDateVariants"/>
+    <informationRequirement>
+      <requiredInput href="#_74a9c3ad-a813-444e-88ee-8a91096ee233"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_178690e3-8936-4914-a735-6243a29b6068"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_e3143b2d-e150-422e-8163-d3e4461988f4"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_ec0d9542-257d-401b-ac6b-ce927014cf25"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#_dfbb843a-bd34-4099-b700-0d9ca5b38d6a"/>
+    </informationRequirement>
+    <context>
+      <contextEntry>
+        <variable name="fromString" typeRef="feel:date"/>
+        <literalExpression>
+          <text>date(dateString)</text>
+        </literalExpression>
+      </contextEntry>
+      <contextEntry>
+        <variable name="fromDateTime" typeRef="feel:date"/>
+        <literalExpression>
+          <text>date(Date-Time)</text>
+        </literalExpression>
+      </contextEntry>
+      <contextEntry>
+        <variable name="fromYearMonthDay" typeRef="feel:date"/>
+        <literalExpression>
+          <text>date(Year,Month,Day)</text>
+        </literalExpression>
+      </contextEntry>
+    </context>
+  </decision>
+  <decision id="_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" name="Date-Time">
+    <variable name="Date-Time" typeRef="feel:date and time"/>
+    <informationRequirement>
+      <requiredInput href="#_c796f29d-d800-4239-b9f6-d4d72f77b183"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>date and time(dateTimeString)</text>
+    </literalExpression>
+  </decision>
+  <decision id="_9e8acf47-790a-4741-8ebb-e8a22a30744c" name="Time">
+    <variable name="Time" typeRef="feel:time"/>
+    <informationRequirement>
+      <requiredInput href="#_e5705a69-0114-4f64-8aca-22500a533a51"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>time(timeString)</text>
+    </literalExpression>
+  </decision>
+  <inputData id="_178690e3-8936-4914-a735-6243a29b6068" name="Year">
+    <variable name="Year" typeRef="feel:number"/>
+  </inputData>
+  <inputData id="_e3143b2d-e150-422e-8163-d3e4461988f4" name="Month">
+    <variable name="Month" typeRef="feel:number"/>
+  </inputData>
+  <inputData id="_ec0d9542-257d-401b-ac6b-ce927014cf25" name="Day">
+    <variable name="Day" typeRef="feel:number"/>
+  </inputData>
+  <decision id="_7df22028-4b5b-4594-89c7-a80b8aec526f" name="Date-Time2">
+    <variable name="Date-Time2" typeRef="feel:date and time"/>
+    <informationRequirement>
+      <requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#_9e8acf47-790a-4741-8ebb-e8a22a30744c"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>date and time(Date.fromString,Time)</text>
+    </literalExpression>
+  </decision>
+  <decision id="_1f2b08ce-3c6b-4e22-a747-8d9f378e9035" name="Time2">
+    <variable name="Time2" typeRef="feel:time"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>time(Date-Time2)</text>
+    </literalExpression>
+  </decision>
+  <inputData id="_c796f29d-d800-4239-b9f6-d4d72f77b183" name="dateTimeString">
+    <variable name="dateTimeString" typeRef="feel:string"/>
+  </inputData>
+  <inputData id="_0dffa0f8-4c84-401e-8403-94c201fbd976" name="Hours">
+    <variable name="Hours" typeRef="feel:number"/>
+  </inputData>
+  <inputData id="_03d8f475-0a28-4c67-8fc5-51d9b1f54781" name="Minutes">
+    <variable name="Minutes" typeRef="feel:number"/>
+  </inputData>
+  <inputData id="_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" name="Seconds">
+    <variable name="Seconds" typeRef="feel:number"/>
+  </inputData>
+  <inputData id="_b133cbd3-884d-4cf9-a750-81d949d17e31" name="Timezone">
+    <variable name="Timezone" typeRef="feel:string"/>
+  </inputData>
+  <decision id="_463b1a36-2505-413a-8056-f6a5efc2b52e" name="Time3">
+    <variable name="Time3" typeRef="feel:time"/>
+    <informationRequirement>
+      <requiredInput href="#_0dffa0f8-4c84-401e-8403-94c201fbd976"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_03d8f475-0a28-4c67-8fc5-51d9b1f54781"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_9225dbc5-fe5c-4fa9-b97c-0a41265abf20"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_b133cbd3-884d-4cf9-a750-81d949d17e31"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>time(Hours,Minutes,Seconds,duration(Timezone))</text>
+    </literalExpression>
+  </decision>
+  <inputData id="_6f8bf858-eed1-4f41-93f2-73431540f91f" name="durationString">
+    <variable name="durationString" typeRef="feel:string"/>
+  </inputData>
+  <decision id="_972ecd98-1c70-4f0c-909c-786f23c61dbb" name="dtDuration1">
+    <variable name="dtDuration1" typeRef="feel:days and time duration"/>
+    <informationRequirement>
+      <requiredInput href="#_6f8bf858-eed1-4f41-93f2-73431540f91f"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>duration(durationString)</text>
+    </literalExpression>
+  </decision>
+  <decision id="_a2c48b03-6e72-4846-99cc-02f3747c6867" name="dtDuration2">
+    <variable name="dtDuration2" typeRef="feel:days and time duration"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#_dfbb843a-bd34-4099-b700-0d9ca5b38d6a"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date-Time - Date-Time2</text>
+    </literalExpression>
+  </decision>
+  <inputData id="_d96a8f03-5cee-42ca-8646-4383ad5ecee2" name="oneHour">
+    <variable name="oneHour" typeRef="feel:days and time duration"/>
+  </inputData>
+  <decision id="_634e7bf4-782f-43f0-8b4f-cd8a3146da38" name="hoursInDuration">
+    <variable name="hoursInDuration" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredInput href="#_d96a8f03-5cee-42ca-8646-4383ad5ecee2"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#_a2c48b03-6e72-4846-99cc-02f3747c6867"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>dtDuration2.hours</text>
+    </literalExpression>
+  </decision>
+  <decision id="_14f9f361-8c3c-455b-9c97-fe15201e3b5e" name="sumDurations">
+    <variable name="sumDurations" typeRef="feel:days and time duration"/>
+    <informationRequirement>
+      <requiredDecision href="#_a2c48b03-6e72-4846-99cc-02f3747c6867"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#_972ecd98-1c70-4f0c-909c-786f23c61dbb"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>dtDuration1 + dtDuration2</text>
+    </literalExpression>
+  </decision>
+  <decision id="_cbac111e-ca71-4fac-a921-175ffd767055" name="ymDuration2">
+    <variable name="ymDuration2" typeRef="feel:days and time duration"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#_dfbb843a-bd34-4099-b700-0d9ca5b38d6a"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>years and months duration(Date-Time2,Date-Time)</text>
+    </literalExpression>
+  </decision>
+  <decision id="_04c6bedc-bc63-464f-8e61-c039d24a47bf" name="cDay">
+    <variable name="cDay" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date.fromString.day</text>
+    </literalExpression>
+  </decision>
+  <decision id="_dc18ebe0-6762-4734-aeb3-ed4fb861865c" name="cYear">
+    <variable name="cYear" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date.fromString.year</text>
+    </literalExpression>
+  </decision>
+  <decision id="_2cf37ed0-590d-4f97-b58b-46eaa424b965" name="cMonth">
+    <variable name="cMonth" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date.fromString.month</text>
+    </literalExpression>
+  </decision>
+  <decision id="_087e3f57-8ea6-4857-a080-fadc5a1dd9e8" name="cHour">
+    <variable name="cHour" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date-Time2.hour</text>
+    </literalExpression>
+  </decision>
+  <decision id="_6836a944-7f7b-4c98-8a7a-a573494110fd" name="cMinute">
+    <variable name="cMinute" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date-Time2.minute</text>
+    </literalExpression>
+  </decision>
+  <decision id="_4af88a8f-92e4-4f2d-bde1-e8a36b27e5bf" name="cSecond">
+    <variable name="cSecond" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date-Time2.second</text>
+    </literalExpression>
+  </decision>
+  <decision id="_81f97dd0-29ea-4bab-9540-b70a2fdf8ff3" name="cTimezone">
+    <variable name="cTimezone" typeRef="feel:string"/>
+    <informationRequirement>
+      <requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>Date-Time2.timezone</text>
+    </literalExpression>
+  </decision>
+  <decision id="_91fb395d-8173-4ed3-95f7-f790bd3967ab" name="years">
+    <variable name="years" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_cbac111e-ca71-4fac-a921-175ffd767055"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>ymDuration2.years</text>
+    </literalExpression>
+  </decision>
+  <decision id="_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" name="d1seconds">
+    <variable name="d1seconds" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredDecision href="#_972ecd98-1c70-4f0c-909c-786f23c61dbb"/>
+    </informationRequirement>
+    <literalExpression>
+      <text>dtDuration1.seconds</text>
+    </literalExpression>
+  </decision>
+</definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/0009-invocation-arithmetic.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/0009-invocation-arithmetic.dmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+             xmlns:tns="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11"
+             xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11"
+             namespace="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11"
+             exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.32.2; 1.0" name="literal invocation1" triso:logoChoice="Default"
+             xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd ../../dmn.xsd"
+             expressionLanguage="http://www.omg.org/spec/FEEL/20140401"
+             typeLanguage="http://www.omg.org/spec/FEEL/20140401">
+  <itemDefinition name="tLoan" isCollection="false">
+    <itemComponent name="amount" isCollection="false">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent name="rate" isCollection="false">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+    <itemComponent name="term" isCollection="false">
+      <typeRef>feel:number</typeRef>
+    </itemComponent>
+  </itemDefinition>
+  <decision id="d_MonthlyPayment" name="MonthlyPayment">
+    <variable name="MonthlyPayment" typeRef="feel:number"/>
+    <informationRequirement>
+      <requiredInput href="#i_Loan"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#i_fee"/>
+    </informationRequirement>
+    <knowledgeRequirement>
+      <requiredKnowledge href="#b_PMT"/>
+    </knowledgeRequirement>
+    <literalExpression>
+      <text>PMT(Loan.amount, Loan.rate, Loan.term)+fee</text>
+    </literalExpression>
+  </decision>
+  <businessKnowledgeModel id="b_PMT" name="PMT">
+    <encapsulatedLogic>
+      <formalParameter name="p"/>
+      <formalParameter name="r"/>
+      <formalParameter name="n"/>
+      <literalExpression expressionLanguage="http://www.omg.org/spec/FEEL/20140401">
+        <text>(p*r/12)/(1-(1+r/12)**-n)</text>
+      </literalExpression>
+    </encapsulatedLogic>
+    <variable name="PMT" typeRef="feel:number"/>
+  </businessKnowledgeModel>
+  <inputData id="i_Loan" name="Loan">
+    <variable name="Loan" typeRef="tns:tLoan"/>
+  </inputData>
+  <inputData id="i_fee" name="fee">
+    <variable name="fee" typeRef="feel:number"/>
+  </inputData>
+</definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/DecisionServiceABC_DMN12.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/DecisionServiceABC_DMN12.dmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60" id="_2443d3f5-f178-47c6-a0c9-b1fd1c933f60" namespace="http://www.trisotech.com/dmn/definitions/_2443d3f5-f178-47c6-a0c9-b1fd1c933f60"          exporter="DMN Modeler" exporterVersion="6.1.6.201808301036" name="Drawing 1" triso:logoChoice="Default">
+    <semantic:extensionElements/>
+    <semantic:decision id="_8786de4a-b9d3-42b9-ba55-3c23610a3017" name="Invoking Decision">
+        <semantic:variable name="Invoking Decision" id="_8a0e33e2-7c18-4f9f-8255-6add99439a75" typeRef="string"/>
+        <semantic:knowledgeRequirement id="_e56ed9ec-efa7-428b-b82f-e58875d39f22">
+            <semantic:requiredKnowledge href="#_f8555b12-15f7-45f2-803c-fb621f44088d"/>
+        </semantic:knowledgeRequirement>
+        <semantic:literalExpression id="_3fa75474-1e59-4590-b4c4-32e6133d1f8a" typeRef="string">
+            <semantic:text>Decision Service ABC()</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_148cc263-b911-4aa5-a59b-b4239b93c03d" name="ABC">
+        <semantic:variable name="ABC" id="_90e44665-56a9-46f6-9385-9b745ac60e3f" typeRef="string"/>
+        <semantic:literalExpression id="_8fcfe696-11b2-44a0-b55c-ffb60ea9c88b" typeRef="string">
+            <semantic:text>"abc"</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decisionService id="_f8555b12-15f7-45f2-803c-fb621f44088d" name="Decision Service ABC">
+        <semantic:variable name="Decision Service ABC" id="_63d05cff-8e3b-4dad-a355-fd88f8bcd613"/>
+        <semantic:outputDecision href="#_148cc263-b911-4aa5-a59b-b4239b93c03d"/>
+    </semantic:decisionService>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_5470f9e3-a994-4b97-83af-22145b0d4148" name="Page 1">
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_5bc0705f-4209-4e80-9e77-28b57c68fc66" dmnElementRef="_8786de4a-b9d3-42b9-ba55-3c23610a3017">
+                <dc:Bounds x="200" y="142" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_2443d3f5-f178-47c6-a0c9-b1fd1c933f60_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="203" y="166"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_36e2f988-23e2-4976-8a13-3a7cc692316a" dmnElementRef="_148cc263-b911-4aa5-a59b-b4239b93c03d">
+                <dc:Bounds x="636" y="142" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_2443d3f5-f178-47c6-a0c9-b1fd1c933f60_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="638.5064935064935" y="165.50819672131146"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_34df83eb-a7c7-4abb-97fa-a8cfaacc140a" dmnElementRef="_f8555b12-15f7-45f2-803c-fb621f44088d" isCollapsed="true">
+                <dc:Bounds x="415.5" y="234" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_2443d3f5-f178-47c6-a0c9-b1fd1c933f60_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="418.5" y="258"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_4e1670df-0c81-45fc-9827-b564f858a157" dmnElementRef="_e56ed9ec-efa7-428b-b82f-e58875d39f22">
+                <di:waypoint x="432" y="234"/>
+                <di:waypoint x="353" y="172"/>
+                <dmndi:DMNLabel sharedStyle="LS_2443d3f5-f178-47c6-a0c9-b1fd1c933f60_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_2443d3f5-f178-47c6-a0c9-b1fd1c933f60_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/PersonListHelloBKM2.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/PersonListHelloBKM2.dmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns="http://www.trisotech.com/definitions/_7e41a76e-2df6-4899-bf81-ae098757a3b6" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="5.1.13" id="_7e41a76e-2df6-4899-bf81-ae098757a3b6" name="PersonListHelloBKM2" namespace="http://www.trisotech.com/definitions/_7e41a76e-2df6-4899-bf81-ae098757a3b6" triso:logoChoice="Default">
+  <semantic:extensionElements/>
+  <semantic:itemDefinition label="tPerson" name="tPerson">
+    <semantic:itemComponent id="_d5de49aa-1aef-4b6d-b4f7-3890718f0d3d" name="Full Name">
+      <semantic:typeRef>feel:string</semantic:typeRef>
+    </semantic:itemComponent>
+    <semantic:itemComponent id="_45b015fb-a5e0-47ea-a749-02acc793aaa3" name="Age">
+      <semantic:typeRef>feel:number</semantic:typeRef>
+    </semantic:itemComponent>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition label="tPersonList" name="tPersonList" isCollection="true">
+    <semantic:typeRef>tPerson</semantic:typeRef>
+  </semantic:itemDefinition>
+  <semantic:itemDefinition label="tStringList" name="tStringList" isCollection="true">
+    <semantic:typeRef>feel:string</semantic:typeRef>
+  </semantic:itemDefinition>
+  <semantic:inputData id="_b35feb3a-b88b-41ca-8970-05f33a916c8b" name="My Input Data" triso:displayName="My Input Data">
+    <semantic:variable id="_f6a8381a-d12b-45e6-a2f7-3ff04c1a48ef" name="My Input Data" typeRef="tPersonList"/>
+  </semantic:inputData>
+  <semantic:decision id="_67087158-8a52-475d-9dc0-766b4873047f" name="My Decision" triso:displayName="My Decision">
+    <semantic:variable id="_43bcf30a-91b7-4bf3-ae54-b039a18497bb" name="My Decision" typeRef="tPersonList"/>
+    <semantic:informationRequirement>
+      <semantic:requiredInput href="#_b35feb3a-b88b-41ca-8970-05f33a916c8b"/>
+    </semantic:informationRequirement>
+    <semantic:knowledgeRequirement>
+      <semantic:requiredKnowledge href="#_b2ae3f58-ab6f-4c0b-9038-e9a873b695b1"/>
+    </semantic:knowledgeRequirement>
+    <semantic:literalExpression id="_88edd628-f9da-4115-8d31-c5d419b277a8">
+      <semantic:text>for A Person in My Input Data return My BKM(A Person.Full Name, A Person.Age)</semantic:text>
+    </semantic:literalExpression>
+  </semantic:decision>
+  <semantic:businessKnowledgeModel id="_b2ae3f58-ab6f-4c0b-9038-e9a873b695b1" name="My BKM" triso:displayName="My BKM">
+    <semantic:encapsulatedLogic id="_c55814da-c236-4dd8-80eb-192d29ea6f50">
+      <semantic:formalParameter id="_6060d4af-0759-408a-9a58-fafffe9997c1" name="pName" typeRef="feel:string"/>
+      <semantic:formalParameter id="_09f0ea5f-3ff4-4ae3-afd2-3eb807a246f7" name="pAge" typeRef="feel:number"/>
+      <semantic:context id="context__c55814da-c236-4dd8-80eb-192d29ea6f50">
+        <semantic:contextEntry>
+          <semantic:variable id="_3774a46f-ffea-49be-9c62-5dafed96c0b1" name="Full Name" typeRef="feel:string"/>
+          <semantic:literalExpression id="_8da964a5-502e-40b9-ab76-f8414252f798">
+            <semantic:text>"Prof. " + pName</semantic:text>
+          </semantic:literalExpression>
+        </semantic:contextEntry>
+        <semantic:contextEntry>
+          <semantic:variable id="_8eeb07c3-7468-43ec-998f-985ebecfdbf3" name="Age" typeRef="feel:number"/>
+          <semantic:context id="_efcebb17-6997-497c-a233-bbb03003d9a9">
+            <semantic:contextEntry>
+              <semantic:variable id="_afc36106-72ae-45a4-b291-c1cbbf2c1589" name="AgePlus1"/>
+              <semantic:literalExpression id="_49d43907-3086-4af6-9549-10fd045ebaad">
+                <semantic:text>pAge + 1</semantic:text>
+              </semantic:literalExpression>
+            </semantic:contextEntry>
+            <semantic:contextEntry>
+              <semantic:variable id="_59dddb62-267e-4d0c-9693-37473c50f0b5" name="AgePlus1Minus1"/>
+              <semantic:literalExpression id="_7787f954-2dbf-42b5-be9b-c2b015fc33c6">
+                <semantic:text>AgePlus1 - 1</semantic:text>
+              </semantic:literalExpression>
+            </semantic:contextEntry>
+            <semantic:contextEntry>
+              <semantic:literalExpression id="_84cbad17-74d9-473d-8fee-49345b193fe1">
+                <semantic:text>AgePlus1Minus1 + 0</semantic:text>
+              </semantic:literalExpression>
+            </semantic:contextEntry>
+          </semantic:context>
+        </semantic:contextEntry>
+      </semantic:context>
+    </semantic:encapsulatedLogic>
+    <semantic:variable id="_1f050e9b-c9b7-448f-b8f3-2a0072d51ac1" name="My BKM" typeRef="tPerson"/>
+  </semantic:businessKnowledgeModel>
+</semantic:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/capitalLetterConflict.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/capitalLetterConflict.dmn
@@ -1,0 +1,97 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_B321C9B1-856E-45DE-B05D-5B4D4D301D37" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_4F85E7BF-E9FB-4A8B-85D7-7000C5E043A7" name="capitalLetterConflict" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_B321C9B1-856E-45DE-B05D-5B4D4D301D37">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_1A1BA3F0-EE91-48C2-A055-56620652EAAD" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_080DB97B-0171-4016-9732-F5763094EEB4" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_76518922-F931-4A90-BBF2-8FB4EE7A0C89" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5" name="myPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_060FDEFD-3453-4CF1-9457-BF030B5C7AF3" name="myPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_09A3F5E4-96D2-432D-A57D-4F000F12CA9E" name="myDecision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D6DB6B95-4544-4B8C-9076-ECF99BABB5FD" name="myDecision" typeRef="string"/>
+    <dmn:informationRequirement id="_7C64E927-D0B8-48DA-A23C-F36417BD3052">
+      <dmn:requiredInput href="#_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_492C7F7B-4E1E-4023-8B89-5BE35D0E7FDA">
+      <dmn:text>"myDecision is " + myPerson.name</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_3C7E1922-D3BC-434F-B3E0-C61596338606" name="MyDecision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_136270A5-7B86-4B3B-AB79-EDBEE435094C" name="MyDecision" typeRef="string"/>
+    <dmn:informationRequirement id="_CC44012C-0B27-480B-AA04-F151A950F971">
+      <dmn:requiredInput href="#_EE5A6478-C501-4D57-9778-11DC47A58E2D"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_A27FDB9F-CB0D-451B-8EA6-98BF080473EA">
+      <dmn:text>"MyDecision is " + MyPerson.name</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_EE5A6478-C501-4D57-9778-11DC47A58E2D" name="MyPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B1BE3E66-5462-49DD-A324-6D6400446C45" name="MyPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_492C7F7B-4E1E-4023-8B89-5BE35D0E7FDA">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_A27FDB9F-CB0D-451B-8EA6-98BF080473EA">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5" dmnElementRef="_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="198" y="397" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_09A3F5E4-96D2-432D-A57D-4F000F12CA9E" dmnElementRef="_09A3F5E4-96D2-432D-A57D-4F000F12CA9E" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="198" y="258" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_3C7E1922-D3BC-434F-B3E0-C61596338606" dmnElementRef="_3C7E1922-D3BC-434F-B3E0-C61596338606" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="258" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_EE5A6478-C501-4D57-9778-11DC47A58E2D" dmnElementRef="_EE5A6478-C501-4D57-9778-11DC47A58E2D" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="399" y="397" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_7C64E927-D0B8-48DA-A23C-F36417BD3052" dmnElementRef="_7C64E927-D0B8-48DA-A23C-F36417BD3052">
+        <di:waypoint x="248" y="422"/>
+        <di:waypoint x="248" y="308"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_CC44012C-0B27-480B-AA04-F151A950F971" dmnElementRef="_CC44012C-0B27-480B-AA04-F151A950F971">
+        <di:waypoint x="449" y="397"/>
+        <di:waypoint x="450" y="308"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/capitalLetterConflictWithInputAndDecision.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/capitalLetterConflictWithInputAndDecision.dmn
@@ -1,0 +1,58 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EE9DAFC0-D50D-4D23-8676-FF8A40E02919" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_2FEB5573-AB8E-4D47-91E4-5109D1DF6128" name="capitalLetterConflictWithInputAndDecision" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EE9DAFC0-D50D-4D23-8676-FF8A40E02919">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_DD870C4F-F623-4FF3-A33E-73BD2E7EF6C5" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_C74FFB4F-F08C-448E-96C5-A393D42DE165" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_41F7C2CB-35BD-44B0-947A-B1C1CCDD5169" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_EEADCDE4-F556-4D5B-9812-45A0E9BB2F33" name="myNode">
+    <dmn:extensionElements/>
+    <dmn:variable id="_798FB123-C2EE-43D1-B310-05FD0F42D28C" name="myNode" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_CDA5E009-A7DF-4789-91B7-5B12DF21E3B9" name="MyNode">
+    <dmn:extensionElements/>
+    <dmn:variable id="_6DE9D334-C7BF-4596-A052-BBC501101DA9" name="MyNode" typeRef="string"/>
+    <dmn:informationRequirement id="_39E30B15-E541-4167-8DFF-B60C1956CEF3">
+      <dmn:requiredInput href="#_EEADCDE4-F556-4D5B-9812-45A0E9BB2F33"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_7C420392-F3F5-4FC6-AFDC-D7A9C4A6E364">
+      <dmn:text>"MyNode is " + myNode.name</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_7C420392-F3F5-4FC6-AFDC-D7A9C4A6E364">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_EEADCDE4-F556-4D5B-9812-45A0E9BB2F33" dmnElementRef="_EEADCDE4-F556-4D5B-9812-45A0E9BB2F33" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="248" y="415" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_CDA5E009-A7DF-4789-91B7-5B12DF21E3B9" dmnElementRef="_CDA5E009-A7DF-4789-91B7-5B12DF21E3B9" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="249" y="258" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_39E30B15-E541-4167-8DFF-B60C1956CEF3" dmnElementRef="_39E30B15-E541-4167-8DFF-B60C1956CEF3">
+        <di:waypoint x="298" y="440"/>
+        <di:waypoint x="299" y="308"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/collections.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/collections.dmn
@@ -1,0 +1,108 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_2A93F258-EF3B-4150-A202-1D02A893DF2B" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_3B9EB03D-B1E0-4ABF-B19B-5AA0F64456D5" name="collections" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_2A93F258-EF3B-4150-A202-1D02A893DF2B">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_F04FE075-AC6F-4E6B-A012-E24AA0EEFD18" name="tAddress" isCollection="false">
+    <dmn:itemComponent id="_08C0661A-F3F0-47D5-9623-1CFC53FC2866" name="city" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_5B7B757D-B7C2-4C0A-8B13-0AB2B5D5AAA7" name="street" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_CDBFD9FD-87A0-4D08-889D-E095A798AE86" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_709FE5E2-66F6-4DD6-98E8-4826BA82F7D9" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_EDE8EA45-C3CB-4E4C-A593-BE4D06D984EA" name="addressList" isCollection="true">
+      <dmn:typeRef>tAddress</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_2CEF57D9-C4CE-4AC0-8796-51B05B56104F" name="inputPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_723DEDDA-A7E6-48D8-A022-F6FEDC2BDB94" name="inputPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_972788BB-C431-4443-A82E-098182E1CE62" name="outputPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_6B1A1E21-9298-44B4-9D86-CB2D6C1D9BF1" name="outputPerson" typeRef="tPerson"/>
+    <dmn:informationRequirement id="_6F8B8391-1C1F-4DC0-80A7-C7C4739DFE7F">
+      <dmn:requiredInput href="#_2CEF57D9-C4CE-4AC0-8796-51B05B56104F"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_4224D7AD-163D-4485-85B7-FDB79EADD83C">
+      <dmn:contextEntry>
+        <dmn:variable id="_30261A45-FAE7-4DBA-B0EA-DACACCCF9D76" name="name" typeRef="string"/>
+        <dmn:literalExpression id="_B0A232E6-34A8-495D-AEC8-A480DBB8676B">
+          <dmn:text>"Paul"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_5D4D8A28-7933-4718-B910-34E3C4317DD9" name="addressList"/>
+        <dmn:relation id="_52EED91E-AE67-4A85-A46A-45284F881A75">
+          <dmn:column id="_1741E5A4-B26C-4EBB-9D36-4C5097CA4ED8" name="city" typeRef="string"/>
+          <dmn:column id="_DE17AD70-F625-4765-A415-ED4CC7CA2538" name="street" typeRef="string"/>
+          <dmn:row id="_B35B07C9-5C02-43E4-875A-C043D102107B">
+            <dmn:literalExpression id="_EB18AB8E-BFDA-4709-BAF1-7A9550575FD0">
+              <dmn:text>"cityA"</dmn:text>
+            </dmn:literalExpression>
+            <dmn:literalExpression id="_C3D993BB-39B1-410D-A601-BC8DFF777B6D">
+              <dmn:text>"streetA"</dmn:text>
+            </dmn:literalExpression>
+          </dmn:row>
+          <dmn:row id="_2CF11F6A-8F84-4BD0-959D-498C3BC3688B">
+            <dmn:literalExpression id="_42325F95-D2A2-4FF5-817F-6ECFF17954A8">
+              <dmn:text>"cityB"</dmn:text>
+            </dmn:literalExpression>
+            <dmn:literalExpression id="_4DEA981E-B8E3-447F-8C15-A86229315D29">
+              <dmn:text>"streetB"</dmn:text>
+            </dmn:literalExpression>
+          </dmn:row>
+        </dmn:relation>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_4224D7AD-163D-4485-85B7-FDB79EADD83C">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>400</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_B0A232E6-34A8-495D-AEC8-A480DBB8676B">
+            <kie:width>400</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_52EED91E-AE67-4A85-A46A-45284F881A75">
+            <kie:width>50</kie:width>
+            <kie:width>230</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_EB18AB8E-BFDA-4709-BAF1-7A9550575FD0"/>
+          <kie:ComponentWidths dmnElementRef="_C3D993BB-39B1-410D-A601-BC8DFF777B6D"/>
+          <kie:ComponentWidths dmnElementRef="_42325F95-D2A2-4FF5-817F-6ECFF17954A8"/>
+          <kie:ComponentWidths dmnElementRef="_4DEA981E-B8E3-447F-8C15-A86229315D29"/>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_2CEF57D9-C4CE-4AC0-8796-51B05B56104F" dmnElementRef="_2CEF57D9-C4CE-4AC0-8796-51B05B56104F" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="243" y="274" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_972788BB-C431-4443-A82E-098182E1CE62" dmnElementRef="_972788BB-C431-4443-A82E-098182E1CE62" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="244" y="172" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_6F8B8391-1C1F-4DC0-80A7-C7C4739DFE7F" dmnElementRef="_6F8B8391-1C1F-4DC0-80A7-C7C4739DFE7F">
+        <di:waypoint x="293" y="299"/>
+        <di:waypoint x="294" y="222"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/collectionsPassTypedObject.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/collectionsPassTypedObject.dmn
@@ -1,0 +1,97 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_10C4DB2B-1DCA-4B4F-A994-FA046AE5C7B0" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_3B9EB03D-B1E0-4ABF-B19B-5AA0F64456D5" name="collectionsPassTypedObject" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_10C4DB2B-1DCA-4B4F-A994-FA046AE5C7B0">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_F04FE075-AC6F-4E6B-A012-E24AA0EEFD18" name="tAddress" isCollection="false">
+    <dmn:itemComponent id="_08C0661A-F3F0-47D5-9623-1CFC53FC2866" name="city" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_5B7B757D-B7C2-4C0A-8B13-0AB2B5D5AAA7" name="street" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_CDBFD9FD-87A0-4D08-889D-E095A798AE86" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_709FE5E2-66F6-4DD6-98E8-4826BA82F7D9" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_EDE8EA45-C3CB-4E4C-A593-BE4D06D984EA" name="addressList" isCollection="true">
+      <dmn:typeRef>tAddress</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_2CEF57D9-C4CE-4AC0-8796-51B05B56104F" name="inputPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_723DEDDA-A7E6-48D8-A022-F6FEDC2BDB94" name="inputPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_972788BB-C431-4443-A82E-098182E1CE62" name="outputPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_6B1A1E21-9298-44B4-9D86-CB2D6C1D9BF1" name="outputPerson" typeRef="tPerson"/>
+    <dmn:informationRequirement id="_6F8B8391-1C1F-4DC0-80A7-C7C4739DFE7F">
+      <dmn:requiredInput href="#_2CEF57D9-C4CE-4AC0-8796-51B05B56104F"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_4224D7AD-163D-4485-85B7-FDB79EADD83C">
+      <dmn:contextEntry>
+        <dmn:variable id="_30261A45-FAE7-4DBA-B0EA-DACACCCF9D76" name="name" typeRef="string"/>
+        <dmn:literalExpression id="_B0A232E6-34A8-495D-AEC8-A480DBB8676B">
+          <dmn:text>"Paul"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_5D4D8A28-7933-4718-B910-34E3C4317DD9" name="addressList"/>
+        <dmn:list id="_B685E8F7-2190-483A-AC19-BEB799CCC965">
+          <dmn:literalExpression id="_BF87F0C9-8D2C-4513-B979-4C7CFACFFC86">
+            <dmn:text>inputPerson.addressList[1]</dmn:text>
+          </dmn:literalExpression>
+          <dmn:literalExpression id="_AF7BE9CD-D7DA-480C-ABA2-94AF19C2359D">
+            <dmn:text>inputPerson.addressList[2]</dmn:text>
+          </dmn:literalExpression>
+        </dmn:list>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_4224D7AD-163D-4485-85B7-FDB79EADD83C">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>400</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_B0A232E6-34A8-495D-AEC8-A480DBB8676B">
+            <kie:width>400</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_B685E8F7-2190-483A-AC19-BEB799CCC965">
+            <kie:width>50</kie:width>
+            <kie:width>330</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_BF87F0C9-8D2C-4513-B979-4C7CFACFFC86">
+            <kie:width>330</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_AF7BE9CD-D7DA-480C-ABA2-94AF19C2359D">
+            <kie:width>330</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_2CEF57D9-C4CE-4AC0-8796-51B05B56104F" dmnElementRef="_2CEF57D9-C4CE-4AC0-8796-51B05B56104F" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="243" y="274" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_972788BB-C431-4443-A82E-098182E1CE62" dmnElementRef="_972788BB-C431-4443-A82E-098182E1CE62" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="244" y="172" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_6F8B8391-1C1F-4DC0-80A7-C7C4739DFE7F" dmnElementRef="_6F8B8391-1C1F-4DC0-80A7-C7C4739DFE7F">
+        <di:waypoint x="293" y="299"/>
+        <di:waypoint x="294" y="222"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/duplicateName.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/duplicateName.dmn
@@ -1,0 +1,97 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_5F544E7E-2C19-464D-9BD5-9DA571D56C6D" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_4F85E7BF-E9FB-4A8B-85D7-7000C5E043A7" name="duplicateName" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_5F544E7E-2C19-464D-9BD5-9DA571D56C6D">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_1A1BA3F0-EE91-48C2-A055-56620652EAAD" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_080DB97B-0171-4016-9732-F5763094EEB4" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_76518922-F931-4A90-BBF2-8FB4EE7A0C89" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5" name="myPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_060FDEFD-3453-4CF1-9457-BF030B5C7AF3" name="myPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_09A3F5E4-96D2-432D-A57D-4F000F12CA9E" name="myDecision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D6DB6B95-4544-4B8C-9076-ECF99BABB5FD" name="myDecision" typeRef="string"/>
+    <dmn:informationRequirement id="_7C64E927-D0B8-48DA-A23C-F36417BD3052">
+      <dmn:requiredInput href="#_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_492C7F7B-4E1E-4023-8B89-5BE35D0E7FDA">
+      <dmn:text>"myDecision is " + myPerson.name</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_3C7E1922-D3BC-434F-B3E0-C61596338606" name="myDecision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_136270A5-7B86-4B3B-AB79-EDBEE435094C" name="myDecision" typeRef="string"/>
+    <dmn:informationRequirement id="_CC44012C-0B27-480B-AA04-F151A950F971">
+      <dmn:requiredInput href="#_EE5A6478-C501-4D57-9778-11DC47A58E2D"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_A27FDB9F-CB0D-451B-8EA6-98BF080473EA">
+      <dmn:text>"MyDecision is " + myPerson.name</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_EE5A6478-C501-4D57-9778-11DC47A58E2D" name="myPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B1BE3E66-5462-49DD-A324-6D6400446C45" name="myPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_492C7F7B-4E1E-4023-8B89-5BE35D0E7FDA">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_A27FDB9F-CB0D-451B-8EA6-98BF080473EA">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5" dmnElementRef="_755CBCF9-45D0-428C-8A7B-AFFB01D2F7F5" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="198" y="397" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_09A3F5E4-96D2-432D-A57D-4F000F12CA9E" dmnElementRef="_09A3F5E4-96D2-432D-A57D-4F000F12CA9E" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="198" y="258" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_3C7E1922-D3BC-434F-B3E0-C61596338606" dmnElementRef="_3C7E1922-D3BC-434F-B3E0-C61596338606" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="258" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_EE5A6478-C501-4D57-9778-11DC47A58E2D" dmnElementRef="_EE5A6478-C501-4D57-9778-11DC47A58E2D" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="399" y="397" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_7C64E927-D0B8-48DA-A23C-F36417BD3052" dmnElementRef="_7C64E927-D0B8-48DA-A23C-F36417BD3052">
+        <di:waypoint x="248" y="422"/>
+        <di:waypoint x="248" y="308"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_CC44012C-0B27-480B-AA04-F151A950F971" dmnElementRef="_CC44012C-0B27-480B-AA04-F151A950F971">
+        <di:waypoint x="449" y="397"/>
+        <di:waypoint x="450" y="308"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/shareTypeForInputAndOutput.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/shareTypeForInputAndOutput.dmn
@@ -1,0 +1,89 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_DBEFBA7B-C568-4631-A89E-AA31F7C6564B" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_7AAE7D44-17FD-4DA2-9C1E-07FA4535AA90" name="shareTypeForInputAndOutput" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_DBEFBA7B-C568-4631-A89E-AA31F7C6564B">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_BE720BF0-3883-4743-B629-1A373816295F" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_D3C08E9E-3FC6-4421-8027-94BF701F8A93" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_D6D913FC-565E-4DC2-9293-05570493CCDD" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_CF9A10E3-2801-4D1D-B518-B04C0256EEA6" name="employmentPeriod" isCollection="false">
+      <dmn:typeRef>years and months duration</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_25862C69-09E7-4BDE-8E57-A8CC0259F187" name="inputPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_8F6281D4-C821-41E5-AFA5-609528A3188E" name="inputPerson" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_089301A5-1307-4D02-9526-7AC4E9D7106D" name="outputPerson">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B6033BED-DAFF-4279-8941-B080D215BB7D" name="outputPerson" typeRef="tPerson"/>
+    <dmn:informationRequirement id="_27270C8E-45B7-47F3-B486-41E0826CCD5B">
+      <dmn:requiredInput href="#_25862C69-09E7-4BDE-8E57-A8CC0259F187"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_A5BD9F6E-52FC-4817-AC81-BB4ED65E1EEF">
+      <dmn:contextEntry>
+        <dmn:variable id="_FD854BB2-39D6-41F7-82A2-2D9964D6C5B1" name="name" typeRef="string"/>
+        <dmn:literalExpression id="_2DC4A0B0-BFB3-4203-AB53-012CA503079D">
+          <dmn:text>"Paul"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_50864E49-4AB9-48AC-B449-AF66C9277B59" name="age" typeRef="number"/>
+        <dmn:literalExpression id="_17E7DE9D-CEEC-43A5-82AF-BFFEDEF8621E">
+          <dmn:text>20</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_11204020-1110-453D-AC4F-0026973934A9" name="employmentPeriod" typeRef="years and months duration"/>
+        <dmn:literalExpression id="_159AA354-FD0B-4772-8A90-C30A80356960">
+          <dmn:text>inputPerson.employmentPeriod + duration("P1M")</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_A5BD9F6E-52FC-4817-AC81-BB4ED65E1EEF">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_2DC4A0B0-BFB3-4203-AB53-012CA503079D">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_17E7DE9D-CEEC-43A5-82AF-BFFEDEF8621E">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_159AA354-FD0B-4772-8A90-C30A80356960">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_25862C69-09E7-4BDE-8E57-A8CC0259F187" dmnElementRef="_25862C69-09E7-4BDE-8E57-A8CC0259F187" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="254" y="343" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_089301A5-1307-4D02-9526-7AC4E9D7106D" dmnElementRef="_089301A5-1307-4D02-9526-7AC4E9D7106D" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="260" y="204" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_27270C8E-45B7-47F3-B486-41E0826CCD5B" dmnElementRef="_27270C8E-45B7-47F3-B486-41E0826CCD5B">
+        <di:waypoint x="304" y="368"/>
+        <di:waypoint x="310" y="254"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
Hi @lucamolteni @tarilabs 

This is a draft implementation of DROOLS-5502. It's still work in progress but I'd like you to check if I'm on the right track. Now we can generate `OutputSet` class and populate it by the map from `DMNResult.getContext().getAll()`. As you can see in DMNRuntimeTypesTest.testFieldCapitalization(), populating `OutputSet` is done outside of DMNRuntime. For example, we will do it in Kogito REST endpoint. Am I right? Feel free to let me know your thoughts.

(If I'm on the right track,) remaining TODO:
- Check the failing test DMNStronglyTypedSupportTest.testDateAndTime (This is interesting. I may ask you about this issue later)
- Refactor DMNOutputSetType/DMNInputSetType to share a super class
- Add more `OutputSet` assertion to existing tests (e.g. currently I assert in only last 3 test methods of DMNRuntimeTypesTest)
- (Maybe) Add another implementation of FieldDefinition for DMNFunction