### PR TITLE
DROOLS-5951 DroolsMvelParserTest fails due to line endings \r\n on Windows

### DIFF
--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -912,11 +912,7 @@ public class DroolsMvelParserTest {
         String expr = "{ a() \nprint(1) }";
 
         assertEquals("There should be 2 statements",
-                     "{\n" +
-                             "    a();\n" +
-                             "    print(1);\n" +
-                             "}",
-                     printConstraint(MvelParser.parseBlock(expr)));
+                     2, MvelParser.parseBlock(expr).getStatements().size());
 
         MvelParser mvelParser = new MvelParser(new ParserConfiguration(), false);
         ParseResult<BlockStmt> r = mvelParser.parse(GeneratedMvelParser::BlockParseStart, new StringProvider(expr));


### PR DESCRIPTION


**JIRA**: https://issues.redhat.com/browse/DROOLS-5951

the issue is that two strings are being compared. 
The fix is as simple as changing the assertion. 

In fact, the "expected" string uses `\n`, but the `printConstraint()` string returns a platform-dependent newline encoding; thus it uses `\r\n` on Windows. – in fact the number of semicolons in both strings is 2; so that should mean that the `expr` string has been parsed correctly


