### PR TITLE
[DROOLS-5982] during an icremental update prevent adding of the path …

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/AddRemoveRule.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/AddRemoveRule.java
@@ -313,22 +313,31 @@ public class AddRemoveRule {
             SegmentMemory sm1 = smems[smemIndex];
             SegmentMemory sm2 = prevSmems[prevSmemIndex];
 
-            if (sm1 != null && sm2 == null) {
-                sm2 = SegmentUtilities.createChildSegment(wm,node);
-                prevSmems[prevSmemIndex] = sm2;
-                sm1.add(sm2);
-            } else if (sm1 == null && sm2 != null) {
-                sm1 = SegmentUtilities.createChildSegment(wm, parentNode);
-                smems[smemIndex] = sm1;
-                sm1.add(sm2);
-            }
+            if (sm1 != null || sm2 != null) {
+                // Temporarily remove the terminal node of the rule to be removed from the rete network to avoid that
+                // its path memory could be added to an existing segment memory during the merge of 2 segments
+                LeftTupleSource removedTerminalSource = tn.getLeftTupleSource();
+                removedTerminalSource.removeTupleSink( tn );
 
-            if (sm1 != null && sm2 != null) {
+                if (sm1 == null) {
+                    sm1 = SegmentUtilities.createChildSegment(wm, parentNode);
+                    smems[smemIndex] = sm1;
+                    sm1.add(sm2);
+                } else if (sm2 == null) {
+                    sm2 = SegmentUtilities.createChildSegment(wm, node);
+                    prevSmems[prevSmemIndex] = sm2;
+                    sm1.add(sm2);
+                }
+
                 mergeSegment(sm1, sm2);
                 smemsToNotify.add(sm1);
                 sm1.unlinkSegment(wm);
                 sm2.unlinkSegment(wm);
                 visited.add(node);
+
+                // Add back the the terminal node of the rule to be removed into the rete network to permit the network
+                // traversal up from it and the removal of all the nodes exclusively belonging to the removed rule
+                removedTerminalSource.addTupleSink( tn );
             }
         }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -4806,4 +4806,51 @@ public class IncrementalCompilationTest {
         kc.updateToVersion(releaseId3);
         ksession = kc.newKieSession();
     }
+
+    @Test
+    public void testUnlinkedPathUpdate() throws Exception {
+        // DROOLS-5982
+        final String drl1 =
+                "rule R1 when\n" +
+                "  Boolean()\n" +
+                "  String()\n" +
+                "then\n" +
+                "end\n";
+
+        final String drl2a =
+                "rule R2 when\n" +
+                "  Boolean()\n" +
+                "  Integer()\n" +
+                "then\n" +
+                "  System.out.println(\"before update\");\n" +
+                "end\n";
+
+        final String drl2b =
+                "rule R2 when\n" +
+                "  Boolean()\n" +
+                "  Integer()\n" +
+                "then\n" +
+                "  System.out.println(\"after update\");\n" +
+                "end\n";
+
+        final KieServices ks = KieServices.Factory.get();
+
+        final ReleaseId releaseId1 = ks.newReleaseId("org.kie", "test-upgrade", "1.0.0");
+        KieUtil.getKieModuleFromDrls(releaseId1, kieBaseTestConfiguration, drl1, drl2a);
+
+        final KieContainer kc = ks.newKieContainer(releaseId1);
+        KieSession ksession = kc.newKieSession();
+
+        ksession.insert("A string");
+        ksession.insert(12);
+        assertEquals(0, ksession.fireAllRules());
+
+        final ReleaseId releaseId2 = ks.newReleaseId("org.kie", "test-upgrade", "1.1.0");
+        KieUtil.getKieModuleFromDrls(releaseId2, kieBaseTestConfiguration, drl1, drl2b);
+
+        kc.updateToVersion(releaseId2);
+
+        ksession.insert(true);
+        assertEquals(2, ksession.fireAllRules());
+    }
 }


### PR DESCRIPTION
…memory of the rule to be romved to an existing segment memory

**JIRA**: https://issues.redhat.com/browse/DROOLS-5982