### PR TITLE
[KOGITO-4160] - Fix StackOverflow error when writing explicit lambdas without fingerprints in Native Image in the executable model

### DIFF
--- a/drools-core/src/main/java/org/drools/core/base/CoreComponentsBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/base/CoreComponentsBuilder.java
@@ -23,7 +23,7 @@ import org.kie.api.internal.utils.ServiceRegistry;
 
 public interface CoreComponentsBuilder {
 
-    boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    boolean IS_NATIVE_IMAGE = Boolean.parseBoolean(System.getProperty("org.graalvm.nativeimage.imagecode"));
 
     String NO_MVEL = "You're trying to compile a Drools asset without mvel. Please add the module org.drools:drools-mvel to your classpath.";
 

--- a/drools-core/src/main/java/org/drools/core/base/CoreComponentsBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/base/CoreComponentsBuilder.java
@@ -23,7 +23,7 @@ import org.kie.api.internal.utils.ServiceRegistry;
 
 public interface CoreComponentsBuilder {
 
-    boolean IS_NATIVE_IMAGE = Boolean.parseBoolean(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     String NO_MVEL = "You're trying to compile a Drools asset without mvel. Please add the module org.drools:drools-mvel to your classpath.";
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -60,7 +60,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
             logger.debug("No HashedExpression provided, generating fingerprint using reflection via org.drools.mvel.asm.LambdaIntrospector, node sharing enabled");
             return LambdaPrinter.print(getLambda());
         } else {
-            logger.warn("No HashedExpression provided with lambda, using Identity Hash Code as a lambda fingerprint, node sharing won't work correctly");
+            logger.warn("No HashedExpression provided with lambda, using System.identityHashCode as the lambda fingerprint, this will impact performances as node sharing won't work correctly");
             return "HASHCODE-FINGEPRINT" + System.identityHashCode(this);
         }
     }

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -27,7 +27,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
     private String lambdaFingerprint;
 
     // Duplicated from CoreComponentsBuilder to avoid dependency on drools-core in drools-canonical-model
-    static Boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    static boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     public abstract Object getLambda();
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -27,7 +27,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
     private String lambdaFingerprint;
 
     // Duplicated from CoreComponentsBuilder to avoid dependency on drools-core in drools-canonical-model
-    static boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    static boolean IS_NATIVE_IMAGE = Boolean.parseBoolean(System.getProperty("org.graalvm.nativeimage.imagecode"));
 
     public abstract Object getLambda();
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -27,10 +27,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
     private String lambdaFingerprint;
 
     // Duplicated from CoreComponentsBuilder to avoid dependency on drools-core in drools-canonical-model
-    static boolean isNativeImage() {
-        String property = System.getProperty("org.graalvm.nativeimage.imagecode");
-        return Boolean.parseBoolean(property);
-    }
+    static boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     public abstract Object getLambda();
 
@@ -58,7 +55,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
         if(this.getLambda() instanceof HashedExpression) {
             logger.debug("The constraint supports org.drools.model.functions.HashedExpression, node sharing is enabled and compile-time fingerprint is used");
             return ((HashedExpression) this.getLambda()).getExpressionHash();
-        } else if(!isNativeImage()) {
+        } else if(!IS_NATIVE_IMAGE) {
             // LambdaIntrospector is not supported on native image (it uses MVEL and reflection)
             logger.debug("No HashedExpression provided, generating fingerprint using reflection via org.drools.mvel.asm.LambdaIntrospector, node sharing enabled");
             return LambdaPrinter.print(getLambda());

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -60,8 +60,8 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
             logger.debug("No HashedExpression provided, generating fingerprint using reflection via org.drools.mvel.asm.LambdaIntrospector, node sharing enabled");
             return LambdaPrinter.print(getLambda());
         } else {
-            logger.debug("No HashedExpression provided, using Object.class.toString(), node sharing might not work correctly");
-            return super.toString();
+            logger.warn("No HashedExpression provided with lambda, using Identity Hash Code as a lambda fingerprint, node sharing won't work correctly");
+            return "HASHCODE-FINGEPRINT" + System.identityHashCode(this);
         }
     }
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -27,7 +27,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
     private String lambdaFingerprint;
 
     // Duplicated from CoreComponentsBuilder to avoid dependency on drools-core in drools-canonical-model
-    static boolean IS_NATIVE_IMAGE = Boolean.parseBoolean(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    static Boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     public abstract Object getLambda();
 

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/IntrospectableLambda.java
@@ -27,7 +27,10 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
     private String lambdaFingerprint;
 
     // Duplicated from CoreComponentsBuilder to avoid dependency on drools-core in drools-canonical-model
-    static boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    static boolean isNativeImage() {
+        String property = System.getProperty("org.graalvm.nativeimage.imagecode");
+        return Boolean.parseBoolean(property);
+    }
 
     public abstract Object getLambda();
 
@@ -55,7 +58,7 @@ public abstract class IntrospectableLambda implements Supplier<Object> {
         if(this.getLambda() instanceof HashedExpression) {
             logger.debug("The constraint supports org.drools.model.functions.HashedExpression, node sharing is enabled and compile-time fingerprint is used");
             return ((HashedExpression) this.getLambda()).getExpressionHash();
-        } else if(!IS_NATIVE_IMAGE) {
+        } else if(!isNativeImage()) {
             // LambdaIntrospector is not supported on native image (it uses MVEL and reflection)
             logger.debug("No HashedExpression provided, generating fingerprint using reflection via org.drools.mvel.asm.LambdaIntrospector, node sharing enabled");
             return LambdaPrinter.print(getLambda());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
@@ -46,20 +46,20 @@ public class FromOnlyExecModelTest {
     public void testFromSharingWithNativeImage() {
         try {
             NativeImageTestUtil.setNativeImage();
-            testFromSharingCommon(kieBaseTestConfiguration, new HashMap<String, String>());
+            testFromSharingCommon(kieBaseTestConfiguration, new HashMap<String, String>(), 2, 2);
         } finally {
             NativeImageTestUtil.unsetNativeImage();
         }
     }
 
     // This test that the node sharing isn't working without lambda externalisation
-    @Test(expected = AssertionError.class)
+    @Test
     public void testFromSharingWithNativeImageWithoutLambdaExternalisation() {
         try {
             NativeImageTestUtil.setNativeImage();
             HashMap<String, String> properties = new HashMap<>();
             properties.put("drools.externaliseCanonicalModelLambda", Boolean.FALSE.toString());
-            testFromSharingCommon(kieBaseTestConfiguration, properties);
+            testFromSharingCommon(kieBaseTestConfiguration, properties, 3, 1);
         } finally {
             NativeImageTestUtil.unsetNativeImage();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
@@ -17,6 +17,7 @@
 package org.drools.compiler.integrationtests.operators;
 
 import java.util.Collection;
+import java.util.HashMap;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.NativeImageTestUtil;
@@ -45,7 +46,20 @@ public class FromOnlyExecModelTest {
     public void testFromSharingWithNativeImage() {
         try {
             NativeImageTestUtil.setNativeImage();
-            testFromSharingCommon(kieBaseTestConfiguration);
+            testFromSharingCommon(kieBaseTestConfiguration, new HashMap<String, String>());
+        } finally {
+            NativeImageTestUtil.unsetNativeImage();
+        }
+    }
+
+    // This test that the node sharing isn't working without lambda externalisation
+    @Test(expected = AssertionError.class)
+    public void testFromSharingWithNativeImageWithoutLambdaExternalisation() {
+        try {
+            NativeImageTestUtil.setNativeImage();
+            HashMap<String, String> properties = new HashMap<>();
+            properties.put("drools.externaliseCanonicalModelLambda", Boolean.FALSE.toString());
+            testFromSharingCommon(kieBaseTestConfiguration, properties);
         } finally {
             NativeImageTestUtil.unsetNativeImage();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromOnlyExecModelTest.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
-import org.drools.testcoverage.common.util.NativeImageTestUtil;
+import org.drools.model.functions.NativeImageTestUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +46,7 @@ public class FromOnlyExecModelTest {
     public void testFromSharingWithNativeImage() {
         try {
             NativeImageTestUtil.setNativeImage();
-            testFromSharingCommon(kieBaseTestConfiguration, new HashMap<String, String>(), 2, 2);
+            testFromSharingCommon(kieBaseTestConfiguration, new HashMap<>(), 2, 2);
         } finally {
             NativeImageTestUtil.unsetNativeImage();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
@@ -99,11 +99,13 @@ public class FromTest {
 
     @Test
     public void testFromSharing() {
-        testFromSharingCommon(kieBaseTestConfiguration, new HashMap<>());
+        testFromSharingCommon(kieBaseTestConfiguration, new HashMap<>(), 2, 2);
     }
 
     public static void testFromSharingCommon(KieBaseTestConfiguration kieBaseTestConfiguration,
-                                             Map<String, String> configurationProperties) {
+                                             Map<String, String> configurationProperties,
+                                             int expectedNumberOfFromNode,
+                                             int numberOfSinksInSecondFromNode) {
         // Keeping original test as non-property reactive by default, just allowed.
         final String drl = fromSharingRule();
 
@@ -126,15 +128,17 @@ public class FromTest {
             assertEquals( 1, otn.getObjectSinkPropagator().size() );
             final LeftInputAdapterNode lian = (LeftInputAdapterNode)otn.getObjectSinkPropagator().getSinks()[0];
 
-            // There are only 2 FromNodes since R2 and R3 are sharing the second From
+            // There are only 2 FromNodes since R2 and R3 with the sharing the second From
+            // There will be 3 FromNodes without the sharing, that is with exec model with plain lambda and native image
             final LeftTupleSink[] sinks = lian.getSinkPropagator().getSinks();
-            assertEquals( 2, sinks.length );
+            assertEquals(expectedNumberOfFromNode, sinks.length );
 
             // The first from has R1 has sink
             assertEquals( 1, sinks[0].getSinkPropagator().size() );
 
-            // The second from has both R2 and R3 as sinks
-            assertEquals( 2, sinks[1].getSinkPropagator().size() );
+            // The second from has both R2 and R3 as sinks when node sharing
+            // When node sharing is disabled, it will only have one
+            assertEquals(numberOfSinksInSecondFromNode, sinks[1].getSinkPropagator().size() );
         } finally {
             ksession.dispose();
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/FromTest.java
@@ -99,21 +99,21 @@ public class FromTest {
 
     @Test
     public void testFromSharing() {
-        testFromSharingCommon(kieBaseTestConfiguration);
+        testFromSharingCommon(kieBaseTestConfiguration, new HashMap<>());
     }
 
-    public static void testFromSharingCommon(KieBaseTestConfiguration kieBaseTestConfiguration) {
+    public static void testFromSharingCommon(KieBaseTestConfiguration kieBaseTestConfiguration,
+                                             Map<String, String> configurationProperties) {
         // Keeping original test as non-property reactive by default, just allowed.
         final String drl = fromSharingRule();
 
         final ReleaseId releaseId1 = KieServices.get().newReleaseId("org.kie", "from-test", "1");
-        final Map<String, String> kieModuleConfigurationProperties = new HashMap<>();
-        kieModuleConfigurationProperties.put(PropertySpecificOption.PROPERTY_NAME, PropertySpecificOption.ALLOWED.toString());
+        configurationProperties.put(PropertySpecificOption.PROPERTY_NAME, PropertySpecificOption.ALLOWED.toString());
 
         final KieModule kieModule = KieUtil.getKieModuleFromDrls(releaseId1,
                                                                  kieBaseTestConfiguration,
                                                                  KieSessionTestConfiguration.STATEFUL_REALTIME,
-                                                                 kieModuleConfigurationProperties,
+                                                                 configurationProperties,
                                                                  drl);
         final KieContainer kieContainer = KieServices.get().newKieContainer(kieModule.getReleaseId());
         final KieBase kbase = kieContainer.getKieBase();

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package org.drools.testcoverage.common.util;
+package org.drools.model.functions;
 
 public class NativeImageTestUtil {
     // Used only for test purposed, do not call this as it simulates the code path for native image
     public static void setNativeImage() {
-        System.setProperty("org.graalvm.nativeimage.imagecode", "true");
+        IntrospectableLambda.IS_NATIVE_IMAGE = true;
     }
 
     // Used only for test purposed, do not call this as it simulates the code path for native image
     public static void unsetNativeImage() {
-        System.clearProperty("org.graalvm.nativeimage.imagecode");
+        IntrospectableLambda.IS_NATIVE_IMAGE = false;
     }
 
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
@@ -24,7 +24,7 @@ public class NativeImageTestUtil {
 
     // Used only for test purposed, do not call this as it simulates the code path for native image
     public static void unsetNativeImage() {
-        IntrospectableLambda.IS_NATIVE_IMAGE = false;
+        IntrospectableLambda.IS_NATIVE_IMAGE = null;
     }
 
 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/model/functions/NativeImageTestUtil.java
@@ -24,7 +24,7 @@ public class NativeImageTestUtil {
 
     // Used only for test purposed, do not call this as it simulates the code path for native image
     public static void unsetNativeImage() {
-        IntrospectableLambda.IS_NATIVE_IMAGE = null;
+        IntrospectableLambda.IS_NATIVE_IMAGE = false;
     }
 
 }


### PR DESCRIPTION

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[https://issues.redhat.com/browse/KOGITO-4160]


See https://github.com/kiegroup/kogito-runtimes/pull/974

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
