### PR TITLE
[DROOLS-5816] executable-model doesn't resolve kcontext with mvel dia…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ChannelTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ChannelTest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.drools.modelcompiler;
 
 import java.util.ArrayList;
@@ -35,11 +34,11 @@ public class ChannelTest extends BaseModelTest {
         super(testRunType);
     }
 
-    @Test
-    public void testChannel() {
+    public void testChannel(boolean isMvel) {
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +
                      "rule R \n" +
+                     (isMvel ? "dialect \"mvel\"\n" : "dialect \"java\"\n") +
                      "when\n" +
                      "    $p: Person()\n" +
                      "then\n" +
@@ -56,6 +55,16 @@ public class ChannelTest extends BaseModelTest {
         ksession.fireAllRules();
 
         assertThat(testChannel.getChannelMessages(), hasItem("Test Message"));
+    }
+
+    @Test
+    public void testChannelWithJava() {
+        testChannel(false);
+    }
+
+    @Test
+    public void testChannelWithMvel() {
+        testChannel(true);
     }
 
     public static class TestChannel implements Channel {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -903,4 +903,26 @@ public class MvelDialectTest extends BaseModelTest {
         assertEquals(1, ksession.fireAllRules());
         assertEquals(new BigDecimal( 0 ), john.getMoney());
     }
+
+    @Test
+    public void testKcontext() {
+        String str =
+                "global java.util.List result;" +
+                     "rule R\n" +
+                     "dialect \"mvel\"\n" +
+                     "when\n" +
+                     "  Integer()\n" +
+                     "then\n" +
+                     "  result.add(kcontext.getRule().getName());\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+        List<String> result = new ArrayList<>();
+        ksession.setGlobal("result", result);
+
+        ksession.insert(47);
+        ksession.fireAllRules();
+
+        assertTrue(result.contains("R"));
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnowledgeContextTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KnowledgeContextTest.java
@@ -43,8 +43,7 @@ public class KnowledgeContextTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-     // TODO: EM failed with testKnowledgeContextMVEL. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @Test


### PR DESCRIPTION
…lect

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-5816

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
