### PR TITLE
[JBPM-9454] Enable multiple mapped variables

### DIFF
--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/VariableEntity.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/VariableEntity.java
@@ -20,10 +20,12 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.CascadeType;
+import javax.persistence.ConstraintMode;
 import javax.persistence.JoinColumn;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 
 @MappedSuperclass
 public abstract class VariableEntity implements Serializable {

--- a/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/VariableEntity.java
+++ b/drools-persistence/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/VariableEntity.java
@@ -29,7 +29,7 @@ import javax.persistence.FetchType;
 public abstract class VariableEntity implements Serializable {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    @JoinColumn(name = "MAP_VAR_ID", nullable = true)
+    @JoinColumn(name = "MAP_VAR_ID", nullable = true, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Set<MappedVariable> mappedVariables;
 
     public Set<MappedVariable> getMappedVariables() {


### PR DESCRIPTION
In order to deploy multiple kjar having mapped variable or to have multiple entities in the same project, it's important to remove the foreign key constraints for mapped variables.

**Thank you for submitting this pull request**

**JIRA**: JBPM-9454

[JBPM-9454](https://issues.redhat.com/browse/JBPM-9454)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
