### PR TITLE
[DROOLS-5795] Disable LambdaReadAccessor hashcode based on LambdaIntr…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/CoreComponentsBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/base/CoreComponentsBuilder.java
@@ -46,6 +46,10 @@ public interface CoreComponentsBuilder {
         return Holder.cBuilder != null;
     }
 
+    static boolean isNativeImage() {
+        return IS_NATIVE_IMAGE;
+    }
+
     InternalReadAccessor getReadAcessor( String className, String expr, boolean typesafe, Class<?> returnType );
 
     Object evaluateMvelExpression( DialectRuntimeData data, ClassLoader classLoader, String expr );

--- a/drools-core/src/main/java/org/drools/core/util/Drools.java
+++ b/drools-core/src/main/java/org/drools/core/util/Drools.java
@@ -110,4 +110,8 @@ public class Drools {
     public static boolean hasMvel() {
         return CoreComponentsBuilder.present();
     }
+
+    public static boolean isNativeImage() {
+        return CoreComponentsBuilder.isNativeImage();
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaReadAccessor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaReadAccessor.java
@@ -22,6 +22,7 @@ import org.drools.core.base.ValueType;
 import org.drools.core.base.extractors.BaseObjectClassFieldReader;
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.spi.InternalReadAccessor;
+import org.drools.core.util.Drools;
 import org.drools.model.functions.Function1;
 
 public class LambdaReadAccessor extends BaseObjectClassFieldReader implements InternalReadAccessor {
@@ -53,6 +54,10 @@ public class LambdaReadAccessor extends BaseObjectClassFieldReader implements In
 
     @Override
     public int hashCode() {
-        return Objects.hash( super.hashCode(), lambda );
+        if(!Drools.isNativeImage()) {
+            return Objects.hash(super.hashCode(), lambda);
+        } else { // DROOLS-5795 disable hash code based on LambdaIntrospector as it's not supported by native image
+            return Objects.hash(super.hashCode(), System.identityHashCode(lambda));
+        }
     }
 }

--- a/drools-mvel/src/main/java/org/drools/mvel/asm/ClassGenerator.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/asm/ClassGenerator.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.drools.core.addon.TypeResolver;
 import org.drools.core.factmodel.ClassBuilderFactory;
 import org.drools.core.util.ClassUtils;
+import org.drools.core.util.Drools;
 import org.drools.reflective.util.ByteArrayClassLoader;
 import org.mvel2.asm.ClassWriter;
 import org.mvel2.asm.MethodVisitor;
@@ -112,12 +113,11 @@ public class ClassGenerator {
     private Class<?> clazz;
 
     private static class DefineMethodInitializer {
-        private static final String PROPERTY_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode";
 
         private static final Method defineClassMethod = createDefineMethod();
 
         private static Method createDefineMethod() {
-            if (inImageCode()) {
+            if (Drools.isNativeImage()) {
                 return null;
             }
 
@@ -128,10 +128,6 @@ public class ClassGenerator {
             } catch (NoSuchMethodException e) {
                 throw new RuntimeException(e);
             }
-        }
-
-        private static boolean inImageCode() {
-            return System.getProperty(PROPERTY_IMAGE_CODE_KEY) != null;
         }
     }
 


### PR DESCRIPTION
…ospector when using Native IMage


https://issues.redhat.com/browse/DROOLS-5795

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
