### PR TITLE
[DROOLS-5637] Hide definedKeySet of InputSet/OutputSet from Swagger/O…

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/typesafe/AbstractDMNSetType.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.AnnotationDefinition;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.FieldDefinition;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.MethodDefinition;
+import org.drools.modelcompiler.builder.generator.declaredtype.api.SimpleAnnotationDefinition;
 import org.drools.modelcompiler.builder.generator.declaredtype.api.TypeDefinition;
 import org.kie.dmn.api.core.DMNType;
 import org.kie.dmn.api.core.FEELPropertyAccessible;
@@ -143,6 +144,18 @@ abstract class AbstractDMNSetType implements TypeDefinition {
         @Override
         public boolean isFinal() {
             return false;
+        }
+
+        @Override
+        public List<AnnotationDefinition> getFieldAnnotations() {
+            List<AnnotationDefinition> annoList = new ArrayList<>();
+            if (codeGenConfig.isWithMPOpenApiAnnotation()) {
+                annoList.add(new SimpleAnnotationDefinition("org.eclipse.microprofile.openapi.annotations.media.Schema").addValue("hidden", "true"));
+            }
+            if (codeGenConfig.isWithIOSwaggerOASv3Annotation()) {
+                annoList.add(new SimpleAnnotationDefinition("io.swagger.v3.oas.annotations.media.Schema").addValue("hidden", "true"));
+            }
+            return annoList;
         }
     }
 }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/AnnotationsTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/stronglytyped/AnnotationsTest.java
@@ -71,6 +71,14 @@ public class AnnotationsTest extends BaseVariantTest {
             org.eclipse.microprofile.openapi.annotations.media.Schema ann = directionAsField.getDeclaredAnnotation(org.eclipse.microprofile.openapi.annotations.media.Schema.class);
             Assertions.assertThat(ann).isNotNull();
             Assertions.assertThat(ann.enumeration()).isNotNull().contains("North", "South", "East", "West");
+
+            Field definedKeySet = inputSetClass.getDeclaredField("definedKeySet");
+            org.eclipse.microprofile.openapi.annotations.media.Schema ann2 = definedKeySet.getDeclaredAnnotation(org.eclipse.microprofile.openapi.annotations.media.Schema.class);
+            Assertions.assertThat(ann2).isNotNull();
+            Assertions.assertThat(ann2.hidden()).isTrue();
+            io.swagger.v3.oas.annotations.media.Schema ann3 = definedKeySet.getDeclaredAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+            Assertions.assertThat(ann3).isNotNull();
+            Assertions.assertThat(ann3.hidden()).isTrue();
         }
     }
 


### PR DESCRIPTION
…penApi

**JIRA**: https://issues.redhat.com/browse/DROOLS-5637

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
