### PR TITLE
Add missing .gitignore in child Maven modules kie-dmn-pmml-tests-parent

### DIFF
--- a/kie-dmn/kie-dmn-pmml-tests-parent/.gitignore
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-legacy/.gitignore
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-legacy/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/.gitignore
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/.gitignore
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml


### PR DESCRIPTION
our `drools.git` repo setup requires to copy the necessary `.gitignore` files in each Maven module.

In this case the file was copied from `/kie-dmn`