### PR TITLE
KOGITO-3778: Fix loading of classes from Spring Boot fat jars

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/NativeJavaCompiler.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/NativeJavaCompiler.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -355,7 +355,7 @@ public class NativeJavaCompiler extends AbstractJavaCompiler {
 
         private List<JavaFileObject> processJar(URL packageFolderURL) throws IOException {
             String jarUri = packageFolderURL.toExternalForm();
-            int separator = jarUri.indexOf('!');
+            int separator = jarUri.lastIndexOf('!');
             if (separator >= 0) {
                 jarUri = jarUri.substring(0, separator);
             }


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KOGITO-3778

### Description

We're building a KIE base in a Spring Boot application running as a fat executable JAR.

The KIE base is being built by OptaPlanner with exec model enabled:

```java
        KieServices kieServices = KieServices.Factory.get();
        KieResources kieResources = kieServices.getResources();
        KieFileSystem kieFileSystem = kieServices.newKieFileSystem();

        // write constraint.drl to kieFileSystem
        writeScoreDrlListToKieFileSystem(kieFileSystem, kieResources, classLoader);

        ...
        // set property reactivity to ALLOWED
        ...

        KieBuilder kieBuilder = kieServices.newKieBuilder(kieFileSystem);
        kieBuilder.buildAll(ExecutableModelProject.class);
```

`kieBuilder.buildAll()` generates some classes and compiles them in runtime. The generated classes depend on `drools-model` and we get errors like this:

```
Message [id=1, level=ERROR, path=src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java, line=10, column=98
   text=cannot access org.drools.model.functions.Function1
  bad class file: file:/home/jlocker/src/github.com/issue-reproducer/target/drools-executable-reproducer-1.0-SNAPSHOT.jar!/org/drools/model/functions/Function1.class
    unable to access file: java.io.FileNotFoundException: JAR entry org/drools/model/functions/Function1.class not found in /home/jlocker/src/github.com/issue-reproducer/target/drools-executable-reproducer-1.0-SNAPSHOT.jar
```

<details>
<summary>
More
</summary>
<pre>Failed to instantiate [org.optaplanner.core.api.solver.SolverManager]: Factory method 'solverManager' threw exception;
nested exception is java.lang.IllegalStateException: There are errors in a score DRL:
Error Messages:
Message [id=1, level=ERROR, path=src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java, line=10, column=98
   text=cannot access org.drools.model.functions.Function1
  bad class file: file:/home/jlocker/src/github.com/issue-reproducer/target/drools-executable-reproducer-1.0-SNAPSHOT.jar!/org/drools/model/functions/Function1.class
    unable to access file: java.io.FileNotFoundException: JAR entry org/drools/model/functions/Function1.class not found in /home/jlocker/src/github.com/issue-reproducer/target/drools-executable-reproducer-1.0-SNAPSHOT.jar
    Please remove or make sure it appears in the correct subdirectory of the classpath.]
Message [id=2, level=ERROR, path=src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java, line=9, column=33
   text=cannot access org.drools.compiler.kie.builder.MaterializedLambda
  bad class file: file:/home/jlocker/src/github.com/issue-reproducer/target/drools-executable-reproducer-1.0-SNAPSHOT.jar!/org/drools/compiler/kie/builder/MaterializedLambda.class
    unable to access file: java.io.FileNotFoundException: JAR entry org/drools/compiler/kie/builder/MaterializedLambda.class not found in /home/jlocker/src/github.com/issue-reproducer/target/drools-executable-reproducer-1.0-SNAPSHOT.jar
    Please remove or make sure it appears in the correct subdirectory of the classpath.]
Message [id=3, level=ERROR, path=src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java, line=16, column=5
   text=method does not override or implement a method from a supertype]
Message [id=4, level=ERROR, path=src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java, line=0, column=0
   text=Java source of src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java in error:
package org.optaplanner.drools.component.PE9;
</pre>
</details>



`src/main/java/org/optaplanner/drools/component/PE9/LambdaExtractorE91637EEC6EB105FB8D9444E011B4D80.java` is one of the generated java sources that needs to be compiled. It implements `org.drools.model.functions.Function1`. That class' location in the fat jar actually is:
```
jar:file:/home/.../target/drools-executable-reproducer-1.0-SNAPSHOT.jar!/BOOT-INF/lib/drools-canonical-model-7.46.0-SNAPSHOT.jar!/org/drools/model/functions
```

So within the exec jar, there is a `BOOT-INF/lib` dir which contains `drools-canonical-model` (and other jars) and that contains `Function1.class`.

`org.drools.compiler.commons.jci.compilers.NativeJavaCompiler` has a file manager that needs to [list classes by package](https://github.com/kiegroup/drools/blob/7.45.0.Final/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/NativeJavaCompiler.java#L301).

For example it asks the classloader for resources URLs matching the `org.drools.model.functions` and `org.springframework.boot.loader.LaunchedURLClassLoader` answers with `jar:file:/home/.../drools-executable-reproducer-1.0-SNAPSHOT.jar!/BOOT-INF/lib/drools-canonical-model-7.46.0-SNAPSHOT.jar!/org/drools/model/functions`.

But that JAR (in general) contains other packages and the file manager needs to collect just classes in the `org.drools.model.functions` package so it [processes](https://github.com/kiegroup/drools/blob/7.45.0.Final/drools-compiler/src/main/java/org/drools/compiler/commons/jci/compilers/NativeJavaCompiler.java#L356) that jar, filters out things that are not classes or are in a different package and returns a collection of "custom" objects representing those classes. During that, it re-creates each classes URI string by cutting everything **after the first** `!/` and recombining it with each `JarEntry` name.

In this step, the `!/BOOT-INF/lib/drools-canonical-model-7.46.0-SNAPSHOT.jar` part **gets lost** and the Spring class loader is subsequently unable to load that class, hence:
```
bad class file: file:/home/.../drools-executable-reproducer-1.0-SNAPSHOT.jar!/org/drools/model/functions/Function1.class
```

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
