### PR TITLE
[DROOLS-5647] Add range indexing to AlphaNode

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/compiled/ObjectTypeNodeParser.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/compiled/ObjectTypeNodeParser.java
@@ -94,6 +94,8 @@ public class ObjectTypeNodeParser {
         } else if (propagator instanceof CompositeObjectSinkAdapter) {
             CompositeObjectSinkAdapter composite = (CompositeObjectSinkAdapter) propagator;
 
+            // TODO: Need to check if rangeIndexableSinks/rangeIndexTreeMap must be handled here
+
             traverseSinkLisk(composite.getHashableSinks(), handler);
             traverseSinkLisk(composite.getOthers(), handler);
             indexableConstraint = traverseHashedAlphaNodes(composite.getHashedSinkMap(), handler);

--- a/drools-core/src/main/java/org/drools/core/util/AlphaNodeRBTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/AlphaNodeRBTree.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.core.util;
+
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.rule.IndexableConstraint;
+import org.drools.core.util.index.IndexUtil.ConstraintType;
+
+public class AlphaNodeRBTree extends RBTree<Comparable<Comparable>, AlphaNode> {
+
+    private static final long serialVersionUID = 510L;
+
+    public FastIterator collectLeft(Comparable upperBound) {
+        Node<Comparable<Comparable>, AlphaNode> first = first();
+        Node<Comparable<Comparable>, AlphaNode> upperNearest = findNearestNode( upperBound, Boundary.UPPER );
+
+        if ( first == null || upperNearest == null ) {
+            return FastIterator.EMPTY;
+        }
+
+        return new RBTreeFastIterator( first , upperNearest );
+    }
+
+    public FastIterator collectRight(Comparable lowerBound) {
+        Node<Comparable<Comparable>, AlphaNode> lowerNearest = findNearestNode( lowerBound, Boundary.LOWER );
+        Node<Comparable<Comparable>, AlphaNode> last = last();
+
+        if ( lowerNearest == null || last == null ) {
+            return FastIterator.EMPTY;
+        }
+
+        return new RBTreeFastIterator( lowerNearest , last );
+    }
+
+    /**
+     * Find the nearest node. If keys are equal, return it only when AlphaNode constraint is inclusive (GREATER_OR_EQUAL/LESS_OR_EQUAL)
+     */
+    public Node<Comparable<Comparable>, AlphaNode> findNearestNode(Comparable key, Boundary boundary) {
+        Node<Comparable<Comparable>, AlphaNode> nearest = null;
+        Node<Comparable<Comparable>, AlphaNode> n = root;
+
+        while (n != null) {
+            int compResult = key.compareTo(n.key);
+            if (compResult == 0 && isInclusive(n.value)) {
+                return n;
+            }
+
+            boolean accepted = acceptNode(compResult, boundary);
+            if (accepted && (nearest == null || acceptNode(n.key.compareTo(nearest.key), boundary))) {
+                nearest = n;
+            }
+
+            if (compResult == 0) {
+                n = boundary == Boundary.LOWER ? n.right : n.left;
+            } else {
+                n = accepted ^ boundary == Boundary.LOWER ? n.right : n.left;
+            }
+        }
+
+        return nearest;
+    }
+
+    private boolean isInclusive(AlphaNode value) {
+        ConstraintType constraintType = ((IndexableConstraint) value.getConstraint()).getConstraintType();
+        return (constraintType == ConstraintType.GREATER_OR_EQUAL || constraintType == ConstraintType.LESS_OR_EQUAL);
+    }
+
+    private boolean acceptNode(int compResult, Boundary boundary) {
+        return compResult != 0 && (compResult > 0 ^ boundary == Boundary.LOWER);
+    }
+
+}

--- a/drools-core/src/main/java/org/drools/core/util/AlphaNodeRBTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/AlphaNodeRBTree.java
@@ -77,9 +77,4 @@ public class AlphaNodeRBTree extends RBTree<Comparable<Comparable>, AlphaNode> {
         ConstraintType constraintType = ((IndexableConstraint) value.getConstraint()).getConstraintType();
         return (constraintType == ConstraintType.GREATER_OR_EQUAL || constraintType == ConstraintType.LESS_OR_EQUAL);
     }
-
-    private boolean acceptNode(int compResult, Boundary boundary) {
-        return compResult != 0 && (compResult > 0 ^ boundary == Boundary.LOWER);
-    }
-
 }

--- a/drools-core/src/main/java/org/drools/core/util/RBTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/RBTree.java
@@ -234,7 +234,7 @@ public class RBTree<K extends Comparable< ? super K>, V> implements Serializable
         return nearest;
     }
 
-    private boolean acceptNode(int compResult, Boundary boundary) {
+    protected boolean acceptNode(int compResult, Boundary boundary) {
         return compResult != 0 && ( compResult > 0 ^ boundary == Boundary.LOWER );
     }
 

--- a/drools-core/src/main/java/org/drools/core/util/index/AlphaIndexRBTree.java
+++ b/drools-core/src/main/java/org/drools/core/util/index/AlphaIndexRBTree.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.drools.core.util.index;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.drools.core.base.SimpleValueType;
+import org.drools.core.base.ValueType;
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.CompositeObjectSinkAdapter;
+import org.drools.core.rule.IndexableConstraint;
+import org.drools.core.spi.FieldValue;
+import org.drools.core.util.AlphaNodeRBTree;
+import org.drools.core.util.FastIterator;
+
+/**
+ * 
+ * Alpha Node range indexing implementation backed by AlphaNodeRBTree
+ *
+ */
+public class AlphaIndexRBTree implements Externalizable {
+
+    private AlphaNodeRBTree tree;
+
+    private CompositeObjectSinkAdapter.FieldIndex fieldIndex;
+
+    private int size;
+
+    public AlphaIndexRBTree() {
+        // constructor for serialisation
+    }
+
+    public AlphaIndexRBTree(CompositeObjectSinkAdapter.FieldIndex fieldIndex) {
+        this.fieldIndex = fieldIndex;
+        tree = new AlphaNodeRBTree();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(tree);
+        out.writeObject(fieldIndex);
+        out.writeInt(size);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        tree = (AlphaNodeRBTree) in.readObject();
+        fieldIndex = (CompositeObjectSinkAdapter.FieldIndex) in.readObject();
+        size = in.readInt();
+    }
+
+    public void add(AlphaNode alphaNode) {
+        Comparable key = extractKey(alphaNode);
+        tree.insert(key, alphaNode);
+        size++;
+    }
+
+    public void remove(AlphaNode alphaNode) {
+        Comparable key = extractKey(alphaNode);
+        tree.delete(key);
+        size--;
+    }
+
+    private Comparable extractKey(AlphaNode alphaNode) {
+        IndexableConstraint constraint = (IndexableConstraint) alphaNode.getConstraint();
+        FieldValue field = constraint.getField();
+        ValueType valueType = fieldIndex.getFieldExtractor().getValueType();
+        if (valueType == ValueType.PCHAR_TYPE || valueType == ValueType.CHAR_TYPE) {
+            return field.getCharValue();
+        } else if (valueType == ValueType.PBYTE_TYPE || valueType == ValueType.BYTE_TYPE) {
+            return field.getByteValue();
+        } else if (valueType == ValueType.PSHORT_TYPE || valueType == ValueType.SHORT_TYPE) {
+            return field.getShortValue();
+        } else if (valueType == ValueType.PINTEGER_TYPE || valueType == ValueType.INTEGER_TYPE) {
+            return field.getIntValue();
+        } else if (valueType == ValueType.PLONG_TYPE || valueType == ValueType.LONG_TYPE) {
+            return field.getLongValue();
+        } else if (valueType == ValueType.PFLOAT_TYPE || valueType == ValueType.FLOAT_TYPE) {
+            return field.getFloatValue();
+        } else if (valueType == ValueType.PDOUBLE_TYPE || valueType == ValueType.DOUBLE_TYPE) {
+            return field.getDoubleValue();
+        } else if (valueType == ValueType.PBOOLEAN_TYPE || valueType == ValueType.BOOLEAN_TYPE) {
+            return field.getBooleanValue();
+        } else if (valueType == ValueType.STRING_TYPE) {
+            return (Comparable) field.getValue();
+        } else if (valueType.getSimpleType() == SimpleValueType.DATE) {
+            return (Comparable) field.getValue();
+        } else if (valueType == ValueType.ARRAY_TYPE) {
+            return (Comparable) field.getValue();
+        } else if (valueType == ValueType.OBJECT_TYPE) {
+            return (Comparable) field.getValue();
+        } else if (valueType == ValueType.TRAIT_TYPE) {
+            return (Comparable) field.getValue();
+        } else if (valueType == ValueType.BIG_DECIMAL_TYPE) {
+            return field.getBigDecimalValue();
+        } else if (valueType == ValueType.BIG_INTEGER_TYPE) {
+            return field.getBigIntegerValue();
+        } else if (valueType == ValueType.CLASS_TYPE) {
+            return (Comparable) field.getValue();
+        } else {
+            return (Comparable) field.getValue(); // TODO: Confirm non-Comparable object can be used in comparable constraint?
+        }
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public FastIterator ascMatchingAlphaNodeIterator(Object object) {
+        Object value = fieldIndex.getFieldExtactor().getValue(object);
+
+        // for ascTree, collect left
+        return tree.collectLeft((Comparable) value);
+    }
+
+    public FastIterator descMatchingAlphaNodeIterator(Object object) {
+        Object value = fieldIndex.getFieldExtactor().getValue(object);
+
+        // for descTree, collect right
+        return tree.collectRight((Comparable) value);
+    }
+
+    public FastIterator fastIterator() {
+        return tree.fastIterator();
+    }
+
+    public void clear() {
+        tree = new AlphaNodeRBTree();
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -67,6 +67,7 @@ import static org.drools.core.util.DroolsTestUtil.rulestoMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -887,8 +888,8 @@ public class IndexingTest {
         }
         assertEquals(6, sinks.length);
         assertEquals(6, sinkAdapter.size());
-        assertEquals(0, sinkAdapter.getRangeIndexableAscSinks().size());
-        assertEquals(0, sinkAdapter.getRangeIndexableDescSinks().size());
+        assertNull(sinkAdapter.getRangeIndexableAscSinks());
+        assertNull(sinkAdapter.getRangeIndexableDescSinks());
         assertEquals(3, sinkAdapter.getRangeIndexAscTreeMap().entrySet().iterator().next().getValue().size());
         assertEquals(3, sinkAdapter.getRangeIndexDescTreeMap().entrySet().iterator().next().getValue().size());
 
@@ -949,8 +950,8 @@ public class IndexingTest {
         }
         assertEquals(6, sinks.length);
         assertEquals(6, sinkAdapter.size());
-        assertEquals(0, sinkAdapter.getRangeIndexableAscSinks().size());
-        assertEquals(0, sinkAdapter.getRangeIndexableDescSinks().size());
+        assertNull(sinkAdapter.getRangeIndexableAscSinks());
+        assertNull(sinkAdapter.getRangeIndexableDescSinks());
         assertEquals(3, sinkAdapter.getRangeIndexAscTreeMap().entrySet().iterator().next().getValue().size());
         assertEquals(3, sinkAdapter.getRangeIndexDescTreeMap().entrySet().iterator().next().getValue().size());
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/IndexingTest.java
@@ -37,6 +37,7 @@ import org.drools.core.reteoo.CompositeObjectSinkAdapter;
 import org.drools.core.reteoo.JoinNode;
 import org.drools.core.reteoo.LeftInputAdapterNode;
 import org.drools.core.reteoo.NotNode;
+import org.drools.core.reteoo.ObjectSink;
 import org.drools.core.reteoo.ObjectSinkNodeList;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ReteDumper;
@@ -836,5 +837,129 @@ public class IndexingTest {
             }
             return row;
         }
+    }
+
+    @Test
+    public void testAlphaNodeRangeIndex() {
+        final String drl =
+                "package org.drools.compiler.test\n" +
+                           "import " + Person.class.getCanonicalName() + "\n" +
+                           "rule test1\n" +
+                           "when\n" +
+                           "   Person( age >= 18 )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test2\n" +
+                           "when\n" +
+                           "   Person( age < 25 )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test3\n" +
+                           "when\n" +
+                           "   Person( age > 8 )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test4\n" +
+                           "when\n" +
+                           "   Person( age < 60 )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test5\n" +
+                           "when\n" +
+                           "   Person( age > 12 )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test6\n" +
+                           "when\n" +
+                           "   Person( age <= 4 )\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("indexing-test", kieBaseTestConfiguration, drl);
+        final KieSession ksession = kbase.newKieSession();
+
+        final ObjectTypeNode otn = KieUtil.getObjectTypeNode(kbase, Person.class);
+        assertNotNull(otn);
+        final CompositeObjectSinkAdapter sinkAdapter = (CompositeObjectSinkAdapter) otn.getObjectSinkPropagator();
+        ObjectSink[] sinks = sinkAdapter.getSinks();
+        for (ObjectSink objectSink : sinks) {
+            System.out.println("sink : " + objectSink);
+        }
+        assertEquals(6, sinks.length);
+        assertEquals(6, sinkAdapter.size());
+        assertEquals(0, sinkAdapter.getRangeIndexableAscSinks().size());
+        assertEquals(0, sinkAdapter.getRangeIndexableDescSinks().size());
+        assertEquals(3, sinkAdapter.getRangeIndexAscTreeMap().entrySet().iterator().next().getValue().size());
+        assertEquals(3, sinkAdapter.getRangeIndexDescTreeMap().entrySet().iterator().next().getValue().size());
+
+        ksession.insert(new Person("John", 18));
+        int fired = ksession.fireAllRules();
+        assertEquals(5, fired);
+
+        ksession.insert(new Person("Paul", 60));
+        fired = ksession.fireAllRules();
+        assertEquals(3, fired);
+    }
+
+    @Test
+    public void testAlphaNodeRangeIndexString() {
+        final String drl =
+                "package org.drools.compiler.test\n" +
+                           "import " + Person.class.getCanonicalName() + "\n" +
+                           "rule test1\n" +
+                           "when\n" +
+                           "   Person( name >= \"Ann\" )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test2\n" +
+                           "when\n" +
+                           "   Person( name < \"Bob\" )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test3\n" +
+                           "when\n" +
+                           "   Person( name > \"Kent\" )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test4\n" +
+                           "when\n" +
+                           "   Person( name < \"Steve\" )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test5\n" +
+                           "when\n" +
+                           "   Person( name > \"John\" )\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule test6\n" +
+                           "when\n" +
+                           "   Person( name <= \"Paul\" )\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("indexing-test", kieBaseTestConfiguration, drl);
+        final KieSession ksession = kbase.newKieSession();
+
+        final ObjectTypeNode otn = KieUtil.getObjectTypeNode(kbase, Person.class);
+        assertNotNull(otn);
+        final CompositeObjectSinkAdapter sinkAdapter = (CompositeObjectSinkAdapter) otn.getObjectSinkPropagator();
+        ObjectSink[] sinks = sinkAdapter.getSinks();
+        for (ObjectSink objectSink : sinks) {
+            System.out.println("sink : " + objectSink);
+        }
+        assertEquals(6, sinks.length);
+        assertEquals(6, sinkAdapter.size());
+        assertEquals(0, sinkAdapter.getRangeIndexableAscSinks().size());
+        assertEquals(0, sinkAdapter.getRangeIndexableDescSinks().size());
+        assertEquals(3, sinkAdapter.getRangeIndexAscTreeMap().entrySet().iterator().next().getValue().size());
+        assertEquals(3, sinkAdapter.getRangeIndexDescTreeMap().entrySet().iterator().next().getValue().size());
+
+        ksession.insert(new Person("John"));
+        int fired = ksession.fireAllRules();
+        assertEquals(3, fired);
+
+        ksession.insert(new Person("Paul"));
+        fired = ksession.fireAllRules();
+        assertEquals(5, fired);
     }
 }


### PR DESCRIPTION
@mdproctor @mariofusco @lucamolteni 
This is a draft implementation to share my early code for review in order not to go too far in the wrong direction.

I simply introduced rangeIndexableAscSinks/rangeIndexableDescSinks, rangeIndexedAscFieldIndexes/rangeIndexedDescFieldIndexes, rangeIndexAscTreeMap/rangeIndexDescTreeMap to CompositeObjectSinkAdapter just like existing hash-indexing logic.

Some parts may look redundant (duplicated code for Asc/Desc). I'll consider if I can write it better.

Good thing is that I can just rely on IndexableConstraint so both standar-drl and executable-model work fine without any special treatment for MvelConstaint or LambdaConstraint at the moment.

Remaining tasks:

- Add more unit tests
- Measure the performance using kie-benchmark
- Make RANGE_INDEX_THRESHOLD configurable
- Maybe need some work on ObjectTypeNodeParser
- Check if there is something to do regarding Alpha Network Compiler
- Check DMN use case

Feel free to share your thoughts/suggestions. Thank you!

**JIRA**: https://issues.redhat.com/browse/DROOLS-5647

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
