### PR TITLE
[DROOLS-5517] Enhance DMNResult/DMNContext to be able to return stron…

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
@@ -33,6 +33,8 @@ public class DMNContextFPAImpl implements DMNContext {
     private Deque<ScopeReference> stack = new LinkedList<>();
     private DMNMetadataImpl metadata;
 
+    public static final String STRONGLY_TYPED_FPA = "STRONGLY_TYPED_FPA"; // metadata key
+
     public DMNContextFPAImpl(FEELPropertyAccessible bean) {
         this.fpa = bean;
         this.metadata = new DMNMetadataImpl();
@@ -46,6 +48,15 @@ public class DMNContextFPAImpl implements DMNContext {
     @Override
     public Object get(String name) {
         return fpa.getFEELProperty(name).toOptional().orElse(null);
+    }
+
+    /**
+     * Internal utility method
+     * 
+     * @return FEELPropertyAccessible which represents strongly typed context
+     */
+    public FEELPropertyAccessible getFpa() {
+        return fpa;
     }
 
     private Map<String, Object> getCurrentEntries() {

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNContextFPAImpl.java
@@ -33,8 +33,6 @@ public class DMNContextFPAImpl implements DMNContext {
     private Deque<ScopeReference> stack = new LinkedList<>();
     private DMNMetadataImpl metadata;
 
-    public static final String STRONGLY_TYPED_FPA = "STRONGLY_TYPED_FPA"; // metadata key
-
     public DMNContextFPAImpl(FEELPropertyAccessible bean) {
         this.fpa = bean;
         this.metadata = new DMNMetadataImpl();

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImpl.java
@@ -38,6 +38,8 @@ public class DMNResultImpl implements DMNResult, DMNMessageManager {
     private Map<String, DMNDecisionResult> decisionResults;
     private final DMNModel model;
 
+    private boolean stronglyTyped = false;
+
     public DMNResultImpl(DMNModel model) {
         this.model = model;
         messages = new DefaultDMNMessagesManager();
@@ -127,4 +129,12 @@ public class DMNResultImpl implements DMNResult, DMNMessageManager {
     public void addAllUnfiltered(List<? extends DMNMessage> messages) {
         this.messages.addAllUnfiltered(messages);
     }
+
+	public boolean isStronglyTyped() {
+		return stronglyTyped;
+	}
+
+	public void setStronglyTyped(boolean stronglyTyped) {
+		this.stronglyTyped = stronglyTyped;
+	}
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNResultImpl.java
@@ -38,8 +38,6 @@ public class DMNResultImpl implements DMNResult, DMNMessageManager {
     private Map<String, DMNDecisionResult> decisionResults;
     private final DMNModel model;
 
-    private boolean stronglyTyped = false;
-
     public DMNResultImpl(DMNModel model) {
         this.model = model;
         messages = new DefaultDMNMessagesManager();
@@ -129,12 +127,4 @@ public class DMNResultImpl implements DMNResult, DMNMessageManager {
     public void addAllUnfiltered(List<? extends DMNMessage> messages) {
         this.messages.addAllUnfiltered(messages);
     }
-
-	public boolean isStronglyTyped() {
-		return stronglyTyped;
-	}
-
-	public void setStronglyTyped(boolean stronglyTyped) {
-		this.stronglyTyped = stronglyTyped;
-	}
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
@@ -36,6 +36,7 @@ import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.api.core.ast.BusinessKnowledgeModelNode;
 import org.kie.dmn.api.core.ast.DMNNode;
 import org.kie.dmn.api.core.ast.DecisionNode;
@@ -114,6 +115,7 @@ public class DMNRuntimeImpl
             evaluateDecision(context, result, decision, performRuntimeTypeCheck);
         }
         DMNRuntimeEventManagerUtils.fireAfterEvaluateAll( eventManager, model, result );
+        convertContext(result);
         return result;
     }
 
@@ -237,13 +239,33 @@ public class DMNRuntimeImpl
     }
 
     private DMNResultImpl createResult(DMNModel model, DMNContext context) {
-        DMNResultImpl result = new DMNResultImpl(model);
-        result.setContext( context.clone() );
+        DMNResultImpl result = createResultImpl(model, context);
 
         for (DecisionNode decision : model.getDecisions().stream().filter(d -> d.getModelNamespace().equals(model.getNamespace())).collect(Collectors.toSet())) {
             result.addDecisionResult(new DMNDecisionResultImpl(decision.getId(), decision.getName()));
         }
         return result;
+    }
+
+    private DMNResultImpl createResultImpl(DMNModel model, DMNContext context) {
+        DMNResultImpl result = new DMNResultImpl(model);
+        if (context instanceof DMNContextFPAImpl) {
+            result.setStronglyTyped(true);
+            context.getMetadata().set(DMNContextFPAImpl.STRONGLY_TYPED_FPA, ((DMNContextFPAImpl)context).getFpa());
+            result.setContext(context.clone()); // DMNContextFPAImpl.clone() creates DMNContextImpl
+        } else {
+            result.setContext(context.clone());
+        }
+        return result;
+    }
+
+    private void convertContext(DMNResultImpl result) {
+        if (result.isStronglyTyped() && !(result.getContext() instanceof DMNContextFPAImpl)) {
+            FEELPropertyAccessible stronglyTypedFpa = (FEELPropertyAccessible)result.getContext().getMetadata().get(DMNContextFPAImpl.STRONGLY_TYPED_FPA);
+            stronglyTypedFpa.fromMap(result.getContext().getAll());
+            DMNContext newContext = new DMNContextFPAImpl(stronglyTypedFpa);
+            result.setContext(newContext);
+        }
     }
 
     @Override
@@ -252,8 +274,8 @@ public class DMNRuntimeImpl
         Objects.requireNonNull(context, () -> MsgUtil.createMessage(Msg.PARAM_CANNOT_BE_NULL, "context"));
         Objects.requireNonNull(decisionServiceName, () -> MsgUtil.createMessage(Msg.PARAM_CANNOT_BE_NULL, "decisionServiceName"));
         boolean typeCheck = performRuntimeTypeCheck(model);
-        DMNResultImpl result = new DMNResultImpl(model);
-        result.setContext(context.clone());
+        DMNResultImpl result = createResultImpl(model, context);
+
         // the engine should evaluate all belonging to the "local" model namespace, not imported nodes explicitly.
         Optional<DecisionServiceNode> lookupDS = ((DMNModelImpl) model).getDecisionServices().stream()
                                                                     .filter(d -> d.getModelNamespace().equals(model.getNamespace()))
@@ -318,6 +340,7 @@ public class DMNRuntimeImpl
                                   Msg.DECISION_SERVICE_NOT_FOUND_FOR_NAME,
                                   decisionServiceName);
         }
+        convertContext(result);
         return result;
     }
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
@@ -36,7 +36,6 @@ import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.DMNType;
-import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.api.core.ast.BusinessKnowledgeModelNode;
 import org.kie.dmn.api.core.ast.DMNNode;
 import org.kie.dmn.api.core.ast.DecisionNode;
@@ -115,7 +114,6 @@ public class DMNRuntimeImpl
             evaluateDecision(context, result, decision, performRuntimeTypeCheck);
         }
         DMNRuntimeEventManagerUtils.fireAfterEvaluateAll( eventManager, model, result );
-        convertContext(result);
         return result;
     }
 
@@ -149,7 +147,6 @@ public class DMNRuntimeImpl
         for (String name : decisionNames) {
             evaluateByNameInternal( model, context, result, name );
         }
-        convertContext(result);
         return result;
     }
 
@@ -195,7 +192,6 @@ public class DMNRuntimeImpl
         for ( String id : decisionIds ) {
             evaluateByIdInternal( model, context, result, id );
         }
-        convertContext(result);
         return result;
     }
 
@@ -251,23 +247,8 @@ public class DMNRuntimeImpl
 
     private DMNResultImpl createResultImpl(DMNModel model, DMNContext context) {
         DMNResultImpl result = new DMNResultImpl(model);
-        if (context instanceof DMNContextFPAImpl) {
-            result.setStronglyTyped(true);
-            context.getMetadata().set(DMNContextFPAImpl.STRONGLY_TYPED_FPA, ((DMNContextFPAImpl)context).getFpa());
-            result.setContext(context.clone()); // DMNContextFPAImpl.clone() creates DMNContextImpl
-        } else {
-            result.setContext(context.clone());
-        }
+        result.setContext(context.clone()); // DMNContextFPAImpl.clone() creates DMNContextImpl
         return result;
-    }
-
-    private void convertContext(DMNResultImpl result) {
-        if (result.isStronglyTyped() && !(result.getContext() instanceof DMNContextFPAImpl)) {
-            FEELPropertyAccessible stronglyTypedFpa = (FEELPropertyAccessible)result.getContext().getMetadata().get(DMNContextFPAImpl.STRONGLY_TYPED_FPA);
-            stronglyTypedFpa.fromMap(result.getContext().getAll());
-            DMNContext newContext = new DMNContextFPAImpl(stronglyTypedFpa);
-            result.setContext(newContext);
-        }
     }
 
     @Override
@@ -342,7 +323,6 @@ public class DMNRuntimeImpl
                                   Msg.DECISION_SERVICE_NOT_FOUND_FOR_NAME,
                                   decisionServiceName);
         }
-        convertContext(result);
         return result;
     }
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNRuntimeImpl.java
@@ -149,6 +149,7 @@ public class DMNRuntimeImpl
         for (String name : decisionNames) {
             evaluateByNameInternal( model, context, result, name );
         }
+        convertContext(result);
         return result;
     }
 
@@ -194,6 +195,7 @@ public class DMNRuntimeImpl
         for ( String id : decisionIds ) {
             evaluateByIdInternal( model, context, result, id );
         }
+        convertContext(result);
         return result;
     }
 

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
@@ -32,7 +32,8 @@ import org.kie.dmn.api.core.FEELPropertyAccessible;
 
 abstract class AbstractDMNSetType implements TypeDefinition {
 
-    List<DMNDeclaredField> fields = new ArrayList<>();
+    List<DMNDeclaredField> dmnFields = new ArrayList<>();
+    List<FieldDefinition> extraFields = new ArrayList<>();
 
     Map<String, DMNType> fieldsKey = new HashMap<>();
 
@@ -53,15 +54,19 @@ abstract class AbstractDMNSetType implements TypeDefinition {
 
     @Override
     public List<? extends FieldDefinition> getFields() {
-        return fields;
+        List<FieldDefinition> combinedFields = new ArrayList<>();
+        combinedFields.addAll(dmnFields);
+        combinedFields.addAll(extraFields);
+        return combinedFields;
     }
 
     public void initFields() {
         FieldGenStrategy fieldGenStrategy = FieldGenStrategy.getFieldGenStrategy(fieldsKey.keySet(), getTypeName());
         for (Map.Entry<String, DMNType> f : fieldsKey.entrySet()) {
             DMNDeclaredField dmnDeclaredField = new DMNDeclaredField(index, f, codeGenConfig, fieldGenStrategy);
-            fields.add(dmnDeclaredField);
+            dmnFields.add(dmnDeclaredField);
         }
+        extraFields.add(new DefinedKeySetField());
     }
 
     @Override
@@ -81,7 +86,7 @@ abstract class AbstractDMNSetType implements TypeDefinition {
 
     @Override
     public List<MethodDefinition> getMethods() {
-        return new FEELPropertyAccessibleImplementation(fields).getMethods();
+        return new FEELPropertyAccessibleImplementation(dmnFields, this).getMethods();
     }
 
     @Override
@@ -101,5 +106,43 @@ abstract class AbstractDMNSetType implements TypeDefinition {
     @Override
     public Optional<String> getJavadoc() {
         return Optional.of(this.javadoc);
+    }
+
+    class DefinedKeySetField implements FieldDefinition {
+
+        @Override
+        public String getFieldName() {
+            return "definedKeySet";
+        }
+
+        @Override
+        public String getObjectType() {
+            return "java.util.Set<String>";
+        }
+
+        @Override
+        public String getInitExpr() {
+            return "new java.util.HashSet<>()";
+        }
+
+        @Override
+        public boolean isKeyField() {
+            return false;
+        }
+
+        @Override
+        public boolean createAccessors() {
+            return false;
+        }
+
+        @Override
+        public boolean isStatic() {
+            return false;
+        }
+
+        @Override
+        public boolean isFinal() {
+            return false;
+        }
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/DMNDeclaredType.java
@@ -95,7 +95,7 @@ class DMNDeclaredType implements TypeDefinition {
 
     @Override
     public List<MethodDefinition> getMethods() {
-        return new FEELPropertyAccessibleImplementation(fields).getMethods();
+        return new FEELPropertyAccessibleImplementation(fields, this).getMethods();
     }
 
     @Override

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
@@ -28,6 +28,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.core.compiler.RuntimeTypeCheckOption;
 import org.kie.dmn.core.impl.DMNContextFPAImpl;
+import org.kie.dmn.core.impl.DMNResultImpl;
 import org.kie.dmn.core.internal.utils.DMNRuntimeBuilder;
 import org.kie.dmn.core.internal.utils.DMNRuntimeBuilder.DMNRuntimeBuilderConfigured;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
@@ -246,23 +247,33 @@ public abstract class BaseVariantTest {
         Map<String, Object> inputMap = context.getAll();
         FEELPropertyAccessible outputSet;
         try {
-            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet = createOutputSetInstance(dmnModel);
             outputSet.fromMap(inputMap);
             DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
-            return runtime.evaluateAll(dmnModel, contextFpa);
+            DMNResult result = runtime.evaluateAll(dmnModel, contextFpa);
+            return convertContext(result, createOutputSetInstance(dmnModel));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private DMNResult evaluateByIdTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String... decisionIds) {
+    protected DMNResult convertContext(DMNResult result, FEELPropertyAccessible outputSet) {
+        outputSet.fromMap(result.getContext().getAll());
+        DMNContext newContext = new DMNContextFPAImpl(outputSet);
+        ((DMNResultImpl)result).setContext(newContext);
+        return result;
+    }
+
+    private DMNResult evaluateByIdTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context,
+            String... decisionIds) {
         Map<String, Object> inputMap = context.getAll();
         FEELPropertyAccessible outputSet;
         try {
-            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet = createOutputSetInstance(dmnModel);
             outputSet.fromMap(inputMap);
             DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
-            return runtime.evaluateById(dmnModel, contextFpa, decisionIds);
+            DMNResult result = runtime.evaluateById(dmnModel, contextFpa, decisionIds);
+            return convertContext(result, createOutputSetInstance(dmnModel));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -272,10 +283,11 @@ public abstract class BaseVariantTest {
         Map<String, Object> inputMap = context.getAll();
         FEELPropertyAccessible outputSet;
         try {
-            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet = createOutputSetInstance(dmnModel);
             outputSet.fromMap(inputMap);
             DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
-            return runtime.evaluateByName(dmnModel, contextFpa, decisionNames);
+            DMNResult result = runtime.evaluateByName(dmnModel, contextFpa, decisionNames);
+            return convertContext(result, createOutputSetInstance(dmnModel));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -285,10 +297,11 @@ public abstract class BaseVariantTest {
         Map<String, Object> inputMap = context.getAll();
         FEELPropertyAccessible outputSet;
         try {
-            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet = createOutputSetInstance(dmnModel);
             outputSet.fromMap(inputMap);
             DMNContext contextFpa =  new DMNContextFPAImpl(outputSet);
-            return runtime.evaluateDecisionService(dmnModel, contextFpa, decisionServiceName);
+            DMNResult result = runtime.evaluateDecisionService(dmnModel, contextFpa, decisionServiceName);
+            return convertContext(result, createOutputSetInstance(dmnModel));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -307,6 +320,10 @@ public abstract class BaseVariantTest {
         assertThat(inputSetClass, notNullValue());
         Object inputSetInstance = inputSetClass.getDeclaredConstructor().newInstance();
         return (FEELPropertyAccessible) inputSetInstance;
+    }
+
+    protected FEELPropertyAccessible createOutputSetInstance(DMNModel dmnModel) throws Exception {
+        return createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
     }
 }
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
@@ -228,11 +228,12 @@ public abstract class BaseVariantTest {
 
     private DMNResult evaluateTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context) {
         Map<String, Object> inputMap = context.getAll();
-        FEELPropertyAccessible inputSet;
+        FEELPropertyAccessible outputSet;
         try {
-            inputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "InputSet");
-            inputSet.fromMap(inputMap);
-            return runtime.evaluateAll(dmnModel, new DMNContextFPAImpl(inputSet));
+            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet.fromMap(inputMap);
+            DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
+            return runtime.evaluateAll(dmnModel, contextFpa);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -240,23 +241,12 @@ public abstract class BaseVariantTest {
 
     private DMNResult evaluateDecisionServiceTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String decisionServiceName) {
         Map<String, Object> inputMap = context.getAll();
-        FEELPropertyAccessible inputSet;
-        try {
-            inputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "InputSet");
-            inputSet.fromMap(inputMap);
-            return runtime.evaluateDecisionService(dmnModel, new DMNContextFPAImpl(inputSet), decisionServiceName);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public FEELPropertyAccessible convertToOutputSet(DMNModel dmnModel, DMNResult dmnResult) {
-        Map<String, Object> contextMap = dmnResult.getContext().getAll();
         FEELPropertyAccessible outputSet;
         try {
             outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
-            outputSet.fromMap(contextMap);
-            return outputSet;
+            outputSet.fromMap(inputMap);
+            DMNContext contextFpa =  new DMNContextFPAImpl(outputSet);
+            return runtime.evaluateDecisionService(dmnModel, contextFpa, decisionServiceName);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/BaseVariantTest.java
@@ -218,6 +218,22 @@ public abstract class BaseVariantTest {
         }
     }
 
+    protected DMNResult evaluateById(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String... decisionIds) {
+        if (testConfig.isTypeSafe()) {
+            return evaluateByIdTypeSafe(runtime, dmnModel, context, decisionIds);
+        } else {
+            return runtime.evaluateById(dmnModel, context, decisionIds);
+        }
+    }
+
+    protected DMNResult evaluateByName(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String... decisionNames) {
+        if (testConfig.isTypeSafe()) {
+            return evaluateByNameTypeSafe(runtime, dmnModel, context, decisionNames);
+        } else {
+            return runtime.evaluateByName(dmnModel, context, decisionNames);
+        }
+    }
+
     protected DMNResult evaluateDecisionService(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String decisionServiceName) {
         if (testConfig.isTypeSafe()) {
             return evaluateDecisionServiceTypeSafe(runtime, dmnModel, context, decisionServiceName);
@@ -234,6 +250,32 @@ public abstract class BaseVariantTest {
             outputSet.fromMap(inputMap);
             DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
             return runtime.evaluateAll(dmnModel, contextFpa);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private DMNResult evaluateByIdTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String... decisionIds) {
+        Map<String, Object> inputMap = context.getAll();
+        FEELPropertyAccessible outputSet;
+        try {
+            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet.fromMap(inputMap);
+            DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
+            return runtime.evaluateById(dmnModel, contextFpa, decisionIds);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private DMNResult evaluateByNameTypeSafe(DMNRuntime runtime, DMNModel dmnModel, DMNContext context, String... decisionNames) {
+        Map<String, Object> inputMap = context.getAll();
+        FEELPropertyAccessible outputSet;
+        try {
+            outputSet = createInstanceFromCompiledClasses(allCompiledClasses, factory.create(dmnModel), "OutputSet");
+            outputSet.fromMap(inputMap);
+            DMNContext contextFpa = new DMNContextFPAImpl(outputSet);
+            return runtime.evaluateByName(dmnModel, contextFpa, decisionNames);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNCompilerTest.java
@@ -32,6 +32,7 @@ import org.kie.dmn.api.core.ast.ItemDefNode;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.compiler.DMNTypeRegistry;
 import org.kie.dmn.core.impl.CompositeTypeImpl;
+import org.kie.dmn.core.impl.DMNContextFPAImpl;
 import org.kie.dmn.core.impl.DMNModelImpl;
 import org.kie.dmn.core.impl.SimpleTypeImpl;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
@@ -270,7 +271,7 @@ public class DMNCompilerTest extends BaseVariantTest {
         assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult(), is("Hello John!"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, evaluateAll);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)evaluateAll.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Greeting"), is("Hello John!"));
         }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNStronglyTypedSupportTest.java
@@ -38,6 +38,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.api.core.ast.InputDataNode;
 import org.kie.dmn.core.api.DMNFactory;
+import org.kie.dmn.core.impl.DMNContextFPAImpl;
 import org.kie.dmn.core.model.Person;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
@@ -134,37 +135,13 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         context.set("Day", 22);
         context.set("oneHour", Duration.parse("PT1H")); // <variable name="oneHour" typeRef="feel:days and time duration"/>
         context.set("durationString", "P13DT2H14S");      // <variable name="durationString" typeRef="feel:string"/>
-        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         final DMNContext ctx = dmnResult.getContext();
 
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
-        assertThat(ctx.get("Date-Time"), is(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5))));
-        assertThat(ctx.get("Date"), is(new HashMap<String, Object>() {{
-            put("fromString", LocalDate.of(2015, 12, 24));
-            put("fromDateTime", LocalDate.of(2016, 12, 24));
-            put("fromYearMonthDay", LocalDate.of(1999, 11, 22));
-        }}));
-        assertThat(ctx.get("Time"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-        assertThat(ctx.get("Date-Time2"), is(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-        assertThat(ctx.get("Time2"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
-        assertThat(ctx.get("Time3"), is(OffsetTime.of(12, 59, 1, 300000000, ZoneOffset.ofHours(-1))));
-        assertThat(ctx.get("dtDuration1"), is(Duration.parse("P13DT2H14S")));
-        assertThat(ctx.get("dtDuration2"), is(Duration.parse("P367DT3H58M59S")));
-        assertThat(ctx.get("hoursInDuration"), is(new BigDecimal("3")));
-        assertThat(ctx.get("sumDurations"), is(Duration.parse("PT9125H59M13S")));
-        assertThat(ctx.get("ymDuration2"), is(ComparablePeriod.parse("P1Y")));
-        assertThat(ctx.get("cDay"), is(BigDecimal.valueOf(24)));
-        assertThat(ctx.get("cYear"), is(BigDecimal.valueOf(2015)));
-        assertThat(ctx.get("cMonth"), is(BigDecimal.valueOf(12)));
-        assertThat(ctx.get("cHour"), is(BigDecimal.valueOf(0)));
-        assertThat(ctx.get("cMinute"), is(BigDecimal.valueOf(0)));
-        assertThat(ctx.get("cSecond"), is(BigDecimal.valueOf(1)));
-        assertThat(ctx.get("cTimezone"), is("GMT-01:00"));
-        assertThat(ctx.get("years"), is(BigDecimal.valueOf(1)));
-        assertThat(ctx.get("d1seconds"), is(BigDecimal.valueOf(14)));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Date-Time"), is(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5))));
             FEELPropertyAccessible resultDate = (FEELPropertyAccessible)allProperties.get("Date");
@@ -190,6 +167,31 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
             assertThat(allProperties.get("cTimezone"), is("GMT-01:00"));
             assertThat(allProperties.get("years"), is(BigDecimal.valueOf(1)));
             assertThat(allProperties.get("d1seconds"), is(BigDecimal.valueOf(14)));
+        } else {
+            assertThat(ctx.get("Date-Time"), is(ZonedDateTime.of(2016, 12, 24, 23, 59, 0, 0, ZoneOffset.ofHours(-5))));
+            assertThat(ctx.get("Date"), is(new HashMap<String, Object>() {{
+                put("fromString", LocalDate.of(2015, 12, 24));
+                put("fromDateTime", LocalDate.of(2016, 12, 24));
+                put("fromYearMonthDay", LocalDate.of(1999, 11, 22));
+            }}));
+            assertThat(ctx.get("Time"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
+            assertThat(ctx.get("Date-Time2"), is(ZonedDateTime.of(2015, 12, 24, 0, 0, 1, 0, ZoneOffset.ofHours(-1))));
+            assertThat(ctx.get("Time2"), is(OffsetTime.of(0, 0, 1, 0, ZoneOffset.ofHours(-1))));
+            assertThat(ctx.get("Time3"), is(OffsetTime.of(12, 59, 1, 300000000, ZoneOffset.ofHours(-1))));
+            assertThat(ctx.get("dtDuration1"), is(Duration.parse("P13DT2H14S")));
+            assertThat(ctx.get("dtDuration2"), is(Duration.parse("P367DT3H58M59S")));
+            assertThat(ctx.get("hoursInDuration"), is(new BigDecimal("3")));
+            assertThat(ctx.get("sumDurations"), is(Duration.parse("PT9125H59M13S")));
+            assertThat(ctx.get("ymDuration2"), is(ComparablePeriod.parse("P1Y")));
+            assertThat(ctx.get("cDay"), is(BigDecimal.valueOf(24)));
+            assertThat(ctx.get("cYear"), is(BigDecimal.valueOf(2015)));
+            assertThat(ctx.get("cMonth"), is(BigDecimal.valueOf(12)));
+            assertThat(ctx.get("cHour"), is(BigDecimal.valueOf(0)));
+            assertThat(ctx.get("cMinute"), is(BigDecimal.valueOf(0)));
+            assertThat(ctx.get("cSecond"), is(BigDecimal.valueOf(1)));
+            assertThat(ctx.get("cTimezone"), is("GMT-01:00"));
+            assertThat(ctx.get("years"), is(BigDecimal.valueOf(1)));
+            assertThat(ctx.get("d1seconds"), is(BigDecimal.valueOf(14)));
         }
     }
 
@@ -204,11 +206,11 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
 
         final DMNContext context = DMNFactory.newContext();
         context.set("datetimestring", "2016-07-29T05:48:23");
-        final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
+        final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.getContext().get("time"), is(LocalTime.of(5, 48, 23)));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("time"), is(LocalTime.of(5, 48, 23)));
         }
@@ -236,7 +238,7 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         assertThat((Map<?, ?>) result.get("DecisionNumberInList"), hasEntry(is("Result_4"), is(true)));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             Map<?, ?> resultMap = (Map<?, ?>) allProperties.get("DecisionNumberInList");
             assertThat(resultMap, hasEntry(is("Result_1_OK"), is(true)));
@@ -264,7 +266,7 @@ public class DMNStronglyTypedSupportTest extends BaseVariantTest {
         assertThat((List<?>) result.get("D5"), contains(is("r1"), is("r2")));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("D4"), is("Contains r1"));
             assertThat((List<?>) allProperties.get("D5"), contains(is("r1"), is("r2")));

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNRuntimeTypesTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus;
@@ -55,9 +54,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 import static org.kie.dmn.core.util.DynamicTypeUtils.entry;
 import static org.kie.dmn.core.util.DynamicTypeUtils.mapOf;
@@ -120,7 +117,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("DecisionTime").getResult(), is(LocalTime.of(10, 0)));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("DecisionString"), is("Hello, John Doe"));
             assertThat(allProperties.get("DecisionNumber"), is(new BigDecimal(2)));
@@ -152,7 +149,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("nameconstclass"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Decision-1"), is("nameconstclass"));
         }
@@ -184,7 +181,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("Decision Employee").getResult(), is("For John Doe total: 3"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Decision Yearly"), is("Total Yearly 10"));
             assertThat(allProperties.get("Decision Employee"), is("For John Doe total: 3"));
@@ -209,7 +206,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("John Doe is S"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Decision-1"), is("John Doe is S"));
         }
@@ -236,7 +233,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("John Doe has 3 pairs."));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Decision-1"), is("John Doe has 3 pairs."));
         }
@@ -258,7 +255,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("Decision-1").getResult(), is("Decision: John Doe"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Decision-1"), is("Decision: John Doe"));
         }
@@ -298,7 +295,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("highlights").getResult(), is("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("highlights"), is("John Doe: reports to John's Manager and is manager of 2 : [ Bob, Carl ]"));
         }
@@ -328,7 +325,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getResult(), is(new BigDecimal(1)));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("DecisionListNumber"), is(new BigDecimal(3)));
             assertThat(allProperties.get("DecisionVowel"), is("the e"));
@@ -362,7 +359,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("DecisionListOfA").getEvaluationStatus(), not(DecisionEvaluationStatus.SUCCEEDED));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("DecisionListNumber"), is(new BigDecimal(3)));
             assertThat(allProperties.get("DecisionVowel"), nullValue());
@@ -396,7 +393,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("decision1").getResult(), is("L1nameL2namename"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("decision1"), is("L1nameL2namename"));
         }
@@ -432,7 +429,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getDecisionResultByName("Should the driver be suspended?").getResult(), is("Yes"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible driver = (FEELPropertyAccessible)allProperties.get("Driver");
             assertThat(driver.getClass().getSimpleName(), is("TDriver"));
@@ -476,11 +473,12 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult1.getMessages()), dmnResult1.hasErrors(), is(false));
 
         final DMNContext result = dmnResult1.getContext();
-        assertThat(result.getAll(), not(hasEntry(is("Invoking Decision"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
+        // assertThat(result.getAll(), not(hasEntry(is("Invoking Decision"), anything()))); // we invoked only the Decision Service, not this other Decision in the model.
+        assertThat(result.get("Invoking Decision"), nullValue());
         assertThat(result.get("ABC"), is("abc"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult1);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult1.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Invoking Decision"), nullValue());
             Object abc = allProperties.get("ABC");
@@ -491,7 +489,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         // evaluateAll
         final DMNContext context2 = DMNFactory.newContext();
 
-        final DMNResult dmnResult2 = runtime.evaluateAll(dmnModel, context2);
+        final DMNResult dmnResult2 = evaluateModel(runtime, dmnModel, context2);
         LOG.debug("{}", dmnResult2);
         dmnResult2.getDecisionResults().forEach(x -> LOG.debug("{}", x));
         assertThat(DMNRuntimeUtil.formatMessages(dmnResult2.getMessages()), dmnResult2.hasErrors(), is(false));
@@ -501,7 +499,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(result2.get("Invoking Decision"), is("abc"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult2);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult2.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             Object decisionService = allProperties.get("Decision Service ABC");
             assertThat(decisionService, instanceOf(FEELFunction.class));
@@ -537,7 +535,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
                    is(new BigDecimal("2878.69354943277").setScale(8, BigDecimal.ROUND_DOWN)));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             Object fee = allProperties.get("fee");
             assertThat(fee, is(100));
@@ -579,7 +577,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getContext().get("MyDecision"), is("MyDecision is Paul"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("myPerson");
             assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
@@ -615,7 +613,7 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         assertThat(dmnResult.getContext().get("MyNode"), is("MyNode is John"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("myNode");
             assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
@@ -642,17 +640,18 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
 
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(dmnResult.hasErrors(), is(false));
-        Map<String, Object> outPerson = (Map<String, Object>)dmnResult.getContext().get("Decision-1");
-        assertThat(outPerson.get("name"), is("paul"));
-        assertThat(outPerson.get("Name"), is("Paul"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("Decision-1");
             assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
             assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("paul"));
             assertThat(myPersonOut.getFEELProperty("Name").toOptional().get(), is("Paul"));
+        } else {
+            Map<String, Object> outPerson = (Map<String, Object>)dmnResult.getContext().get("Decision-1");
+            assertThat(outPerson.get("name"), is("paul"));
+            assertThat(outPerson.get("Name"), is("Paul"));
         }
     }
 
@@ -674,19 +673,19 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(dmnResult.hasErrors(), is(false));
 
-        Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
-        assertThat(outputPerson.get("name"), is("Paul"));
-        assertThat(outputPerson.get("age"), is(new BigDecimal(20)));
-        assertThat(outputPerson.get("employmentPeriod"), is(ComparablePeriod.of(1, 3, 1)));
-
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible myPersonOut = (FEELPropertyAccessible) allProperties.get("outputPerson");
             assertThat(myPersonOut.getClass().getSimpleName(), is("TPerson"));
             assertThat(myPersonOut.getFEELProperty("name").toOptional().get(), is("Paul"));
             assertThat(myPersonOut.getFEELProperty("age").toOptional().get(), is(new BigDecimal(20)));
             assertThat(myPersonOut.getFEELProperty("employmentPeriod").toOptional().get(), is(ComparablePeriod.of(1, 3, 1)));
+        } else {
+            Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
+            assertThat(outputPerson.get("name"), is("Paul"));
+            assertThat(outputPerson.get("age"), is(new BigDecimal(20)));
+            assertThat(outputPerson.get("employmentPeriod"), is(ComparablePeriod.of(1, 3, 1)));
         }
     }
 
@@ -708,12 +707,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(dmnResult.hasErrors(), is(false));
 
-        assertThat((List<?>) dmnResult.getContext().get("My Decision"),
-                contains(prototype(entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33))),
-                         prototype(entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47)))));
-
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             List<FEELPropertyAccessible> personList = (List<FEELPropertyAccessible>) allProperties.get("My Decision");
             FEELPropertyAccessible person1 = personList.get(0);
@@ -722,6 +717,10 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
             assertThat(person1.getFEELProperty("Age").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(33)), is(EvalHelper.coerceNumber(47))));
             assertThat(person2.getFEELProperty("Full Name").toOptional().get(), anyOf(is("Prof. John Doe"),is("Prof. 47")));
             assertThat(person2.getFEELProperty("Age").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(33)), is(EvalHelper.coerceNumber(47))));
+        } else {
+            assertThat((List<?>) dmnResult.getContext().get("My Decision"),
+            contains(prototype(entry("Full Name", "Prof. John Doe"), entry("Age", EvalHelper.coerceNumber(33))),
+                     prototype(entry("Full Name", "Prof. 47"), entry("Age", EvalHelper.coerceNumber(47)))));
         }
     }
 
@@ -744,12 +743,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(dmnResult.hasErrors(), is(false));
 
-        assertThat((List<?>) dmnResult.getContext().get("Decision-1"),
-                contains(mapOf(entry("letter", "ABC"), entry("num", EvalHelper.coerceNumber(123))),
-                         mapOf(entry("letter", "DEF"), entry("num", EvalHelper.coerceNumber(456)))));
-
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             List<FEELPropertyAccessible> pairList = (List<FEELPropertyAccessible>) allProperties.get("Decision-1");
             FEELPropertyAccessible pair1 = pairList.get(0);
@@ -758,6 +753,10 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
             assertThat(pair1.getFEELProperty("num").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(123)), is(EvalHelper.coerceNumber(456))));
             assertThat(pair2.getFEELProperty("letter").toOptional().get(), anyOf(is("ABC"),is("DEF")));
             assertThat(pair2.getFEELProperty("num").toOptional().get(), anyOf(is(EvalHelper.coerceNumber(123)), is(EvalHelper.coerceNumber(456))));
+        } else {
+            assertThat((List<?>) dmnResult.getContext().get("Decision-1"),
+            contains(mapOf(entry("letter", "ABC"), entry("num", EvalHelper.coerceNumber(123))),
+                     mapOf(entry("letter", "DEF"), entry("num", EvalHelper.coerceNumber(456)))));
         }
     }
 
@@ -780,19 +779,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(dmnResult.hasErrors(), is(false));
 
-        Map<String, Object> outputPerson = (Map<String, Object>)dmnResult.getContext().get("outputPerson");
-
-        assertThat(outputPerson.get("name"), is("Paul"));
-        Map<String, Object> outputAddr1 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(0);
-        Map<String, Object> outputAddr2 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(1);
-
-        assertThat(outputAddr1.get("city"), anyOf(is("cityA"), is("cityB")));
-        assertThat(outputAddr1.get("street"), anyOf(is("streetA"), is("streetB")));
-        assertThat(outputAddr2.get("city"), anyOf(is("cityA"), is("cityB")));
-        assertThat(outputAddr2.get("street"), anyOf(is("streetA"), is("streetB")));
-
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible typedOutputPerson = (FEELPropertyAccessible) allProperties.get("outputPerson");
             assertThat(typedOutputPerson.getClass().getSimpleName(), is("TPerson"));
@@ -804,6 +792,17 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
             assertThat(typedOutputAddr1.getFEELProperty("street").toOptional().get(), anyOf(is("streetA"), is("streetB")));
             assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get(), anyOf(is("cityA"), is("cityB")));
             assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get(), anyOf(is("streetA"), is("streetB")));
+        } else {
+            Map<String, Object> outputPerson = (Map<String, Object>)dmnResult.getContext().get("outputPerson");
+
+            assertThat(outputPerson.get("name"), is("Paul"));
+            Map<String, Object> outputAddr1 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(0);
+            Map<String, Object> outputAddr2 = (Map<String, Object>)((List)outputPerson.get("addressList")).get(1);
+
+            assertThat(outputAddr1.get("city"), anyOf(is("cityA"), is("cityB")));
+            assertThat(outputAddr1.get("street"), anyOf(is("streetA"), is("streetB")));
+            assertThat(outputAddr2.get("city"), anyOf(is("cityA"), is("cityB")));
+            assertThat(outputAddr2.get("street"), anyOf(is("streetA"), is("streetB")));
         }
     }
 
@@ -826,12 +825,8 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
         final DMNResult dmnResult = evaluateModel(runtime, dmnModel, context);
         assertThat(dmnResult.hasErrors(), is(false));
 
-        Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
-
-        assertThat(outputPerson.get("name"), is("Paul"));
-
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             FEELPropertyAccessible typedOutputPerson = (FEELPropertyAccessible) allProperties.get("outputPerson");
             assertThat(typedOutputPerson.getClass().getSimpleName(), is("TPerson"));
@@ -844,7 +839,10 @@ public class DMNRuntimeTypesTest extends BaseVariantTest {
             assertThat(typedOutputAddr2.getFEELProperty("city").toOptional().get(), anyOf(is("city1"), is("city2")));
             assertThat(typedOutputAddr2.getFEELProperty("street").toOptional().get(), anyOf(is("street1"), is("street2")));
         } else {
-            // if TypeSafe, ((List) outputPerson.get("addressList")).get(0) returns TAddress
+            Map<String, Object> outputPerson = (Map<String, Object>) dmnResult.getContext().get("outputPerson");
+
+            assertThat(outputPerson.get("name"), is("Paul"));
+
             Map<String, Object> outputAddr1 = (Map<String, Object>) ((List) outputPerson.get("addressList")).get(0);
             Map<String, Object> outputAddr2 = (Map<String, Object>) ((List) outputPerson.get("addressList")).get(1);
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -97,7 +97,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         FEELPropertyAccessible street2 = tAddress(compiledClasses, "Street2", 2);
 
         FEELPropertyAccessible tPersonInstance = tPerson(compiledClasses, asList(street1, street2));
-        FEELPropertyAccessible context = inputSet(compiledClasses, tPersonInstance);
+        FEELPropertyAccessible context = outputSet(compiledClasses, tPersonInstance);
 
         DMNResult evaluateAll = evaluateTyped(context, runtime, dmnModel);
 
@@ -105,8 +105,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
 
-        FEELPropertyAccessible outputSet = createInstanceFromCompiledClasses(compiledClasses, packageName, "OutputSet");
-        outputSet.fromMap(result.getAll());
+        FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)result).getFpa();
 
         assertThat(outputSet.getFEELProperty("p").toOptional().get(), equalTo(tPersonInstance));
         Map<String, Object> dContext = (Map<String, Object>)outputSet.getFEELProperty("d").toOptional().get();
@@ -130,8 +129,8 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         return feelPropertyAccessible;
     }
 
-    private FEELPropertyAccessible inputSet(Map<String, Class<?>> compile, FEELPropertyAccessible tPersonInstance) throws Exception {
-        FEELPropertyAccessible feelPropertyAccessible = createInstanceFromCompiledClasses(compile, packageName, "InputSet");
+    private FEELPropertyAccessible outputSet(Map<String, Class<?>> compile, FEELPropertyAccessible tPersonInstance) throws Exception {
+        FEELPropertyAccessible feelPropertyAccessible = createInstanceFromCompiledClasses(compile, packageName, "OutputSet");
         feelPropertyAccessible.setFEELProperty("p", tPersonInstance);
         return feelPropertyAccessible;
     }
@@ -143,7 +142,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
 
         Map<String, Class<?>> classes = generateSourceCodeAndCreateInput(dmnModel, modelFactory, this.getClass().getClassLoader());
 
-        FEELPropertyAccessible context = createInstanceFromCompiledClasses(classes, packageName, "InputSet");
+        FEELPropertyAccessible context = createInstanceFromCompiledClasses(classes, packageName, "OutputSet");
 
         Map<String, Object> inputSetMap = new HashMap<>();
 
@@ -165,8 +164,7 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
 
-        FEELPropertyAccessible outputSet = createInstanceFromCompiledClasses(classes, packageName, "OutputSet");
-        outputSet.fromMap(result.getAll());
+        FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)result).getFpa();
 
         assertThat(outputSet.getFEELProperty("p").toOptional().get(), equalTo(context.getFEELProperty("p").toOptional().get()));
         Map<String, Object> dContext = (Map<String, Object>)outputSet.getFEELProperty("d").toOptional().get();

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/DMNTypeSafeTest.java
@@ -100,8 +100,10 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         FEELPropertyAccessible context = outputSet(compiledClasses, tPersonInstance);
 
         DMNResult evaluateAll = evaluateTyped(context, runtime, dmnModel);
+        convertContext(evaluateAll, createInstanceFromCompiledClasses(compiledClasses, packageName, "OutputSet"));
 
         DMNContext result = evaluateAll.getContext();
+
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
 
@@ -159,8 +161,10 @@ public class DMNTypeSafeTest extends BaseVariantTest {
         context.fromMap(inputSetMap);
 
         DMNResult evaluateAll = evaluateTyped(context, runtime, dmnModel);
+        convertContext(evaluateAll, createInstanceFromCompiledClasses(classes, packageName, "OutputSet"));
 
         DMNContext result = evaluateAll.getContext();
+
         Map<String, Object> d = (Map<String, Object>) result.get("d");
         assertThat(d.get("Hello"), is("Hello Mr. x"));
 

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/v1_3/DMN13specificTest.java
@@ -27,6 +27,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.core.BaseVariantTest;
 import org.kie.dmn.core.api.DMNFactory;
+import org.kie.dmn.core.impl.DMNContextFPAImpl;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,7 @@ public class DMN13specificTest extends BaseVariantTest {
         assertThat(result.get("salutation"), is("Hello, John"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("salutation"), is("Hello, John"));
         }
@@ -102,7 +103,7 @@ public class DMN13specificTest extends BaseVariantTest {
         assertThat(result.get("Routing"), is("ACCEPT"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Strategy"), is("THROUGH"));
             assertThat(allProperties.get("Routing"), is("ACCEPT"));
@@ -141,7 +142,7 @@ public class DMN13specificTest extends BaseVariantTest {
         assertThat(result.get("Routing"), is("ACCEPT"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, dmnResult);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)dmnResult.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Strategy"), is("THROUGH"));
             assertThat(allProperties.get("Routing"), is("ACCEPT"));

--- a/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/2decisions.dmn
+++ b/kie-dmn/kie-dmn-core/src/test/resources/org/kie/dmn/core/stronglytyped/2decisions.dmn
@@ -1,0 +1,122 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_6453A539-85B5-4A4E-800E-6721C50B6B55" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_F345B832-96D9-458B-A722-04B89430243B" name="2decisions" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_6453A539-85B5-4A4E-800E-6721C50B6B55">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_44E3AB9E-017A-466B-971A-B864E4BBCE73" name="tPerson" isCollection="false">
+    <dmn:itemComponent id="_AF12E8C5-67FC-4EB5-8CCC-B1742E5E61BA" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_3BC59762-3375-49BB-AC68-D563D0375087" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_5A123A7C-BBD4-4536-A1FA-9D849A075189" name="InputData-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_8E514781-62BE-4EEC-9791-CA20842AA3CA" name="InputData-1" typeRef="tPerson"/>
+  </dmn:inputData>
+  <dmn:decision id="_0BD595AB-B8C6-4FBF-B2DD-BEB49420EDFE" name="Decision-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_077F1E66-0635-4F28-B100-D476EC07F642" name="Decision-1" typeRef="tPerson"/>
+    <dmn:informationRequirement id="_951C84CC-91F4-4589-9946-F6A6B77C6613">
+      <dmn:requiredInput href="#_5A123A7C-BBD4-4536-A1FA-9D849A075189"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_5BC75468-E4EC-4317-AF9D-13BBE99E48DE">
+      <dmn:contextEntry>
+        <dmn:variable id="_01DB1849-2EFF-4980-B06C-F376508720AF" name="name" typeRef="string"/>
+        <dmn:literalExpression id="_C7864C6A-66FE-4603-A4CE-54C8892CEFBA">
+          <dmn:text>"Paul"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_1C6D7096-4164-4FCB-82C9-E384AD271253" name="age" typeRef="number"/>
+        <dmn:literalExpression id="_12C0A73E-AC6A-4D27-8476-EB4F379DAAFF">
+          <dmn:text>28</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmn:decision id="_DFFE942F-7A6D-4B4A-9DD5-D323451857CC" name="Decision-2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_03BBD496-878C-4BC4-8F81-C75DFBC9579F" name="Decision-2" typeRef="tPerson"/>
+    <dmn:informationRequirement id="_34CF0D53-8168-4BCC-AAAC-07CD42714E89">
+      <dmn:requiredInput href="#_5A123A7C-BBD4-4536-A1FA-9D849A075189"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_D8B33110-1DB9-4A43-88BF-3EC8C745FE83">
+      <dmn:contextEntry>
+        <dmn:variable id="_8E45EC8B-8C5B-469A-B281-4C3D3C04A272" name="name" typeRef="string"/>
+        <dmn:literalExpression id="_0A3815D1-4A49-4F72-9458-D8635FBF8481">
+          <dmn:text>"George"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_F379D636-34A9-4CCF-8072-63611F91E9F6" name="age" typeRef="number"/>
+        <dmn:literalExpression id="_81377DFD-0C4F-4382-90FD-48455FC366E8">
+          <dmn:text>27</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_5BC75468-E4EC-4317-AF9D-13BBE99E48DE">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_C7864C6A-66FE-4603-A4CE-54C8892CEFBA">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_12C0A73E-AC6A-4D27-8476-EB4F379DAAFF">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_D8B33110-1DB9-4A43-88BF-3EC8C745FE83">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_0A3815D1-4A49-4F72-9458-D8635FBF8481">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_81377DFD-0C4F-4382-90FD-48455FC366E8">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_5A123A7C-BBD4-4536-A1FA-9D849A075189" dmnElementRef="_5A123A7C-BBD4-4536-A1FA-9D849A075189" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="256.29906542056074" y="356" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_0BD595AB-B8C6-4FBF-B2DD-BEB49420EDFE" dmnElementRef="_0BD595AB-B8C6-4FBF-B2DD-BEB49420EDFE" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="163" y="237" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_DFFE942F-7A6D-4B4A-9DD5-D323451857CC" dmnElementRef="_DFFE942F-7A6D-4B4A-9DD5-D323451857CC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="350" y="237" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_951C84CC-91F4-4589-9946-F6A6B77C6613" dmnElementRef="_951C84CC-91F4-4589-9946-F6A6B77C6613">
+        <di:waypoint x="306.29906542056074" y="381"/>
+        <di:waypoint x="213" y="262"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_34CF0D53-8168-4BCC-AAAC-07CD42714E89" dmnElementRef="_34CF0D53-8168-4BCC-AAAC-07CD42714E89">
+        <di:waypoint x="306.29906542056074" y="381"/>
+        <di:waypoint x="400" y="287"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -305,7 +305,7 @@ public class EvalHelper {
 
         @Override
         public Optional<Object> toOptional() {
-            return valueResult.cata(l -> Optional.empty(), Optional::of);
+            return valueResult.cata(l -> Optional.empty(), Optional::ofNullable);
         }
 
     }

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/java/org/kie/dmn/legacy/tests/core/v1_1/DMNCompilerTest.java
@@ -30,6 +30,7 @@ import org.kie.dmn.api.core.FEELPropertyAccessible;
 import org.kie.dmn.api.core.ast.ItemDefNode;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.impl.CompositeTypeImpl;
+import org.kie.dmn.core.impl.DMNContextFPAImpl;
 import org.kie.dmn.core.impl.SimpleTypeImpl;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
@@ -174,7 +175,7 @@ public class DMNCompilerTest extends BaseDMN1_1VariantTest {
         assertThat(evaluateAll.getDecisionResultByName("Greeting").getResult(), is("Hello John!"));
 
         if (isTypeSafe()) {
-            FEELPropertyAccessible outputSet = convertToOutputSet(dmnModel, evaluateAll);
+            FEELPropertyAccessible outputSet = ((DMNContextFPAImpl)evaluateAll.getContext()).getFpa();
             Map<String, Object> allProperties = outputSet.allFEELProperties();
             assertThat(allProperties.get("Greeting"), is("Hello John!"));
         }


### PR DESCRIPTION
…gly typed OutputSet

WIP: This is a draft PR. Feel free to share your thoughts/ideas. @tarilabs @lucamolteni 

* I created DMNResultFPAImpl which has `getOutputSet()` method. But it means you need to cast the result in order to use the method. Should I move the method to Interface DMNResult?
* In this draft, DMNResultFPAImpl receives an OutputSet instance from DMNContextFPAImpl. It means that you need to instantiate InputSet/OutputSet instances before executing DMNRuntime. (as we do in BaseVariantTest.createTypeSafeInput/evaluateTypeSafe). Or do we want to encapsulate those logic inside DMNRuntime?
