### PR TITLE
[DROOLS-5768] Executable model compiler casting int to short causes compilation error when number is inside the bracket

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/TypedExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/TypedExpression.java
@@ -129,11 +129,16 @@ public class TypedExpression {
     }
 
     public boolean isNumberLiteral() {
+        return isNumberLiteral(expression);
+    }
+
+    public static boolean isNumberLiteral(Expression expression) {
         return expression != null &&
                 (expression.isCharLiteralExpr()
                         || expression.isIntegerLiteralExpr()
                         || expression.isLongLiteralExpr()
-                        || expression.isDoubleLiteralExpr());
+                        || expression.isDoubleLiteralExpr()
+                        || expression.isEnclosedExpr() && isNumberLiteral(expression.asEnclosedExpr().getInner()));
     }
 
     public TypedExpression cloneWithNewExpression( Expression newExpression) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -2120,7 +2120,7 @@ public class CompilerTest extends BaseModelTest {
     }
 
 
-    @Test // DROOLS-5709
+    @Test // DROOLS-5709 // DROOLS-5768
     public void testCastingIntegerToShort() {
         String str =
                 "import " + IntegerToShort.class.getCanonicalName() + ";\n " +
@@ -2128,15 +2128,16 @@ public class CompilerTest extends BaseModelTest {
                         "rule \"test_rule\"\n" +
                         "dialect \"java\"\n" +
                         "when\n" +
-                        "$integerToShort : IntegerToShort( " +
-                        "$testInt : testInt, " +
-                        "testBoolean != null, " +
-                        "testBoolean == false" +
+                        "   $integerToShort : IntegerToShort( " +
+                        "           $testInt : testInt, " +
+                        "           testBoolean != null, " +
+                        "           testBoolean == false" +
                         ") \n" +
                         "then\n" +
-                        "$integerToShort.setTestShort((short)($testInt)); \n" +
-                        "$integerToShort.setTestBoolean(true);\n" +
-                        "update($integerToShort);\n" +
+                        "   $integerToShort.setTestShort((short)(12)); \n" +
+                        "   $integerToShort.setTestShort((short)($testInt)); \n" +
+                        "   $integerToShort.setTestBoolean(true);\n" +
+                        "   update($integerToShort);\n" +
                         "end";
 
         KieSession ksession = getKieSession(str);

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
@@ -5,11 +5,10 @@ import java.util.Collections;
 import org.drools.core.addon.ClassTypeResolver;
 import org.drools.core.addon.TypeResolver;
 import org.drools.modelcompiler.builder.PackageModel;
-import org.drools.modelcompiler.domain.Address;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.*;
 
 public class PrimitiveTypeConsequenceRewriteTest {
 
@@ -23,6 +22,17 @@ public class PrimitiveTypeConsequenceRewriteTest {
 
         assertThat(rewritten,
                    equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.shortValue()); }"));
+    }
+
+    @Test
+    public void doNotConverLiterals() {
+        RuleContext context = createContext();
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{ $address.setShortNumber((short) (12)); }");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber((short) (12)); }"));
     }
 
     @Test


### PR DESCRIPTION
Backport for https://github.com/kiegroup/drools/pull/3234

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
