### PR TITLE
[DROOLS-5799] Second accumulate produces a wrong result

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -255,7 +255,6 @@ public class PhreakAccumulateNode {
             AccumulateContext accctx = (AccumulateContext) leftTuple.getContextObject();
             if (accctx == null) {
                 accctx = initAccumulateContextOnLeftTuple( am, wm, accumulate, leftTuple );
-                leftTuple.setContextObject(accctx);
             }
 
             constraints.updateFromTuple(contextEntry,

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -104,9 +104,6 @@ public class PhreakAccumulateNode {
         for (LeftTuple leftTuple = tempLeftTuples.getUpdateFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
             AccumulateContext accCtx = (AccumulateContext) leftTuple.getContextObject();
-            if (accCtx == null) {
-                accCtx = initAccumulateContextOnLeftTuple( am, wm, accumulate, leftTuple );
-            }
             evaluateResultConstraints( accNode, sink, accumulate, leftTuple, leftTuple.getPropagationContext(),
                                        wm, am, accCtx,
                                        trgLeftTuples, stagedLeftTuples );
@@ -255,7 +252,11 @@ public class PhreakAccumulateNode {
 
         for (LeftTuple leftTuple = srcLeftTuples.getUpdateFirst(); leftTuple != null; ) {
             LeftTuple next = leftTuple.getStagedNext();
-            final AccumulateContext accctx = (AccumulateContext) leftTuple.getContextObject();
+            AccumulateContext accctx = (AccumulateContext) leftTuple.getContextObject();
+            if (accctx == null) {
+                accctx = initAccumulateContextOnLeftTuple( am, wm, accumulate, leftTuple );
+                leftTuple.setContextObject(accctx);
+            }
 
             constraints.updateFromTuple(contextEntry,
                                         wm,

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -804,7 +804,9 @@ public class RuleNetworkEvaluator {
 
         // sides must first be re-ordered, to ensure iteration integrity
         for (LeftTuple leftTuple = srcLeftTuples.getUpdateFirst(); leftTuple != null; leftTuple = leftTuple.getStagedNext()) {
-            ltm.remove(leftTuple);
+            if (leftTuple.getMemory() != null) {
+                ltm.remove(leftTuple);
+            }
         }
 
         for (LeftTuple leftTuple = srcLeftTuples.getUpdateFirst(); leftTuple != null; leftTuple = leftTuple.getStagedNext()) {


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/DROOLS-5799

DROOLS-5786 solved the NPE but the second accumulate (in AccumulateTest.testDoubleAccumulateNPE()) produces a wrong result (= 0 instead of 2). 2 points to be fixed:

1. RuleNetworkEvaluator.doUpdatesReorderLeftMemory() causes wrong LeftTupleMemory size when calling TupleList.remove() for a tuple which doesn't exist in the list. (When removed, size becomes -1. Then added, size becomes 0. so the leftTuple is not evaluated in doRightInserts() : https://github.com/kiegroup/drools/blob/master/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java#L215 )

2. Creating AccumulateContext right before evaluateResultConstraints() is too late. It is used by addMatch() so it needs to be created earlier (e.g. in doLeftUpdates())

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
