### PR TITLE
RHPAM-3226 show example test using sys properties instead of kmodule.xml

### DIFF
--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
@@ -16,45 +16,73 @@
 
 package org.kie.dmn.core.classloader;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.runtime.KieContainer;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
-import org.kie.dmn.api.core.event.AfterEvaluateDecisionEvent;
 import org.kie.dmn.core.api.DMNFactory;
-import org.kie.dmn.core.api.event.DefaultDMNRuntimeEventListener;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertTrue;
 
 public class DMNRuntimeListenerPropertyTest {
 
     public static final Logger LOG = LoggerFactory.getLogger(DMNRuntimeListenerPropertyTest.class);
 
-    public static class TestPropertyListener extends DefaultDMNRuntimeEventListener {
-        private static final List<Object> results = new ArrayList<>();
-
-        @Override
-        public void afterEvaluateDecision(AfterEvaluateDecisionEvent event) {
-            results.add(event.getResult().getDecisionResultByName(event.getDecision().getName()).getResult());
-        }
-    }
-
     @Test
     public void test() {
         final String LISTENER_KEY = "org.kie.dmn.runtime.listeners.DMNRuntimeListenerPropertyTest";
-        System.setProperty(LISTENER_KEY, TestPropertyListener.class.getCanonicalName());
+        final String LISTENER_VALUE = "com.acme.TestPropertyListener";
+        System.setProperty(LISTENER_KEY, LISTENER_VALUE);
         try {
-            final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Greetings.dmn", this.getClass());
+            final String javaSource = "package com.acme;\n" +
+                                      "\n" +
+                                      "public class TestPropertyListener implements org.kie.dmn.api.core.event.DMNRuntimeEventListener {\n" +
+                                      "\n" +
+                                      "    private static final java.util.List<Object> results = new java.util.concurrent.CopyOnWriteArrayList<>();\n" +
+                                      "\n" +
+                                      "    @Override\n" +
+                                      "    public void afterEvaluateDecision(org.kie.dmn.api.core.event.AfterEvaluateDecisionEvent event) {\n" +
+                                      "        results.add(event.getResult().getDecisionResultByName(event.getDecision().getName()).getResult());\n" +
+                                      "    }\n" +
+                                      "\n" +
+                                      "    public java.util.List<Object> getResults() {\n" +
+                                      "        return java.util.Collections.unmodifiableList(results);\n" +
+                                      "    }\n" +
+                                      "}";
+            LOG.debug("javaSource:\n{}", javaSource);
+            final KieServices ks = KieServices.Factory.get();
+            ReleaseId releaseId = ks.newReleaseId("org.kie", "dmn-test-" + UUID.randomUUID(), "1.0");
+
+            final KieFileSystem kfs = ks.newKieFileSystem();
+            kfs.write("src/main/java/com/acme/TestPropertyListener.java", javaSource);
+            kfs.write(ks.getResources().newClassPathResource("Greetings.dmn", this.getClass()));
+            kfs.generateAndWritePomXML(releaseId);
+
+            final KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
+            assertTrue(kieBuilder.getResults().getMessages().toString(), kieBuilder.getResults().getMessages().isEmpty());
+
+            final KieContainer kieContainer = ks.newKieContainer(releaseId);
+
+            final DMNRuntime runtime = DMNRuntimeUtil.typeSafeGetKieRuntime(kieContainer);
+            Assert.assertNotNull(runtime);
+
             final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_2027051c-0030-40f1-8b96-1b1422f8b257", "Drawing 1");
             assertThat(dmnModel, notNullValue());
             assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
@@ -65,7 +93,12 @@ public class DMNRuntimeListenerPropertyTest {
             final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
             assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
 
-            assertThat(TestPropertyListener.results).contains("Hello John Doe");
+            Object listenerInstance = kieContainer.getClassLoader().loadClass(LISTENER_VALUE).newInstance();
+            @SuppressWarnings("unchecked") // this was by necessity classloaded
+            List<Object> results = (List<Object>) listenerInstance.getClass().getMethod("getResults").invoke(listenerInstance);
+            assertThat(results, contains("Hello John Doe"));
+        } catch (Exception e) {
+            e.printStackTrace();
         } finally {
             System.clearProperty(LISTENER_KEY);
         }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerPropertyTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.core.classloader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionEvent;
+import org.kie.dmn.core.api.DMNFactory;
+import org.kie.dmn.core.api.event.DefaultDMNRuntimeEventListener;
+import org.kie.dmn.core.util.DMNRuntimeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class DMNRuntimeListenerPropertyTest {
+
+    public static final Logger LOG = LoggerFactory.getLogger(DMNRuntimeListenerPropertyTest.class);
+
+    public static class TestPropertyListener extends DefaultDMNRuntimeEventListener {
+        private static final List<Object> results = new ArrayList<>();
+
+        @Override
+        public void afterEvaluateDecision(AfterEvaluateDecisionEvent event) {
+            results.add(event.getResult().getDecisionResultByName(event.getDecision().getName()).getResult());
+        }
+    }
+
+    @Test
+    public void test() {
+        final String LISTENER_KEY = "org.kie.dmn.runtime.listeners.DMNRuntimeListenerPropertyTest";
+        System.setProperty(LISTENER_KEY, TestPropertyListener.class.getCanonicalName());
+        try {
+            final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("Greetings.dmn", this.getClass());
+            final DMNModel dmnModel = runtime.getModel("http://www.trisotech.com/definitions/_2027051c-0030-40f1-8b96-1b1422f8b257", "Drawing 1");
+            assertThat(dmnModel, notNullValue());
+            assertThat(DMNRuntimeUtil.formatMessages(dmnModel.getMessages()), dmnModel.hasErrors(), is(false));
+
+            final DMNContext context = DMNFactory.newContext();
+            context.set("Name", "John Doe");
+
+            final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
+            assertThat(DMNRuntimeUtil.formatMessages(dmnResult.getMessages()), dmnResult.hasErrors(), is(false));
+
+            assertThat(TestPropertyListener.results).contains("Hello John Doe");
+        } finally {
+            System.clearProperty(LISTENER_KEY);
+        }
+    }
+}


### PR DESCRIPTION
Demonstrates a test using the system properties, although that is totally equivalent for drools kiebuilder internals to https://github.com/kiegroup/drools/blob/9fad66b15d8e48aa9a58a22a8e0617a83ffe9aa1/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/classloader/DMNRuntimeListenerTest.java#L109

**JIRA**: https://issues.redhat.com/browse/RHPAM-3226

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
