### PR TITLE
JBPM-9421 - Previous "no-vulnerabilities" partially reverted due to unsupported ACCESS_EXTERNAL_DTD parameter

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/util/DOMParserUtil.java
@@ -340,8 +340,6 @@ public class DOMParserUtil {
     public static String getString(Document toRead) throws Exception {
         DOMSource domSource = new DOMSource(toRead);
         TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = factory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");


### PR DESCRIPTION
Root cause:
`Unexpected HTTP response code when requesting URI 'http://localhost:38673/kie-server-services/services/rest/server/containers/input-data-string/scesim'! Error code: 400, message: <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<response type="FAILURE" msg="Test scenario parsing error: Not supported: http://javax.xml.XMLConstants/property/accessExternalDTD"/>`
Stacktrace
`org.kie.server.api.exception.KieServicesHttpException: 
Unexpected HTTP response code when requesting URI 'http://localhost:38673/kie-server-services/services/rest/server/containers/input-data-string/scesim'! Error code: 400, message: <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<response type="FAILURE" msg="Test scenario parsing error: Not supported: http://javax.xml.XMLConstants/property/accessExternalDTD"/>`


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
