### PR TITLE
Unexpected rule firing

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
@@ -165,6 +165,7 @@ public class GroupByTest {
         final Variable<Person> var_$p = DSL.declarationOf(Person.class);
         final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
         final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
+        final Variable<Integer> var_$derivedFromKey = DSL.declarationOf(Integer.class);
 
         final Rule rule1 = PatternDSL.rule("R1").build(
                 DSL.groupBy(
@@ -175,10 +176,12 @@ public class GroupByTest {
                         // Accumulate Result (can be more than one)
                         DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                PatternDSL.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                PatternDSL.pattern(var_$sumOfAges)
+                        .expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10))
+                        .bind(var_$derivedFromKey, var_$key, k -> 1),
                 // Consequence
-                DSL.on(var_$key, var_results, var_$sumOfAges)
-                        .execute(($key, results, $sumOfAges) -> results.put($key, $sumOfAges))
+                DSL.on(var_$key, var_$derivedFromKey, var_results, var_$sumOfAges)
+                        .execute(($key, derived, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
         final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
@@ -453,6 +456,11 @@ public class GroupByTest {
         assertEquals( 119, results.get("M4") );
         assertEquals( 40, results.get("G5") );
         assertEquals( 119, results.get("M5") );
+    }
+
+    @Test
+    public void testGroupBy1VarExtractFromKey() {
+
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
@@ -22,9 +22,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
 import org.drools.core.base.accumulators.CountAccumulateFunction;
+import org.drools.core.base.accumulators.IntegerSumAccumulateFunction;
 import org.drools.model.DSL;
+import org.drools.model.Drools;
 import org.drools.model.Global;
 import org.drools.model.Model;
+import org.drools.model.PatternDSL;
 import org.drools.model.Rule;
 import org.drools.model.Variable;
 import org.drools.model.consequences.ConsequenceBuilder;
@@ -47,65 +50,65 @@ import static org.junit.Assert.assertNull;
 
 public class GroupByTest {
     @Test
-    public void testSumPersonAgeGroupByInitialWithAcc() throws Exception {
-        final Variable<Person> var_GENERATED_$pattern_Person$4$ = D.declarationOf(Person.class);
-        final Variable<String> var_$initial = D.declarationOf(String.class);
-        final Variable<GroupKey> var_sCoPe3_GENERATED_$pattern_GroupKey$3$ = D.declarationOf(GroupKey.class);
+    public void testSumPersonAgeGroupByInitialWithAcc() {
+        final Variable<Person> var_GENERATED_$pattern_Person$4$ = DSL.declarationOf(Person.class);
+        final Variable<String> var_$initial = DSL.declarationOf(String.class);
+        final Variable<GroupKey> var_sCoPe3_GENERATED_$pattern_GroupKey$3$ = DSL.declarationOf(GroupKey.class);
 
-        Rule rule1 = D.rule("R1").build(
-                D.pattern(var_GENERATED_$pattern_Person$4$)
+        final Rule rule1 = PatternDSL.rule("R1").build(
+                PatternDSL.pattern(var_GENERATED_$pattern_Person$4$)
                         .bind(var_$initial, (Person _this) -> _this.getName().substring(0, 1)),
-                D.not(D.pattern(var_sCoPe3_GENERATED_$pattern_GroupKey$3$).expr("FF3B1999B2904B3324A471615B8760C9",
+                DSL.not(PatternDSL.pattern(var_sCoPe3_GENERATED_$pattern_GroupKey$3$).expr("FF3B1999B2904B3324A471615B8760C9",
                         var_$initial,
-                        (GroupKey _this, java.lang.String $initial) -> EvaluationUtil.areNullSafeEquals(_this.getKey(), $initial),
-                        D.reactOn("key"))),
-                D.on(var_$initial).execute((org.drools.model.Drools drools, java.lang.String $initial) -> {
+                        (GroupKey _this, String $initial) -> EvaluationUtil.areNullSafeEquals(_this.getKey(), $initial),
+                        PatternDSL.reactOn("key"))),
+                DSL.on(var_$initial).execute((Drools drools, String $initial) -> {
                     {
                         drools.insert(new GroupKey("a", $initial));
                     }
                 }));
 
-        final Variable<GroupKey> var_$k = D.declarationOf(GroupKey.class);
-        final Variable<Object> var_$key = D.declarationOf(Object.class);
-        final Variable<Person> var_sCoPe4_GENERATED_$pattern_Person$5$ = D.declarationOf(Person.class);
+        final Variable<GroupKey> var_$k = DSL.declarationOf(GroupKey.class);
+        final Variable<Object> var_$key = DSL.declarationOf(Object.class);
+        final Variable<Person> var_sCoPe4_GENERATED_$pattern_Person$5$ = DSL.declarationOf(Person.class);
 
-        Rule rule2 = D.rule("R2").build(
-                D.pattern(var_$k).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", (GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
-                        D.reactOn("topic"))
+        final Rule rule2 = PatternDSL.rule("R2").build(
+                PatternDSL.pattern(var_$k).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", (GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
+                        PatternDSL.reactOn("topic"))
                         .bind(var_$key, (GroupKey _this) -> _this.getKey(),
-                                D.reactOn("key")),
-                D.not(D.pattern(var_sCoPe4_GENERATED_$pattern_Person$5$).expr("AFBC8D66DD9165C71D89004BBF5B0F9C",
+                                PatternDSL.reactOn("key")),
+                DSL.not(PatternDSL.pattern(var_sCoPe4_GENERATED_$pattern_Person$5$).expr("AFBC8D66DD9165C71D89004BBF5B0F9C",
                         var_$key,
                         (Person _this, Object $key) -> EvaluationUtil.areNullSafeEquals(_this.getName().substring(0, 1), $key.toString()),
-                        D.reactOn("name"))),
-                D.on(var_$k).execute((org.drools.model.Drools drools, GroupKey $k) -> {
+                        PatternDSL.reactOn("name"))),
+                DSL.on(var_$k).execute((Drools drools, GroupKey $k) -> {
                     {
                         drools.delete($k);
                     }
                 }));
 
-        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<GroupKey> var_GENERATED_$pattern_GroupKey$4$ = D.declarationOf(GroupKey.class);
-        final Variable<Person> var_GENERATED_$pattern_Person$6$ = D.declarationOf(Person.class);
-        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = D.declarationOf(java.lang.Integer.class);
+        final Variable<GroupKey> var_GENERATED_$pattern_GroupKey$4$ = DSL.declarationOf(GroupKey.class);
+        final Variable<Person> var_GENERATED_$pattern_Person$6$ = DSL.declarationOf(Person.class);
+        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
 
-        Rule rule3 = D.rule("R3").build(
-                D.pattern(var_GENERATED_$pattern_GroupKey$4$).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", ( GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
-                        D.reactOn("topic")).bind(var_$key,
+        final Rule rule3 = PatternDSL.rule("R3").build(
+                PatternDSL.pattern(var_GENERATED_$pattern_GroupKey$4$).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", ( GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
+                        PatternDSL.reactOn("topic")).bind(var_$key,
                         (GroupKey _this) -> _this.getKey(),
-                        D.reactOn("key")),
-                D.accumulate(D.pattern(var_GENERATED_$pattern_Person$6$)
-                                .bind(var_$age, (Person _this) -> _this.getAge(), D.reactOn("age"))
+                        PatternDSL.reactOn("key")),
+                DSL.accumulate(PatternDSL.pattern(var_GENERATED_$pattern_Person$6$)
+                                .bind(var_$age, (Person _this) -> _this.getAge(), PatternDSL.reactOn("age"))
                                 .expr("AFBC8D66DD9165C71D89004BBF5B0F9C",
                                         var_$key,
                                         (Person _this, Object $key) -> EvaluationUtil.areNullSafeEquals(_this.getName().substring(0, 1), $key),
-                                        D.reactOn("name")),
-                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
-                D.pattern(var_$sumOfAges).expr("00DE1D5962263283D8D799CF83F1A729",
-                        (java.lang.Integer $sumOfAges) -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
-                D.on(var_$key,
+                                        PatternDSL.reactOn("name")),
+                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                PatternDSL.pattern(var_$sumOfAges).expr("00DE1D5962263283D8D799CF83F1A729",
+                        (Integer $sumOfAges) -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                DSL.on(var_$key,
                         var_results,
                         var_$sumOfAges).execute((Object $key, Map results, Integer $sumOfAges) -> {
                     {
@@ -113,18 +116,18 @@ public class GroupByTest {
                     }
                 }));
 
-        Model model = new ModelImpl().addRule( rule1 ).addRule( rule2 ).addRule( rule3 ).addGlobal( var_results );
-        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        final Model model = new ModelImpl().addRule( rule1 ).addRule( rule2 ).addRule( rule3 ).addGlobal( var_results );
+        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        Map results = new HashMap();
+        final Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
         ksession.fireAllRules();
 
         assertEquals( 3, results.size() );
@@ -152,40 +155,40 @@ public class GroupByTest {
 
     @Test
     public void testSumPersonAgeGroupByInitial() throws Exception {
-        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<String> var_$key = D.declarationOf(String.class);
-        final Variable<Person> var_$p = D.declarationOf(Person.class);
-        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = D.declarationOf(Integer.class);
+        final Variable<String> var_$key = DSL.declarationOf(String.class);
+        final Variable<Person> var_$p = DSL.declarationOf(Person.class);
+        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
 
-        Rule rule1 = D.rule("R1").build(
-                D.groupBy(
+        final Rule rule1 = PatternDSL.rule("R1").build(
+                DSL.groupBy(
                         // Patterns
-                        D.pattern(var_$p).bind(var_$age, person -> person.getAge(), D.reactOn("age")),
+                        PatternDSL.pattern(var_$p).bind(var_$age, person -> person.getAge(), PatternDSL.reactOn("age")),
                         // Grouping Function
                         var_$p, var_$key, person -> person.getName().substring(0, 1),
                         // Accumulate Result (can be more than one)
-                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                D.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                PatternDSL.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
                 // Consequence
-                D.on(var_$key, var_results, var_$sumOfAges)
+                DSL.on(var_$key, var_results, var_$sumOfAges)
                         .execute(($key, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
-        Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
-        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
+        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        Map results = new HashMap();
+        final Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
         ksession.fireAllRules();
 
         assertEquals( 3, results.size() );
@@ -212,47 +215,47 @@ public class GroupByTest {
 
     @Test
     public void testSumPersonAgeGroupByInitialWithExists() throws Exception {
-        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<String> var_$key = D.declarationOf(String.class);
-        final Variable<String> var_$string = D.declarationOf(String.class);
-        final Variable<String> var_$initial = D.declarationOf(String.class);
-        final Variable<Person> var_$p = D.declarationOf(Person.class);
-        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = D.declarationOf(Integer.class);
+        final Variable<String> var_$key = DSL.declarationOf(String.class);
+        final Variable<String> var_$string = DSL.declarationOf(String.class);
+        final Variable<String> var_$initial = DSL.declarationOf(String.class);
+        final Variable<Person> var_$p = DSL.declarationOf(Person.class);
+        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
 
-        Rule rule1 = D.rule("R1").build(
-                D.groupBy(
+        final Rule rule1 = PatternDSL.rule("R1").build(
+                DSL.groupBy(
                         // Patterns
-                        D.and(
-                            D.pattern(var_$p)
-                                    .bind(var_$age, person -> person.getAge(), D.reactOn("age"))
-                                    .bind(var_$initial, person -> person.getName().substring(0, 1)),
-                            D.exists(D.pattern(var_$string).expr(var_$initial, (_this, $initial) -> EvaluationUtil.areNullSafeEquals(_this, $initial)))
+                        DSL.and(
+                                PatternDSL.pattern(var_$p)
+                                        .bind(var_$age, person -> person.getAge(), PatternDSL.reactOn("age"))
+                                        .bind(var_$initial, person -> person.getName().substring(0, 1)),
+                                DSL.exists(PatternDSL.pattern(var_$string).expr(var_$initial, (_this, $initial) -> EvaluationUtil.areNullSafeEquals(_this, $initial)))
                         ),
                         // Grouping Function
                         var_$p, var_$key, person -> person.getName().substring(0, 1),
                         // Accumulate Result (can be more than one)
-                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                D.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                PatternDSL.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
                 // Consequence
-                D.on(var_$key, var_results, var_$sumOfAges)
+                DSL.on(var_$key, var_results, var_$sumOfAges)
                         .execute(($key, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
-        Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
-        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
+        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        Map results = new HashMap();
+        final Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
 
         ksession.insert( "G" );
         ksession.insert( "M" );
@@ -284,46 +287,46 @@ public class GroupByTest {
 
     private static final class MyType {
 
-        private final MyType nested;
+        private final GroupByTest.MyType nested;
 
-        public MyType(MyType nested) {
+        public MyType(final GroupByTest.MyType nested) {
             this.nested = nested;
         }
 
-        public MyType getNested() {
+        public GroupByTest.MyType getNested() {
             return nested;
         }
     }
 
     @Test
     public void testWithNull() {
-        Variable<MyType> var = D.declarationOf(MyType.class);
-        Variable<MyType> groupKey = D.declarationOf(MyType.class);
-        Variable<Long> count = D.declarationOf(Long.class);
+        final Variable<GroupByTest.MyType> var = DSL.declarationOf(GroupByTest.MyType.class);
+        final Variable<GroupByTest.MyType> groupKey = DSL.declarationOf(GroupByTest.MyType.class);
+        final Variable<Long> count = DSL.declarationOf(Long.class);
 
-        AtomicInteger mappingFunctionCallCounter = new AtomicInteger(0);
-        Function1<MyType, MyType> mappingFunction = ( a) -> {
+        final AtomicInteger mappingFunctionCallCounter = new AtomicInteger(0);
+        final Function1<GroupByTest.MyType, GroupByTest.MyType> mappingFunction = ( a) -> {
             mappingFunctionCallCounter.incrementAndGet();
             return a.getNested();
         };
-        D.PatternDef<MyType> onlyOnesWithNested = D.pattern(var)
+        final D.PatternDef<GroupByTest.MyType> onlyOnesWithNested = PatternDSL.pattern(var)
                 .expr(myType -> myType.getNested() != null);
-        ExprViewItem groupBy = D.groupBy(onlyOnesWithNested, var, groupKey, mappingFunction,
-                D.accFunction( CountAccumulateFunction::new).as(count));
+        final ExprViewItem groupBy = DSL.groupBy(onlyOnesWithNested, var, groupKey, mappingFunction,
+                DSL.accFunction(CountAccumulateFunction::new).as(count));
 
-        List<MyType> result = new ArrayList<>();
+        final List<GroupByTest.MyType> result = new ArrayList<>();
 
-        Rule rule = D.rule("R")
+        final Rule rule = PatternDSL.rule("R")
                 .build(groupBy,
-                        D.on(groupKey, count)
+                        DSL.on(groupKey, count)
                                 .execute((drools, key, acc) -> result.add(key)));
 
-        Model model = new ModelImpl().addRule( rule );
-        KieBase kieBase = KieBaseBuilder.createKieBaseFromModel( model );
+        final Model model = new ModelImpl().addRule( rule );
+        final KieBase kieBase = KieBaseBuilder.createKieBaseFromModel( model );
 
-        MyType objectWithoutNestedObject = new MyType(null);
-        MyType objectWithNestedObject = new MyType(objectWithoutNestedObject);
-        KieSession ksession = kieBase.newKieSession();
+        final GroupByTest.MyType objectWithoutNestedObject = new GroupByTest.MyType(null);
+        final GroupByTest.MyType objectWithNestedObject = new GroupByTest.MyType(objectWithoutNestedObject);
+        final KieSession ksession = kieBase.newKieSession();
         ksession.insert(objectWithNestedObject);
         ksession.insert(objectWithoutNestedObject);
         ksession.fireAllRules();
@@ -336,32 +339,32 @@ public class GroupByTest {
 
     @Test
     public void testWithGroupByAfterExists() {
-        Global<Map> groupResultVar = D.globalOf(Map.class, "defaultPkg", "glob");
+        final Global<Map> groupResultVar = DSL.globalOf(Map.class, "defaultPkg", "glob");
 
-        Variable<Integer> patternVar = D.declarationOf(Integer.class);
-        Variable<String> existsVar = D.declarationOf(String.class);
-        Variable<Integer> keyVar = D.declarationOf(Integer.class);
-        Variable<Long> resultVar = D.declarationOf(Long.class);
+        final Variable<Integer> patternVar = DSL.declarationOf(Integer.class);
+        final Variable<String> existsVar = DSL.declarationOf(String.class);
+        final Variable<Integer> keyVar = DSL.declarationOf(Integer.class);
+        final Variable<Long> resultVar = DSL.declarationOf(Long.class);
 
-        D.PatternDef<Integer> pattern = D.pattern(patternVar);
-        D.PatternDef<String> exist = D.pattern(existsVar);
-        ViewItem patternAndExists = D.and(
+        final D.PatternDef<Integer> pattern = PatternDSL.pattern(patternVar);
+        final D.PatternDef<String> exist = PatternDSL.pattern(existsVar);
+        final ViewItem patternAndExists = DSL.and(
                 pattern,
-                D.exists(exist));
+                DSL.exists(exist));
 
-        ViewItem groupBy = D.groupBy(patternAndExists, patternVar, keyVar, Math::abs,
+        final ViewItem groupBy = DSL.groupBy(patternAndExists, patternVar, keyVar, Math::abs,
                 DSL.accFunction(CountAccumulateFunction::new).as(resultVar));
-        ConsequenceBuilder._3 consequence = D.on(keyVar, resultVar, groupResultVar)
+        final ConsequenceBuilder._3 consequence = DSL.on(keyVar, resultVar, groupResultVar)
                 .execute((key, count, result) -> {
                     result.put(key, count.intValue());
                 });
 
-        Rule rule = D.rule("R").build(groupBy, consequence);
+        final Rule rule = PatternDSL.rule("R").build(groupBy, consequence);
 
-        Model model = new ModelImpl().addRule(rule).addGlobal( groupResultVar );
-        KieBase kieBase = KieBaseBuilder.createKieBaseFromModel(model);
-        KieSession session = kieBase.newKieSession();
-        Map<Integer, Integer> global = new HashMap<>();
+        final Model model = new ModelImpl().addRule(rule).addGlobal( groupResultVar );
+        final KieBase kieBase = KieBaseBuilder.createKieBaseFromModel(model);
+        final KieSession session = kieBase.newKieSession();
+        final Map<Integer, Integer> global = new HashMap<>();
         session.setGlobal("glob", global);
 
         session.insert("Something");
@@ -377,47 +380,47 @@ public class GroupByTest {
 
     @Test
     public void testGroupBy2Vars() throws Exception {
-        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<String> var_$key = D.declarationOf(String.class);
-        final Variable<Person> var_$p = D.declarationOf(Person.class);
-        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
-        final Variable<String> var_$s = D.declarationOf(String.class);
-        final Variable<Integer> var_$l = D.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = D.declarationOf(Integer.class);
+        final Variable<String> var_$key = DSL.declarationOf(String.class);
+        final Variable<Person> var_$p = DSL.declarationOf(Person.class);
+        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
+        final Variable<String> var_$s = DSL.declarationOf(String.class);
+        final Variable<Integer> var_$l = DSL.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
 
-        Rule rule1 = D.rule("R1").build(
-                D.groupBy(
+        final Rule rule1 = PatternDSL.rule("R1").build(
+                DSL.groupBy(
                         // Patterns
-                        D.and(
-                            D.pattern(var_$p).bind(var_$age, Person::getAge, D.reactOn("age")),
-                            D.pattern(var_$s).bind(var_$l, String::length, D.reactOn("length"))
+                        DSL.and(
+                                PatternDSL.pattern(var_$p).bind(var_$age, Person::getAge, PatternDSL.reactOn("age")),
+                                PatternDSL.pattern(var_$s).bind(var_$l, String::length, PatternDSL.reactOn("length"))
                         ),
                         // Grouping Function
                         var_$p, var_$s, var_$key, (person, string) -> person.getName().substring(0, 1) + string.length(),
                         // Accumulate Result (can be more than one)
-                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                D.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                PatternDSL.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
                 // Consequence
-                D.on(var_$key, var_results, var_$sumOfAges)
+                DSL.on(var_$key, var_results, var_$sumOfAges)
                         .execute(($key, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
-        Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
-        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
+        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        Map results = new HashMap();
+        final Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert( "test" );
         ksession.insert( "check" );
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
         ksession.fireAllRules();
 
         assertEquals( 6, results.size() );

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GroupByTest.java
@@ -25,9 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
 import org.drools.core.base.accumulators.CountAccumulateFunction;
-import org.drools.core.base.accumulators.IntegerSumAccumulateFunction;
 import org.drools.model.DSL;
-import org.drools.model.Drools;
 import org.drools.model.Global;
 import org.drools.model.Model;
 import org.drools.model.PatternDSL;
@@ -54,65 +52,65 @@ import static org.junit.Assert.assertNull;
 
 public class GroupByTest {
     @Test
-    public void testSumPersonAgeGroupByInitialWithAcc() {
-        final Variable<Person> var_GENERATED_$pattern_Person$4$ = DSL.declarationOf(Person.class);
-        final Variable<String> var_$initial = DSL.declarationOf(String.class);
-        final Variable<GroupKey> var_sCoPe3_GENERATED_$pattern_GroupKey$3$ = DSL.declarationOf(GroupKey.class);
+    public void testSumPersonAgeGroupByInitialWithAcc() throws Exception {
+        final Variable<Person> var_GENERATED_$pattern_Person$4$ = D.declarationOf(Person.class);
+        final Variable<String> var_$initial = D.declarationOf(String.class);
+        final Variable<GroupKey> var_sCoPe3_GENERATED_$pattern_GroupKey$3$ = D.declarationOf(GroupKey.class);
 
-        final Rule rule1 = PatternDSL.rule("R1").build(
-                PatternDSL.pattern(var_GENERATED_$pattern_Person$4$)
+        Rule rule1 = D.rule("R1").build(
+                D.pattern(var_GENERATED_$pattern_Person$4$)
                         .bind(var_$initial, (Person _this) -> _this.getName().substring(0, 1)),
-                DSL.not(PatternDSL.pattern(var_sCoPe3_GENERATED_$pattern_GroupKey$3$).expr("FF3B1999B2904B3324A471615B8760C9",
+                D.not(D.pattern(var_sCoPe3_GENERATED_$pattern_GroupKey$3$).expr("FF3B1999B2904B3324A471615B8760C9",
                         var_$initial,
-                        (GroupKey _this, String $initial) -> EvaluationUtil.areNullSafeEquals(_this.getKey(), $initial),
-                        PatternDSL.reactOn("key"))),
-                DSL.on(var_$initial).execute((Drools drools, String $initial) -> {
+                        (GroupKey _this, java.lang.String $initial) -> EvaluationUtil.areNullSafeEquals(_this.getKey(), $initial),
+                        D.reactOn("key"))),
+                D.on(var_$initial).execute((org.drools.model.Drools drools, java.lang.String $initial) -> {
                     {
                         drools.insert(new GroupKey("a", $initial));
                     }
                 }));
 
-        final Variable<GroupKey> var_$k = DSL.declarationOf(GroupKey.class);
-        final Variable<Object> var_$key = DSL.declarationOf(Object.class);
-        final Variable<Person> var_sCoPe4_GENERATED_$pattern_Person$5$ = DSL.declarationOf(Person.class);
+        final Variable<GroupKey> var_$k = D.declarationOf(GroupKey.class);
+        final Variable<Object> var_$key = D.declarationOf(Object.class);
+        final Variable<Person> var_sCoPe4_GENERATED_$pattern_Person$5$ = D.declarationOf(Person.class);
 
-        final Rule rule2 = PatternDSL.rule("R2").build(
-                PatternDSL.pattern(var_$k).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", (GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
-                        PatternDSL.reactOn("topic"))
+        Rule rule2 = D.rule("R2").build(
+                D.pattern(var_$k).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", (GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
+                        D.reactOn("topic"))
                         .bind(var_$key, (GroupKey _this) -> _this.getKey(),
-                                PatternDSL.reactOn("key")),
-                DSL.not(PatternDSL.pattern(var_sCoPe4_GENERATED_$pattern_Person$5$).expr("AFBC8D66DD9165C71D89004BBF5B0F9C",
+                                D.reactOn("key")),
+                D.not(D.pattern(var_sCoPe4_GENERATED_$pattern_Person$5$).expr("AFBC8D66DD9165C71D89004BBF5B0F9C",
                         var_$key,
                         (Person _this, Object $key) -> EvaluationUtil.areNullSafeEquals(_this.getName().substring(0, 1), $key.toString()),
-                        PatternDSL.reactOn("name"))),
-                DSL.on(var_$k).execute((Drools drools, GroupKey $k) -> {
+                        D.reactOn("name"))),
+                D.on(var_$k).execute((org.drools.model.Drools drools, GroupKey $k) -> {
                     {
                         drools.delete($k);
                     }
                 }));
 
-        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<GroupKey> var_GENERATED_$pattern_GroupKey$4$ = DSL.declarationOf(GroupKey.class);
-        final Variable<Person> var_GENERATED_$pattern_Person$6$ = DSL.declarationOf(Person.class);
-        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
+        final Variable<GroupKey> var_GENERATED_$pattern_GroupKey$4$ = D.declarationOf(GroupKey.class);
+        final Variable<Person> var_GENERATED_$pattern_Person$6$ = D.declarationOf(Person.class);
+        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = D.declarationOf(java.lang.Integer.class);
 
-        final Rule rule3 = PatternDSL.rule("R3").build(
-                PatternDSL.pattern(var_GENERATED_$pattern_GroupKey$4$).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", ( GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
-                        PatternDSL.reactOn("topic")).bind(var_$key,
+        Rule rule3 = D.rule("R3").build(
+                D.pattern(var_GENERATED_$pattern_GroupKey$4$).expr("8313F8B6FD1C0612B7758BFDB93F0DE4", ( GroupKey _this) -> EvaluationUtil.areNullSafeEquals(_this.getTopic(), "a"),
+                        D.reactOn("topic")).bind(var_$key,
                         (GroupKey _this) -> _this.getKey(),
-                        PatternDSL.reactOn("key")),
-                DSL.accumulate(PatternDSL.pattern(var_GENERATED_$pattern_Person$6$)
-                                .bind(var_$age, (Person _this) -> _this.getAge(), PatternDSL.reactOn("age"))
+                        D.reactOn("key")),
+                D.accumulate(D.pattern(var_GENERATED_$pattern_Person$6$)
+                                .bind(var_$age, (Person _this) -> _this.getAge(), D.reactOn("age"))
                                 .expr("AFBC8D66DD9165C71D89004BBF5B0F9C",
                                         var_$key,
                                         (Person _this, Object $key) -> EvaluationUtil.areNullSafeEquals(_this.getName().substring(0, 1), $key),
-                                        PatternDSL.reactOn("name")),
-                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
-                PatternDSL.pattern(var_$sumOfAges).expr("00DE1D5962263283D8D799CF83F1A729",
-                        (Integer $sumOfAges) -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
-                DSL.on(var_$key,
+                                        D.reactOn("name")),
+                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                D.pattern(var_$sumOfAges).expr("00DE1D5962263283D8D799CF83F1A729",
+                        (java.lang.Integer $sumOfAges) -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                D.on(var_$key,
                         var_results,
                         var_$sumOfAges).execute((Object $key, Map results, Integer $sumOfAges) -> {
                     {
@@ -120,18 +118,18 @@ public class GroupByTest {
                     }
                 }));
 
-        final Model model = new ModelImpl().addRule( rule1 ).addRule( rule2 ).addRule( rule3 ).addGlobal( var_results );
-        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        Model model = new ModelImpl().addRule( rule1 ).addRule( rule2 ).addRule( rule3 ).addGlobal( var_results );
+        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        final Map results = new HashMap();
+        Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
         ksession.fireAllRules();
 
         assertEquals( 3, results.size() );
@@ -159,43 +157,44 @@ public class GroupByTest {
 
     @Test
     public void testSumPersonAgeGroupByInitial() throws Exception {
-        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
+        Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<String> var_$key = DSL.declarationOf(String.class);
-        final Variable<Person> var_$p = DSL.declarationOf(Person.class);
-        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
-        final Variable<Integer> var_$derivedFromKey = DSL.declarationOf(Integer.class);
+        Variable<String> var_$key = D.declarationOf(String.class);
+        Variable<Person> var_$p = D.declarationOf(Person.class);
+        Variable<Integer> var_$age = D.declarationOf(Integer.class);
+        Variable<Integer> var_$sumOfAges = D.declarationOf(Integer.class);
+        Variable<Integer> var_$derivedFromKey = D.declarationOf(Integer.class);
 
-        final Rule rule1 = PatternDSL.rule("R1").build(
-                DSL.groupBy(
+        Rule rule1 = D.rule("R1").build(
+                D.groupBy(
                         // Patterns
-                        PatternDSL.pattern(var_$p).bind(var_$age, person -> person.getAge(), PatternDSL.reactOn("age")),
+                        D.pattern(var_$p).bind(var_$age, person -> person.getAge(), D.reactOn("age")),
                         // Grouping Function
                         var_$p, var_$key, person -> person.getName().substring(0, 1),
                         // Accumulate Result (can be more than one)
-                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                PatternDSL.pattern(var_$sumOfAges)
+                D.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                D.pattern(var_$sumOfAges)
                         .expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10))
                         .bind(var_$derivedFromKey, var_$key, k -> 1),
                 // Consequence
-                DSL.on(var_$key, var_$derivedFromKey, var_results, var_$sumOfAges)
+                D.on(var_$key, var_$derivedFromKey, var_results, var_$sumOfAges)
                         .execute(($key, derived, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
-        final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
-        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
+        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        final Map results = new HashMap();
+        Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
         ksession.fireAllRules();
 
         assertEquals( 3, results.size() );
@@ -222,47 +221,47 @@ public class GroupByTest {
 
     @Test
     public void testSumPersonAgeGroupByInitialWithExists() throws Exception {
-        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<String> var_$key = DSL.declarationOf(String.class);
-        final Variable<String> var_$string = DSL.declarationOf(String.class);
-        final Variable<String> var_$initial = DSL.declarationOf(String.class);
-        final Variable<Person> var_$p = DSL.declarationOf(Person.class);
-        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
+        final Variable<String> var_$key = D.declarationOf(String.class);
+        final Variable<String> var_$string = D.declarationOf(String.class);
+        final Variable<String> var_$initial = D.declarationOf(String.class);
+        final Variable<Person> var_$p = D.declarationOf(Person.class);
+        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = D.declarationOf(Integer.class);
 
-        final Rule rule1 = PatternDSL.rule("R1").build(
-                DSL.groupBy(
+        Rule rule1 = D.rule("R1").build(
+                D.groupBy(
                         // Patterns
-                        DSL.and(
-                                PatternDSL.pattern(var_$p)
-                                        .bind(var_$age, person -> person.getAge(), PatternDSL.reactOn("age"))
-                                        .bind(var_$initial, person -> person.getName().substring(0, 1)),
-                                DSL.exists(PatternDSL.pattern(var_$string).expr(var_$initial, (_this, $initial) -> EvaluationUtil.areNullSafeEquals(_this, $initial)))
+                        D.and(
+                            D.pattern(var_$p)
+                                    .bind(var_$age, person -> person.getAge(), D.reactOn("age"))
+                                    .bind(var_$initial, person -> person.getName().substring(0, 1)),
+                            D.exists(D.pattern(var_$string).expr(var_$initial, (_this, $initial) -> EvaluationUtil.areNullSafeEquals(_this, $initial)))
                         ),
                         // Grouping Function
                         var_$p, var_$key, person -> person.getName().substring(0, 1),
                         // Accumulate Result (can be more than one)
-                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                PatternDSL.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                D.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
                 // Consequence
-                DSL.on(var_$key, var_results, var_$sumOfAges)
+                D.on(var_$key, var_results, var_$sumOfAges)
                         .execute(($key, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
-        final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
-        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
+        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        final Map results = new HashMap();
+        Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
 
         ksession.insert( "G" );
         ksession.insert( "M" );
@@ -294,46 +293,46 @@ public class GroupByTest {
 
     private static final class MyType {
 
-        private final GroupByTest.MyType nested;
+        private final MyType nested;
 
-        public MyType(final GroupByTest.MyType nested) {
+        public MyType(MyType nested) {
             this.nested = nested;
         }
 
-        public GroupByTest.MyType getNested() {
+        public MyType getNested() {
             return nested;
         }
     }
 
     @Test
     public void testWithNull() {
-        final Variable<GroupByTest.MyType> var = DSL.declarationOf(GroupByTest.MyType.class);
-        final Variable<GroupByTest.MyType> groupKey = DSL.declarationOf(GroupByTest.MyType.class);
-        final Variable<Long> count = DSL.declarationOf(Long.class);
+        Variable<MyType> var = D.declarationOf(MyType.class);
+        Variable<MyType> groupKey = D.declarationOf(MyType.class);
+        Variable<Long> count = D.declarationOf(Long.class);
 
-        final AtomicInteger mappingFunctionCallCounter = new AtomicInteger(0);
-        final Function1<GroupByTest.MyType, GroupByTest.MyType> mappingFunction = ( a) -> {
+        AtomicInteger mappingFunctionCallCounter = new AtomicInteger(0);
+        Function1<MyType, MyType> mappingFunction = ( a) -> {
             mappingFunctionCallCounter.incrementAndGet();
             return a.getNested();
         };
-        final D.PatternDef<GroupByTest.MyType> onlyOnesWithNested = PatternDSL.pattern(var)
+        D.PatternDef<MyType> onlyOnesWithNested = D.pattern(var)
                 .expr(myType -> myType.getNested() != null);
-        final ExprViewItem groupBy = DSL.groupBy(onlyOnesWithNested, var, groupKey, mappingFunction,
-                DSL.accFunction(CountAccumulateFunction::new).as(count));
+        ExprViewItem groupBy = D.groupBy(onlyOnesWithNested, var, groupKey, mappingFunction,
+                D.accFunction( CountAccumulateFunction::new).as(count));
 
-        final List<GroupByTest.MyType> result = new ArrayList<>();
+        List<MyType> result = new ArrayList<>();
 
-        final Rule rule = PatternDSL.rule("R")
+        Rule rule = D.rule("R")
                 .build(groupBy,
-                        DSL.on(groupKey, count)
+                        D.on(groupKey, count)
                                 .execute((drools, key, acc) -> result.add(key)));
 
-        final Model model = new ModelImpl().addRule( rule );
-        final KieBase kieBase = KieBaseBuilder.createKieBaseFromModel( model );
+        Model model = new ModelImpl().addRule( rule );
+        KieBase kieBase = KieBaseBuilder.createKieBaseFromModel( model );
 
-        final GroupByTest.MyType objectWithoutNestedObject = new GroupByTest.MyType(null);
-        final GroupByTest.MyType objectWithNestedObject = new GroupByTest.MyType(objectWithoutNestedObject);
-        final KieSession ksession = kieBase.newKieSession();
+        MyType objectWithoutNestedObject = new MyType(null);
+        MyType objectWithNestedObject = new MyType(objectWithoutNestedObject);
+        KieSession ksession = kieBase.newKieSession();
         ksession.insert(objectWithNestedObject);
         ksession.insert(objectWithoutNestedObject);
         ksession.fireAllRules();
@@ -346,32 +345,32 @@ public class GroupByTest {
 
     @Test
     public void testWithGroupByAfterExists() {
-        final Global<Map> groupResultVar = DSL.globalOf(Map.class, "defaultPkg", "glob");
+        Global<Map> groupResultVar = D.globalOf(Map.class, "defaultPkg", "glob");
 
-        final Variable<Integer> patternVar = DSL.declarationOf(Integer.class);
-        final Variable<String> existsVar = DSL.declarationOf(String.class);
-        final Variable<Integer> keyVar = DSL.declarationOf(Integer.class);
-        final Variable<Long> resultVar = DSL.declarationOf(Long.class);
+        Variable<Integer> patternVar = D.declarationOf(Integer.class);
+        Variable<String> existsVar = D.declarationOf(String.class);
+        Variable<Integer> keyVar = D.declarationOf(Integer.class);
+        Variable<Long> resultVar = D.declarationOf(Long.class);
 
-        final D.PatternDef<Integer> pattern = PatternDSL.pattern(patternVar);
-        final D.PatternDef<String> exist = PatternDSL.pattern(existsVar);
-        final ViewItem patternAndExists = DSL.and(
+        D.PatternDef<Integer> pattern = D.pattern(patternVar);
+        D.PatternDef<String> exist = D.pattern(existsVar);
+        ViewItem patternAndExists = D.and(
                 pattern,
-                DSL.exists(exist));
+                D.exists(exist));
 
-        final ViewItem groupBy = DSL.groupBy(patternAndExists, patternVar, keyVar, Math::abs,
+        ViewItem groupBy = D.groupBy(patternAndExists, patternVar, keyVar, Math::abs,
                 DSL.accFunction(CountAccumulateFunction::new).as(resultVar));
-        final ConsequenceBuilder._3 consequence = DSL.on(keyVar, resultVar, groupResultVar)
+        ConsequenceBuilder._3 consequence = D.on(keyVar, resultVar, groupResultVar)
                 .execute((key, count, result) -> {
                     result.put(key, count.intValue());
                 });
 
-        final Rule rule = PatternDSL.rule("R").build(groupBy, consequence);
+        Rule rule = D.rule("R").build(groupBy, consequence);
 
-        final Model model = new ModelImpl().addRule(rule).addGlobal( groupResultVar );
-        final KieBase kieBase = KieBaseBuilder.createKieBaseFromModel(model);
-        final KieSession session = kieBase.newKieSession();
-        final Map<Integer, Integer> global = new HashMap<>();
+        Model model = new ModelImpl().addRule(rule).addGlobal( groupResultVar );
+        KieBase kieBase = KieBaseBuilder.createKieBaseFromModel(model);
+        KieSession session = kieBase.newKieSession();
+        Map<Integer, Integer> global = new HashMap<>();
         session.setGlobal("glob", global);
 
         session.insert("Something");
@@ -387,47 +386,47 @@ public class GroupByTest {
 
     @Test
     public void testGroupBy2Vars() throws Exception {
-        final Global<Map> var_results = DSL.globalOf(Map.class, "defaultpkg", "results");
+        final Global<Map> var_results = D.globalOf(Map.class, "defaultpkg", "results");
 
-        final Variable<String> var_$key = DSL.declarationOf(String.class);
-        final Variable<Person> var_$p = DSL.declarationOf(Person.class);
-        final Variable<Integer> var_$age = DSL.declarationOf(Integer.class);
-        final Variable<String> var_$s = DSL.declarationOf(String.class);
-        final Variable<Integer> var_$l = DSL.declarationOf(Integer.class);
-        final Variable<Integer> var_$sumOfAges = DSL.declarationOf(Integer.class);
+        final Variable<String> var_$key = D.declarationOf(String.class);
+        final Variable<Person> var_$p = D.declarationOf(Person.class);
+        final Variable<Integer> var_$age = D.declarationOf(Integer.class);
+        final Variable<String> var_$s = D.declarationOf(String.class);
+        final Variable<Integer> var_$l = D.declarationOf(Integer.class);
+        final Variable<Integer> var_$sumOfAges = D.declarationOf(Integer.class);
 
-        final Rule rule1 = PatternDSL.rule("R1").build(
-                DSL.groupBy(
+        Rule rule1 = D.rule("R1").build(
+                D.groupBy(
                         // Patterns
-                        DSL.and(
-                                PatternDSL.pattern(var_$p).bind(var_$age, Person::getAge, PatternDSL.reactOn("age")),
-                                PatternDSL.pattern(var_$s).bind(var_$l, String::length, PatternDSL.reactOn("length"))
+                        D.and(
+                            D.pattern(var_$p).bind(var_$age, Person::getAge, D.reactOn("age")),
+                            D.pattern(var_$s).bind(var_$l, String::length, D.reactOn("length"))
                         ),
                         // Grouping Function
                         var_$p, var_$s, var_$key, (person, string) -> person.getName().substring(0, 1) + string.length(),
                         // Accumulate Result (can be more than one)
-                        DSL.accFunction(IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
+                        D.accFunction(org.drools.core.base.accumulators.IntegerSumAccumulateFunction::new, var_$age).as(var_$sumOfAges)),
                 // Filter
-                PatternDSL.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
+                D.pattern(var_$sumOfAges).expr($sumOfAges -> EvaluationUtil.greaterThanNumbers($sumOfAges, 10)),
                 // Consequence
-                DSL.on(var_$key, var_results, var_$sumOfAges)
+                D.on(var_$key, var_results, var_$sumOfAges)
                         .execute(($key, results, $sumOfAges) -> results.put($key, $sumOfAges))
         );
 
-        final Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
-        final KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
+        Model model = new ModelImpl().addRule( rule1 ).addGlobal( var_results );
+        KieSession ksession = KieBaseBuilder.createKieBaseFromModel( model ).newKieSession();
 
-        final Map results = new HashMap();
+        Map results = new HashMap();
         ksession.setGlobal( "results", results );
 
         ksession.insert( "test" );
         ksession.insert( "check" );
         ksession.insert(new Person("Mark", 42));
         ksession.insert(new Person("Edson", 38));
-        final FactHandle meFH = ksession.insert(new Person("Mario", 45));
+        FactHandle meFH = ksession.insert(new Person("Mario", 45));
         ksession.insert(new Person("Maciej", 39));
         ksession.insert(new Person("Edoardo", 33));
-        final FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
+        FactHandle geoffreyFH = ksession.insert(new Person("Geoffrey", 35));
         ksession.fireAllRules();
 
         assertEquals( 6, results.size() );


### PR DESCRIPTION
I think that the difference from the other tests is that:

- `exists` checks for other fact type (`Child`) than the first pattern (`Parent`).
- `groupBy` uses  the other fact type (`Child`) as key (`Parent::getChild`).
- and I then remove one instance of the `Child` fact.

Therefore the `exists` should remove the match altogether.
I have not seen a test like that in there.