### PR TITLE
DROOLS-5584: Retrieving the DMNModel has failed.

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/InternalKnowledgeBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/InternalKnowledgeBuilder.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
@@ -112,7 +111,7 @@ public interface InternalKnowledgeBuilder extends KnowledgeBuilder, DroolsAssemb
 
         @Override
         public Collection<KiePackage> getKnowledgePackages() {
-            return Arrays.stream(getKnowledgeBuilder().getPackages()).collect(Collectors.toList());
+            return Arrays.asList(getKnowledgeBuilder().getPackages());
         }
 
         @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/InternalKnowledgeBuilder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/InternalKnowledgeBuilder.java
@@ -14,12 +14,14 @@
 
 package org.drools.compiler.builder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
@@ -110,7 +112,7 @@ public interface InternalKnowledgeBuilder extends KnowledgeBuilder, DroolsAssemb
 
         @Override
         public Collection<KiePackage> getKnowledgePackages() {
-            return Collections.emptyList();
+            return Arrays.stream(getKnowledgeBuilder().getPackages()).collect(Collectors.toList());
         }
 
         @Override


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-5584

The reported issue occurs when a user try to create a new DMN-based test scenario on a new created project and with a manually loaded DMN file. The reason of the issue is on `InternalKnowledgeBuilder` default `EMPTY` implementation, which always returns an empty collection when calling `getKnowledgePackages()` method, which is required during the process to retrieve built DMN files after an incremental build.

@Rikkola @mariofusco @danielezonca @jstastny-cz  Can you please review and test it?

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
