### PR TITLE
DROOLS-5612 DMN integrate test example from DMN spec not listed in ADOC p2

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/FromSpecificationNotInAdoc.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/FromSpecificationNotInAdoc.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package org.kie.dmn.feel.runtime;
+package org.kie.dmn.feel.documentation;
 
 import java.util.Collection;
 
 import org.junit.runners.Parameterized;
+import org.kie.dmn.feel.runtime.BaseFEELTest;
 
 /**
  * Some examples (/tests) from the DMN spec were omitted in the ADOC due to policy about specific keywords

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/FromSpecificationNotInAdocTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/documentation/FromSpecificationNotInAdocTest.java
@@ -25,7 +25,7 @@ import org.kie.dmn.feel.runtime.BaseFEELTest;
  * Some examples (/tests) from the DMN spec were omitted in the ADOC due to policy about specific keywords
  * Those tests are placed here to make sure all the examples from the DMN spec are integrated and running as expected.
  */
-public class FromSpecificationNotInAdoc extends BaseFEELTest {
+public class FromSpecificationNotInAdocTest extends BaseFEELTest {
 
     @Parameterized.Parameters(name = "{3}: {0} ({1}) = {2}")
     public static Collection<Object[]> data() {


### PR DESCRIPTION
renaming JUnit to end with `Test` otherwise it's not picked up by Maven (surefire)

**JIRA**: https://issues.redhat.com/browse/DROOLS-5612

**referenced Pull Requests**: none, were already merged on master

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
