### PR TITLE
[DROOLS-5613] Disable Trusty pmml when jpmml is present

### DIFF
--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerService.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerService.java
@@ -68,11 +68,24 @@ public class PMMLAssemblerService implements KieAssemblerService {
     }
 
     private static boolean isToEnable() {
+        if (isjPMMLAvailableToClassLoader()) {
+            return false;
+        }
         if (!isOtherImplementationPresent()) {
             return true;
         } else {
             final String property = System.getProperty(KIE_PMML_IMPLEMENTATION.getName(), LEGACY.getName());
             return property.equals(NEW.getName());
+        }
+    }
+
+    private static boolean isjPMMLAvailableToClassLoader() {
+        try {
+            Thread.currentThread().getContextClassLoader().loadClass("org.kie.dmn.jpmml.DMNjPMMLInvocationEvaluator");
+            logger.info("jpmml libraries available on classpath, skipping kie-pmml parsing and compilation");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik

See 
https://issues.redhat.com/browse/DROOLS-5613

This PR
1) make uniform management of jpmml presence in legacy and trusty pmml
2) completely disable kie-pmml (legacy and trusty) if jpmml is present