### PR TITLE
DROOLS-5883: Allow contains operator for string fields

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
@@ -979,17 +979,24 @@ public class GuidedDTDRLPersistence {
         //expansion and contraction of decision table columns.... this might have to go.
         if (no(c.getOperator())) {
 
-            String[] a = cell.split("\\s");
-            if (a.length > 1) {
-                //Operator might be 1 part (e.g. "==") or two parts (e.g. "not in")
-                StringBuilder operator = new StringBuilder(a[0]);
-                for (int i = 1; i < a.length - 1; i++) {
-                    operator.append(a[i]);
-                }
-                sfc.setOperator(operator.toString());
-                sfc.setValue(a[a.length - 1]);
+            int quotesIndex = cell.indexOf('"');
+            if (quotesIndex > 0) {
+                // DROOLS-5883
+                sfc.setOperator(cell.substring(0, quotesIndex).trim());
+                sfc.setValue(cell.substring(quotesIndex));
             } else {
-                sfc.setValue(cell);
+                String[] a = cell.split("\\s");
+                if (a.length > 1) {
+                    //Operator might be 1 part (e.g. "==") or two parts (e.g. "not in")
+                    StringBuilder operator = new StringBuilder(a[0]);
+                    for (int i = 1; i < a.length - 1; i++) {
+                        operator.append(a[i]);
+                    }
+                    sfc.setOperator(operator.toString());
+                    sfc.setValue(a[a.length - 1]);
+                } else {
+                    sfc.setValue(cell);
+                }
             }
         } else {
 

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
@@ -1726,6 +1726,92 @@ public class GuidedDTDRLPersistenceTest {
     }
 
     @Test
+    public void testNoOperatorContainsWhitespacesLiteralValue() {
+        GuidedDTDRLPersistence p = new GuidedDTDRLPersistence();
+        String[] row = new String[]{"1", "desc", "a", "contains \"abc efg\""};
+        String[][] data = new String[1][];
+        data[0] = row;
+
+        List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
+        List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
+        allColumns.add(new RowNumberCol52());
+        allColumns.add(new DescriptionCol52());
+        allColumns.add(new MetadataCol52());
+
+        Pattern52 p1 = new Pattern52();
+        p1.setBoundName("p1");
+        p1.setFactType("Person");
+        allPatterns.add(p1);
+
+        ConditionCol52 col1 = new ConditionCol52();
+        col1.setFactField("name");
+        col1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        col1.setOperator("");
+        p1.getChildColumns().add(col1);
+        allColumns.add(col1);
+
+        RuleModel rm = new RuleModel();
+
+        List<DTCellValue52> rowData = DataUtilities.makeDataRowList(row);
+        TemplateDataProvider rowDataProvider = new GuidedDTTemplateDataProvider(allColumns,
+                                                                                rowData);
+
+        p.doConditions(allColumns,
+                       allPatterns,
+                       rowDataProvider,
+                       rowData,
+                       DataUtilities.makeDataLists(data),
+                       rm);
+
+        String drl = RuleModelDRLPersistenceImpl.getInstance().marshal(rm);
+        System.out.println(drl);
+        assertTrue(drl.indexOf("name contains \"abc efg\"") > 0);
+    }
+
+    @Test
+    public void testNoOperatorContainsWhitespacesFormula() {
+        GuidedDTDRLPersistence p = new GuidedDTDRLPersistence();
+        String[] row = new String[]{"1", "desc", "a", "contains \"abc efg\""};
+        String[][] data = new String[1][];
+        data[0] = row;
+
+        List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
+        List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
+        allColumns.add(new RowNumberCol52());
+        allColumns.add(new DescriptionCol52());
+        allColumns.add(new MetadataCol52());
+
+        Pattern52 p1 = new Pattern52();
+        p1.setBoundName("p1");
+        p1.setFactType("Person");
+        allPatterns.add(p1);
+
+        ConditionCol52 col1 = new ConditionCol52();
+        col1.setFactField("name");
+        col1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_RET_VALUE);
+        col1.setOperator("");
+        p1.getChildColumns().add(col1);
+        allColumns.add(col1);
+
+        RuleModel rm = new RuleModel();
+
+        List<DTCellValue52> rowData = DataUtilities.makeDataRowList(row);
+        TemplateDataProvider rowDataProvider = new GuidedDTTemplateDataProvider(allColumns,
+                                                                                rowData);
+
+        p.doConditions(allColumns,
+                       allPatterns,
+                       rowDataProvider,
+                       rowData,
+                       DataUtilities.makeDataLists(data),
+                       rm);
+
+        String drl = RuleModelDRLPersistenceImpl.getInstance().marshal(rm);
+        System.out.println(drl);
+        assertTrue(drl.indexOf("name contains ( \"abc efg\" ) ") > 0);
+    }
+
+    @Test
     public void testRHS() {
         GuidedDTDRLPersistence p = new GuidedDTDRLPersistence();
         String[] row = new String[]{"1", "desc", "a", "a condition", "actionsetfield1", "actionupdatefield2", "retract", "actioninsertfact1", "actioninsertfact2"};
@@ -2821,6 +2907,37 @@ public class GuidedDTDRLPersistenceTest {
         index = drl.indexOf("Smurf( )",
                             index + 1);
         assertFalse(index > -1);
+    }
+
+    @Test
+    public void testLHSContainsOperator() {
+        GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+        dt.setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
+        dt.setTableName("extended-entry");
+
+        Pattern52 p1 = new Pattern52();
+        p1.setBoundName("p1");
+        p1.setFactType("Smurf");
+        dt.getConditions().add(p1);
+
+        ConditionCol52 cc1 = new ConditionCol52();
+        cc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        cc1.setFieldType(DataType.TYPE_STRING);
+        cc1.setFactField("name");
+        cc1.setOperator("contains");
+        p1.getChildColumns().add(cc1);
+
+        dt.setData(DataUtilities.makeDataLists(new Object[][]{
+                new Object[]{1l, "", "desc", "a b"},
+        }));
+
+        GuidedDTDRLPersistence p = GuidedDTDRLPersistence.getInstance();
+        String drl = p.marshal(dt);
+
+        int index = -1;
+        index = drl.indexOf("Smurf( name contains \"a b\" )");
+        assertTrue(index > -1);
+
     }
 
     @Test

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistenceTest.java
@@ -1727,88 +1727,54 @@ public class GuidedDTDRLPersistenceTest {
 
     @Test
     public void testNoOperatorContainsWhitespacesLiteralValue() {
-        GuidedDTDRLPersistence p = new GuidedDTDRLPersistence();
-        String[] row = new String[]{"1", "desc", "a", "contains \"abc efg\""};
-        String[][] data = new String[1][];
-        data[0] = row;
-
-        List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
-        List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
-        allColumns.add(new RowNumberCol52());
-        allColumns.add(new DescriptionCol52());
-        allColumns.add(new MetadataCol52());
-
         Pattern52 p1 = new Pattern52();
         p1.setBoundName("p1");
         p1.setFactType("Person");
-        allPatterns.add(p1);
 
         ConditionCol52 col1 = new ConditionCol52();
         col1.setFactField("name");
         col1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
         col1.setOperator("");
         p1.getChildColumns().add(col1);
-        allColumns.add(col1);
 
-        RuleModel rm = new RuleModel();
+        GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+        dt.getConditions().add(p1);
 
-        List<DTCellValue52> rowData = DataUtilities.makeDataRowList(row);
-        TemplateDataProvider rowDataProvider = new GuidedDTTemplateDataProvider(allColumns,
-                                                                                rowData);
+        dt.setData(DataUtilities.makeDataLists(new Object[][] {
+                new String[]{"1", "contains test", "desc", "contains \"abc efg\""},
+                new String[]{"2", "not contains test", "desc", "not contains \"x y z\""}
+        }));
 
-        p.doConditions(allColumns,
-                       allPatterns,
-                       rowDataProvider,
-                       rowData,
-                       DataUtilities.makeDataLists(data),
-                       rm);
-
-        String drl = RuleModelDRLPersistenceImpl.getInstance().marshal(rm);
-        System.out.println(drl);
+        GuidedDTDRLPersistence p = GuidedDTDRLPersistence.getInstance();
+        String drl = p.marshal(dt);
         assertTrue(drl.indexOf("name contains \"abc efg\"") > 0);
+        assertTrue(drl.indexOf("name not contains \"x y z\"") > 0);
     }
 
     @Test
     public void testNoOperatorContainsWhitespacesFormula() {
-        GuidedDTDRLPersistence p = new GuidedDTDRLPersistence();
-        String[] row = new String[]{"1", "desc", "a", "contains \"abc efg\""};
-        String[][] data = new String[1][];
-        data[0] = row;
-
-        List<BaseColumn> allColumns = new ArrayList<BaseColumn>();
-        List<CompositeColumn<? extends BaseColumn>> allPatterns = new ArrayList<CompositeColumn<? extends BaseColumn>>();
-        allColumns.add(new RowNumberCol52());
-        allColumns.add(new DescriptionCol52());
-        allColumns.add(new MetadataCol52());
-
         Pattern52 p1 = new Pattern52();
         p1.setBoundName("p1");
         p1.setFactType("Person");
-        allPatterns.add(p1);
 
         ConditionCol52 col1 = new ConditionCol52();
         col1.setFactField("name");
         col1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_RET_VALUE);
         col1.setOperator("");
         p1.getChildColumns().add(col1);
-        allColumns.add(col1);
 
-        RuleModel rm = new RuleModel();
+        GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+        dt.getConditions().add(p1);
 
-        List<DTCellValue52> rowData = DataUtilities.makeDataRowList(row);
-        TemplateDataProvider rowDataProvider = new GuidedDTTemplateDataProvider(allColumns,
-                                                                                rowData);
+        dt.setData(DataUtilities.makeDataLists(new Object[][] {
+                new String[]{"1", "contains test", "desc", "contains \"abc efg\""},
+                new String[]{"2", "not contains test", "desc", "not contains \"x y z\""}
+        }));
 
-        p.doConditions(allColumns,
-                       allPatterns,
-                       rowDataProvider,
-                       rowData,
-                       DataUtilities.makeDataLists(data),
-                       rm);
-
-        String drl = RuleModelDRLPersistenceImpl.getInstance().marshal(rm);
-        System.out.println(drl);
-        assertTrue(drl.indexOf("name contains ( \"abc efg\" ) ") > 0);
+        GuidedDTDRLPersistence p = GuidedDTDRLPersistence.getInstance();
+        String drl = p.marshal(dt);
+        assertTrue(drl.indexOf("name contains ( \"abc efg\" )") > 0);
+        assertTrue(drl.indexOf("name not contains ( \"x y z\" )") > 0);
     }
 
     @Test
@@ -2937,7 +2903,36 @@ public class GuidedDTDRLPersistenceTest {
         int index = -1;
         index = drl.indexOf("Smurf( name contains \"a b\" )");
         assertTrue(index > -1);
+    }
 
+    @Test
+    public void testLHSNotContainsOperator() {
+        GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+        dt.setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
+        dt.setTableName("extended-entry");
+
+        Pattern52 p1 = new Pattern52();
+        p1.setBoundName("p1");
+        p1.setFactType("Smurf");
+        dt.getConditions().add(p1);
+
+        ConditionCol52 cc1 = new ConditionCol52();
+        cc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        cc1.setFieldType(DataType.TYPE_STRING);
+        cc1.setFactField("name");
+        cc1.setOperator("not contains");
+        p1.getChildColumns().add(cc1);
+
+        dt.setData(DataUtilities.makeDataLists(new Object[][]{
+                new Object[]{1l, "", "desc", "a b"},
+        }));
+
+        GuidedDTDRLPersistence p = GuidedDTDRLPersistence.getInstance();
+        String drl = p.marshal(dt);
+
+        int index = -1;
+        index = drl.indexOf("Smurf( name not contains \"a b\" )");
+        assertTrue(index > -1);
     }
 
     @Test


### PR DESCRIPTION
Guided decision table and guided rule editor will ofer 'contains' operator also for string fields

For more details see https://issues.redhat.com/browse/DROOLS-5883

**Thank you for submitting this pull request**

**JIRA**: [DROOLS-5883](https://issues.redhat.com/browse/DROOLS-5883)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-soup/pull/165
* https://github.com/kiegroup/drools-wb/pull/1448

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
