### PR TITLE
DROOLS-5879 Optional newline handling in MVEL parser

### DIFF
--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -64,6 +64,7 @@ import static org.drools.mvel.parser.Providers.resourceProvider;
  */
 public final class MvelParser {
     private final ParserConfiguration configuration;
+    private boolean ignoreNewlines = false;
 
     private GeneratedMvelParser astParser = null;
     private static ParserConfiguration staticConfiguration = new ParserConfiguration();
@@ -118,6 +119,10 @@ public final class MvelParser {
         return this.configuration;
     }
 
+    public void setIgnoreNewlines(boolean ignoreNewlines) {
+        this.ignoreNewlines = ignoreNewlines;
+    }
+
     private GeneratedMvelParser getParserForProvider(Provider provider) {
         if (astParser == null) {
             astParser = new GeneratedMvelParser(provider);
@@ -126,6 +131,10 @@ public final class MvelParser {
         }
         astParser.setTabSize(configuration.getTabSize());
         astParser.setStoreTokens(configuration.isStoreTokens());
+        if (ignoreNewlines) {
+            astParser.getTokenSource()
+                    .setDefaultState(GeneratedMvelParserTokenManager.NEWLINES_SKIPPED);
+        }
         return astParser;
     }
 

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -90,9 +90,7 @@ public final class MvelParser {
      * Creating an instance will reduce setup time between parsing files.
      */
     public MvelParser(ParserConfiguration configuration) {
-        this.configuration = configuration;
-        configuration.getPostProcessors().clear();
-        this.optionalSemicolon = true;
+        this(configuration, true /* default to optional semicolon */);
     }
 
     public MvelParser(ParserConfiguration configuration, boolean optionalSemicolon) {

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -64,7 +64,7 @@ import static org.drools.mvel.parser.Providers.resourceProvider;
  */
 public final class MvelParser {
     private final ParserConfiguration configuration;
-    private boolean ignoreNewlines = false;
+    private final boolean ignoreNewlines;
 
     private GeneratedMvelParser astParser = null;
     private static ParserConfiguration staticConfiguration = new ParserConfiguration();
@@ -92,6 +92,13 @@ public final class MvelParser {
     public MvelParser(ParserConfiguration configuration) {
         this.configuration = configuration;
         configuration.getPostProcessors().clear();
+        this.ignoreNewlines = false;
+    }
+
+    public MvelParser(ParserConfiguration configuration, boolean ignoreNewlines) {
+        this.configuration = configuration;
+        configuration.getPostProcessors().clear();
+        this.ignoreNewlines = ignoreNewlines;
     }
 
     /**
@@ -117,10 +124,6 @@ public final class MvelParser {
      */
     public ParserConfiguration getParserConfiguration() {
         return this.configuration;
-    }
-
-    public void setIgnoreNewlines(boolean ignoreNewlines) {
-        this.ignoreNewlines = ignoreNewlines;
     }
 
     private GeneratedMvelParser getParserForProvider(Provider provider) {

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/MvelParser.java
@@ -64,7 +64,7 @@ import static org.drools.mvel.parser.Providers.resourceProvider;
  */
 public final class MvelParser {
     private final ParserConfiguration configuration;
-    private final boolean ignoreNewlines;
+    private final boolean optionalSemicolon;
 
     private GeneratedMvelParser astParser = null;
     private static ParserConfiguration staticConfiguration = new ParserConfiguration();
@@ -92,13 +92,13 @@ public final class MvelParser {
     public MvelParser(ParserConfiguration configuration) {
         this.configuration = configuration;
         configuration.getPostProcessors().clear();
-        this.ignoreNewlines = false;
+        this.optionalSemicolon = true;
     }
 
-    public MvelParser(ParserConfiguration configuration, boolean ignoreNewlines) {
+    public MvelParser(ParserConfiguration configuration, boolean optionalSemicolon) {
         this.configuration = configuration;
         configuration.getPostProcessors().clear();
-        this.ignoreNewlines = ignoreNewlines;
+        this.optionalSemicolon = optionalSemicolon;
     }
 
     /**
@@ -134,10 +134,7 @@ public final class MvelParser {
         }
         astParser.setTabSize(configuration.getTabSize());
         astParser.setStoreTokens(configuration.isStoreTokens());
-        if (ignoreNewlines) {
-            astParser.getTokenSource()
-                    .setDefaultState(GeneratedMvelParserTokenManager.NEWLINES_SKIPPED);
-        }
+        astParser.setOptionalSemicolon(optionalSemicolon);
         return astParser;
     }
 

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -175,13 +175,11 @@ import static org.drools.mvel.parser.GeneratedMvelParserConstants.TRUE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.TRY;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNICODE_ESCAPE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNIX_EOL;
-import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNIX_EOL_SKIPPED;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.USES;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.VOID;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.VOLATILE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WHILE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WINDOWS_EOL;
-import static org.drools.mvel.parser.GeneratedMvelParserConstants.WINDOWS_EOL_SKIPPED;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WITH;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.XOR;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.XORASSIGN;
@@ -268,8 +266,6 @@ public class TokenTypes {
                 return JavaToken.Category.KEYWORD;
             case WINDOWS_EOL:
             case UNIX_EOL:
-            case WINDOWS_EOL_SKIPPED:
-            case UNIX_EOL_SKIPPED:
             case OLD_MAC_EOL:
                 return JavaToken.Category.EOL;
             case EOF:

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/TokenTypes.java
@@ -175,11 +175,13 @@ import static org.drools.mvel.parser.GeneratedMvelParserConstants.TRUE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.TRY;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNICODE_ESCAPE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNIX_EOL;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.UNIX_EOL_SKIPPED;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.USES;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.VOID;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.VOLATILE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WHILE;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WINDOWS_EOL;
+import static org.drools.mvel.parser.GeneratedMvelParserConstants.WINDOWS_EOL_SKIPPED;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.WITH;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.XOR;
 import static org.drools.mvel.parser.GeneratedMvelParserConstants.XORASSIGN;
@@ -266,6 +268,8 @@ public class TokenTypes {
                 return JavaToken.Category.KEYWORD;
             case WINDOWS_EOL:
             case UNIX_EOL:
+            case WINDOWS_EOL_SKIPPED:
+            case UNIX_EOL_SKIPPED:
             case OLD_MAC_EOL:
                 return JavaToken.Category.EOL;
             case EOF:

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -125,6 +125,14 @@ PARSER_END(GeneratedMvelParser)
 
 /* WHITE SPACE */
 
+<NEWLINES_SKIPPED>
+SPECIAL_TOKEN :
+{
+<UNIX_EOL_SKIPPED: "\n">
+| <WINDOWS_EOL_SKIPPED : "\r\n">
+}
+
+<DEFAULT, NEWLINES_SKIPPED>
 SPECIAL_TOKEN :
 {
   <SPACE: [" ", "\t", "\f", "\u0085", "\u00A0", "\u1680", "\u180e", "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005",
@@ -139,6 +147,16 @@ TOKEN_MGR_DECLS :
     private JavaToken homeToken;
     private Stack<Token> tokenWorkStack = new Stack<Token>();
     private boolean storeTokens;
+    private int defaultState = DEFAULT;
+
+    void switchToDefaultState() {
+        SwitchTo(defaultState);
+    }
+
+    void setDefaultState(int defaultState) {
+        this.defaultState = defaultState;
+        SwitchTo(defaultState);
+    }
 
     void reset() {
         tokens = new ArrayList<JavaToken>();
@@ -199,11 +217,13 @@ TOKEN_MGR_DECLS :
 
 /* COMMENTS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 SPECIAL_TOKEN :
 {
   <SINGLE_LINE_COMMENT: "//" (~["\n","\r"])* >
 }
 
+<DEFAULT, NEWLINES_SKIPPED>
 MORE :
 {
   <ENTER_JAVADOC_COMMENT: "/**" ~["/"]> { input_stream.backup(1); } : IN_JAVADOC_COMMENT
@@ -214,13 +234,13 @@ MORE :
 <IN_JAVADOC_COMMENT>
 SPECIAL_TOKEN :
 {
-  <JAVADOC_COMMENT: "*/" > : DEFAULT
+  <JAVADOC_COMMENT: "*/" > { switchToDefaultState(); }
 }
 
 <IN_MULTI_LINE_COMMENT>
 SPECIAL_TOKEN :
 {
-  <MULTI_LINE_COMMENT: "*/" > : DEFAULT
+  <MULTI_LINE_COMMENT: "*/" >  { switchToDefaultState(); }
 }
 
 <IN_JAVADOC_COMMENT, IN_MULTI_LINE_COMMENT>
@@ -231,6 +251,7 @@ MORE :
 
 /* RESERVED WORDS AND LITERALS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < ABSTRACT: "abstract" >
@@ -305,13 +326,18 @@ TOKEN :
 | < DOT_DOT_SLASH: "../" >
 | < HASHMARK: "#" >
 | < EXCL_DOT: "!." >
-| <UNIX_EOL: "\n">
-| <WINDOWS_EOL : "\r\n">
+}
 
+<DEFAULT>
+TOKEN :
+{
+<UNIX_EOL: "\n">
+| <WINDOWS_EOL : "\r\n">
 }
 
 /* LITERALS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < LONG_LITERAL:
@@ -411,6 +437,7 @@ TOKEN :
 
 /* IDENTIFIERS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < IDENTIFIER: <LETTER> (<PART_LETTER>)* >
@@ -577,6 +604,7 @@ TOKEN :
 
 /* SEPARATORS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < LPAREN: "(" >
@@ -593,6 +621,7 @@ TOKEN :
 
 /* OPERATORS */
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < ASSIGN: "=" >
@@ -635,6 +664,7 @@ TOKEN :
 }
 
 /* >'s need special attention due to generics syntax. */
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < RUNSIGNEDSHIFT: ">>>" >
@@ -652,6 +682,7 @@ TOKEN :
 | < GT: ">" >
 }
 
+<DEFAULT, NEWLINES_SKIPPED>
 TOKEN: { <CTRL_Z: "\u001A" /** ctrl+z char **/> }
 
 /*****************************************

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -329,9 +329,9 @@ TOKEN :
 }
 
 <DEFAULT>
-TOKEN :
+SPECIAL_TOKEN :
 {
-<UNIX_EOL: "\n">
+<UNIX_EOL: "\n"> { System.out.println("NEWLINESSS"); }
 | <WINDOWS_EOL : "\r\n">
 }
 
@@ -2275,7 +2275,7 @@ Statement BlockStatement():
             modifier = Modifiers()
             typeDecl = ClassOrInterfaceDeclaration(modifier) { ret = new LocalClassDeclarationStmt(range(typeDecl, token()), typeDecl); }
         | LOOKAHEAD(VariableDeclarationExpression() )
-            expr = VariableDeclarationExpression() ";"
+            expr = VariableDeclarationExpression() EOS()
             { ret = new ExpressionStmt(range(expr, token()), expr); }
         |
             ret = Statement()
@@ -2351,8 +2351,7 @@ ExpressionStmt StatementExpression():
             op = AssignmentOperator() value = Expression() { expr = new AssignExpr(range(expr, token()), expr, value, op); }
         ]
     )
-    (";")*
-    (EOL())* // TODO: should support also windows EOL
+    (EOS())// TODO: should support also windows EOL
     { return new ExpressionStmt(range(expr, token()), expr); }
 }
 
@@ -2648,13 +2647,13 @@ ModifyStatement ModifyStatement():
     (
         (
             <MODIFY><LPAREN> (modifyObject = UnaryExpressionNotPlusMinus())<RPAREN> <LBRACE>
-            (first = Statement()(<SEMICOLON>|EOL())?)* { begin=token(); all.add(first); }
+            (first = Statement()(EOS()))* { begin=token(); all.add(first); }
             (
                           (<COMMA>)*(EOL())*
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
-            (<SEMICOLON>|EOL())*
+            EOS()
             {
                 return new ModifyStatement(range(begin, token()), modifyObject, all);
             }
@@ -2676,13 +2675,13 @@ WithStatement WithStatement():
     (
         (
             <WITH><LPAREN> (withObject = Expression())<RPAREN> <LBRACE>
-            (first = Statement()(<SEMICOLON>|EOL())?)* { begin=token(); all.add(first); }
+            (first = Statement()(EOS()))* { begin=token(); all.add(first); }
             (
                           (<COMMA>|EOL())
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
-            (<SEMICOLON>|EOL())*
+            (EOS())
             {
                 return new WithStatement(range(begin, token()), withObject, all);
             }
@@ -3399,5 +3398,12 @@ void EOL():
 {
 }
 {
-    <UNIX_EOL>|<WINDOWS_EOL>
+    "%%%"//<UNIX_EOL>|<WINDOWS_EOL>
+}
+
+void EOS():
+{
+}
+{
+   (<SEMICOLON>)* | ( LOOKAHEAD( { getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL } ) {} )
 }

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -2637,7 +2637,7 @@ ModifyStatement ModifyStatement():
     (
         (
             <MODIFY><LPAREN> (modifyObject = UnaryExpressionNotPlusMinus())<RPAREN> <LBRACE>
-            (first = Statement()(";")?)* { begin=token(); all.add(first); }
+            (first = Statement()(<SEMICOLON>)?)* { begin=token(); all.add(first); }
             (
                           (<COMMA>)*
                           other = Statement() { all.add(other); }
@@ -2667,13 +2667,13 @@ WithStatement WithStatement():
     (
         (
             <WITH><LPAREN> (withObject = Expression())<RPAREN> <LBRACE>
-            (first = Statement()(";")*)* { begin=token(); all.add(first); }
+            (first = Statement()(<SEMICOLON>)*)* { begin=token(); all.add(first); }
             (
                           <COMMA>
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
-            (";")?
+            (<SEMICOLON>)?
             {
                 this.isWithOrModify = false;
                 return new WithStatement(range(begin, token()), withObject, all);

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -92,6 +92,7 @@ import static org.drools.mvel.parser.GeneratedMvelParserTokenManagerBase.*;
 @Generated("JavaCC")
 public final class GeneratedMvelParser extends GeneratedMvelParserBase {
     private boolean optionalSemicolon = true;
+    private boolean isWithOrModify = false;
 
     public void setOptionalSemicolon(boolean optionalSemicolon) {
         this.optionalSemicolon = optionalSemicolon;
@@ -2619,10 +2620,11 @@ ModifyStatement ModifyStatement():
     Expression modifyObject = null;
 }
 {
+    { this.isWithOrModify = true; }
     (
         (
             <MODIFY><LPAREN> (modifyObject = UnaryExpressionNotPlusMinus())<RPAREN> <LBRACE>
-            (first = Statement()(";")*)* { begin=token(); all.add(first); }
+            (first = Statement()(";")?)* { begin=token(); all.add(first); }
             (
                           (<COMMA>)*
                           other = Statement() { all.add(other); }
@@ -2630,6 +2632,7 @@ ModifyStatement ModifyStatement():
             <RBRACE>
             (<SEMICOLON>)?
             {
+                this.isWithOrModify = false;
                 return new ModifyStatement(range(begin, token()), modifyObject, all);
             }
 
@@ -2647,6 +2650,7 @@ WithStatement WithStatement():
     Expression withObject = null;
 }
 {
+    { this.isWithOrModify = true; }
     (
         (
             <WITH><LPAREN> (withObject = Expression())<RPAREN> <LBRACE>
@@ -2656,8 +2660,9 @@ WithStatement WithStatement():
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
-            (EOS())
+            (";")?
             {
+                this.isWithOrModify = false;
                 return new WithStatement(range(begin, token()), withObject, all);
             }
 
@@ -3373,8 +3378,16 @@ void EOS():
 {
 }
 {
-   <SEMICOLON>
-   | LOOKAHEAD("}") {}
-   | LOOKAHEAD( { this.optionalSemicolon && ( getToken(1).specialToken != null &&
-                    ( getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL ) ) } ) {}
+   <SEMICOLON> | AutoEOS()
+}
+
+void AutoEOS():
+{
+}
+{
+    LOOKAHEAD( { this.optionalSemicolon && (
+                    ( getToken(1).kind == RBRACE ) ||
+                    ( this.isWithOrModify && getToken(1).kind == COMMA ) ||
+                    ( getToken(1).specialToken != null &&
+                        ( getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL ) ) ) } ) {}
 }

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -2622,13 +2622,13 @@ ModifyStatement ModifyStatement():
     (
         (
             <MODIFY><LPAREN> (modifyObject = UnaryExpressionNotPlusMinus())<RPAREN> <LBRACE>
-            (first = Statement()(EOS()))* { begin=token(); all.add(first); }
+            (first = Statement()(";")*)* { begin=token(); all.add(first); }
             (
                           (<COMMA>)*
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
-            EOS()
+            (<SEMICOLON>)?
             {
                 return new ModifyStatement(range(begin, token()), modifyObject, all);
             }
@@ -2650,7 +2650,7 @@ WithStatement WithStatement():
     (
         (
             <WITH><LPAREN> (withObject = Expression())<RPAREN> <LBRACE>
-            (first = Statement()(EOS()))* { begin=token(); all.add(first); }
+            (first = Statement()(";")*)* { begin=token(); all.add(first); }
             (
                           <COMMA>
                           other = Statement() { all.add(other); }
@@ -3373,5 +3373,8 @@ void EOS():
 {
 }
 {
-   (<SEMICOLON>)* | ( LOOKAHEAD( { this.optionalSemicolon && getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL } ) {} )
+   <SEMICOLON>
+   | LOOKAHEAD("}") {}
+   | LOOKAHEAD( { this.optionalSemicolon && ( getToken(1).specialToken != null &&
+                    ( getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL ) ) } ) {}
 }

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -98,6 +98,19 @@ public final class GeneratedMvelParser extends GeneratedMvelParserBase {
         this.optionalSemicolon = optionalSemicolon;
     }
 
+    public boolean shouldTerminateStatement() {
+        Token token = getToken(1);
+        return (this.optionalSemicolon && (
+                    ( token.kind == RBRACE ) ||
+                    ( token.kind == IDENTIFIER ) ||
+                    ( this.isWithOrModify && token.kind == COMMA ) ||
+                    ( token.specialToken != null &&
+                        ( token.specialToken.kind == UNIX_EOL ||
+                          token.specialToken.kind == WINDOWS_EOL ||
+                          token.specialToken.kind == SINGLE_LINE_COMMENT ) ) ) );
+
+    }
+
     /* Returns the JavaParser specific token type of the last matched token */
     JavaToken token() {
         if(token.toString() == null) {
@@ -3378,16 +3391,5 @@ void EOS():
 {
 }
 {
-   <SEMICOLON> | AutoEOS()
-}
-
-void AutoEOS():
-{
-}
-{
-    LOOKAHEAD( { this.optionalSemicolon && (
-                    ( getToken(1).kind == RBRACE ) ||
-                    ( this.isWithOrModify && getToken(1).kind == COMMA ) ||
-                    ( getToken(1).specialToken != null &&
-                        ( getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL ) ) ) } ) {}
+   <SEMICOLON> | <EOF> | LOOKAHEAD( { this.shouldTerminateStatement() } ) {}
 }

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -91,6 +91,12 @@ import static org.drools.mvel.parser.GeneratedMvelParserTokenManagerBase.*;
 
 @Generated("JavaCC")
 public final class GeneratedMvelParser extends GeneratedMvelParserBase {
+    private boolean optionalSemicolon = true;
+
+    public void setOptionalSemicolon(boolean optionalSemicolon) {
+        this.optionalSemicolon = optionalSemicolon;
+    }
+
     /* Returns the JavaParser specific token type of the last matched token */
     JavaToken token() {
         if(token.toString() == null) {
@@ -125,19 +131,17 @@ PARSER_END(GeneratedMvelParser)
 
 /* WHITE SPACE */
 
-<NEWLINES_SKIPPED>
-SPECIAL_TOKEN :
-{
-<UNIX_EOL_SKIPPED: "\n">
-| <WINDOWS_EOL_SKIPPED : "\r\n">
-}
-
-<DEFAULT, NEWLINES_SKIPPED>
 SPECIAL_TOKEN :
 {
   <SPACE: [" ", "\t", "\f", "\u0085", "\u00A0", "\u1680", "\u180e", "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005",
       "\u2006", "\u2007", "\u2008", "\u2009", "\u200a", "\u200b", "\u200c", "\u200d", "\u2028", "\u2029", "\u202f", "\u205f", "\u2060", "\u3000", "\ufeff"]>
 | <OLD_MAC_EOL: "\r">
+}
+
+SPECIAL_TOKEN :
+{
+<UNIX_EOL: "\n">
+| <WINDOWS_EOL : "\r\n">
 }
 
 TOKEN_MGR_DECLS :
@@ -147,16 +151,6 @@ TOKEN_MGR_DECLS :
     private JavaToken homeToken;
     private Stack<Token> tokenWorkStack = new Stack<Token>();
     private boolean storeTokens;
-    private int defaultState = DEFAULT;
-
-    void switchToDefaultState() {
-        SwitchTo(defaultState);
-    }
-
-    void setDefaultState(int defaultState) {
-        this.defaultState = defaultState;
-        SwitchTo(defaultState);
-    }
 
     void reset() {
         tokens = new ArrayList<JavaToken>();
@@ -217,13 +211,11 @@ TOKEN_MGR_DECLS :
 
 /* COMMENTS */
 
-<DEFAULT, NEWLINES_SKIPPED>
 SPECIAL_TOKEN :
 {
   <SINGLE_LINE_COMMENT: "//" (~["\n","\r"])* >
 }
 
-<DEFAULT, NEWLINES_SKIPPED>
 MORE :
 {
   <ENTER_JAVADOC_COMMENT: "/**" ~["/"]> { input_stream.backup(1); } : IN_JAVADOC_COMMENT
@@ -234,13 +226,13 @@ MORE :
 <IN_JAVADOC_COMMENT>
 SPECIAL_TOKEN :
 {
-  <JAVADOC_COMMENT: "*/" > { switchToDefaultState(); }
+  <JAVADOC_COMMENT: "*/" > : DEFAULT
 }
 
 <IN_MULTI_LINE_COMMENT>
 SPECIAL_TOKEN :
 {
-  <MULTI_LINE_COMMENT: "*/" >  { switchToDefaultState(); }
+  <MULTI_LINE_COMMENT: "*/" > : DEFAULT
 }
 
 <IN_JAVADOC_COMMENT, IN_MULTI_LINE_COMMENT>
@@ -251,7 +243,6 @@ MORE :
 
 /* RESERVED WORDS AND LITERALS */
 
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < ABSTRACT: "abstract" >
@@ -328,16 +319,8 @@ TOKEN :
 | < EXCL_DOT: "!." >
 }
 
-<DEFAULT>
-SPECIAL_TOKEN :
-{
-<UNIX_EOL: "\n"> { System.out.println("NEWLINESSS"); }
-| <WINDOWS_EOL : "\r\n">
-}
-
 /* LITERALS */
 
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < LONG_LITERAL:
@@ -437,7 +420,6 @@ TOKEN :
 
 /* IDENTIFIERS */
 
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < IDENTIFIER: <LETTER> (<PART_LETTER>)* >
@@ -604,7 +586,6 @@ TOKEN :
 
 /* SEPARATORS */
 
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < LPAREN: "(" >
@@ -621,7 +602,6 @@ TOKEN :
 
 /* OPERATORS */
 
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < ASSIGN: "=" >
@@ -664,7 +644,6 @@ TOKEN :
 }
 
 /* >'s need special attention due to generics syntax. */
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN :
 {
   < RUNSIGNEDSHIFT: ">>>" >
@@ -682,7 +661,6 @@ TOKEN :
 | < GT: ">" >
 }
 
-<DEFAULT, NEWLINES_SKIPPED>
 TOKEN: { <CTRL_Z: "\u001A" /** ctrl+z char **/> }
 
 /*****************************************
@@ -1524,7 +1502,7 @@ Expression ConditionalOrExpression():
 }
 {
   ret = ConditionalAndExpression()
-  ( "||" (EOL())* right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.OR); } )*
+  ( "||"  right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.OR); } )*
   { return ret; }
 }
 
@@ -1534,7 +1512,7 @@ Expression ConditionalAndExpression():
 	Expression right;
 }
 {
-  ret = InclusiveOrExpression() ( "&&" (EOL())* right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.AND); } )*
+  ret = InclusiveOrExpression() ( "&&"  right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.AND); } )*
   { return ret; }
 }
 
@@ -1680,7 +1658,6 @@ Expression UnaryExpression():
 	  ( "+" { op = UnaryExpr.Operator.PLUS; begin=token();} |
 	    "-" { op = UnaryExpr.Operator.MINUS; begin=token();}
 	  ) ret = UnaryExpression()
-	  (EOL())*
 	  {
         ret = new UnaryExpr(range(begin, token()), ret, op);
 	  }
@@ -2103,10 +2080,8 @@ NodeList<Expression> ArgumentList():
 	Expression expr;
 }
 {
-  (EOL())*
   expr = Expression() { ret.add(expr); }
-  (EOL())*
-  ( "," (EOL())* expr = Expression() { ret.add(expr); } )*
+  ( ","  expr = Expression() { ret.add(expr); } )*
   { return ret; }
 }
 
@@ -2305,7 +2280,7 @@ VariableDeclarationExpr VariableDeclarationExpression():
 EmptyStmt EmptyStatement():
 {}
 {
-    (";"|EOL())
+    ";"
     { return new EmptyStmt(tokenRange()); }
 }
 
@@ -2649,7 +2624,7 @@ ModifyStatement ModifyStatement():
             <MODIFY><LPAREN> (modifyObject = UnaryExpressionNotPlusMinus())<RPAREN> <LBRACE>
             (first = Statement()(EOS()))* { begin=token(); all.add(first); }
             (
-                          (<COMMA>)*(EOL())*
+                          (<COMMA>)*
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
@@ -2677,7 +2652,7 @@ WithStatement WithStatement():
             <WITH><LPAREN> (withObject = Expression())<RPAREN> <LBRACE>
             (first = Statement()(EOS()))* { begin=token(); all.add(first); }
             (
-                          (<COMMA>|EOL())
+                          <COMMA>
                           other = Statement() { all.add(other); }
             )*
             <RBRACE>
@@ -3394,16 +3369,9 @@ TemporalLiteralChunkExpr TemporalLiteralChunk():
   { return ret; }
 }
 
-void EOL():
-{
-}
-{
-    "%%%"//<UNIX_EOL>|<WINDOWS_EOL>
-}
-
 void EOS():
 {
 }
 {
-   (<SEMICOLON>)* | ( LOOKAHEAD( { getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL } ) {} )
+   (<SEMICOLON>)* | ( LOOKAHEAD( { this.optionalSemicolon && getToken(1).specialToken.kind == UNIX_EOL ||  getToken(1).specialToken.kind == WINDOWS_EOL } ) {} )
 }

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -911,13 +911,18 @@ public class DroolsMvelParserTest {
 
     @Test
     public void testSpecialNewlineHandling() {
-        String expr = "{ a() \n + 1}";
+        String expr = "{ a() \nprint(1) }";
 
-        assertThrows("Parsing should stop at newline", ParseProblemException.class, () -> MvelParser.parseBlock(expr));
+        assertEquals("There should be 2 statements",
+                     "{\n" +
+                             "    a();\n" +
+                             "    print(1);\n" +
+                             "}",
+                     printConstraint(MvelParser.parseBlock(expr)));
 
-//        MvelParser mvelParser = new MvelParser(new ParserConfiguration(), true);
-//        BlockStmt r2 = mvelParser.parse(GeneratedMvelParser::BlockParseStart, new StringProvider(expr)).getResult().get();
-//        assertEquals("Parsing must ignore newlines","1 + 1", r2.toString());
+        MvelParser mvelParser = new MvelParser(new ParserConfiguration(), false);
+        ParseResult<BlockStmt> r = mvelParser.parse(GeneratedMvelParser::BlockParseStart, new StringProvider(expr));
+        assertFalse("Parsing should break at newline", r.isSuccessful());
     }
 
     private void testMvelSquareOperator(String wholeExpression, String operator, String left, String right, boolean isNegated) {

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
@@ -52,10 +53,12 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.drools.mvel.parser.DrlxParser.parseExpression;
+import static org.drools.mvel.parser.Providers.provider;
 import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -903,6 +906,18 @@ public class DroolsMvelParserTest {
         assertEquals(expr, printConstraint(expression));
     }
 
+    @Test
+    public void testSpecialNewlineHandling() {
+        String expr = "1 \n + 1";
+
+        Expression r1 = parseExpression(parser, expr).getExpr();
+        assertEquals("Parsing should stop at newline", "1", printConstraint(r1));
+
+        MvelParser mvelParser = new MvelParser();
+        mvelParser.setIgnoreNewlines(true);
+        Expression r2 = mvelParser.parse(GeneratedMvelParser::Expression, new StringProvider(expr)).getResult().get();
+        assertEquals("Parsing must ignore newlines","1 + 1", printConstraint(r2));
+    }
 
     private void testMvelSquareOperator(String wholeExpression, String operator, String left, String right, boolean isNegated) {
         String expr = wholeExpression;

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class DroolsMvelParserTest {
@@ -723,14 +724,14 @@ public class DroolsMvelParserTest {
     @Test
     public void testWithoutSemicolon() {
         String expr = "{             " +
-                        "a" + newLine() +
-                        "b" + newLine() +
+                        "a()" + newLine() +
+                        "b()" + newLine() +
                         "}";
 
         BlockStmt expression = MvelParser.parseBlock(expr);
         assertEquals("{" + newLine() +
-                             "    a;" + newLine() +
-                             "    b;" + newLine() +
+                             "    a();" + newLine() +
+                             "    b();" + newLine() +
                              "}", printConstraint(expression));
     }
 
@@ -822,8 +823,8 @@ public class DroolsMvelParserTest {
 
         BlockStmt expression = MvelParser.parseBlock(expr);
         assertEquals("{" + newLine() +
-                             "    ;" + newLine() +
-                             "    ;" + newLine() +
+//                             "    ;" + newLine() +
+//                             "    ;" + newLine() +
                              "    setAge(47);" + newLine() +
                              "}", printConstraint(expression));
     }
@@ -912,14 +913,13 @@ public class DroolsMvelParserTest {
 
     @Test
     public void testSpecialNewlineHandling() {
-        String expr = "1 \n + 1";
+        String expr = "{ a() \n + 1}";
 
-        Expression r1 = parseExpression(parser, expr).getExpr();
-        assertEquals("Parsing should stop at newline", "1", printConstraint(r1));
+        assertThrows("Parsing should stop at newline", ParseProblemException.class, () -> MvelParser.parseBlock(expr));
 
-        MvelParser mvelParser = new MvelParser(new ParserConfiguration(), true);
-        Expression r2 = mvelParser.parse(GeneratedMvelParser::Expression, new StringProvider(expr)).getResult().get();
-        assertEquals("Parsing must ignore newlines","1 + 1", printConstraint(r2));
+//        MvelParser mvelParser = new MvelParser(new ParserConfiguration(), true);
+//        BlockStmt r2 = mvelParser.parse(GeneratedMvelParser::BlockParseStart, new StringProvider(expr)).getResult().get();
+//        assertEquals("Parsing must ignore newlines","1 + 1", r2.toString());
     }
 
     private void testMvelSquareOperator(String wholeExpression, String operator, String left, String right, boolean isNegated) {

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -821,8 +821,6 @@ public class DroolsMvelParserTest {
 
         BlockStmt expression = MvelParser.parseBlock(expr);
         assertEquals("{" + newLine() +
-                             "    ;" + newLine() +
-                             "    ;" + newLine() +
                              "    setAge(47);" + newLine() +
                              "}", printConstraint(expression));
     }

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -105,7 +105,6 @@ public class DroolsMvelParserTest {
         assertEquals("(addresses == 2 && addresses == 3)", printConstraint(and));
     }
 
-    @Test(expected = ParseProblemException.class)
     public void testBinaryWithNewLineBeginning() {
         Expression or = parseExpression(parser, "(" + newLine() + "addresses == 2 || addresses == 3  )").getExpr();
         assertEquals("(addresses == 2 || addresses == 3)", printConstraint(or));
@@ -114,7 +113,6 @@ public class DroolsMvelParserTest {
         assertEquals("(addresses == 2 && addresses == 3)", printConstraint(and));
     }
 
-    @Test(expected = ParseProblemException.class)
     public void testBinaryWithNewLineEnd() {
         Expression or = parseExpression(parser, "(addresses == 2 || addresses == 3 " + newLine() + ")").getExpr();
         assertEquals("(addresses == 2 || addresses == 3)", printConstraint(or));
@@ -131,7 +129,7 @@ public class DroolsMvelParserTest {
         assertEquals("(addresses == 2 && addresses == 3)", printConstraint(and2));
 
         String orExpr = "(addresses == 2" + newLine() + "|| addresses == 3  )";
-        MvelParser mvelParser2 = new MvelParser(new ParserConfiguration(), true);
+        MvelParser mvelParser2 = new MvelParser(new ParserConfiguration(), false);
         Expression or2 = mvelParser2.parse(GeneratedMvelParser::Expression, new StringProvider(orExpr)).getResult().get();
         assertEquals("(addresses == 2 || addresses == 3)", printConstraint(or2));
     }

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -821,8 +821,8 @@ public class DroolsMvelParserTest {
 
         BlockStmt expression = MvelParser.parseBlock(expr);
         assertEquals("{" + newLine() +
-//                             "    ;" + newLine() +
-//                             "    ;" + newLine() +
+                             "    ;" + newLine() +
+                             "    ;" + newLine() +
                              "    setAge(47);" + newLine() +
                              "}", printConstraint(expression));
     }

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
@@ -122,12 +123,15 @@ public class DroolsMvelParserTest {
     }
 
     @Test
-    @Ignore
     public void testBinaryWithNewLineBeforeOperator() {
-        Expression and2 = parseExpression(parser, "(addresses == 2" + newLine() + "&& addresses == 3  )").getExpr();
+        String andExpr = "(addresses == 2" + newLine() + "&& addresses == 3  )";
+        MvelParser mvelParser1 = new MvelParser(new ParserConfiguration(), true);
+        Expression and2 = mvelParser1.parse(GeneratedMvelParser::Expression, new StringProvider(andExpr)).getResult().get();
         assertEquals("(addresses == 2 && addresses == 3)", printConstraint(and2));
 
-        Expression or2 = parseExpression(parser, "(addresses == 2" + newLine() + "|| addresses == 3  )").getExpr();
+        String orExpr = "(addresses == 2" + newLine() + "|| addresses == 3  )";
+        MvelParser mvelParser2 = new MvelParser(new ParserConfiguration(), true);
+        Expression or2 = mvelParser2.parse(GeneratedMvelParser::Expression, new StringProvider(orExpr)).getResult().get();
         assertEquals("(addresses == 2 || addresses == 3)", printConstraint(or2));
     }
 
@@ -913,8 +917,7 @@ public class DroolsMvelParserTest {
         Expression r1 = parseExpression(parser, expr).getExpr();
         assertEquals("Parsing should stop at newline", "1", printConstraint(r1));
 
-        MvelParser mvelParser = new MvelParser();
-        mvelParser.setIgnoreNewlines(true);
+        MvelParser mvelParser = new MvelParser(new ParserConfiguration(), true);
         Expression r2 = mvelParser.parse(GeneratedMvelParser::Expression, new StringProvider(expr)).getResult().get();
         assertEquals("Parsing must ignore newlines","1 + 1", printConstraint(r2));
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5762

This is an alternative IMO cleaner version of https://github.com/kiegroup/drools/pull/3275. 

Instead of a new lexer state, we take inspiration for [this antlr JavaScript grammar](https://github.com/antlr/grammars-v4/blob/master/javascript/javascript/JavaScriptParser.g4#L506-L510)

The change is even more minimal that the other PR, plus it makes IMO cleaner the grammar, by getting rid of `EOL()`.

- it makes all whitespace, including new lines, SPECIAL_TOKENs -- so they are processed by the lexer, but not emitted directly to the parser
- it introduces a new rule in the parser EOS() -- End Of Statement
- EOS() is either a semicolon or EOF or a _semantic lookahead_ (i.e. a predicate)
- in the semantic lookahead -- if semicolons are optional -- we look for either:
   (1) a newline on the "special" channel before the next token;
   (2) a closing brace '}';
   (3) an identifier (this is probably a special case)
   (4) if it's a `with` or `modify` statement, a comma may also terminate the statement

(4) uses a minor hack which assumes that `modify` and `with` cannot nest; i.e. I am using a **boolean** when we descend into a `with` or `modify` statement (I think the grammar may still allow for nesting but I think that probably we can safely disallow it). 

Finally, a flag is exposed in `MvelParser` via a boolean field. We may consider forking `ParserConfiguration` and add it there (currently we are reusing the same class in JavaParser's library, so that can't be customized).

enabling the special behavior is as easy as setting the flag with `mvelParser.setOptionalSemicolon(false)` (see the test)

we may consider flipping the default (i.e. default to nonsignificant whitespace) but I wanted to keep the change minimal for now.

