### PR TITLE
[DROOLS-5781] Wrong count when accumulate contains "and exists"

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/KiePackagesBuilder.java
@@ -723,7 +723,11 @@ public class KiePackagesBuilder {
 
     private void buildExistentialPatternImpl( RuleContext ctx, GroupElement group, GroupElement allSubConditions, Condition condition ) {
         ExistentialPatternImpl existentialPattern = (ExistentialPatternImpl) condition;
-        recursivelyAddConditions(ctx, group, allSubConditions, existentialPattern.getSubConditions().iterator().next());
+
+        GroupElement existGroupElement = new GroupElement(GroupElement.Type.EXISTS);
+        allSubConditions.addChild(existGroupElement);
+
+        recursivelyAddConditions(ctx, existGroupElement, existGroupElement, existentialPattern.getSubConditions().iterator().next());
     }
 
     private void buildCompositePatterns( RuleContext ctx, GroupElement group, GroupElement allSubConditions, Condition condition ) {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-5781

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
