### PR TITLE
fix incorrect variable reference in isConvertible method

### DIFF
--- a/drools-core-reflective/src/main/java/org/drools/reflective/util/ClassUtils.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/util/ClassUtils.java
@@ -548,7 +548,7 @@ public abstract class ClassUtils {
     public static boolean isConvertible( Class<?> srcPrimitive, Class<?> tgtPrimitive ) {
         if ( Boolean.TYPE.equals( srcPrimitive ) ) {
             return Boolean.TYPE.equals( tgtPrimitive );
-        } else if ( Byte.TYPE.equals( tgtPrimitive ) ) {
+        } else if ( Byte.TYPE.equals( srcPrimitive ) ) {
             return Byte.TYPE.equals( tgtPrimitive )
                    || Short.TYPE.equals( tgtPrimitive )
                    || Integer.TYPE.equals( tgtPrimitive )

--- a/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
@@ -624,7 +624,7 @@ public final class ClassUtils {
     public static boolean isConvertible( Class<?> srcPrimitive, Class<?> tgtPrimitive ) {
         if ( Boolean.TYPE.equals( srcPrimitive ) ) {
             return Boolean.TYPE.equals( tgtPrimitive );
-        } else if ( Byte.TYPE.equals( tgtPrimitive ) ) {
+        } else if ( Byte.TYPE.equals( srcPrimitive ) ) {
             return Byte.TYPE.equals( tgtPrimitive )
                    || Short.TYPE.equals( tgtPrimitive )
                    || Integer.TYPE.equals( tgtPrimitive )


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: NA

within the `isConvertible` method block, the 2nd if logic should be based on `Byte.TYPE.equals( srcPrimitive )` instead of `Byte.TYPE.equals( tgtPrimitive )`. I believe it is a typo.

