### PR TITLE
[DROOLS-5920] Wrong BetaIndex offset with Or in executable-model

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
@@ -92,6 +92,11 @@ public class LambdaConstraint extends AbstractConstraint {
         evaluator.replaceDeclaration( oldDecl, newDecl );
         if (indexingDeclaration == oldDecl) {
             this.indexingDeclaration = newDecl;
+        } else if (indexingDeclaration != null && indexingDeclaration.getIdentifier().equals(oldDecl.getIdentifier()) && indexingDeclaration.getPattern() == oldDecl.getPattern()) {
+            // indexingDeclaration was cloned from oldDecl
+            Declaration newIndexingDeclaration = newDecl.clone();
+            newIndexingDeclaration.setReadAccessor(indexingDeclaration.getExtractor());
+            indexingDeclaration = newIndexingDeclaration;
         }
     }
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OrTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/OrTest.java
@@ -85,6 +85,30 @@ public class OrTest extends BaseModelTest {
     }
 
     @Test
+    public void testOrWithBetaIndexOffset() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "  $e : Person(name == \"Edson\")\n" +
+                     "  $p : Person(name == \"Mark\") or\n" +
+                     "  ( $mark : Person(name == \"Mark\")\n" +
+                     "    and\n" +
+                     "    $p : Person(age == $mark.age) )\n" +
+                     "  $s: String(this == $p.name)\n" +
+                     "then\n" +
+                     "  System.out.println(\"Found: \" + $s);\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert("Mario");
+        ksession.insert(new Person("Mark", 37));
+        ksession.insert(new Person("Edson", 35));
+        ksession.insert(new Person("Mario", 37));
+        assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
     public void testOrConditional() {
         final String drl =
                 "import " + Employee.class.getCanonicalName() + ";" +


### PR DESCRIPTION
Fix for DROOLS-5916 was not enough. LambdaConstraint.indexingDeclaration needs to be updated when an original Declaration is replaced. If not, betaIndex uses a wrong offset to retrieve a fact from a tuple.

**JIRA**:

https://issues.redhat.com/browse/DROOLS-5920

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
