### PR TITLE
DROOLS-5879 Optional newline handling in MVEL parser

### DIFF
--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -64,6 +64,7 @@ import static org.drools.mvel.parser.Providers.resourceProvider;
  */
 public final class MvelParser {
     private final ParserConfiguration configuration;
+    private boolean ignoreNewlines = false;
 
     private GeneratedMvelParser astParser = null;
     private static ParserConfiguration staticConfiguration = new ParserConfiguration();
@@ -118,6 +119,10 @@ public final class MvelParser {
         return this.configuration;
     }
 
+    public void setIgnoreNewlines(boolean ignoreNewlines) {
+        this.ignoreNewlines = ignoreNewlines;
+    }
+
     private GeneratedMvelParser getParserForProvider(Provider provider) {
         if (astParser == null) {
             astParser = new GeneratedMvelParser(provider);
@@ -126,6 +131,10 @@ public final class MvelParser {
         }
         astParser.setTabSize(configuration.getTabSize());
         astParser.setStoreTokens(configuration.isStoreTokens());
+        if (ignoreNewlines) {
+            astParser.getTokenSource()
+                    .setDefaultState(GeneratedMvelParserTokenManager.NEWLINES_SKIPPED);
+        }
         return astParser;
     }
 

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -64,7 +64,7 @@ import static org.drools.mvel.parser.Providers.resourceProvider;
  */
 public final class MvelParser {
     private final ParserConfiguration configuration;
-    private boolean ignoreNewlines = false;
+    private final boolean ignoreNewlines;
 
     private GeneratedMvelParser astParser = null;
     private static ParserConfiguration staticConfiguration = new ParserConfiguration();
@@ -92,6 +92,13 @@ public final class MvelParser {
     public MvelParser(ParserConfiguration configuration) {
         this.configuration = configuration;
         configuration.getPostProcessors().clear();
+        this.ignoreNewlines = false;
+    }
+
+    public MvelParser(ParserConfiguration configuration, boolean ignoreNewlines) {
+        this.configuration = configuration;
+        configuration.getPostProcessors().clear();
+        this.ignoreNewlines = ignoreNewlines;
     }
 
     /**
@@ -117,10 +124,6 @@ public final class MvelParser {
      */
     public ParserConfiguration getParserConfiguration() {
         return this.configuration;
-    }
-
-    public void setIgnoreNewlines(boolean ignoreNewlines) {
-        this.ignoreNewlines = ignoreNewlines;
     }
 
     private GeneratedMvelParser getParserForProvider(Provider provider) {

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -175,11 +175,13 @@ import static org.drools.mvel.parser.GeneratedMvelParserConstants.TRUE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.TRY;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNICODE_ESCAPE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNIX_EOL;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNIX_EOL_SKIPPED;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.USES;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.VOID;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.VOLATILE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WHILE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WINDOWS_EOL;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.WINDOWS_EOL_SKIPPED;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WITH;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.XOR;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.XORASSIGN;
@@ -266,6 +268,8 @@ public class TokenTypes {
                 return JavaToken.Category.KEYWORD;
             case WINDOWS_EOL:
             case UNIX_EOL:
+            case WINDOWS_EOL_SKIPPED:
+            case UNIX_EOL_SKIPPED:
             case OLD_MAC_EOL:
                 return JavaToken.Category.EOL;
             case EOF:

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -125,6 +125,14 @@ PARSER_END(GeneratedMvelParser)
 
 /* WHITE SPACE */
 
+<NEWLINES_SKIPPED>
+SPECIAL_TOKEN :
+{
+<UNIX_EOL_SKIPPED: "\n">
+| <WINDOWS_EOL_SKIPPED : "\r\n">
+}
+
+<DEFAULT, NEWLINES_SKIPPED>
 SPECIAL_TOKEN :
 {
   <SPACE: [" ", "\t", "\f", "\u0085", "\u00A0", "\u1680", "\u180e", "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005",
@@ -139,6 +147,16 @@ TOKEN_MGR_DECLS :
     private JavaToken homeToken;
     private Stack<Token> tokenWorkStack = new Stack<Token>();
     private boolean storeTokens;
+    private int defaultState = DEFAULT;
+
+    void switchToDefaultState() {
+        SwitchTo(defaultState);
+    }
+
+    void setDefaultState(int defaultState) {
+        this.defaultState = defaultState;
+        SwitchTo(defaultState);
+    }
 
     void reset() {
         tokens = new ArrayList<JavaToken>();
@@ -199,11 +217,13 @@ TOKEN_MGR_DECLS :
 
 /* COMMENTS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 SPECIAL_TOKEN :
 {
   <SINGLE_LINE_COMMENT: "//" (~["\n","\r"])* >
 }
 
+<DEFAULT, NEWLINES_SKIPPED>
 MORE :
 {
   <ENTER_JAVADOC_COMMENT: "/**" ~["/"]> { input_stream.backup(1); } : IN_JAVADOC_COMMENT
@@ -214,13 +234,13 @@ MORE :
 <IN_JAVADOC_COMMENT>
 SPECIAL_TOKEN :
 {
-  <JAVADOC_COMMENT: "*/" > : DEFAULT
+  <JAVADOC_COMMENT: "*/" > { switchToDefaultState(); }
 }
 
 <IN_MULTI_LINE_COMMENT>
 SPECIAL_TOKEN :
 {
-  <MULTI_LINE_COMMENT: "*/" > : DEFAULT
+  <MULTI_LINE_COMMENT: "*/" >  { switchToDefaultState(); }
 }
 
 <IN_JAVADOC_COMMENT, IN_MULTI_LINE_COMMENT>
@@ -231,6 +251,7 @@ MORE :
 
 /* RESERVED WORDS AND LITERALS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < ABSTRACT: "abstract" >
@@ -305,13 +326,18 @@ TOKEN :
 | < DOT_DOT_SLASH: "../" >
 | < HASHMARK: "#" >
 | < EXCL_DOT: "!." >
-| <UNIX_EOL: "\n">
-| <WINDOWS_EOL : "\r\n">
+}
 
+<DEFAULT>
+TOKEN :
+{
+<UNIX_EOL: "\n">
+| <WINDOWS_EOL : "\r\n">
 }
 
 /* LITERALS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < LONG_LITERAL:
@@ -411,6 +437,7 @@ TOKEN :
 
 /* IDENTIFIERS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < IDENTIFIER: <LETTER> (<PART_LETTER>)* >
@@ -577,6 +604,7 @@ TOKEN :
 
 /* SEPARATORS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < LPAREN: "(" >
@@ -593,6 +621,7 @@ TOKEN :
 
 /* OPERATORS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < ASSIGN: "=" >
@@ -635,6 +664,7 @@ TOKEN :
 }
 
 /* >'s need special attention due to generics syntax. */
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < RUNSIGNEDSHIFT: ">>>" >
@@ -652,6 +682,7 @@ TOKEN :
 | < GT: ">" >
 }
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN: { <CTRL_Z: "\u001A" /** ctrl+z char **/> }
 
 /*****************************************

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
@@ -52,10 +53,12 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.drools.mvel.parser.DrlxParser.parseExpression;
+import static org.drools.mvel.parser.Providers.provider;
 import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -903,6 +906,18 @@ public class DroolsMvelParserTest {
         assertEquals(expr, printConstraint(expression));
     }
 
+    @Test
+    public void testSpecialNewlineHandling() {
+        String expr = "1 \n + 1";
+
+        Expression r1 = parseExpression(parser, expr).getExpr();
+        assertEquals("Parsing should stop at newline", "1", printConstraint(r1));
+
+        MvelParser mvelParser = new MvelParser();
+        mvelParser.setIgnoreNewlines(true);
+        Expression r2 = mvelParser.parse(GeneratedMvelParser::Expression, new StringProvider(expr)).getResult().get();
+        assertEquals("Parsing must ignore newlines","1 + 1", printConstraint(r2));
+    }
 
     private void testMvelSquareOperator(String wholeExpression, String operator, String left, String right, boolean isNegated) {
         String expr = wholeExpression;

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
@@ -122,12 +123,15 @@ public class DroolsMvelParserTest {
     }
 
     @Test
-    @Ignore
     public void testBinaryWithNewLineBeforeOperator() {
-        Expression and2 = parseExpression(parser, "(addresses == 2" + newLine() + "&& addresses == 3  )").getExpr();
+        String andExpr = "(addresses == 2" + newLine() + "&& addresses == 3  )";
+        MvelParser mvelParser1 = new MvelParser(new ParserConfiguration(), true);
+        Expression and2 = mvelParser1.parse(GeneratedMvelParser::Expression, new StringProvider(andExpr)).getResult().get();
         assertEquals("(addresses == 2 && addresses == 3)", printConstraint(and2));
 
-        Expression or2 = parseExpression(parser, "(addresses == 2" + newLine() + "|| addresses == 3  )").getExpr();
+        String orExpr = "(addresses == 2" + newLine() + "|| addresses == 3  )";
+        MvelParser mvelParser2 = new MvelParser(new ParserConfiguration(), true);
+        Expression or2 = mvelParser2.parse(GeneratedMvelParser::Expression, new StringProvider(orExpr)).getResult().get();
         assertEquals("(addresses == 2 || addresses == 3)", printConstraint(or2));
     }
 
@@ -913,8 +917,7 @@ public class DroolsMvelParserTest {
         Expression r1 = parseExpression(parser, expr).getExpr();
         assertEquals("Parsing should stop at newline", "1", printConstraint(r1));
 
-        MvelParser mvelParser = new MvelParser();
-        mvelParser.setIgnoreNewlines(true);
+        MvelParser mvelParser = new MvelParser(new ParserConfiguration(), true);
         Expression r2 = mvelParser.parse(GeneratedMvelParser::Expression, new StringProvider(expr)).getResult().get();
         assertEquals("Parsing must ignore newlines","1 + 1", printConstraint(r2));
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5762

MVEL parser explicitly handles newlines so that statements can be terminated automatically without semicolons. However, in some situations this is not necessary. For instance, 
- while parsing constraints, newlines may be treated as non-significant whitespace. 
- the consequence, unless the dialect is MVEL, should treat code as regular Java code. 

We add support to a new lexer state, that can be switched at run-time (parser instantiation time), to allow for whitespace to be fully ignored, newlines included. 

This feature will be also used in the DRLX research experiment.

The change is actually quite minimal

1. we add a new lexical state called NEWLINES_SKIPPED
2. we explicitly add all tokens to the DEFAULT lexical state (which, unless specified, is indeed the default state)
3. we add newlines to SPECIAL_TOKENS only in the NEWLINES_SKIPPED lexical state
4. we add newlines to TOKENS only in the DEFAULT lexical state
5. we add a method `setDefaultState(state)` to the TokenManager (the lexer) so that it is possible to set the default state of the lexer (to NEWLINES_SKIPPED or DEFAULT).  

there is then a bit of boilerplate to make sure that when a lexical state transition really is necessary (`IN_MULTI_LINE_COMMENT`) we return to the new default lexical state, instead of just DEFAULT

Finally, a flag is exposed in `MvelParser` via a boolean field. We may consider forking `ParserConfiguration` and add it there (currently we are reusing the same class in JavaParser's library, so that can't be customized).

enabling the special behavior is as easy as setting the flag with `mvelParser.setIgnoreNewlines(true)`; e.g:

```
         String expr = "1 \n + 1";

        Expression r1 = parseExpression(parser, expr).getExpr();
        assertEquals("Parsing should stop at newline", "1", printConstraint(r1));

        MvelParser mvelParser = new MvelParser();
        mvelParser.setIgnoreNewlines(true);
        Expression r2 = mvelParser.parse(GeneratedMvelParser::Expression, new StringProvider(expr)).getResult().get();
        assertEquals("Parsing must ignore newlines","1 + 1", printConstraint(r2)); 
```

we may consider flipping the default (i.e. default to nonsignificant whitespace) but I wanted to keep the change minimal for now.

