### PR TITLE
[7.48.x] [DROOLS-5933] NullPointerException at ConstraintEvaluator.findPattern…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitorPatternDSL.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitorPatternDSL.java
@@ -85,12 +85,28 @@ public class AccumulateVisitorPatternDSL extends AccumulateVisitor {
     }
 
     private void composeTwoBindings(String binding, MethodCallExpr newBindingExpression) {
-        context.findBindingExpression( binding ).ifPresent(oldBind -> {
+        context.findBindingExpression(binding).ifPresent(oldBind -> {
+
+            // compose newComposedBinding using oldBind and newBindingExpression. But still keep oldBind.
+
             LambdaExpr oldBindLambda = oldBind.findFirst(LambdaExpr.class).orElseThrow(RuntimeException::new);
             LambdaExpr newBindLambda = newBindingExpression.findFirst(LambdaExpr.class).orElseThrow(RuntimeException::new);
 
-            Expression newComposedLambda = LambdaUtil.appendNewLambdaToOld(oldBindLambda, newBindLambda);
-            oldBind.setArgument( 0, newBindingExpression.getArgument( 0 ) );
+            LambdaExpr tmpOldBindLambda = oldBindLambda.clone();
+            Expression newComposedLambda = LambdaUtil.appendNewLambdaToOld(tmpOldBindLambda, newBindLambda);
+
+            MethodCallExpr newComposedBinding = new MethodCallExpr(PatternExpressionBuilder.BIND_CALL, newBindingExpression.getArgument(0), newComposedLambda);
+            newComposedBinding.setScope(oldBind.getScope().orElseThrow(RuntimeException::new));
+
+            Optional<MethodCallExpr> optReactOn = oldBind.getArguments().stream()
+                                                         .filter(MethodCallExpr.class::isInstance)
+                                                         .map(MethodCallExpr.class::cast)
+                                                         .filter(exp -> exp.getName().asString().equals(PatternExpressionBuilder.REACT_ON_CALL))
+                                                         .findFirst();
+            if (optReactOn.isPresent()) {
+                newComposedBinding.addArgument(optReactOn.get().clone());
+            }
+            oldBind.setScope(newComposedBinding); // insert newComposedBinding at the first in the chain
         });
     }
 


### PR DESCRIPTION
…AndRequiredDeclaration() in accumulate with exec-model (#3312)

Backport https://github.com/kiegroup/drools/commit/5f9a27a83fca99427383e722efaa80396bfcae37 to 7.48.x branch

**JIRA**: 

https://issues.redhat.com/browse/RHDM-1556

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
