### PR TITLE
[DROOLS-5709] Executable model compiler casting int to short causes compilation error when variable is inside the bracket (#3174)

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -72,6 +72,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.Type;
@@ -330,7 +331,9 @@ public class DrlxParseUtil {
 
     public static Optional<Node> findRootNodeViaParent(Node expr) {
         final Optional<Node> parentNode = expr.getParentNode();
-        if (parentNode.isPresent()) {
+        if(expr instanceof Statement) { // we never use this method to navigate up to the statement
+            return Optional.empty();
+        } else if (parentNode.isPresent()) {
             return findRootNodeViaParent(parentNode.get());
         } else {
             return Optional.of(expr);
@@ -799,6 +802,14 @@ public class DrlxParseUtil {
             return Optional.of(typeResolver.resolveType(typeName));
         } catch (ClassNotFoundException e) {
             return Optional.empty();
+        }
+    }
+
+    public static Expression unEncloseExpr(Expression expression) {
+        if(expression.isEnclosedExpr()) {
+            return unEncloseExpr(expression.asEnclosedExpr().getInner());
+        } else {
+            return expression;
         }
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
@@ -127,6 +127,11 @@ public class ExpressionTyper {
         this(ruleContext, patternType, bindingId, isPositional, new ExpressionTyperContext());
     }
 
+    // When using the ExpressionTyper outside of a pattern
+    public ExpressionTyper(RuleContext ruleContext) {
+        this(ruleContext, Object.class, null, false, new ExpressionTyperContext());
+    }
+
     public ExpressionTyper(RuleContext ruleContext, Class<?> patternType, String bindingId, boolean isPositional, ExpressionTyperContext context) {
         this.ruleContext = ruleContext;
         packageModel = ruleContext.getPackageModel();

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -41,6 +41,7 @@ import org.drools.modelcompiler.domain.Result;
 import org.drools.modelcompiler.domain.StockTick;
 import org.drools.modelcompiler.domain.Toy;
 import org.drools.modelcompiler.domain.Woman;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.definition.type.FactType;
@@ -2061,7 +2062,44 @@ public class CompilerTest extends BaseModelTest {
         assertEquals( 5, pet.getAge() );
     }
 
-    @Test
+    public static class IntegerToShort {
+
+        private Boolean testBoolean;
+        private int testInt;
+        private Short testShort;
+
+        public IntegerToShort(Boolean testBoolean, int testInt, Short testShort) {
+            this.testBoolean = testBoolean;
+            this.testInt = testInt;
+            this.testShort = testShort;
+        }
+
+        public void setTestBoolean(Boolean testBoolean) {
+            this.testBoolean = testBoolean;
+        }
+
+        public void setTestInt(int testInt) {
+            this.testInt = testInt;
+        }
+
+        public void setTestShort(Short testShort) {
+            this.testShort = testShort;
+        }
+
+        public Boolean getTestBoolean() {
+            return testBoolean;
+        }
+
+        public int getTestInt() {
+            return testInt;
+        }
+
+        public Short getTestShort() {
+            return testShort;
+        }
+    }
+
+    @Test // DROOLS-5007
     public void testIntToShortCast() {
         String str = "import " + Address.class.getCanonicalName() + ";\n" +
                 "rule \"rule1\"\n" +
@@ -2079,6 +2117,39 @@ public class CompilerTest extends BaseModelTest {
         address.setNumber(1);
         ksession.insert( address );
         assertEquals( 1, ksession.fireAllRules() );
+    }
+
+
+    @Test // DROOLS-5709
+    public void testCastingIntegerToShort() {
+        String str =
+                "import " + IntegerToShort.class.getCanonicalName() + ";\n " +
+                        "global java.util.List list;\n" +
+                        "rule \"test_rule\"\n" +
+                        "dialect \"java\"\n" +
+                        "when\n" +
+                        "$integerToShort : IntegerToShort( " +
+                        "$testInt : testInt, " +
+                        "testBoolean != null, " +
+                        "testBoolean == false" +
+                        ") \n" +
+                        "then\n" +
+                        "$integerToShort.setTestShort((short)($testInt)); \n" +
+                        "$integerToShort.setTestBoolean(true);\n" +
+                        "update($integerToShort);\n" +
+                        "end";
+
+        KieSession ksession = getKieSession(str);
+        final List<String> list = new ArrayList<>();
+
+        ksession.setGlobal("list", list);
+
+        IntegerToShort integerToShort = new IntegerToShort(false, Integer.MAX_VALUE, Short.MAX_VALUE);
+
+        ksession.insert(integerToShort);
+        int rulesFired = ksession.fireAllRules();
+
+        Assert.assertEquals(1, rulesFired);
     }
 
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import org.drools.core.addon.ClassTypeResolver;
 import org.drools.core.addon.TypeResolver;
 import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.domain.Address;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
@@ -22,6 +23,60 @@ public class PrimitiveTypeConsequenceRewriteTest {
 
         assertThat(rewritten,
                    equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.shortValue()); }"));
+    }
+
+    @Test
+    public void shouldConvertCastOfShortToShortValueEnclosed() {
+        RuleContext context = createContext();
+        context.addDeclaration("$interimVar", int.class);
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{ $address.setShortNumber((short)($interimVar)); }");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.shortValue()); }"));
+    }
+
+    public static class WithIntegerField {
+        private Integer integerField;
+
+        public WithIntegerField(Integer integerField) {
+            this.integerField = integerField;
+        }
+
+        public Integer boxed() {
+            return integerField;
+        }
+        public int unboxed() {
+            return integerField.intValue();
+        }
+    }
+
+    @Test
+    public void shouldConvertCastOfShortToShortValueEnclosedWithField() {
+        RuleContext context = createContext();
+        context.addDeclaration("$interimVar", WithIntegerField.class);
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{ $address.setShortNumber((short)($interimVar.unboxed())); }");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.unboxed().shortValue()); }"));
+    }
+
+
+    @Test
+    public void doNotPreProcessDowncastToNonPrimitiveTypes() {
+        RuleContext context = createContext();
+        context.addDeclaration("$interimVar", WithIntegerField.class);
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{\n" +
+                                 "  org.kie.dmn.model.api.List row = (org.kie.dmn.model.api.List) $e.getParent();\n" +
+                                 "}");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{ org.kie.dmn.model.api.List row = (org.kie.dmn.model.api.List) $e.getParent(); }"));
     }
 
     private RuleContext createContext() {


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5709

Backport of https://github.com/kiegroup/drools/pull/3174
