### PR TITLE
[KOGITO-2836] Math predicates not processed correctly when null and bad error messaging

### DIFF
--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/Constraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/Constraint.java
@@ -19,6 +19,8 @@ package org.drools.model;
 
 import java.util.List;
 
+import org.drools.model.functions.PredicateInformation;
+
 public interface Constraint {
 
     enum Type { SINGLE, MULTIPLE, OR, AND }
@@ -30,4 +32,6 @@ public interface Constraint {
     Constraint negate();
 
     Constraint replaceVariable( Variable oldVar, Variable newVar );
+
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/SingleConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/SingleConstraint.java
@@ -33,6 +33,7 @@ import org.drools.model.constraints.SingleConstraint7;
 import org.drools.model.constraints.SingleConstraint8;
 import org.drools.model.constraints.SingleConstraint9;
 import org.drools.model.functions.Predicate1;
+import org.drools.model.functions.PredicateInformation;
 import org.drools.model.functions.PredicateN;
 import org.drools.model.impl.ModelComponent;
 import org.drools.model.view.Expr10ViewItemImpl;
@@ -75,7 +76,7 @@ public interface SingleConstraint extends Constraint {
         return Type.SINGLE;
     }
 
-    SingleConstraint TRUE = new AbstractSingleConstraint("TRUE") {
+    SingleConstraint TRUE = new AbstractSingleConstraint("TRUE", PredicateInformation.EMPTY_PREDICATE_INFORMATION) {
         @Override
         public Constraint negate() {
             return FALSE;
@@ -107,7 +108,7 @@ public interface SingleConstraint extends Constraint {
         }
     };
 
-    SingleConstraint FALSE = new AbstractSingleConstraint("FALSE") {
+    SingleConstraint FALSE = new AbstractSingleConstraint("FALSE", PredicateInformation.EMPTY_PREDICATE_INFORMATION) {
         @Override
         public Constraint negate() {
             return TRUE;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AbstractSingleConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AbstractSingleConstraint.java
@@ -24,6 +24,7 @@ import org.drools.model.BitMask;
 import org.drools.model.Constraint;
 import org.drools.model.Index;
 import org.drools.model.SingleConstraint;
+import org.drools.model.functions.PredicateInformation;
 import org.drools.model.impl.ModelComponent;
 import org.drools.model.view.Expr1ViewItemImpl;
 import org.drools.model.view.Expr2ViewItemImpl;
@@ -37,8 +38,11 @@ public abstract class AbstractSingleConstraint extends AbstractConstraint implem
 
     private ReactivitySpecs reactivitySpecs = ReactivitySpecs.EMPTY;
 
-    protected AbstractSingleConstraint(String exprId) {
+    protected PredicateInformation predicateInformation;
+
+    protected AbstractSingleConstraint(String exprId, PredicateInformation predicateInformation) {
         this.exprId = exprId;
+        this.predicateInformation = predicateInformation;
     }
 
     @Override
@@ -72,6 +76,11 @@ public abstract class AbstractSingleConstraint extends AbstractConstraint implem
     @Override
     public String getExprId() {
         return exprId;
+    }
+
+    @Override
+    public PredicateInformation predicateInformation() {
+        return predicateInformation;
     }
 
     @Override

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AndConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AndConstraints.java
@@ -19,6 +19,7 @@ package org.drools.model.constraints;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.drools.model.Constraint;
 import org.drools.model.Variable;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AndConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/AndConstraints.java
@@ -19,7 +19,6 @@ package org.drools.model.constraints;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.drools.model.Constraint;
 import org.drools.model.Variable;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/MultipleConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/MultipleConstraints.java
@@ -19,6 +19,7 @@ package org.drools.model.constraints;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.drools.model.Constraint;
 import org.drools.model.Variable;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/MultipleConstraints.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/MultipleConstraints.java
@@ -19,7 +19,6 @@ package org.drools.model.constraints;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.drools.model.Constraint;
 import org.drools.model.Variable;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint1.java
@@ -30,13 +30,13 @@ public class SingleConstraint1<A> extends AbstractSingleConstraint {
     private final Predicate1<A> predicate;
 
     public SingleConstraint1(Variable<A> variable, Predicate1<A> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation());
         this.variable = variable;
         this.predicate = predicate;
     }
 
     public SingleConstraint1(String exprId, Variable<A> variable, Predicate1<A> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.variable = variable;
         this.predicate = predicate;
     }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint10.java
@@ -41,7 +41,7 @@ public class SingleConstraint10<A, B, C, D, E, F, G, H, I, J> extends AbstractSi
     public SingleConstraint10( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10,
                                Predicate10<A, B, C, D, E, F, G, H, I, J> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -58,7 +58,7 @@ public class SingleConstraint10<A, B, C, D, E, F, G, H, I, J> extends AbstractSi
     public SingleConstraint10( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10,
                                Predicate10<A, B, C, D, E, F, G, H, I, J> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint11.java
@@ -42,7 +42,7 @@ public class SingleConstraint11<A, B, C, D, E, F, G, H, I, J, K> extends Abstrac
     public SingleConstraint11( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10, Variable<K> var11,
                                Predicate11<A, B, C, D, E, F, G, H, I, J, K> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -60,7 +60,7 @@ public class SingleConstraint11<A, B, C, D, E, F, G, H, I, J, K> extends Abstrac
     public SingleConstraint11( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10, Variable<K> var11,
                                Predicate11<A, B, C, D, E, F, G, H, I, J, K> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint12.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint12.java
@@ -43,7 +43,7 @@ public class SingleConstraint12<A, B, C, D, E, F, G, H, I, J, K, L> extends Abst
     public SingleConstraint12( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10, Variable<K> var11, Variable<L> var12,
                                Predicate12<A, B, C, D, E, F, G, H, I, J, K, L> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -62,7 +62,7 @@ public class SingleConstraint12<A, B, C, D, E, F, G, H, I, J, K, L> extends Abst
     public SingleConstraint12( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10, Variable<K> var11, Variable<L> var12,
                                Predicate12<A, B, C, D, E, F, G, H, I, J, K, L> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint13.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint13.java
@@ -44,7 +44,7 @@ public class SingleConstraint13<A, B, C, D, E, F, G, H, I, J, K, L, M> extends A
     public SingleConstraint13( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10, Variable<K> var11, Variable<L> var12, Variable<M> var13,
                                Predicate13<A, B, C, D, E, F, G, H, I, J, K, L, M> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -64,7 +64,7 @@ public class SingleConstraint13<A, B, C, D, E, F, G, H, I, J, K, L, M> extends A
     public SingleConstraint13( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                                Variable<H> var8, Variable<I> var9, Variable<J> var10, Variable<K> var11, Variable<L> var12, Variable<M> var13,
                                Predicate13<A, B, C, D, E, F, G, H, I, J, K, L, M> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint2.java
@@ -31,14 +31,14 @@ public class SingleConstraint2<A, B> extends AbstractSingleConstraint {
     private final Predicate2<A, B> predicate;
 
     public SingleConstraint2(Variable<A> var1, Variable<B> var2, Predicate2<A, B> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.predicate = predicate;
     }
 
     public SingleConstraint2(String exprId, Variable<A> var1, Variable<B> var2, Predicate2<A, B> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.predicate = predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint3.java
@@ -32,7 +32,7 @@ public class SingleConstraint3<A, B, C> extends AbstractSingleConstraint {
     private final Predicate3<A, B, C> predicate;
 
     public SingleConstraint3(Variable<A> var1, Variable<B> var2, Variable<C> var3, Predicate3<A, B, C> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -40,7 +40,7 @@ public class SingleConstraint3<A, B, C> extends AbstractSingleConstraint {
     }
 
     public SingleConstraint3(String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Predicate3<A, B, C> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint4.java
@@ -33,7 +33,7 @@ public class SingleConstraint4<A, B, C, D> extends AbstractSingleConstraint {
     private final Predicate4<A, B, C, D> predicate;
 
     public SingleConstraint4( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Predicate4<A, B, C, D> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -42,7 +42,7 @@ public class SingleConstraint4<A, B, C, D> extends AbstractSingleConstraint {
     }
 
     public SingleConstraint4( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Predicate4<A, B, C, D> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint5.java
@@ -34,7 +34,7 @@ public class SingleConstraint5<A, B, C, D, E> extends AbstractSingleConstraint {
     private final Predicate5<A, B, C, D, E> predicate;
 
     public SingleConstraint5( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Predicate5<A, B, C, D, E> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -44,7 +44,7 @@ public class SingleConstraint5<A, B, C, D, E> extends AbstractSingleConstraint {
     }
 
     public SingleConstraint5( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Predicate5<A, B, C, D, E> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint6.java
@@ -35,7 +35,7 @@ public class SingleConstraint6<A, B, C, D, E, F> extends AbstractSingleConstrain
     private final Predicate6<A, B, C, D, E, F> predicate;
 
     public SingleConstraint6( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Predicate6<A, B, C, D, E, F> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -46,7 +46,7 @@ public class SingleConstraint6<A, B, C, D, E, F> extends AbstractSingleConstrain
     }
 
     public SingleConstraint6( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Predicate6<A, B, C, D, E, F> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint7.java
@@ -36,7 +36,7 @@ public class SingleConstraint7<A, B, C, D, E, F, G> extends AbstractSingleConstr
     private final Predicate7<A, B, C, D, E, F, G> predicate;
 
     public SingleConstraint7( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7, Predicate7<A, B, C, D, E, F, G> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -48,7 +48,7 @@ public class SingleConstraint7<A, B, C, D, E, F, G> extends AbstractSingleConstr
     }
 
     public SingleConstraint7( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7, Predicate7<A, B, C, D, E, F, G> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint8.java
@@ -39,7 +39,7 @@ public class SingleConstraint8<A, B, C, D, E, F, G, H> extends AbstractSingleCon
     public SingleConstraint8( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                               Variable<H> var8,
                               Predicate8<A, B, C, D, E, F, G, H> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -54,7 +54,7 @@ public class SingleConstraint8<A, B, C, D, E, F, G, H> extends AbstractSingleCon
     public SingleConstraint8( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                               Variable<H> var8,
                               Predicate8<A, B, C, D, E, F, G, H> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/SingleConstraint9.java
@@ -40,7 +40,7 @@ public class SingleConstraint9<A, B, C, D, E, F, G, H, I> extends AbstractSingle
     public SingleConstraint9( Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                               Variable<H> var8, Variable<I> var9,
                               Predicate9<A, B, C, D, E, F, G, H, I> predicate) {
-        super( LambdaPrinter.print(predicate) );
+        super( LambdaPrinter.print(predicate), predicate.predicateInformation() );
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;
@@ -56,7 +56,7 @@ public class SingleConstraint9<A, B, C, D, E, F, G, H, I> extends AbstractSingle
     public SingleConstraint9( String exprId, Variable<A> var1, Variable<B> var2, Variable<C> var3, Variable<D> var4, Variable<E> var5, Variable<F> var6, Variable<G> var7,
                               Variable<H> var8, Variable<I> var9,
                               Predicate9<A, B, C, D, E, F, G, H, I> predicate) {
-        super(exprId);
+        super(exprId, predicate.predicateInformation());
         this.var1 = var1;
         this.var2 = var2;
         this.var3 = var3;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/TemporalConstraint.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/constraints/TemporalConstraint.java
@@ -18,6 +18,7 @@ package org.drools.model.constraints;
 
 import org.drools.model.Variable;
 import org.drools.model.functions.Function1;
+import org.drools.model.functions.PredicateInformation;
 import org.drools.model.functions.PredicateN;
 import org.drools.model.functions.temporal.TemporalPredicate;
 import org.drools.model.view.FixedTemporalExprViewItem;
@@ -30,7 +31,7 @@ public abstract class TemporalConstraint<A> extends AbstractSingleConstraint {
     protected final TemporalPredicate temporalPredicate;
 
     public TemporalConstraint( String exprId, Variable<A> var1, TemporalPredicate temporalPredicate ) {
-        super(exprId);
+        super(exprId, PredicateInformation.EMPTY_PREDICATE_INFORMATION);
         this.var1 = var1;
         this.temporalPredicate = temporalPredicate;
     }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
@@ -26,6 +26,8 @@ public interface Predicate1<A> extends Serializable {
         return a -> !test( a );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A> extends IntrospectableLambda implements Predicate1<A> {
 
         private final Predicate1<A> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
@@ -26,7 +26,9 @@ public interface Predicate1<A> extends Serializable {
         return a -> !test( a );
     }
 
-    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+    default PredicateInformation predicateInformation() {
+        throw new UnsupportedOperationException("Shouldn't call this");
+    }
 
     class Impl<A> extends IntrospectableLambda implements Predicate1<A> {
 
@@ -44,6 +46,11 @@ public interface Predicate1<A> extends Serializable {
         @Override
         public Object getLambda() {
             return predicate;
+        }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
         }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate1.java
@@ -26,9 +26,7 @@ public interface Predicate1<A> extends Serializable {
         return a -> !test( a );
     }
 
-    default PredicateInformation predicateInformation() {
-        throw new UnsupportedOperationException("Shouldn't call this");
-    }
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
 
     class Impl<A> extends IntrospectableLambda implements Predicate1<A> {
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate10.java
@@ -46,5 +46,10 @@ public interface Predicate10<A, B, C, D, E, F, G, H, I, J> extends Serializable 
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate10.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate10.java
@@ -27,6 +27,8 @@ public interface Predicate10<A, B, C, D, E, F, G, H, I, J> extends Serializable 
         return (a, b, c, d, e, f, g, h, i, j) -> !test( a, b, c, d, e, f, g, h, i, j );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G, H, I, J> extends IntrospectableLambda implements Predicate10<A, B, C, D, E, F, G, H, I, J> {
 
         private final Predicate10<A, B, C, D, E, F, G, H, I, J> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate11.java
@@ -46,5 +46,10 @@ public interface Predicate11<A, B, C, D, E, F, G, H, I, J, K> extends Serializab
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate11.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate11.java
@@ -27,6 +27,8 @@ public interface Predicate11<A, B, C, D, E, F, G, H, I, J, K> extends Serializab
         return (a, b, c, d, e, f, g, h, i, j, k) -> !test( a, b, c, d, e, f, g, h, i, j, k );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G, H, I, J, K> extends IntrospectableLambda implements Predicate11<A, B, C, D, E, F, G, H, I, J, K> {
 
         private final Predicate11<A, B, C, D, E, F, G, H, I, J, K> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate12.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate12.java
@@ -46,5 +46,10 @@ public interface Predicate12<A, B, C, D, E, F, G, H, I, J, K, L> extends Seriali
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate12.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate12.java
@@ -27,6 +27,8 @@ public interface Predicate12<A, B, C, D, E, F, G, H, I, J, K, L> extends Seriali
         return (a, b, c, d, e, f, g, h, i, j, k, l) -> !test( a, b, c, d, e, f, g, h, i, j, k, l );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G, H, I, J, K, L> extends IntrospectableLambda implements Predicate12<A, B, C, D, E, F, G, H, I, J, K, L> {
 
         private final Predicate12<A, B, C, D, E, F, G, H, I, J, K, L> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate13.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate13.java
@@ -46,5 +46,10 @@ public interface Predicate13<A, B, C, D, E, F, G, H, I, J, K, L, M> extends Seri
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate13.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate13.java
@@ -27,6 +27,8 @@ public interface Predicate13<A, B, C, D, E, F, G, H, I, J, K, L, M> extends Seri
         return (a, b, c, d, e, f, g, h, i, j, k, l, m) -> !test( a, b, c, d, e, f, g, h, i, j, k, l, m );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G, H, I, J, K, L, M> extends IntrospectableLambda implements Predicate13<A, B, C, D, E, F, G, H, I, J, K, L, M> {
 
         private final Predicate13<A, B, C, D, E, F, G, H, I, J, K, L, M> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate2.java
@@ -45,5 +45,10 @@ public interface Predicate2<A, B> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate2.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate2.java
@@ -26,6 +26,8 @@ public interface Predicate2<A, B> extends Serializable {
         return (a, b) -> !test( a, b );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B> extends IntrospectableLambda implements Predicate2<A, B> {
 
         private final Predicate2<A, B> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate3.java
@@ -46,5 +46,10 @@ public interface Predicate3<A, B, C> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate3.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate3.java
@@ -27,6 +27,8 @@ public interface Predicate3<A, B, C> extends Serializable {
         return (a, b, c) -> !test( a, b, c );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C> extends IntrospectableLambda implements Predicate3<A, B, C> {
 
         private final Predicate3<A, B, C> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate4.java
@@ -46,5 +46,10 @@ public interface Predicate4<A, B, C, D> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate4.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate4.java
@@ -27,6 +27,8 @@ public interface Predicate4<A, B, C, D> extends Serializable {
         return (a, b, c, d) -> !test( a, b, c, d );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D> extends IntrospectableLambda implements Predicate4<A, B, C, D> {
 
         private final Predicate4<A, B, C, D> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate5.java
@@ -27,6 +27,8 @@ public interface Predicate5<A, B, C, D, E> extends Serializable {
         return (a, b, c, d, e) -> !test( a, b, c, d, e );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E> extends IntrospectableLambda implements Predicate5<A, B, C, D, E> {
 
         private final Predicate5<A, B, C, D, E> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate5.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate5.java
@@ -46,5 +46,10 @@ public interface Predicate5<A, B, C, D, E> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate6.java
@@ -27,6 +27,8 @@ public interface Predicate6<A, B, C, D, E, F> extends Serializable {
         return (a, b, c, d, e, f) -> !test( a, b, c, d, e, f );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F> extends IntrospectableLambda implements Predicate6<A, B, C, D, E, F> {
 
         private final Predicate6<A, B, C, D, E, F> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate6.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate6.java
@@ -46,5 +46,10 @@ public interface Predicate6<A, B, C, D, E, F> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate7.java
@@ -46,5 +46,10 @@ public interface Predicate7<A, B, C, D, E, F, G> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate7.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate7.java
@@ -27,6 +27,8 @@ public interface Predicate7<A, B, C, D, E, F, G> extends Serializable {
         return (a, b, c, d, e, f, g) -> !test( a, b, c, d, e, f, g );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G> extends IntrospectableLambda implements Predicate7<A, B, C, D, E, F, G> {
 
         private final Predicate7<A, B, C, D, E, F, G> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate8.java
@@ -46,5 +46,10 @@ public interface Predicate8<A, B, C, D, E, F, G, H> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate8.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate8.java
@@ -27,6 +27,8 @@ public interface Predicate8<A, B, C, D, E, F, G, H> extends Serializable {
         return (a, b, c, d, e, f, g, h) -> !test( a, b, c, d, e, f, g, h );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G, H> extends IntrospectableLambda implements Predicate8<A, B, C, D, E, F, G, H> {
 
         private final Predicate8<A, B, C, D, E, F, G, H> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate9.java
@@ -27,6 +27,8 @@ public interface Predicate9<A, B, C, D, E, F, G, H, I> extends Serializable {
         return (a, b, c, d, e, f, g, h, i) -> !test( a, b, c, d, e, f, g, h, i );
     }
 
+    default PredicateInformation predicateInformation() { return PredicateInformation.EMPTY_PREDICATE_INFORMATION; }
+
     class Impl<A, B, C, D, E, F, G, H, I> extends IntrospectableLambda implements Predicate9<A, B, C, D, E, F, G, H, I> {
 
         private final Predicate9<A, B, C, D, E, F, G, H, I> predicate;

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate9.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/Predicate9.java
@@ -46,5 +46,10 @@ public interface Predicate9<A, B, C, D, E, F, G, H, I> extends Serializable {
         public Object getLambda() {
             return predicate;
         }
+
+        @Override
+        public PredicateInformation predicateInformation() {
+            return predicate.predicateInformation();
+        }
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -16,6 +16,8 @@
 
 package org.drools.model.functions;
 
+import java.util.Objects;
+
 /**
  * Used to generate better error message
  */
@@ -59,5 +61,28 @@ public class PredicateInformation {
 
     public String getRuleFileName() {
         return ruleFileName;
+    }
+
+    public boolean isEmpty() {
+        return EMPTY_PREDICATE_INFORMATION.equals(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PredicateInformation that = (PredicateInformation) o;
+        return Objects.equals(stringConstraint, that.stringConstraint) &&
+                Objects.equals(ruleName, that.ruleName) &&
+                Objects.equals(ruleFileName, that.ruleFileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringConstraint, ruleName, ruleFileName);
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -17,6 +17,7 @@
 package org.drools.model.functions;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Used to generate better error message
@@ -33,9 +34,13 @@ public class PredicateInformation {
     private final String ruleFileName;
 
     public PredicateInformation(String stringConstraint, String ruleName, String ruleFileName) {
-        this.stringConstraint = stringConstraint;
-        this.ruleName = ruleName;
-        this.ruleFileName = ruleFileName;
+        this.stringConstraint = defaultToEmptyString(stringConstraint);
+        this.ruleName = defaultToEmptyString(ruleName);
+        this.ruleFileName = defaultToEmptyString(ruleFileName);
+    }
+
+    private String defaultToEmptyString(String stringConstraint) {
+        return Optional.ofNullable(stringConstraint).orElse("");
     }
 
     public RuntimeException betterErrorMessage(RuntimeException originalException) {

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Used to generate better error message
+ * Used to generate a better error message when constraints fail
  */
 public class PredicateInformation {
 
@@ -89,5 +89,14 @@ public class PredicateInformation {
     @Override
     public int hashCode() {
         return Objects.hash(stringConstraint, ruleName, ruleFileName);
+    }
+
+    @Override
+    public String toString() {
+        return "PredicateInformation{" +
+                "stringConstraint='" + stringConstraint + '\'' +
+                ", ruleName='" + ruleName + '\'' +
+                ", ruleFileName='" + ruleFileName + '\'' +
+                '}';
     }
 }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -49,7 +49,7 @@ public class PredicateInformation {
         }
 
         String errorMessage = String.format(
-                "Error evaluating constraint '%s' in [Rule %s in %s]",
+                "Error evaluating constraint '%s' in [Rule \"%s\" in %s]",
                 stringConstraint,
                 ruleName,
                 ruleFileName);

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.model.functions;
+
+/**
+ * Used to generate better error message
+ */
+public class PredicateInformation {
+
+    public static final PredicateInformation EMPTY_PREDICATE_INFORMATION =
+            new PredicateInformation("", "", "");
+
+
+    // Used to generate a significant error message
+    private final String stringConstraint;
+    private final String ruleName;
+    private final String ruleFileName;
+
+    public PredicateInformation(String stringConstraint, String ruleName, String ruleFileName) {
+        this.stringConstraint = stringConstraint;
+        this.ruleName = ruleName;
+        this.ruleFileName = ruleFileName;
+    }
+
+    public RuntimeException betterErrorMessage(RuntimeException originalException) {
+        if("".equals(stringConstraint)) {
+            return originalException;
+        }
+
+        String errorMessage = String.format(
+                "Error evaluating constraint '%s' in [Rule %s in %s]",
+                stringConstraint,
+                ruleName,
+                ruleFileName);
+        return new RuntimeException(errorMessage, originalException);
+    }
+
+    public String getStringConstraint() {
+        return stringConstraint;
+    }
+
+    public String getRuleName() {
+        return ruleName;
+    }
+
+    public String getRuleFileName() {
+        return ruleFileName;
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
@@ -946,7 +946,7 @@ public class KiePackagesBuilder {
         for ( Predicate1<T> predicate : window.getPredicates()) {
             SingleConstraint singleConstraint = new SingleConstraint1<>( generateName("expr"), variable, predicate );
             ConstraintEvaluator constraintEvaluator = new ConstraintEvaluator( windowPattern, singleConstraint );
-            windowPattern.addConstraint( new LambdaConstraint( constraintEvaluator ) );
+            windowPattern.addConstraint( new LambdaConstraint( constraintEvaluator, singleConstraint.predicateInformation()) );
         }
         windowPattern.addBehavior( createWindow( window ) );
         ctx.getPkg().addWindowDeclaration(windowDeclaration);
@@ -994,7 +994,7 @@ public class KiePackagesBuilder {
                                                   new ConstraintEvaluator( declarations, pattern, singleConstraint );
         return unificationDeclaration != null ?
                                          new UnificationConstraint(unificationDeclaration, constraintEvaluator) :
-                                         new LambdaConstraint( constraintEvaluator );
+                                         new LambdaConstraint( constraintEvaluator, singleConstraint.predicateInformation());
     }
 
     private Declaration collectConstraintDeclarations( RuleContext ctx, Pattern pattern, SingleConstraint singleConstraint, Variable[] vars, Declaration[] declarations ) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.StaticJavaParser;
@@ -64,6 +65,7 @@ import org.drools.model.Query;
 import org.drools.model.Rule;
 import org.drools.model.RulesSupplier;
 import org.drools.model.WindowReference;
+import org.drools.model.functions.PredicateInformation;
 import org.drools.modelcompiler.builder.generator.DRLIdGenerator;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
 import org.drools.modelcompiler.builder.generator.QueryGenerator;
@@ -145,6 +147,8 @@ public class PackageModel {
     private Set<RuleUnitDescription> ruleUnits = new HashSet<>();
 
     private Map<LambdaExpr, java.lang.reflect.Type> lambdaReturnTypes = new HashMap<>();
+
+    private Map<String, PredicateInformation> exprDebugInformationMap = new HashMap<>();
 
     private boolean oneClassPerRule;
 
@@ -857,5 +861,17 @@ public class PackageModel {
 
     public Map<LambdaExpr, java.lang.reflect.Type> getLambdaReturnTypes() {
         return lambdaReturnTypes;
+    }
+
+    public void addExprDebugInformation(String exprId, PredicateInformation predicateInformation) {
+        exprDebugInformationMap.put(exprId, predicateInformation);
+    }
+
+    public Optional<PredicateInformation> getExprDebugInformation(String exprId) {
+        return Optional.ofNullable(exprDebugInformationMap.get(exprId));
+    }
+
+    public Map<String, PredicateInformation> getExprDebugInformationMap() {
+        return exprDebugInformationMap;
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -148,7 +148,7 @@ public class PackageModel {
 
     private Map<LambdaExpr, java.lang.reflect.Type> lambdaReturnTypes = new HashMap<>();
 
-    private Map<String, PredicateInformation> exprDebugInformationMap = new HashMap<>();
+    private Map<String, PredicateInformation> allConstraintsMap = new HashMap<>();
 
     private boolean oneClassPerRule;
 
@@ -863,15 +863,15 @@ public class PackageModel {
         return lambdaReturnTypes;
     }
 
-    public void addExprDebugInformation(String exprId, PredicateInformation predicateInformation) {
-        exprDebugInformationMap.put(exprId, predicateInformation);
+    public void indexConstraint(String exprId, PredicateInformation predicateInformation) {
+        allConstraintsMap.put(exprId, predicateInformation);
     }
 
-    public Optional<PredicateInformation> getExprDebugInformation(String exprId) {
-        return Optional.ofNullable(exprDebugInformationMap.get(exprId));
+    public Optional<PredicateInformation> findConstraintWithExprId(String exprId) {
+        return Optional.ofNullable(allConstraintsMap.get(exprId));
     }
 
-    public Map<String, PredicateInformation> getExprDebugInformationMap() {
-        return exprDebugInformationMap;
+    public Map<String, PredicateInformation> getAllConstraintsMap() {
+        return allConstraintsMap;
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -872,6 +872,6 @@ public class PackageModel {
     }
 
     public Map<String, PredicateInformation> getAllConstraintsMap() {
-        return allConstraintsMap;
+        return Collections.unmodifiableMap(allConstraintsMap);
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -425,7 +425,7 @@ public abstract class AbstractExpressionBuilder {
     protected String getExprId(SingleDrlxParseSuccess drlxParseResult) {
         String exprId = drlxParseResult.getExprId(context.getPackageModel().getExprIdGenerator());
 
-        context.getPackageModel().addExprDebugInformation(exprId, new PredicateInformation(
+        context.getPackageModel().indexConstraint(exprId, new PredicateInformation(
                 drlxParseResult.getOriginalDrlConstraint(),
                 context.getRuleName(),
                 context.getRuleName()

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -44,6 +44,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.Type;
+import org.drools.compiler.lang.descr.RuleDescr;
 import org.drools.model.Index;
 import org.drools.model.functions.PredicateInformation;
 import org.drools.modelcompiler.builder.errors.InvalidExpressionErrorResult;
@@ -57,6 +58,7 @@ import org.drools.modelcompiler.builder.generator.drlxparse.SingleDrlxParseSucce
 import org.drools.modelcompiler.util.ClassUtil;
 import org.drools.mvel.parser.ast.expr.BigDecimalLiteralExpr;
 import org.drools.mvel.parser.ast.expr.BigIntegerLiteralExpr;
+import org.kie.api.io.Resource;
 
 import static java.util.Optional.ofNullable;
 
@@ -422,13 +424,16 @@ public abstract class AbstractExpressionBuilder {
         return opt.get().equals(THIS_PLACEHOLDER);
     }
 
-    protected String getExprId(SingleDrlxParseSuccess drlxParseResult) {
+    protected String createExprId(SingleDrlxParseSuccess drlxParseResult) {
         String exprId = drlxParseResult.getExprId(context.getPackageModel().getExprIdGenerator());
 
         context.getPackageModel().indexConstraint(exprId, new PredicateInformation(
                 drlxParseResult.getOriginalDrlConstraint(),
                 context.getRuleName(),
-                context.getRuleName()
+                Optional.ofNullable(context.getRuleDescr())
+                    .map(RuleDescr::getResource)
+                    .map(Resource::getSourcePath)
+                    .orElse("")
         ));
         return exprId;
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -45,6 +45,7 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.Type;
 import org.drools.model.Index;
+import org.drools.model.functions.PredicateInformation;
 import org.drools.modelcompiler.builder.errors.InvalidExpressionErrorResult;
 import org.drools.modelcompiler.builder.generator.DeclarationSpec;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
@@ -419,5 +420,16 @@ public abstract class AbstractExpressionBuilder {
             return false;
         }
         return opt.get().equals(THIS_PLACEHOLDER);
+    }
+
+    protected String getExprId(SingleDrlxParseSuccess drlxParseResult) {
+        String exprId = drlxParseResult.getExprId(context.getPackageModel().getExprIdGenerator());
+
+        context.getPackageModel().addExprDebugInformation(exprId, new PredicateInformation(
+                drlxParseResult.getOriginalDrlConstraint(),
+                context.getRuleName(),
+                context.getRuleName()
+        ));
+        return exprId;
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
@@ -109,7 +109,7 @@ public class FlowExpressionBuilder extends AbstractExpressionBuilder {
     }
 
     private MethodCallExpr buildSingleExpressionWithIndexing(SingleDrlxParseSuccess drlxParseResult) {
-        String exprId = getExprId(drlxParseResult);
+        String exprId = createExprId(drlxParseResult);
         MethodCallExpr exprDSL = new MethodCallExpr(null, EXPR_CALL);
         if (exprId != null && !"".equals(exprId)) {
             exprDSL.addArgument( new StringLiteralExpr(exprId) );

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/FlowExpressionBuilder.java
@@ -109,7 +109,7 @@ public class FlowExpressionBuilder extends AbstractExpressionBuilder {
     }
 
     private MethodCallExpr buildSingleExpressionWithIndexing(SingleDrlxParseSuccess drlxParseResult) {
-        String exprId = drlxParseResult.getExprId(context.getPackageModel().getExprIdGenerator());
+        String exprId = getExprId(drlxParseResult);
         MethodCallExpr exprDSL = new MethodCallExpr(null, EXPR_CALL);
         if (exprId != null && !"".equals(exprId)) {
             exprDSL.addArgument( new StringLiteralExpr(exprId) );

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
@@ -92,7 +92,7 @@ public class PatternExpressionBuilder extends AbstractExpressionBuilder {
     }
 
     private MethodCallExpr buildSingleExpressionWithIndexing(SingleDrlxParseSuccess drlxParseResult) {
-        String exprId = drlxParseResult.getExprId(context.getPackageModel().getExprIdGenerator());
+        String exprId = getExprId(drlxParseResult);
         MethodCallExpr exprDSL = new MethodCallExpr(null, EXPR_CALL);
         if (exprId != null && !"".equals(exprId)) {
             exprDSL.addArgument(new StringLiteralExpr(exprId));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
@@ -92,7 +92,7 @@ public class PatternExpressionBuilder extends AbstractExpressionBuilder {
     }
 
     private MethodCallExpr buildSingleExpressionWithIndexing(SingleDrlxParseSuccess drlxParseResult) {
-        String exprId = getExprId(drlxParseResult);
+        String exprId = createExprId(drlxParseResult);
         MethodCallExpr exprDSL = new MethodCallExpr(null, EXPR_CALL);
         if (exprId != null && !"".equals(exprId)) {
             exprDSL.addArgument(new StringLiteralExpr(exprId));

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/CreatedClass.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/CreatedClass.java
@@ -65,4 +65,8 @@ public class CreatedClass {
     public int hashCode() {
         return Objects.hash(compilationUnit, className, packageName);
     }
+
+    public CompilationUnit getCompilationUnit() {
+        return compilationUnit;
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/CreatedClass.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/CreatedClass.java
@@ -65,8 +65,4 @@ public class CreatedClass {
     public int hashCode() {
         return Objects.hash(compilationUnit, className, packageName);
     }
-
-    public CompilationUnit getCompilationUnit() {
-        return compilationUnit;
-    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessor.java
@@ -92,7 +92,7 @@ public class ExecModelLambdaPostProcessor {
         this.imports = pkgModel.getImports();
         this.staticImports = pkgModel.getStaticImports();
         this.lambdaReturnTypes = pkgModel.getLambdaReturnTypes();
-        this.debugPredicateInformation = pkgModel.getExprDebugInformationMap();
+        this.debugPredicateInformation = pkgModel.getAllConstraintsMap();
         this.clone = clone;
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessor.java
@@ -73,6 +73,7 @@ public class ExecModelLambdaPostProcessor {
     private final Collection<String> imports;
     private final Collection<String> staticImports;
     private final Map<LambdaExpr, java.lang.reflect.Type> lambdaReturnTypes;
+    private final Map<String, PredicateInformation> debugPredicateInformation;
     private final CompilationUnit clone;
 
     private static final PrettyPrinterConfiguration configuration = new PrettyPrinterConfiguration();
@@ -91,6 +92,7 @@ public class ExecModelLambdaPostProcessor {
         this.imports = pkgModel.getImports();
         this.staticImports = pkgModel.getStaticImports();
         this.lambdaReturnTypes = pkgModel.getLambdaReturnTypes();
+        this.debugPredicateInformation = pkgModel.getExprDebugInformationMap();
         this.clone = clone;
     }
 
@@ -100,6 +102,7 @@ public class ExecModelLambdaPostProcessor {
                                         Collection<String> imports,
                                         Collection<String> staticImports,
                                         Map<LambdaExpr, java.lang.reflect.Type> lambdaReturnTypes,
+                                        Map<String, PredicateInformation> debugPredicateInformation,
                                         CompilationUnit clone) {
         this.lambdaClasses = lambdaClasses;
         this.packageName = packageName;
@@ -107,6 +110,7 @@ public class ExecModelLambdaPostProcessor {
         this.imports = imports;
         this.staticImports = staticImports;
         this.lambdaReturnTypes = lambdaReturnTypes;
+        this.debugPredicateInformation = debugPredicateInformation;
         this.clone = clone;
     }
 
@@ -150,8 +154,8 @@ public class ExecModelLambdaPostProcessor {
     }
 
     private PredicateInformation getPredicateInformation(Optional<String> exprId) {
-
-        return PredicateInformation.EMPTY_PREDICATE_INFORMATION;
+        return exprId.flatMap(e -> Optional.ofNullable(debugPredicateInformation.get(e)))
+                .orElse(PredicateInformation.EMPTY_PREDICATE_INFORMATION);
     }
 
     private void convertTemporalExpr(MethodCallExpr methodCallExpr) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambda.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambda.java
@@ -78,7 +78,7 @@ abstract class MaterializedLambda {
 
         EnumDeclaration classDeclaration = create(compilationUnit);
 
-        createMethodDeclaration(classDeclaration);
+        createMethodsDeclaration(classDeclaration);
 
         String classHash = classHash(MATERIALIZED_LAMBDA_PRETTY_PRINTER.print(compilationUnit));
         String isolatedPackageName = getIsolatedPackageName(classHash);
@@ -170,7 +170,7 @@ abstract class MaterializedLambda {
 
     abstract ClassOrInterfaceType functionType();
 
-    abstract void createMethodDeclaration(EnumDeclaration classDeclaration);
+    abstract void createMethodsDeclaration(EnumDeclaration classDeclaration);
 
     static class LambdaParameter {
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequence.java
@@ -42,7 +42,7 @@ public class MaterializedLambdaConsequence extends MaterializedLambda {
     }
 
     @Override
-    void createMethodDeclaration(EnumDeclaration classDeclaration) {
+    void createMethodsDeclaration(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("execute", Modifier.Keyword.PUBLIC);
         methodDeclaration.setThrownExceptions(NodeList.nodeList(parseClassOrInterfaceType("java.lang.Exception")));
         methodDeclaration.addAnnotation("Override");

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaExtractor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaExtractor.java
@@ -43,7 +43,7 @@ public class MaterializedLambdaExtractor extends MaterializedLambda {
     }
 
     @Override
-    void createMethodDeclaration(EnumDeclaration classDeclaration) {
+    void createMethodsDeclaration(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("apply", Modifier.Keyword.PUBLIC);
         methodDeclaration.addAnnotation("Override");
         methodDeclaration.setType(returnTypeJP());

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -76,9 +76,9 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
         methodDeclaration.setType(predicateInformationType);
 
         ObjectCreationExpr newPredicateInformation = new ObjectCreationExpr(null, predicateInformationType, NodeList.nodeList(
-            new StringLiteralExpr(predicateInformation.getStringConstraint()),
-            new StringLiteralExpr(predicateInformation.getRuleName()),
-            new StringLiteralExpr(predicateInformation.getRuleFileName())
+            new StringLiteralExpr().setString(predicateInformation.getStringConstraint()),
+            new StringLiteralExpr().setString(predicateInformation.getRuleName()),
+            new StringLiteralExpr().setString(predicateInformation.getRuleFileName())
         ));
         methodDeclaration.setBody(new BlockStmt(NodeList.nodeList(new ReturnStmt(newPredicateInformation))));
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -28,7 +28,6 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
-import com.github.javaparser.ast.type.Type;
 import org.drools.model.functions.PredicateInformation;
 
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
@@ -51,13 +50,13 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
 
     @Override
     void createMethodsDeclaration(EnumDeclaration classDeclaration) {
-        testMethod(classDeclaration);
+        createTestMethod(classDeclaration);
         if(!predicateInformation.isEmpty()) {
-            predicateInformationMethod(classDeclaration);
+            createPredicateInformationMethod(classDeclaration);
         }
     }
 
-    private void testMethod(EnumDeclaration classDeclaration) {
+    private void createTestMethod(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("test", Modifier.Keyword.PUBLIC);
         methodDeclaration.setThrownExceptions(NodeList.nodeList(parseClassOrInterfaceType("java.lang.Exception")));
         methodDeclaration.addAnnotation("Override");
@@ -69,7 +68,7 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
         methodDeclaration.setBody(new BlockStmt(NodeList.nodeList(new ReturnStmt(clone.getExpression()))));
     }
 
-    private void predicateInformationMethod(EnumDeclaration classDeclaration) {
+    private void createPredicateInformationMethod(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("predicateInformation", Modifier.Keyword.PUBLIC);
         methodDeclaration.addAnnotation("Override");
         ClassOrInterfaceType predicateInformationType = (ClassOrInterfaceType) parseType(PredicateInformation.class.getCanonicalName());

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -21,20 +21,27 @@ import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.Type;
+import org.drools.model.functions.PredicateInformation;
 
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 
 public class MaterializedLambdaPredicate extends MaterializedLambda {
 
     private final static String CLASS_NAME_PREFIX = "LambdaPredicate";
+    private PredicateInformation predicateInformation;
 
-    MaterializedLambdaPredicate(String packageName, String ruleClassName) {
+    MaterializedLambdaPredicate(String packageName, String ruleClassName, PredicateInformation predicateInformation) {
         super(packageName, ruleClassName);
+        this.predicateInformation = predicateInformation;
     }
 
     @Override
@@ -43,7 +50,12 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
     }
 
     @Override
-    void createMethodDeclaration(EnumDeclaration classDeclaration) {
+    void createMethodsDeclaration(EnumDeclaration classDeclaration) {
+        testMethod(classDeclaration);
+        predicateInformationMethod(classDeclaration);
+    }
+
+    private void testMethod(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("test", Modifier.Keyword.PUBLIC);
         methodDeclaration.setThrownExceptions(NodeList.nodeList(parseClassOrInterfaceType("java.lang.Exception")));
         methodDeclaration.addAnnotation("Override");
@@ -53,6 +65,20 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
 
         ExpressionStmt clone = (ExpressionStmt) lambdaExpr.getBody().clone();
         methodDeclaration.setBody(new BlockStmt(NodeList.nodeList(new ReturnStmt(clone.getExpression()))));
+    }
+
+    private void predicateInformationMethod(EnumDeclaration classDeclaration) {
+        MethodDeclaration methodDeclaration = classDeclaration.addMethod("predicateInformation", Modifier.Keyword.PUBLIC);
+        methodDeclaration.addAnnotation("Override");
+        ClassOrInterfaceType predicateInformationType = (ClassOrInterfaceType) parseType(PredicateInformation.class.getCanonicalName());
+        methodDeclaration.setType(predicateInformationType);
+
+        ObjectCreationExpr newPredicateInformation = new ObjectCreationExpr(null, predicateInformationType, NodeList.nodeList(
+            new StringLiteralExpr(predicateInformation.getStringConstraint()),
+            new StringLiteralExpr(predicateInformation.getRuleName()),
+            new StringLiteralExpr(predicateInformation.getRuleFileName())
+        ));
+        methodDeclaration.setBody(new BlockStmt(NodeList.nodeList(new ReturnStmt(newPredicateInformation))));
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -36,8 +36,8 @@ import static com.github.javaparser.StaticJavaParser.parseType;
 
 public class MaterializedLambdaPredicate extends MaterializedLambda {
 
-    private final static String CLASS_NAME_PREFIX = "LambdaPredicate";
-    private PredicateInformation predicateInformation;
+    private static final String CLASS_NAME_PREFIX = "LambdaPredicate";
+    private final PredicateInformation predicateInformation;
 
     MaterializedLambdaPredicate(String packageName, String ruleClassName, PredicateInformation predicateInformation) {
         super(packageName, ruleClassName);
@@ -52,7 +52,9 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
     @Override
     void createMethodsDeclaration(EnumDeclaration classDeclaration) {
         testMethod(classDeclaration);
-        predicateInformationMethod(classDeclaration);
+        if(!predicateInformation.isEmpty()) {
+            predicateInformationMethod(classDeclaration);
+        }
     }
 
     private void testMethod(EnumDeclaration classDeclaration) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -2402,7 +2402,7 @@ public class CompilerTest extends BaseModelTest {
     @Test
     public void testNPEOnConstraint() {
         exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(startsWith("Error evaluating constraint 'money < salary * 20' in"));
+        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]"));
 
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -2395,6 +2395,7 @@ public class CompilerTest extends BaseModelTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
+    @Ignore
     public void testNPEOnConstraint() {
         exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]");

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -43,7 +43,9 @@ import org.drools.modelcompiler.domain.Toy;
 import org.drools.modelcompiler.domain.Woman;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessContext;
@@ -2387,5 +2389,28 @@ public class CompilerTest extends BaseModelTest {
         ksession.fireAllRules();
 
         Assertions.assertThat(list).containsExactly("John");
+    }
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testNPEOnConstraint() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]");
+
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                        "rule R when\n" +
+                        "  $p : Person(money < salary * 20 )\n" +
+                        "then\n" +
+                        "end";
+
+        KieSession ksession = getKieSession( str );
+
+        Person me = new Person( "Luca");
+        me.setMoney(null);
+        ksession.insert( me );
+        ksession.fireAllRules();
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -2395,7 +2395,6 @@ public class CompilerTest extends BaseModelTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    @Ignore
     public void testNPEOnConstraint() {
         exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]");

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -52,6 +52,10 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessContext;
 import org.kie.api.runtime.rule.FactHandle;
 
+import static org.drools.core.base.evaluators.StrEvaluatorDefinition.Operations.startsWith;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -2396,10 +2400,9 @@ public class CompilerTest extends BaseModelTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    @Ignore
     public void testNPEOnConstraint() {
         exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]");
+        exceptionRule.expectMessage(startsWith("Error evaluating constraint 'money < salary * 20' in"));
 
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import org.assertj.core.api.Assertions;
 import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.Adult;
@@ -2395,6 +2396,7 @@ public class CompilerTest extends BaseModelTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
+    @Ignore
     public void testNPEOnConstraint() {
         exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage("Error evaluating constraint 'money < salary * 20' in [Rule \"R\" in r0.drl]");
@@ -2412,5 +2414,23 @@ public class CompilerTest extends BaseModelTest {
         me.setMoney(null);
         ksession.insert( me );
         ksession.fireAllRules();
+    }
+
+    @Test
+    public void testWithQuotedStringConcatenationOnConstraint() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                        "rule R when\n" +
+                        "  $p : Person(name == \"Luca\" + \" II\"  )\n" +
+                        "then\n" +
+                        "end";
+
+        KieSession ksession = getKieSession( str );
+
+        Person me = new Person( "Luca II");
+        me.setMoney(null);
+        ksession.insert( me );
+        int rulesFired = ksession.fireAllRules();
+        assertEquals(rulesFired, 1);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
@@ -28,7 +28,7 @@ public class ExecModelLambdaPostProcessorTest {
         CompilationUnit inputCU = parseResource("org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java");
         CompilationUnit clone = inputCU.clone();
 
-        new ExecModelLambdaPostProcessor(new HashMap<>(), "mypackage", "rulename", new ArrayList<>(), new ArrayList<>(), new HashMap<>(), clone).convertLambdas();
+        new ExecModelLambdaPostProcessor(new HashMap<>(), "mypackage", "rulename", new ArrayList<>(), new ArrayList<>(), new HashMap<>(), new HashMap<>(), clone).convertLambdas();
 
         String PATTERN_HARNESS = "PatternTestHarness";
         MethodDeclaration expectedResult = getMethodChangingName(inputCU, PATTERN_HARNESS, "expectedOutput");

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
@@ -34,6 +34,7 @@ public class ExecModelLambdaPostProcessorTest {
         MethodDeclaration expectedResult = getMethodChangingName(inputCU, PATTERN_HARNESS, "expectedOutput");
         MethodDeclaration actual = getMethodChangingName(clone, PATTERN_HARNESS, "inputMethod");
 
+//        assertEquals(expectedResult, actual); // better diff - fails on String equals
         assertThat(actual.toString(), equalToIgnoringWhiteSpace(expectedResult.toString()));
     }
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import static com.github.javaparser.StaticJavaParser.parseResource;
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class ExecModelLambdaPostProcessorTest {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/ExecModelLambdaPostProcessorTest.java
@@ -11,9 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.github.javaparser.StaticJavaParser.parseResource;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.drools.modelcompiler.util.lambdareplace.MaterializedLambdaTestUtils.verifyCreatedClass;
 
 public class ExecModelLambdaPostProcessorTest {
 
@@ -34,8 +32,7 @@ public class ExecModelLambdaPostProcessorTest {
         MethodDeclaration expectedResult = getMethodChangingName(inputCU, PATTERN_HARNESS, "expectedOutput");
         MethodDeclaration actual = getMethodChangingName(clone, PATTERN_HARNESS, "inputMethod");
 
-//        assertEquals(expectedResult, actual); // better diff - fails on String equals
-        assertThat(actual.toString(), equalToIgnoringWhiteSpace(expectedResult.toString()));
+        verifyCreatedClass(expectedResult, actual);
     }
 
     private MethodDeclaration getMethodChangingName(CompilationUnit inputCU, String className, String methodName) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
@@ -6,8 +6,7 @@ import java.util.Collections;
 
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.*;
+import static org.drools.modelcompiler.util.lambdareplace.MaterializedLambdaTestUtils.verifyCreatedClass;
 
 public class MaterializedLambdaConsequenceTest {
 
@@ -32,8 +31,7 @@ public class MaterializedLambdaConsequenceTest {
                 "        }\n" +
                 "    }\n";
 
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
-
+        verifyCreatedClass(aClass, expectedResult);
     }
 
     @Test
@@ -65,7 +63,7 @@ public class MaterializedLambdaConsequenceTest {
                 "        }\n" +
                 "    }\n";
 
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+        verifyCreatedClass(aClass, expectedResult);
     }
 
     @Test
@@ -109,7 +107,7 @@ public class MaterializedLambdaConsequenceTest {
                 "    }\n" +
                 "}";
 
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+        verifyCreatedClass(aClass, expectedResult);
     }
 
     @Test
@@ -149,6 +147,6 @@ public class MaterializedLambdaConsequenceTest {
                 "    }\n" +
                 "}";
 
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+        verifyCreatedClass(aClass, expectedResult);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaExtractorTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaExtractorTest.java
@@ -4,8 +4,7 @@ import java.util.ArrayList;
 
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.*;
+import static org.drools.modelcompiler.util.lambdareplace.MaterializedLambdaTestUtils.verifyCreatedClass;
 
 public class MaterializedLambdaExtractorTest {
 
@@ -30,6 +29,6 @@ public class MaterializedLambdaExtractorTest {
                 "        }\n" +
                 "    }\n";
 
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+        verifyCreatedClass(aClass, expectedResult);
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
@@ -5,8 +5,7 @@ import java.util.ArrayList;
 import org.drools.model.functions.PredicateInformation;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.assertThat;
+import static org.drools.modelcompiler.util.lambdareplace.MaterializedLambdaTestUtils.verifyCreatedClass;
 
 
 public class MaterializedLambdaPredicateTest {
@@ -38,8 +37,7 @@ public class MaterializedLambdaPredicateTest {
                 "        }\n" +
                 "    }\n";
 
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
-
+        verifyCreatedClass(aClass, expectedResult);
     }
 
     @Test
@@ -63,8 +61,7 @@ public class MaterializedLambdaPredicateTest {
                 "        }\n" +
                 "    }\n";
 
-//        assertEquals(StaticJavaParser.parse(expectedResult), aClass.getCompilationUnit()); // Better diff
-        assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
-
+        verifyCreatedClass(aClass, expectedResult);
     }
+
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
@@ -2,6 +2,7 @@ package org.drools.modelcompiler.util.lambdareplace;
 
 import java.util.ArrayList;
 
+import org.drools.model.functions.PredicateInformation;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
@@ -12,22 +13,28 @@ public class MaterializedLambdaPredicateTest {
 
     @Test
     public void createClassWithOneParameter() {
-        CreatedClass aClass = new MaterializedLambdaPredicate("org.drools.modelcompiler.util.lambdareplace", "rulename")
+        CreatedClass aClass = new MaterializedLambdaPredicate("org.drools.modelcompiler.util.lambdareplace",
+                                                              "rulename",
+                                                              new PredicateInformation("p.age > 35", "rule1", "rulefilename.drl"))
                 .create("(org.drools.modelcompiler.domain.Person p) -> p.getAge() > 35", new ArrayList<>(), new ArrayList());
 
         //language=JAVA
         String expectedResult = "" +
-                "package org.drools.modelcompiler.util.lambdareplace.P76;\n" +
+                "package org.drools.modelcompiler.util.lambdareplace.P19;\n" +
                 "import static rulename.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "" +
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaPredicate76225D48A900C3A3B5A4F199EDD5E88A implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person> {\n" +
+                "public enum LambdaPredicate199715077FD778E73FC7EC5041C3B4ED implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person> {\n" +
                 " INSTANCE; \n" +
                 "public static final String EXPRESSION_HASH = \"4DEB93975D9859892B1A5FD4B38E2155\";" +
                 "        @Override()\n" +
                 "        public boolean test(org.drools.modelcompiler.domain.Person p) throws java.lang.Exception {\n" +
                 "            return p.getAge() > 35;\n" +
+                "        }\n" +
+                "        @Override()\n" +
+                "        public org.drools.model.functions.PredicateInformation predicateInformation() {\n" +
+                "            return new org.drools.model.functions.PredicateInformation(\"p.age > 35\", \"rule1\", \"rulefilename.drl\");" +
                 "        }\n" +
                 "    }\n";
 
@@ -37,7 +44,7 @@ public class MaterializedLambdaPredicateTest {
 
     @Test
     public void createClassWithTwoParameters() {
-        CreatedClass aClass = new MaterializedLambdaPredicate("org.drools.modelcompiler.util.lambdareplace", "rulename")
+        CreatedClass aClass = new MaterializedLambdaPredicate("org.drools.modelcompiler.util.lambdareplace", "rulename", PredicateInformation.EMPTY_PREDICATE_INFORMATION)
                 .create("(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) -> p1.getAge() > p2.getAge()", new ArrayList<>(), new ArrayList());
 
         //language=JAVA

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
@@ -63,6 +63,7 @@ public class MaterializedLambdaPredicateTest {
                 "        }\n" +
                 "    }\n";
 
+//        assertEquals(StaticJavaParser.parse(expectedResult), aClass.getCompilationUnit()); // Better diff
         assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
 
     }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaTestUtils.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaTestUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.util.lambdareplace;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import org.hamcrest.MatcherAssert;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertEquals;
+
+/* The diff produced while using equalToIgnoringWhiteSpace is abysmal but is correct, while the one
+ * produced by JavaParser's equals is better but it fails also on identical ASTs.
+ * By using this method to verify produced classes we've got the best of two worlds
+ */
+public class MaterializedLambdaTestUtils {
+
+
+    public static void verifyCreatedClass(CreatedClass aClass, String expectedResult) {
+        try {
+            MatcherAssert.assertThat(aClass.getCompilationUnitAsString(), equalToIgnoringWhiteSpace(expectedResult));
+        } catch (AssertionError e) {
+            assertEquals(StaticJavaParser.parse(expectedResult), aClass.getCompilationUnit());
+        }
+    }
+
+    public static void verifyCreatedClass(MethodDeclaration expected, MethodDeclaration actual) {
+        try {
+            MatcherAssert.assertThat(actual.toString(), equalToIgnoringWhiteSpace(expected.toString()));
+        } catch (AssertionError e) {
+            MatcherAssert.assertThat(actual, equalTo(expected));
+        }
+    }
+}

--- a/drools-model/drools-model-compiler/src/test/resources/logback-test.xml
+++ b/drools-model/drools-model-compiler/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
   <logger name="org.kie" level="info"/>
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <!--<logger name="org.drools.modelcompiler.builder.generator.expressiontyper" level="debug"/>-->
-  <logger name="org.drools.modelcompiler.builder" level="debug"/>
+<!--  <logger name="org.drools.modelcompiler.builder" level="debug"/>-->
   <logger name="org.drools.ancompiler" level="info"/>
 
   <logger name="org.drools" level="info"/>

--- a/drools-model/drools-model-compiler/src/test/resources/logback-test.xml
+++ b/drools-model/drools-model-compiler/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
   <logger name="org.kie" level="info"/>
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <!--<logger name="org.drools.modelcompiler.builder.generator.expressiontyper" level="debug"/>-->
-<!--  <logger name="org.drools.modelcompiler.builder" level="debug"/>-->
+  <logger name="org.drools.modelcompiler.builder" level="debug"/>
   <logger name="org.drools.ancompiler" level="info"/>
 
   <logger name="org.drools" level="info"/>

--- a/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
+++ b/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
@@ -46,14 +46,14 @@ class PatternTestHarness {
         Rule rule = rule("beta")
                 .build(
                         pattern(markV)
-                                .expr("exprA", mypackage.P67.LambdaPredicate6747C0A7EC77FAA24F45371866DD66D8.INSTANCE,
+                                .expr("exprA", mypackage.PB4.LambdaPredicateB4BD3C13169578B6FA8E952113BF43FE.INSTANCE,
                                       alphaIndexedBy(String.class, Index.ConstraintType.EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name", "age")),
                         pattern(olderV)
-                                .expr("exprB", mypackage.PA0.LambdaPredicateA0BDDB1AA0D6B30378010D68BB6F15C5.INSTANCE,
+                                .expr("exprB", mypackage.PAA.LambdaPredicateAA0174191F4A6806B804030B95638BF9.INSTANCE,
                                       alphaIndexedBy(String.class, Index.ConstraintType.NOT_EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name"))
-                                .expr("exprC", markV,  mypackage.P30.LambdaPredicate3090CBA8A26410ED75B8E749F8C07F68.INSTANCE,
+                                .expr("exprC", markV,  mypackage.PC0.LambdaPredicateC06E24C125614C09F9319B8C2B0D7A08.INSTANCE,
                                       betaIndexedBy(int.class, Index.ConstraintType.GREATER_THAN, 0, mypackage.P6F.LambdaExtractor6F66D90C869211C6AEC2E67F99D874D8.INSTANCE, mypackage.P6F.LambdaExtractor6F66D90C869211C6AEC2E67F99D874D8.INSTANCE),
                                       reactOn("age")),
                         on(olderV, markV).execute(mypackage.P73.LambdaConsequence73B957CDB8CD5D5A17BDA94A7D62ED86.INSTANCE)

--- a/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
+++ b/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
@@ -46,7 +46,7 @@ class PatternTestHarness {
         Rule rule = rule("beta")
                 .build(
                         pattern(markV)
-                                .expr("exprA", mypackage.PB4.LambdaPredicateB4BD3C13169578B6FA8E952113BF43FE.INSTANCE,
+                                .expr("exprA", mypackage.P67.LambdaPredicate6747C0A7EC77FAA24F45371866DD66D8.INSTANCE,
                                       alphaIndexedBy(String.class, Index.ConstraintType.EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name", "age")),
                         pattern(olderV)

--- a/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
+++ b/drools-model/drools-model-compiler/src/test/resources/org/drools/modelcompiler/util/lambdareplace/PatternTestHarness.java
@@ -50,10 +50,10 @@ class PatternTestHarness {
                                       alphaIndexedBy(String.class, Index.ConstraintType.EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name", "age")),
                         pattern(olderV)
-                                .expr("exprB", mypackage.PAA.LambdaPredicateAA0174191F4A6806B804030B95638BF9.INSTANCE,
+                                .expr("exprB", mypackage.PA0.LambdaPredicateA0BDDB1AA0D6B30378010D68BB6F15C5.INSTANCE,
                                       alphaIndexedBy(String.class, Index.ConstraintType.NOT_EQUAL, 1, mypackage.PF1.LambdaExtractorF1957A9B73DCC850FB61E5A94549014A.INSTANCE, "Mark"),
                                       reactOn("name"))
-                                .expr("exprC", markV,  mypackage.PC0.LambdaPredicateC06E24C125614C09F9319B8C2B0D7A08.INSTANCE,
+                                .expr("exprC", markV,  mypackage.P30.LambdaPredicate3090CBA8A26410ED75B8E749F8C07F68.INSTANCE,
                                       betaIndexedBy(int.class, Index.ConstraintType.GREATER_THAN, 0, mypackage.P6F.LambdaExtractor6F66D90C869211C6AEC2E67F99D874D8.INSTANCE, mypackage.P6F.LambdaExtractor6F66D90C869211C6AEC2E67F99D874D8.INSTANCE),
                                       reactOn("age")),
                         on(olderV, markV).execute(mypackage.P73.LambdaConsequence73B957CDB8CD5D5A17BDA94A7D62ED86.INSTANCE)


### PR DESCRIPTION
Each time we create an expression (`expr`) in the executable model we index it in the PackageModel using the exprId as the key.

In the lambda extractor post processing, we therefore use such map to add the original MVEL constraint to the materialized lambda, this information is propagated in every constraint until we can print it in the `.isAllowed` method of the `LambdaConstraint` in case of an error.

In this `PredicateInformation` class there is currently the support for the rule name and the rule file, but it's not as significant as it could be as an identical constraint would be shared among two rules, so it will return the last added to the map. It's still useful because it gives you an occurrence of a used constraint, but it doesn't tell you every place where it's used.

WDYT?

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/KOGITO-2836

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
