### PR TITLE
DROOLS-5691 Fix (classic) BuildMojo no exec model after descope protobuf

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/CompilationCacheProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/CompilationCacheProvider.java
@@ -16,7 +16,7 @@ package org.drools.compiler.kie.builder.impl;
 
 import java.util.Map;
 
-import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.commons.jci.stores.ResourceStore;
 import org.kie.api.internal.utils.ServiceRegistry;
 
 public interface CompilationCacheProvider {
@@ -36,7 +36,7 @@ public interface CompilationCacheProvider {
 
     InternalKieModule.CompilationCache getCompilationCache( AbstractKieModule kieModule, Map<String, InternalKieModule.CompilationCache> compilationCache, String kbaseName);
 
-    void writeKieModuleMetaInfo( InternalKieModule kModule, MemoryFileSystem trgMfs );
+    void writeKieModuleMetaInfo(InternalKieModule kModule, ResourceStore trgMfs);
 
     enum DefaultCompilationCacheProvider implements CompilationCacheProvider {
         INSTANCE;
@@ -47,7 +47,7 @@ public interface CompilationCacheProvider {
         }
 
         @Override
-        public void writeKieModuleMetaInfo( InternalKieModule kModule, MemoryFileSystem trgMfs ) {
+        public void writeKieModuleMetaInfo(InternalKieModule kModule, ResourceStore trgMfs) {
             new KieMetaInfoBuilder( kModule ).writeKieModuleMetaInfo( trgMfs );
         }
     }

--- a/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/CompilationCacheProviderImpl.java
+++ b/drools-serialization-protobuf/src/main/java/org/drools/serialization/protobuf/CompilationCacheProviderImpl.java
@@ -18,19 +18,19 @@ import java.io.ByteArrayInputStream;
 import java.util.Map;
 
 import com.google.protobuf.ExtensionRegistry;
-import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.commons.jci.stores.ResourceStore;
 import org.drools.compiler.kie.builder.impl.AbstractKieModule;
 import org.drools.compiler.kie.builder.impl.CompilationCacheProvider;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.InternalKieModule.CompilationCache;
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.core.util.Drools;
-import org.drools.serialization.protobuf.kie.MarshallingKieMetaInfoBuilder;
 import org.drools.serialization.protobuf.kie.KieModuleCache.CompDataEntry;
 import org.drools.serialization.protobuf.kie.KieModuleCache.CompilationData;
 import org.drools.serialization.protobuf.kie.KieModuleCache.Header;
 import org.drools.serialization.protobuf.kie.KieModuleCache.KModuleCache;
 import org.drools.serialization.protobuf.kie.KieModuleCacheHelper;
+import org.drools.serialization.protobuf.kie.MarshallingKieMetaInfoBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +76,7 @@ public class CompilationCacheProviderImpl implements CompilationCacheProvider {
     }
 
     @Override
-    public void writeKieModuleMetaInfo( InternalKieModule kModule, MemoryFileSystem trgMfs ) {
+    public void writeKieModuleMetaInfo(InternalKieModule kModule, ResourceStore trgMfs) {
         new MarshallingKieMetaInfoBuilder( kModule ).writeKieModuleMetaInfo( trgMfs );
     }
 }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-5691

**referenced Pull Requests**: downstream

* https://github.com/kiegroup/droolsjbpm-integration/pull/2260

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
