### PR TITLE
DROOLS-5794 LambdaReadAccessor hashCode uses toString on the Lambda

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaReadAccessor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaReadAccessor.java
@@ -53,6 +53,6 @@ public class LambdaReadAccessor extends BaseObjectClassFieldReader implements In
 
     @Override
     public int hashCode() {
-        return Objects.hash( super.hashCode(), lambda );
+        return Objects.hash(super.hashCode(), System.identityHashCode(lambda));
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5794

This in turn, for some lambdas, causes LambdaIntrospector to be used, which causes exceptions at runtime in native mode.

In this trivial PR, I have changed LambdaReadAccessor to use identityHashCode() instead of the lambda hashCode, which should avoid the issue in https://issues.redhat.com/browse/KOGITO-3577

relevant trace:

```
Caused by: java.lang.RuntimeException: java.lang.NoSuchMethodException: org.optaplanner.core.impl.score.stream.drools.common.rules.AbstractUniGroupByMutator$$Lambda$32c3a1ddb2f6da6ceeacbdadd46ec5994fb7d9e7.writeReplace()
	at org.drools.mvel.asm.LambdaIntrospector.extractLambda(LambdaIntrospector.java:84)
	at org.drools.mvel.asm.LambdaIntrospector.apply(LambdaIntrospector.java:55)
	at org.drools.mvel.asm.LambdaIntrospector.apply(LambdaIntrospector.java:35)
	at org.drools.model.functions.LambdaPrinter$LambdaVisitor.getLambdaFingerprint(LambdaPrinter.java:79)
	at org.drools.model.functions.LambdaPrinter.print(LambdaPrinter.java:27)
	at org.drools.model.functions.IntrospectableLambda.toString(IntrospectableLambda.java:34)
	at org.drools.model.functions.IntrospectableLambda.hashCode(IntrospectableLambda.java:48)
	at java.util.Arrays.hashCode(Arrays.java:4685)
	at java.util.Objects.hash(Objects.java:146)
	at org.drools.modelcompiler.constraints.LambdaReadAccessor.hashCode(LambdaReadAccessor.java:56)
	at org.drools.core.rule.Declaration.hashCode(Declaration.java:336)
	at java.util.Arrays.hashCode(Arrays.java:4685)
	at org.drools.core.rule.SingleAccumulate.hashCode(SingleAccumulate.java:190)
	at org.drools.core.reteoo.AccumulateNode.<init>(AccumulateNode.java:92)
```

the example in `process-optaplanner-quarkus` seems fixed by installing this patch and then running

```
./mvnw install -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman  -D=version.org.kie7=7.46.0-SNAPSHOT
```

however, this fix may cause other issues in turn (re: incremental compilation?), so this may be not a "proper" fix, but a workaround, so first of all, let's see if CI is green


