### PR TITLE
DROOLS-5553 - fix getMetadata in DMNContextFPAImpl

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
@@ -30,10 +30,12 @@ import org.kie.dmn.core.impl.DMNContextImpl.ScopeReference;
 public class DMNContextFPAImpl implements DMNContext {
 
     private final FEELPropertyAccessible fpa;
-    private Deque<ScopeReference> stack    = new LinkedList<>();
+    private Deque<ScopeReference> stack = new LinkedList<>();
+    private DMNMetadataImpl metadata;
 
     public DMNContextFPAImpl(FEELPropertyAccessible bean) {
         this.fpa = bean;
+        this.metadata = new DMNMetadataImpl();
     }
 
     @Override
@@ -86,16 +88,15 @@ public class DMNContextFPAImpl implements DMNContext {
 
     @Override
     public DMNMetadata getMetadata() {
-        return new DMNMetadataImpl();
+        return this.metadata;
     }
 
     @Override
     public DMNContext clone() {
-        DMNContextImpl newCtx = new DMNContextImpl(fpa.allFEELProperties());
+        DMNContextImpl newCtx = new DMNContextImpl(fpa.allFEELProperties(), metadata.asMap());
         for (ScopeReference e : stack) {
             newCtx.pushScope(e.getName(), e.getNamespace());
         }
         return newCtx;
     }
-
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -167,6 +167,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         context.getMetadata().set(key, value);
 
         assertEquals(value, context.getMetadata().get(key));
+        assertEquals(value, context.clone().getMetadata().get(key));
     }
 
     private static DMNResult evaluateTyped(FEELPropertyAccessible context, DMNRuntime runtime, DMNModel dmnModel) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -81,8 +81,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
     @Test
     public void test() throws Exception {
 
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertValidDmnModel(dmnModel);
 
         DMNAllTypesIndex index = new DMNAllTypesIndex(new DMNTypeSafePackageName.ModelFactory(), dmnModel);
 
@@ -131,8 +130,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
     @Test
     public void testDynamic() throws Exception {
 
-        assertThat(dmnModel, notNullValue());
-        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+        assertValidDmnModel(dmnModel);
 
         Map<String, Class<?>> classes = generateSourceCodeAndCreateInput(dmnModel, modelFactory, this.getClass().getClassLoader());
 
@@ -160,14 +158,25 @@ public class DMNTypeSafeTest extends BaseVariantTest {
     }
 
     @Test
-    public void testMetadata(){
-        String key = "test";
-        String value = "value";
-        DMNContext context = new DMNContextFPAImpl(null);
-        context.getMetadata().set(key, value);
+    public void testMetadata() throws Exception {
 
-        assertEquals(value, context.getMetadata().get(key));
-        assertEquals(value, context.clone().getMetadata().get(key));
+        assertValidDmnModel(dmnModel);
+
+        Map<String, Class<?>> classes = generateSourceCodeAndCreateInput(dmnModel, modelFactory, this.getClass().getClassLoader());
+        FEELPropertyAccessible feelPropertyAccessibleContext = createInstanceFromCompiledClasses(classes, packageName, "InputSet");
+
+        String metadataKey = "test";
+        String metadataValue = "value";
+        DMNContext context = new DMNContextFPAImpl(feelPropertyAccessibleContext);
+        context.getMetadata().set(metadataKey, metadataValue);
+
+        assertEquals(metadataValue, context.getMetadata().get(metadataKey));
+        assertEquals(metadataValue, context.clone().getMetadata().get(metadataKey));
+    }
+
+    private void assertValidDmnModel(DMNModel dmnModel){
+        assertThat(dmnModel, notNullValue());
+        assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
     }
 
     private static DMNResult evaluateTyped(FEELPropertyAccessible context, DMNRuntime runtime, DMNModel dmnModel) {

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.kie.dmn.core.BaseVariantTest.VariantTestConf.KIE_API_TYPECHECK_TYPESAFE;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
@@ -156,6 +157,16 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         DMNContext result = evaluateAll.getContext();
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
+    }
+
+    @Test
+    public void testMetadata(){
+        String key = "test";
+        String value = "value";
+        DMNContext context = new DMNContextFPAImpl(null);
+        context.getMetadata().set(key, value);
+
+        assertEquals(value, context.getMetadata().get(key));
     }
 
     private static DMNResult evaluateTyped(FEELPropertyAccessible context, DMNRuntime runtime, DMNModel dmnModel) {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/DROOLS-5553

Hi!
I've found that when `kogito.decisions.stronglytyped=true` then `DMNContextFPAImpl` is used. The problem is that the kogito-tracing-addon is storing some information in the metadata of such class, but the `get` always return a new object -> the tracing addon is then broken in such case. 

 