### PR TITLE
[DROOLS-5681]ByteArrayResource bytes attribute read/write twice

### DIFF
--- a/drools-core/src/main/java/org/drools/core/io/impl/ByteArrayResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/ByteArrayResource.java
@@ -58,14 +58,12 @@ public class ByteArrayResource extends BaseResource
     public void readExternal(ObjectInput in) throws IOException,
             ClassNotFoundException {
         super.readExternal( in );
-        bytes = (byte[]) in.readObject();
         encoding = (String) in.readObject();
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal( out );
-        out.writeObject( bytes );
         out.writeObject(this.encoding);
     }
 

--- a/drools-core/src/test/java/org/drools/core/io/impl/ByteArrayResourceSerializationTest.java
+++ b/drools-core/src/test/java/org/drools/core/io/impl/ByteArrayResourceSerializationTest.java
@@ -1,0 +1,35 @@
+package org.drools.core.io.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class ByteArrayResourceSerializationTest {
+
+	//FIX https://issues.redhat.com/browse/DROOLS-5681
+	@Test
+	public void bytesAttributesIsStillSerializedDeserializedCorrectly() throws IOException, ClassNotFoundException {
+
+		final byte[] content = "some content".getBytes(StandardCharsets.UTF_8);
+
+		ByteArrayResource bar = new ByteArrayResource(content, StandardCharsets.UTF_8.toString());
+		byte[] serializedBar;
+		try(ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				ObjectOutputStream oos = new ObjectOutputStream(baos)){
+			oos.writeObject(bar);
+			serializedBar = baos.toByteArray();
+		}
+		ByteArrayResource desBar;
+		try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(serializedBar))){
+			desBar = (ByteArrayResource) ois.readObject();
+		}
+		Assertions.assertThat(desBar.getBytes()).isEqualTo(content);
+	}
+
+}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [link](https://issues.redhat.com/browse/DROOLS-5681)

