### PR TITLE
[DROOLS-5891] The use of BigDecimal literal causes a build failure in executable model.

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -475,6 +475,35 @@ public class MvelDialectTest extends BaseModelTest {
     }
 
     @Test
+    public void testModifyOnBigDecimalWithLiteral() {
+        // DROOLS-5891
+        String drl =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "dialect \"mvel\"\n" +
+                "rule R\n" +
+                "when\n" +
+                "    $p : Person( age >= 26 )\n" +
+                "then\n" +
+                "   modify($p) {" +
+                "       money = 1000.23B;\n" +
+                "   } " +
+                "end";
+
+        KieSession ksession = getKieSession(drl);
+
+        Person john = new Person("John", 30);
+        john.setMoney( new BigDecimal( 70000 ) );
+
+        Person leonardo = new Person("Leonardo", 4);
+        leonardo.setMoney( new BigDecimal( 500 ) );
+
+        ksession.insert(john);
+        assertEquals(1, ksession.fireAllRules());
+        assertEquals(new BigDecimal( "1000.23" ), john.getMoney());
+        assertEquals(new BigDecimal( 500 ), leonardo.getMoney());
+    }
+
+    @Test
     public void testBinaryOperationOnInteger() {
         // RHDM-1421
         String drl =

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
@@ -25,8 +25,8 @@ import com.github.javaparser.ast.stmt.Statement;
 import org.drools.mvel.parser.ast.expr.DrlNameExpr;
 import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
 import org.drools.mvelcompiler.ast.AssignExprT;
+import org.drools.mvelcompiler.ast.BigDecimalArithmeticExprT;
 import org.drools.mvelcompiler.ast.BlockStmtT;
-import org.drools.mvelcompiler.ast.BigDecimalExprT;
 import org.drools.mvelcompiler.ast.ExpressionStmtT;
 import org.drools.mvelcompiler.ast.FieldToAccessorTExpr;
 import org.drools.mvelcompiler.ast.ForEachDowncastStmtT;
@@ -215,8 +215,8 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, Void> {
         }
 
         if (target.getType().filter(t -> t == BigDecimal.class).isPresent()) {
-            String bigDecimalMethod = BigDecimalExprT.toBigDecimalMethod(operator.toString());
-            BigDecimalExprT convertedBigDecimalExpr = new BigDecimalExprT(bigDecimalMethod, target, value);
+            String bigDecimalMethod = BigDecimalArithmeticExprT.toBigDecimalMethod(operator.toString());
+            BigDecimalArithmeticExprT convertedBigDecimalExpr = new BigDecimalArithmeticExprT(bigDecimalMethod, target, value);
             return Optional.of(new AssignExprT(AssignExpr.Operator.ASSIGN, target, convertedBigDecimalExpr));
         }
         return Optional.empty();

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ReProcessRHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ReProcessRHSPhase.java
@@ -8,7 +8,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
 import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
-import org.drools.mvelcompiler.ast.BigDecimalExprT;
+import org.drools.mvelcompiler.ast.BigDecimalConstantExprT;
 import org.drools.mvelcompiler.ast.IntegerLiteralExpressionT;
 import org.drools.mvelcompiler.ast.LongLiteralExpressionT;
 import org.drools.mvelcompiler.ast.TypedExpression;
@@ -46,6 +46,6 @@ public class ReProcessRHSPhase implements DrlGenericVisitor<Optional<TypedExpres
     private Optional<TypedExpression> convertWhenLHSISBigDecimal(Supplier<TypedExpression> conversionFunction) {
         return lhs.getType()
                 .filter(BigDecimal.class::equals)
-                .flatMap(t -> Optional.of(BigDecimalExprT.valueOf(conversionFunction.get())));
+                .flatMap(t -> Optional.of(new BigDecimalConstantExprT(conversionFunction.get())));
     }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalArithmeticExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalArithmeticExprT.java
@@ -5,15 +5,12 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 
 import static com.github.javaparser.ast.NodeList.nodeList;
 
-public class BigDecimalExprT implements TypedExpression {
+public class BigDecimalArithmeticExprT implements TypedExpression {
 
     private final String name;
     private final TypedExpression argument;
@@ -32,17 +29,12 @@ public class BigDecimalExprT implements TypedExpression {
         throw new RuntimeException("Unknown operator");
     }
 
-    public BigDecimalExprT(String bigDecimalMethod,
-                           TypedExpression scope,
-                           TypedExpression argument) {
+    public BigDecimalArithmeticExprT(String bigDecimalMethod,
+                                     TypedExpression scope,
+                                     TypedExpression argument) {
         this.name = bigDecimalMethod;
         this.scope = scope;
         this.argument = argument;
-    }
-
-    public static BigDecimalExprT valueOf(TypedExpression value) {
-        return new BigDecimalExprT("valueOf", new SimpleNameTExpr(BigDecimal.class.getCanonicalName(), BigDecimal.class),
-                                   value);
     }
 
     @Override

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalConstantExprT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/BigDecimalConstantExprT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.ast;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class BigDecimalConstantExprT implements TypedExpression {
+
+    private final TypedExpression value;
+    private final Type type = BigDecimal.class;
+
+    public BigDecimalConstantExprT(TypedExpression value) {
+        this.value = value;
+    }
+
+    @Override
+    public Optional<Type> getType() {
+        return Optional.of(type);
+    }
+
+    @Override
+    public Node toJavaExpression() {
+
+        return new ObjectCreationExpr(null,
+                                      StaticJavaParser.parseClassOrInterfaceType(type.getTypeName()),
+                                      nodeList((Expression) value.toJavaExpression()));
+    }
+
+    @Override
+    public String toString() {
+        return "BigDecimalConstantExprT{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -112,28 +112,36 @@ public class MvelCompilerTest implements CompilerTest {
     public void testSetterBigDecimal() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.salary = $p.salary + 50000; }",
-             "{ $p.setSalary($p.getSalary().add(java.math.BigDecimal.valueOf(50000))); }");
+             "{ $p.setSalary($p.getSalary().add(new java.math.BigDecimal(50000))); }");
     }
 
     @Test
     public void testSetterBigDecimalConstant() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.salary = 50000; }",
-             "{ $p.setSalary(java.math.BigDecimal.valueOf(50000)); }");
+             "{ $p.setSalary(new java.math.BigDecimal(50000)); }");
     }
 
     @Test
     public void testSetterBigDecimalConstantFromLong() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.salary = 50000L; }",
-             "{ $p.setSalary(java.math.BigDecimal.valueOf(50000L)); }");
+             "{ $p.setSalary(new java.math.BigDecimal(50000L)); }");
     }
 
     @Test
     public void testSetterBigDecimalConstantModify() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify ( $p )  { salary = 50000 }; }",
-             "{ $p.setSalary(java.math.BigDecimal.valueOf(50000)); }",
+             "{ $p.setSalary(new java.math.BigDecimal(50000)); }",
+             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+    }
+
+    @Test
+    public void testSetterBigDecimalLiteralModify() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "{ modify ( $p )  { salary = 50000B }; }",
+             "{ $p.setSalary(new java.math.BigDecimal(\"50000\")); }",
              result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
     }
 
@@ -147,7 +155,7 @@ public class MvelCompilerTest implements CompilerTest {
                           "}",
              "{\n " +
                          "      list.add(\"before \" + $p + \", money = \" + $p.getSalary()); " +
-                         "      $p.setSalary(java.math.BigDecimal.valueOf(50000));" +
+                         "      $p.setSalary(new java.math.BigDecimal(50000));" +
                          "      list.add(\"after \" + $p + \", money = \" + $p.getSalary()); " +
                          "}\n",
              result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
@@ -341,8 +349,8 @@ public class MvelCompilerTest implements CompilerTest {
                      "    sum -= money;\n" +
                      "}",
              "{ " +
-                     "    java.math.BigDecimal sum = java.math.BigDecimal.valueOf(0);\n" +
-                     "    java.math.BigDecimal money = java.math.BigDecimal.valueOf(10);\n" +
+                     "    java.math.BigDecimal sum = new java.math.BigDecimal(0);\n" +
+                     "    java.math.BigDecimal money = new java.math.BigDecimal(10);\n" +
                      "    sum = sum.add(money);\n" +
                      "    sum = sum.subtract(money);\n" +
                      "}");

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigDecimalLiteralExpr.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/BigDecimalLiteralExpr.java
@@ -82,12 +82,16 @@ public final class BigDecimalLiteralExpr extends LiteralStringValueExpr {
      * @return the literal value as an long while respecting different number representations
      */
     public BigDecimal asBigDecimal() {
+        return new BigDecimal(getValue());
+    }
+
+    public String getValue() {
         String result = value.replaceAll("_", "");
         char lastChar = result.charAt(result.length() - 1);
         if (lastChar == 'B') {
             result = result.substring(0, result.length() - 1);
         }
-        return new BigDecimal(result);
+        return result;
     }
 
     public BigDecimalLiteralExpr setLong(long value) {


### PR DESCRIPTION
**Thank you for submitting this pull request**

https://issues.redhat.com/browse/DROOLS-5891

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
