### PR TITLE
DROOLS-5931 DMN document with further examples decimal() built-in fn

### DIFF
--- a/kie-dmn/ref-dmn-feel-builtin-functions.adoc
+++ b/kie-dmn/ref-dmn-feel-builtin-functions.adoc
@@ -1360,7 +1360,7 @@ Returns a number with the specified scale.
 |`number` in the range `[−6111..6176]`
 |===
 
-NOTE: This function is implemented to be consistent with the `FEEL:number` definition for _rounding toward the nearest neighbor with ties favoring the even neighbor_.
+NOTE: This function is implemented to be consistent with the `FEEL:number` definition for rounding decimal numbers to the nearest even decimal number.
 
 .Examples
 [source,FEEL]


### PR DESCRIPTION
Align with docs review
https://github.com/kiegroup/kie-docs/pull/3130#pullrequestreview-565311606

**JIRA**: https://issues.redhat.com/browse/DROOLS-5931

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
