### PR TITLE
[DROOLS-5709] Executable model compiler casting int to short causes compilation error when variable is inside the bracket

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -72,6 +72,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.Type;
@@ -330,7 +331,9 @@ public class DrlxParseUtil {
 
     public static Optional<Node> findRootNodeViaParent(Node expr) {
         final Optional<Node> parentNode = expr.getParentNode();
-        if (parentNode.isPresent()) {
+        if(expr instanceof Statement) { // we never use this method to navigate up to the statement
+            return Optional.empty();
+        } else if (parentNode.isPresent()) {
             return findRootNodeViaParent(parentNode.get());
         } else {
             return Optional.of(expr);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -802,6 +802,14 @@ public class DrlxParseUtil {
         }
     }
 
+    public static Expression unEncloseExpr(Expression expression) {
+        if(expression.isEnclosedExpr()) {
+            return unEncloseExpr(expression.asEnclosedExpr().getInner());
+        } else {
+            return expression;
+        }
+    }
+
     private DrlxParseUtil() {
         // It is not allowed to create instances of util classes.
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewrite.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewrite.java
@@ -26,7 +26,6 @@ public class PrimitiveTypeConsequenceRewrite {
     }
 
     public String rewrite(String consequence) {
-
         BlockStmt blockStmt;
         try {
             blockStmt = StaticJavaParser.parseBlock(consequence);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewrite.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewrite.java
@@ -44,22 +44,23 @@ public class PrimitiveTypeConsequenceRewrite {
         Expression innerExpr = ce.getExpression();
         Optional<Class<?>> castType = context.resolveType(ce.getType().asString());
 
-        TypedExpressionResult typedExpressionResult = new ExpressionTyper(context, Object.class, innerExpr.toString(), false)
+        TypedExpressionResult typedExpressionResult =
+                new ExpressionTyper(context)
                 .toTypedExpression(innerExpr);
 
         Optional<TypedExpression> optTypeExpression = typedExpressionResult.getTypedExpression();
 
-        if(optTypeExpression.isPresent()) {
-            TypedExpression typedExpression = optTypeExpression.get();
-            if (    castType.isPresent() &&
-                    !(typedExpression.isNumberLiteral()) &&
+        optTypeExpression.ifPresent(typedExpression -> {
+            if (castType.isPresent() &&
                     castType.get().equals(short.class) &&
-                    optTypeExpression.get().getRawClass().equals(int.class)
+                    !typedExpression.isNumberLiteral() &&
+                    typedExpression.getRawClass().equals(int.class)
             ) {
-                Expression scope = StaticJavaParser.parseExpression(unEncloseExpr(typedExpression.getExpression()).toString());
+                Expression unenclosedExpression = unEncloseExpr(typedExpression.getExpression());
+                Expression scope = StaticJavaParser.parseExpression(unenclosedExpression.toString());
                 MethodCallExpr shortValue = new MethodCallExpr(scope, "shortValue");
                 ce.replace(shortValue);
             }
-        }
+        });
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
@@ -127,6 +127,11 @@ public class ExpressionTyper {
         this(ruleContext, patternType, bindingId, isPositional, new ExpressionTyperContext());
     }
 
+    // When using the ExpressionTyper outside of a pattern
+    public ExpressionTyper(RuleContext ruleContext) {
+        this(ruleContext, Object.class, null, false, new ExpressionTyperContext());
+    }
+
     public ExpressionTyper(RuleContext ruleContext, Class<?> patternType, String bindingId, boolean isPositional, ExpressionTyperContext context) {
         this.ruleContext = ruleContext;
         packageModel = ruleContext.getPackageModel();

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -41,6 +41,7 @@ import org.drools.modelcompiler.domain.Result;
 import org.drools.modelcompiler.domain.StockTick;
 import org.drools.modelcompiler.domain.Toy;
 import org.drools.modelcompiler.domain.Woman;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.definition.type.FactType;
@@ -2316,5 +2317,74 @@ public class CompilerTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Assertions.assertThat(list).containsExactly("John");
+    }
+
+    public static class IntegerToShort {
+
+        private Boolean testBoolean;
+        private int testInt;
+        private Short testShort;
+
+        public IntegerToShort(Boolean testBoolean, int testInt, Short testShort) {
+            this.testBoolean = testBoolean;
+            this.testInt = testInt;
+            this.testShort = testShort;
+        }
+
+        public void setTestBoolean(Boolean testBoolean) {
+            this.testBoolean = testBoolean;
+        }
+
+        public void setTestInt(int testInt) {
+            this.testInt = testInt;
+        }
+
+        public void setTestShort(Short testShort) {
+            this.testShort = testShort;
+        }
+
+        public Boolean getTestBoolean() {
+            return testBoolean;
+        }
+
+        public int getTestInt() {
+            return testInt;
+        }
+
+        public Short getTestShort() {
+            return testShort;
+        }
+    }
+
+    @Test // DROOLS-5709
+    public void testCastingIntegerToShort() {
+        String str =
+                "import " + IntegerToShort.class.getCanonicalName() + ";\n " +
+                "global java.util.List list;\n" +
+                "rule \"test_rule\"\n" +
+                "dialect \"java\"\n" +
+                "when\n" +
+                    "$integerToShort : IntegerToShort( " +
+                        "$testInt : testInt, " +
+                        "testBoolean != null, " +
+                        "testBoolean == false" +
+                        ") \n" +
+                "then\n" +
+                    "$integerToShort.setTestShort((short)($testInt)); \n" +
+                    "$integerToShort.setTestBoolean(true);\n" +
+                    "update($integerToShort);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+        final List<String> list = new ArrayList<>();
+
+        ksession.setGlobal("list", list);
+
+        IntegerToShort integerToShort = new IntegerToShort(false, Integer.MAX_VALUE, Short.MAX_VALUE);
+
+        ksession.insert(integerToShort);
+        int rulesFired = ksession.fireAllRules();
+
+        Assert.assertEquals(1, rulesFired);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -2062,7 +2062,44 @@ public class CompilerTest extends BaseModelTest {
         assertEquals( 5, pet.getAge() );
     }
 
-    @Test
+    public static class IntegerToShort {
+
+        private Boolean testBoolean;
+        private int testInt;
+        private Short testShort;
+
+        public IntegerToShort(Boolean testBoolean, int testInt, Short testShort) {
+            this.testBoolean = testBoolean;
+            this.testInt = testInt;
+            this.testShort = testShort;
+        }
+
+        public void setTestBoolean(Boolean testBoolean) {
+            this.testBoolean = testBoolean;
+        }
+
+        public void setTestInt(int testInt) {
+            this.testInt = testInt;
+        }
+
+        public void setTestShort(Short testShort) {
+            this.testShort = testShort;
+        }
+
+        public Boolean getTestBoolean() {
+            return testBoolean;
+        }
+
+        public int getTestInt() {
+            return testInt;
+        }
+
+        public Short getTestShort() {
+            return testShort;
+        }
+    }
+
+    @Test // DROOLS-5007
     public void testIntToShortCast() {
         String str = "import " + Address.class.getCanonicalName() + ";\n" +
                 "rule \"rule1\"\n" +
@@ -2080,6 +2117,39 @@ public class CompilerTest extends BaseModelTest {
         address.setNumber(1);
         ksession.insert( address );
         assertEquals( 1, ksession.fireAllRules() );
+    }
+
+
+    @Test // DROOLS-5709
+    public void testCastingIntegerToShort() {
+        String str =
+                "import " + IntegerToShort.class.getCanonicalName() + ";\n " +
+                        "global java.util.List list;\n" +
+                        "rule \"test_rule\"\n" +
+                        "dialect \"java\"\n" +
+                        "when\n" +
+                        "$integerToShort : IntegerToShort( " +
+                        "$testInt : testInt, " +
+                        "testBoolean != null, " +
+                        "testBoolean == false" +
+                        ") \n" +
+                        "then\n" +
+                        "$integerToShort.setTestShort((short)($testInt)); \n" +
+                        "$integerToShort.setTestBoolean(true);\n" +
+                        "update($integerToShort);\n" +
+                        "end";
+
+        KieSession ksession = getKieSession(str);
+        final List<String> list = new ArrayList<>();
+
+        ksession.setGlobal("list", list);
+
+        IntegerToShort integerToShort = new IntegerToShort(false, Integer.MAX_VALUE, Short.MAX_VALUE);
+
+        ksession.insert(integerToShort);
+        int rulesFired = ksession.fireAllRules();
+
+        Assert.assertEquals(1, rulesFired);
     }
 
     @Test
@@ -2317,74 +2387,5 @@ public class CompilerTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Assertions.assertThat(list).containsExactly("John");
-    }
-
-    public static class IntegerToShort {
-
-        private Boolean testBoolean;
-        private int testInt;
-        private Short testShort;
-
-        public IntegerToShort(Boolean testBoolean, int testInt, Short testShort) {
-            this.testBoolean = testBoolean;
-            this.testInt = testInt;
-            this.testShort = testShort;
-        }
-
-        public void setTestBoolean(Boolean testBoolean) {
-            this.testBoolean = testBoolean;
-        }
-
-        public void setTestInt(int testInt) {
-            this.testInt = testInt;
-        }
-
-        public void setTestShort(Short testShort) {
-            this.testShort = testShort;
-        }
-
-        public Boolean getTestBoolean() {
-            return testBoolean;
-        }
-
-        public int getTestInt() {
-            return testInt;
-        }
-
-        public Short getTestShort() {
-            return testShort;
-        }
-    }
-
-    @Test // DROOLS-5709
-    public void testCastingIntegerToShort() {
-        String str =
-                "import " + IntegerToShort.class.getCanonicalName() + ";\n " +
-                "global java.util.List list;\n" +
-                "rule \"test_rule\"\n" +
-                "dialect \"java\"\n" +
-                "when\n" +
-                    "$integerToShort : IntegerToShort( " +
-                        "$testInt : testInt, " +
-                        "testBoolean != null, " +
-                        "testBoolean == false" +
-                        ") \n" +
-                "then\n" +
-                    "$integerToShort.setTestShort((short)($testInt)); \n" +
-                    "$integerToShort.setTestBoolean(true);\n" +
-                    "update($integerToShort);\n" +
-                "end";
-
-        KieSession ksession = getKieSession(str);
-        final List<String> list = new ArrayList<>();
-
-        ksession.setGlobal("list", list);
-
-        IntegerToShort integerToShort = new IntegerToShort(false, Integer.MAX_VALUE, Short.MAX_VALUE);
-
-        ksession.insert(integerToShort);
-        int rulesFired = ksession.fireAllRules();
-
-        Assert.assertEquals(1, rulesFired);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
@@ -60,12 +60,6 @@ public class PrimitiveTypeConsequenceRewriteTest {
         String rewritten = new PrimitiveTypeConsequenceRewrite(context)
                 .rewrite("{ $address.setShortNumber((short)($interimVar.unboxed())); }");
 
-        WithIntegerField wif = new WithIntegerField(2);
-
-        // new Address().setShortNumber((short)(wif.getIntegerField()));
-        new Address().setShortNumber((short)(wif.unboxed()));
-        new Address().setShortNumber(wif.boxed().shortValue());
-
         assertThat(rewritten,
                    equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.unboxed().shortValue()); }"));
     }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
@@ -64,6 +64,21 @@ public class PrimitiveTypeConsequenceRewriteTest {
                    equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.unboxed().shortValue()); }"));
     }
 
+
+    @Test
+    public void doNotPreProcessDowncastToNonPrimitiveTypes() {
+        RuleContext context = createContext();
+        context.addDeclaration("$interimVar", WithIntegerField.class);
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{\n" +
+                                 "  org.kie.dmn.model.api.List row = (org.kie.dmn.model.api.List) $e.getParent();\n" +
+                                 "}");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{ org.kie.dmn.model.api.List row = (org.kie.dmn.model.api.List) $e.getParent(); }"));
+    }
+
     private RuleContext createContext() {
         TypeResolver typeResolver = new ClassTypeResolver(Collections.emptySet(), this.getClass().getClassLoader());
         PackageModel packageModel = new PackageModel("", "", null, true, null, null);

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -22,8 +22,8 @@
     <module>kie-dmn-feel</module>
     <module>kie-dmn-backend</module>
     <module>kie-dmn-core</module>
-<!--    <module>kie-dmn-validation-bootstrap</module>-->
-<!--    <module>kie-dmn-validation</module>-->
+    <module>kie-dmn-validation-bootstrap</module>
+    <module>kie-dmn-validation</module>
     <module>kie-dmn-openapi</module>
     <module>kie-dmn-tck</module>
     <module>kie-dmn-signavio</module>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -22,8 +22,8 @@
     <module>kie-dmn-feel</module>
     <module>kie-dmn-backend</module>
     <module>kie-dmn-core</module>
-    <module>kie-dmn-validation-bootstrap</module>
-    <module>kie-dmn-validation</module>
+<!--    <module>kie-dmn-validation-bootstrap</module>-->
+<!--    <module>kie-dmn-validation</module>-->
     <module>kie-dmn-openapi</module>
     <module>kie-dmn-tck</module>
     <module>kie-dmn-signavio</module>


### PR DESCRIPTION
**Thank you for submitting this pull request**

https://issues.redhat.com/browse/DROOLS-5709


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
