### PR TITLE
DROOLS-5760 Use named tokens in TokenTypes

### DIFF
--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -59,6 +59,7 @@ import static org.drools.mvel.parser.GeneratedMvelParserConstants.DECIMAL_LITERA
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.DECR;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.DO;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.DOT;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.DOT_DOT_SLASH;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.DOUBLE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.DOUBLECOLON;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.ELLIPSIS;
@@ -67,6 +68,7 @@ import static org.drools.mvel.parser.GeneratedMvelParserConstants.ENTER_JAVADOC_
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.ENTER_MULTILINE_COMMENT;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.EOF;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.EQ;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.EXCL_DOT;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.EXPORTS;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.EXTENDS;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.FALSE;
@@ -78,6 +80,7 @@ import static org.drools.mvel.parser.GeneratedMvelParserConstants.FOR;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.GE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.GOTO;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.GT;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.HASHMARK;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.HEXADECIMAL_EXPONENT;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.HEXADECIMAL_FLOATING_POINT_LITERAL;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.HEX_DIGITS;
@@ -373,10 +376,9 @@ public class TokenTypes {
             case MVEL_ENDS_WITH:
             case MVEL_LENGTH:
             case NOT:
-            case 151:
-            case 152:
-            case 153:
-            // The following are tokens that are only used internally by the lexer
+            case DOT_DOT_SLASH:
+            case HASHMARK:
+            case EXCL_DOT:
             case ASSIGN:
             case LT:
             case BANG:

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -302,6 +302,9 @@ TOKEN :
 | < MVEL_STARTS_WITH: "str[startsWith]" >
 | < MVEL_ENDS_WITH: "str[endsWith]" >
 | < MVEL_LENGTH: "str[length]" >
+| < DOT_DOT_SLASH: "../" >
+| < HASHMARK: "#" >
+| < EXCL_DOT: "!." >
 | <UNIX_EOL: "\n">
 | <WINDOWS_EOL : "\r\n">
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-5760

Minor annoyance: the generated code of the MVEL parser moves numeric IDs around when a token is added to the grammar. Manually written code in TypeTokens break because some of these integer values are referred directly, because their corresponding token is unnamed.
This tiny PR should fix the issue by assigning a name to these anonymous tokens.