### PR TITLE
DROOLS-5644: Queries should be not considered on RULE based Test Scenario	

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilderTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/fluent/RuleScenarioExecutableBuilderTest.java
@@ -17,16 +17,18 @@ package org.drools.scenariosimulation.backend.fluent;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.drools.core.definitions.rule.impl.RuleImpl;
+import org.drools.core.rule.QueryImpl;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.rule.Rule;
-import org.kie.internal.definition.rule.InternalRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -53,6 +55,10 @@ public class RuleScenarioExecutableBuilderTest {
         packagesToRules.put("package1", Arrays.asList("rule1", "rule2", "rule3"));
         packagesToRules.put("package2", Arrays.asList("rule4", "rule5", "rule6"));
 
+        Map<String, List<String>> queryToRules = new HashMap<>();
+        queryToRules.put("package1", Arrays.asList("query1", "query2"));
+        queryToRules.put("package2", Collections.emptyList());
+
         Map<String, String> ruleToAgendaGroup = new HashMap<>();
         ruleToAgendaGroup.put("rule1", "agenda1");
         ruleToAgendaGroup.put("rule2", "agenda1");
@@ -61,27 +67,27 @@ public class RuleScenarioExecutableBuilderTest {
 
         RuleScenarioExecutableBuilder builder = RuleScenarioExecutableBuilder.createBuilder(null, null, false);
 
-        Set<String> agenda1 = builder.getAvailableRules(createKieBaseMock(packagesToRules, ruleToAgendaGroup), "agenda1");
+        Set<String> agenda1 = builder.getAvailableRules(createKieBaseMock(packagesToRules, ruleToAgendaGroup, queryToRules), "agenda1");
         assertEquals(5, agenda1.size());
 
-        Set<String> agenda2 = builder.getAvailableRules(createKieBaseMock(packagesToRules, ruleToAgendaGroup), "agenda2");
+        Set<String> agenda2 = builder.getAvailableRules(createKieBaseMock(packagesToRules, ruleToAgendaGroup, queryToRules), "agenda2");
         assertEquals(3, agenda2.size());
 
-        Set<String> noAgenda = builder.getAvailableRules(createKieBaseMock(packagesToRules, ruleToAgendaGroup), null);
+        Set<String> noAgenda = builder.getAvailableRules(createKieBaseMock(packagesToRules, ruleToAgendaGroup, queryToRules), null);
         assertEquals(2, noAgenda.size());
     }
 
-    private KieBase createKieBaseMock(Map<String, List<String>> packagesToRules, Map<String, String> ruleToAgendaGroup) {
+    private KieBase createKieBaseMock(Map<String, List<String>> packagesToRules, Map<String, String> ruleToAgendaGroup, Map<String, List<String>> packagesToQueries) {
         KieBase kieBaseMock = mock(KieBase.class);
         List<KiePackage> kiePackagesMock = new ArrayList<>();
         when(kieBaseMock.getKiePackages()).thenReturn(kiePackagesMock);
         for (Map.Entry<String, List<String>> packageToRule : packagesToRules.entrySet()) {
-            kiePackagesMock.add(createKiePackageMock(packageToRule.getKey(), packageToRule.getValue(), ruleToAgendaGroup));
+            kiePackagesMock.add(createKiePackageMock(packageToRule.getKey(), packageToRule.getValue(), ruleToAgendaGroup, packagesToQueries.get(packageToRule.getKey())));
         }
         return kieBaseMock;
     }
 
-    private KiePackage createKiePackageMock(String packageName, List<String> ruleNames, Map<String, String> ruleToAgendaGroup) {
+    private KiePackage createKiePackageMock(String packageName, List<String> ruleNames, Map<String, String> ruleToAgendaGroup, List<String> queries) {
         KiePackage kiePackageMock = mock(KiePackage.class);
         when(kiePackageMock.getName()).thenReturn(packageName);
         List<Rule> ruleListMock = new ArrayList<>();
@@ -89,15 +95,27 @@ public class RuleScenarioExecutableBuilderTest {
         for (String ruleName : ruleNames) {
             ruleListMock.add(createRuleMock(ruleName, ruleToAgendaGroup.get(ruleName)));
         }
+        for (String queryName : queries) {
+            ruleListMock.add(createQueryImplMock(queryName));
+        }
         return kiePackageMock;
     }
 
-    private InternalRule createRuleMock(String fullName, String agendaGroup) {
-        InternalRule ruleMock = mock(InternalRule.class);
+    private RuleImpl createRuleMock(String fullName, String agendaGroup) {
+        RuleImpl ruleMock = mock(RuleImpl.class);
         when(ruleMock.getName()).thenReturn(fullName);
         when(ruleMock.getPackageName()).thenReturn("");
         when(ruleMock.isMainAgendaGroup()).thenReturn(agendaGroup == null);
         when(ruleMock.getAgendaGroup()).thenReturn(agendaGroup);
+        when(ruleMock.getKnowledgeType()).thenCallRealMethod();
         return ruleMock;
+    }
+
+    private QueryImpl createQueryImplMock(String fullName) {
+        QueryImpl queryImplMock = mock(QueryImpl.class);
+        when(queryImplMock.getName()).thenReturn(fullName);
+        when(queryImplMock.getPackageName()).thenReturn("");
+        when(queryImplMock.getKnowledgeType()).thenCallRealMethod();
+        return queryImplMock;
     }
 }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/RHDM-1448 
https://issues.redhat.com/browse/DROOLS-5644

@danielezonca @jstastny-cz Can you please review and test?
To filter out all `Query` and retain `Rule` only, I based my filter on `rule.getKnowledgeType()` method, which returns an enum `RULE` value in such a case. (`QUERY` is returned in case of a `Query`).

![Screenshot from 2020-09-15 13-11-20](https://user-images.githubusercontent.com/16005046/93211598-c065b200-f761-11ea-8dc4-5d26554049cd.png)
