### PR TITLE
[DROOLS-5916] Wrong BetaIndex with Or in executable-model

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
@@ -90,7 +90,9 @@ public class LambdaConstraint extends AbstractConstraint {
     @Override
     public void replaceDeclaration(Declaration oldDecl, Declaration newDecl) {
         evaluator.replaceDeclaration( oldDecl, newDecl );
-        this.indexingDeclaration = newDecl;
+        if (indexingDeclaration == oldDecl) {
+            this.indexingDeclaration = newDecl;
+        }
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OrTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OrTest.java
@@ -24,8 +24,6 @@ import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.Employee;
 import org.drools.modelcompiler.domain.Person;
 import org.junit.Test;
-import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.Message;
 import org.kie.api.builder.Results;
 import org.kie.api.runtime.KieSession;
 
@@ -60,7 +58,30 @@ public class OrTest extends BaseModelTest {
         ksession.insert( new Person( "Mark", 37 ) );
         ksession.insert( new Person( "Edson", 35 ) );
         ksession.insert( new Person( "Mario", 40 ) );
-        ksession.fireAllRules();
+        assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testOrWithBetaIndex() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "  $p : Person(name == \"Mark\") or\n" +
+                     "  ( $mark : Person(name == \"Mark\")\n" +
+                     "    and\n" +
+                     "    $p : Person(age == $mark.age) )\n" +
+                     "  $s: String(this == $p.name)\n" +
+                     "then\n" +
+                     "  System.out.println(\"Found: \" + $s);\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert("Mario");
+        ksession.insert(new Person("Mark", 37));
+        ksession.insert(new Person("Edson", 35));
+        ksession.insert(new Person("Mario", 37));
+        assertEquals(1, ksession.fireAllRules());
     }
 
     @Test


### PR DESCRIPTION
When a pattern inside "or" has a constraint which compares to a property of a bind variable, LambdaConstraint.indexingDeclaration is wrongly replaced (during LogicTransformer.transform()) so results in a wrong rule execution.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-5916

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
