### PR TITLE
DROOLS-5803 Fix kie-camel dep not in MavenCentral xercesImpl 2.12.0.SP02

### DIFF
--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -33,23 +33,8 @@
         <surefire.forkCount>2</surefire.forkCount>
         <excludedGroups>org.kie.test.testcategory.TurtleTestCategory</excludedGroups>
     </properties>
-    
-    <dependencyManagement>
-    <dependencies>
-        <!-- https://mvnrepository.com/artifact/com.sun.xml.parsers/jaxp-ri -->
-<dependency>
-    <groupId>com.sun.xml.parsers</groupId>
-    <artifactId>jaxp-ri</artifactId>
-    <version>1.4.5</version>
-</dependency>
-    </dependencies>
-    </dependencyManagement>
 
     <dependencies>
-<dependency>
-    <groupId>com.sun.xml.parsers</groupId>
-    <artifactId>jaxp-ri</artifactId>
-</dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>

--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -33,8 +33,23 @@
         <surefire.forkCount>2</surefire.forkCount>
         <excludedGroups>org.kie.test.testcategory.TurtleTestCategory</excludedGroups>
     </properties>
+    
+    <dependencyManagement>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/com.sun.xml.parsers/jaxp-ri -->
+<dependency>
+    <groupId>com.sun.xml.parsers</groupId>
+    <artifactId>jaxp-ri</artifactId>
+    <version>1.4.5</version>
+</dependency>
+    </dependencies>
+    </dependencyManagement>
 
     <dependencies>
+<dependency>
+    <groupId>com.sun.xml.parsers</groupId>
+    <artifactId>jaxp-ri</artifactId>
+</dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.mvel.compiler.runtime.pipeline.impl;
+
+import java.util.List;
+
+import com.sun.tools.xjc.Language;
+import com.sun.tools.xjc.Options;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+import org.kie.api.io.KieResources;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.builder.JaxbConfiguration;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class DroolsJaxbHelperXSDInKJARTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DroolsJaxbHelperXSDInKJARTest.class);
+
+    private static final String simpleXsdRelativePath = "simple.xsd";
+
+    @Test
+    public void testInternalsDryRun() {
+        System.getProperties().entrySet().forEach(e -> LOG.debug("{}", e));
+        LOG.info("{}", javax.xml.parsers.SAXParserFactory.newInstance().getClass());
+        LOG.info("{}", javax.xml.validation.SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI).getClass());
+        LOG.info("{}", com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI, false).getClass());
+    }
+
+    @Test
+    public void testXsdModelInKJAR() {
+        KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem();
+        KieResources kieResources = ks.getResources();
+
+        Options xjcOpts = new Options();
+        xjcOpts.setSchemaLanguage(Language.XMLSCHEMA);
+        JaxbConfiguration jaxbConfiguration = KnowledgeBuilderFactory.newJaxbConfiguration(xjcOpts, "xsd");
+        kfs.write(kieResources.newClassPathResource(simpleXsdRelativePath, getClass()).setResourceType(ResourceType.XSD).setConfiguration(jaxbConfiguration));
+
+        KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
+
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        if (!errors.isEmpty()) {
+            fail("" + errors);
+        }
+
+        KieSession ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
+        assertNotNull(ksession);
+    }
+
+}

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
@@ -35,6 +35,9 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+/**
+ * DROOLS-5803 RHDM-851
+ */
 public class DroolsJaxbHelperXSDInKJARTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(DroolsJaxbHelperXSDInKJARTest.class);
@@ -43,6 +46,7 @@ public class DroolsJaxbHelperXSDInKJARTest {
 
     @Test
     public void testInternalsDryRun() {
+        // DROOLS-5803 RHDM-851
         System.getProperties().entrySet().forEach(e -> LOG.debug("{}", e));
         LOG.info("{}", javax.xml.parsers.SAXParserFactory.newInstance().getClass());
         LOG.info("{}", javax.xml.validation.SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI).getClass());
@@ -51,6 +55,7 @@ public class DroolsJaxbHelperXSDInKJARTest {
 
     @Test
     public void testXsdModelInKJAR() {
+        // DROOLS-5803 RHDM-851
         KieServices ks = KieServices.Factory.get();
         KieFileSystem kfs = ks.newKieFileSystem();
         KieResources kieResources = ks.getResources();


### PR DESCRIPTION
Fix kie-camel dep not available in Maven Central:
xerces:xercesImpl:jar:2.12.0.SP02

**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/DROOLS-5803

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
