### PR TITLE
BAQE-1567 - Change revapi to check against 7.44.0.Final

### DIFF
--- a/drools-core/src/build/revapi-config.json
+++ b/drools-core/src/build/revapi-config.json
@@ -43,7 +43,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.39.0.Final and the current branch. These changes are desired and thus ignored.",
+      "_comment": "Changes between 7.44.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": []
     }
   }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [BAQE-1567](https://issues.redhat.com/browse/BAQE-1567)

depends on kiegroup/droolsjbpm-build-bootstrap#1485