### PR TITLE
DROOLS-5621 remove unused logger field from KieComponentFactory

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/KieComponentFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/KieComponentFactory.java
@@ -57,8 +57,6 @@ import org.slf4j.LoggerFactory;
 
 public class KieComponentFactory implements Serializable {
 
-    Logger logger = LoggerFactory.getLogger(KieComponentFactory.class);
-
     public static final KieComponentFactory DEFAULT = new KieComponentFactory();
 
     public static KieComponentFactory createKieComponentFactory() {


### PR DESCRIPTION
**JIRA**: [DROOLS-5621](https://issues.redhat.com/browse/DROOLS-5621)
