### PR TITLE
[DROOLS-5677] STANDARD_DRL property reactivity doesn't recognize mult…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/PropertyReactivityTest.java
@@ -922,4 +922,92 @@ public class PropertyReactivityTest extends BaseModelTest {
 
         assertEquals("Mario1", p.getName());
     }
+
+    @Test
+    public void test2PropertiesInOneExpression() {
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "\n" +
+                           "rule R1a\n" +
+                           "agenda-group \"group1\"\n" +
+                           "when\n" +
+                           "    $p : Person( age == 0 )\n" +
+                           "then\n" +
+                           "    modify($p) { setAge( 20 ) };\n" +
+                           "end\n" +
+                           "rule R1b \n" +
+                           "agenda-group \"group1\"\n" +
+                           "when\n" +
+                           "    $p : Person( salary == 0 )\n" +
+                           "then\n" +
+                           "    modify($p) { setSalary( 20 ) };\n" +
+                           "end\n" +
+                           "rule R2 \n" +
+                           "agenda-group \"group2\"\n" +
+                           "when\n" +
+                           "    $p : Person( age > salary )\n" +
+                           "then\n" +
+                           "    modify($p) { setSalary( 100 ) };\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("John", 0);
+        p.setSalary(0);
+        ksession.insert(p);
+        ksession.getAgenda().getAgendaGroup("group1").setFocus();
+        ksession.fireAllRules();
+        ksession.getAgenda().getAgendaGroup("group2").setFocus();
+        ksession.fireAllRules();
+
+        assertEquals(20, p.getSalary().intValue()); // R2 should be cancelled
+    }
+
+    @Test
+    public void test3PropertiesInOneExpression() {
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "\n" +
+                           "rule R1a\n" +
+                           "agenda-group \"group1\"\n" +
+                           "when\n" +
+                           "    $p : Person( age == 0 )\n" +
+                           "then\n" +
+                           "    modify($p) { setAge( 20 ) };\n" +
+                           "end\n" +
+                           "rule R1b \n" +
+                           "agenda-group \"group1\"\n" +
+                           "when\n" +
+                           "    $p : Person( salary == 0 )\n" +
+                           "then\n" +
+                           "    modify($p) { setSalary( 10 ) };\n" +
+                           "end\n" +
+                           "rule R1c \n" +
+                           "agenda-group \"group1\"\n" +
+                           "when\n" +
+                           "    $p : Person( id == 0 )\n" +
+                           "then\n" +
+                           "    modify($p) { setId( 10 ) };\n" +
+                           "end\n" +
+                           "rule R2 \n" +
+                           "agenda-group \"group2\"\n" +
+                           "when\n" +
+                           "    $p : Person( age > salary + id )\n" +
+                           "then\n" +
+                           "    modify($p) { setSalary( 100 ) };\n" +
+                           "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("John", 0);
+        p.setSalary(0);
+        p.setId(0);
+        ksession.insert(p);
+        ksession.getAgenda().getAgendaGroup("group1").setFocus();
+        ksession.fireAllRules();
+        ksession.getAgenda().getAgendaGroup("group2").setFocus();
+        ksession.fireAllRules();
+
+        assertEquals(10, p.getSalary().intValue()); // R2 should be cancelled
+    }
 }


### PR DESCRIPTION
…iple properties in an expression

- Test case

See PropertyReactivityTest#test2PropertiesInOneExpression and test3PropertiesInOneExpression

Only STANDARD_FROM_DRL fails.

**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/DROOLS-5677

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
