### PR TITLE
[7.44.x] DROOLS-5690 : It should be possible to add free form insert with FreeForm Field

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -2993,6 +2993,10 @@ public class RuleModelDRLPersistenceImpl
                                            m,
                                            isJavaDialect);
                     }
+                } else {
+                    FreeFormLine ffl = new FreeFormLine();
+                    ffl.setText(line);
+                    m.addRhsItem(ffl);
                 }
             } else if (line.startsWith("update")) {
                 String variable = unwrapParenthesis(line);

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -1075,6 +1075,34 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
         assertEquals("eval( true )",
                      ((FreeFormLine) m.lhs[0]).getText());
     }
+    @Test
+    public void testInsertFreeFormLine() {
+        String drl = "package com.myspace;\n" +
+                "\n" +
+                "import java.util.logging.Logger;\n" +
+                "\n" +
+                "rule \"initialize\"\n" +
+                "\tdialect \"mvel\"\n" +
+                "\twhen\n" +
+                "\tthen\n" +
+                "\t\tinsert(Logger log = Logger.getLogger(\"com.somepkg\"));\n" +
+                "\t\tinsert(new String(\"hello\"));\n" +
+                "end\n";
+
+        RuleModel m = RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                          Collections.emptyList(),
+                                                                          dmo);
+
+        assertNotNull(m);
+        assertEquals(2,
+                     m.rhs.length);
+        assertTrue(m.rhs[0] instanceof FreeFormLine);
+        assertEquals("insert(Logger log = Logger.getLogger(\"com.somepkg\"));",
+                     ((FreeFormLine) m.rhs[0]).getText());
+        assertTrue(m.rhs[1] instanceof FreeFormLine);
+        assertEquals("insert(new String(\"hello\"));",
+                     ((FreeFormLine) m.rhs[1]).getText());
+    }
 
     @Test
     public void testEval2() {


### PR DESCRIPTION

(cherry picked from commit 0af429e89538d28f6cd79a55547f12641396fc32)


[link](https://issues.redhat.com/browse/DROOLS-5690)

Makes it possible to free form the inside of a insert()

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
