### PR TITLE
[DROOLS-5968] Propagating values inside MiningField/OutputField

### DIFF
--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/Interval.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/Interval.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.api.models;
+
+/**
+ * KiePMML representation of an <b>OutputField</b>
+ */
+public class Interval {
+
+    private final Number leftMargin;
+    private final Number rightMargin;
+
+    public Interval(Number leftMargin, Number rightMargin) {
+        this.leftMargin = leftMargin;
+        this.rightMargin = rightMargin;
+    }
+
+    public Number getLeftMargin() {
+        return leftMargin;
+    }
+
+    public Number getRightMargin() {
+        return rightMargin;
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/Interval.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/Interval.java
@@ -15,11 +15,14 @@
  */
 package org.kie.pmml.api.models;
 
+import java.io.Serializable;
+
 /**
  * KiePMML representation of an <b>OutputField</b>
  */
-public class Interval {
+public class Interval implements Serializable {
 
+    private static final long serialVersionUID = -5245266051098683475L;
     private final Number leftMargin;
     private final Number rightMargin;
 

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
@@ -32,7 +32,7 @@ public class MiningField {
     private final DATA_TYPE dataType;
     private final String missingValueReplacement;
     private final List<String> allowedValues;
-    private final List<String> intervals;
+    private final List<Interval> intervals;
 
     public MiningField(String name,
                        FIELD_USAGE_TYPE usageType,
@@ -40,7 +40,7 @@ public class MiningField {
                        DATA_TYPE dataType,
                        String missingValueReplacement,
                        List<String> allowedValues,
-                       List<String> intervals) {
+                       List<Interval> intervals) {
         this.name = name;
         this.usageType = usageType;
         this.opType = opType;
@@ -74,7 +74,7 @@ public class MiningField {
         return allowedValues;
     }
 
-    public List<String> getIntervals() {
+    public List<Interval> getIntervals() {
         return intervals;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.api.models;
 
+import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.api.enums.FIELD_USAGE_TYPE;
 import org.kie.pmml.api.enums.OP_TYPE;
 
@@ -26,11 +27,13 @@ public class MiningField {
     private final String name;
     private final FIELD_USAGE_TYPE usageType;
     private final OP_TYPE opType;
+    private final DATA_TYPE dataType;
 
-    public MiningField(String name, FIELD_USAGE_TYPE usageType, OP_TYPE opType) {
+    public MiningField(String name, FIELD_USAGE_TYPE usageType, OP_TYPE opType, DATA_TYPE dataType) {
         this.name = name;
         this.usageType = usageType;
         this.opType = opType;
+        this.dataType = dataType;
     }
 
     public String getName() {
@@ -43,5 +46,9 @@ public class MiningField {
 
     public OP_TYPE getOpType() {
         return opType;
+    }
+
+    public DATA_TYPE getDataType() {
+        return dataType;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
@@ -15,6 +15,8 @@
  */
 package org.kie.pmml.api.models;
 
+import java.util.List;
+
 import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.api.enums.FIELD_USAGE_TYPE;
 import org.kie.pmml.api.enums.OP_TYPE;
@@ -28,12 +30,24 @@ public class MiningField {
     private final FIELD_USAGE_TYPE usageType;
     private final OP_TYPE opType;
     private final DATA_TYPE dataType;
+    private final String missingValueReplacement;
+    private final List<String> allowedValues;
+    private final List<String> intervals;
 
-    public MiningField(String name, FIELD_USAGE_TYPE usageType, OP_TYPE opType, DATA_TYPE dataType) {
+    public MiningField(String name,
+                       FIELD_USAGE_TYPE usageType,
+                       OP_TYPE opType,
+                       DATA_TYPE dataType,
+                       String missingValueReplacement,
+                       List<String> allowedValues,
+                       List<String> intervals) {
         this.name = name;
         this.usageType = usageType;
         this.opType = opType;
         this.dataType = dataType;
+        this.missingValueReplacement = missingValueReplacement;
+        this.allowedValues = allowedValues;
+        this.intervals = intervals;
     }
 
     public String getName() {
@@ -50,5 +64,17 @@ public class MiningField {
 
     public DATA_TYPE getDataType() {
         return dataType;
+    }
+
+    public String getMissingValueReplacement() {
+        return missingValueReplacement;
+    }
+
+    public List<String> getAllowedValues() {
+        return allowedValues;
+    }
+
+    public List<String> getIntervals() {
+        return intervals;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/OutputField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/OutputField.java
@@ -15,6 +15,8 @@
  */
 package org.kie.pmml.api.models;
 
+import java.util.List;
+
 import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.api.enums.OP_TYPE;
 import org.kie.pmml.api.enums.RESULT_FEATURE;
@@ -29,17 +31,20 @@ public class OutputField {
     private final DATA_TYPE dataType;
     private final String targetField;
     private final RESULT_FEATURE resultFeature;
+    private final List<String> allowedValues;
 
     public OutputField(final String name,
                        final OP_TYPE opType,
                        final DATA_TYPE dataType,
                        final String targetField,
-                       final RESULT_FEATURE resultFeature) {
+                       final RESULT_FEATURE resultFeature,
+                       List<String> allowedValues) {
         this.name = name;
         this.opType = opType;
         this.dataType = dataType;
         this.targetField = targetField;
         this.resultFeature = resultFeature;
+        this.allowedValues = allowedValues;
     }
 
     public String getName() {
@@ -60,5 +65,9 @@ public class OutputField {
 
     public RESULT_FEATURE getResultFeature() {
         return resultFeature;
+    }
+
+    public List<String> getAllowedValues() {
+        return allowedValues;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -127,7 +127,13 @@ public class KiePMMLModelRetriever {
         if (output != null) {
             final List<OutputField> outputFields = output.getOutputFields()
                     .stream()
-                    .map(ModelUtils::convertToKieOutputField)
+                    .map(outputField -> {
+                        DataField dataField = dataDictionary.getDataFields().stream()
+                                .filter(df -> df.getName().equals(outputField.getTargetField()))
+                                .findFirst()
+                                .orElse(null);
+                        return ModelUtils.convertToKieOutputField(outputField, dataField);
+                    })
                     .collect(Collectors.toList());
             toPopulate.setOutputFields(outputFields);
         }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -112,30 +112,12 @@ public class KiePMMLModelRetriever {
                                                         final MiningSchema miningSchema,
                                                         final Output output) {
         if (miningSchema != null) {
-            final List<MiningField> miningFields = miningSchema.getMiningFields()
-                    .stream()
-                    .map(miningField -> {
-                        DataField dataField =  dataDictionary.getDataFields().stream()
-                                .filter(df -> df.getName().equals(miningField.getName()))
-                                .findFirst()
-                                .orElseThrow(() -> new KiePMMLException("Cannot find " + miningField.getName() + " in DataDictionary"));
-                        return convertToKieMiningField(miningField, dataField);
-                    })
-                    .collect(Collectors.toList());
-            toPopulate.setMiningFields(miningFields);
+            final List<org.kie.pmml.api.models.MiningField> converted = ModelUtils.convertToKieMiningFieldList(miningSchema, dataDictionary);
+            toPopulate.setMiningFields(converted);
         }
         if (output != null) {
-            final List<OutputField> outputFields = output.getOutputFields()
-                    .stream()
-                    .map(outputField -> {
-                        DataField dataField = dataDictionary.getDataFields().stream()
-                                .filter(df -> df.getName().equals(outputField.getTargetField()))
-                                .findFirst()
-                                .orElse(null);
-                        return ModelUtils.convertToKieOutputField(outputField, dataField);
-                    })
-                    .collect(Collectors.toList());
-            toPopulate.setOutputFields(outputFields);
+            final List<org.kie.pmml.api.models.OutputField> converted = ModelUtils.convertToKieOutputFieldList(output, dataDictionary);
+            toPopulate.setOutputFields(converted);
         }
         return toPopulate;
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetriever.java
@@ -17,19 +17,15 @@ package org.kie.pmml.compiler.commons.implementations;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.dmg.pmml.DataDictionary;
-import org.dmg.pmml.DataField;
 import org.dmg.pmml.MiningSchema;
 import org.dmg.pmml.Model;
 import org.dmg.pmml.Output;
 import org.dmg.pmml.TransformationDictionary;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.api.exceptions.KiePMMLException;
-import org.kie.pmml.api.models.MiningField;
-import org.kie.pmml.api.models.OutputField;
 import org.kie.pmml.commons.model.HasClassLoader;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.compiler.api.provider.ModelImplementationProvider;
@@ -37,8 +33,6 @@ import org.kie.pmml.compiler.api.provider.ModelImplementationProviderFinder;
 import org.kie.pmml.compiler.commons.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.kie.pmml.compiler.commons.utils.ModelUtils.convertToKieMiningField;
 
 public class KiePMMLModelRetriever {
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtils.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.compiler.commons.utils;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +37,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
@@ -208,8 +210,22 @@ public class CommonCodegenUtils {
         });
     }
 
-    public static ObjectCreationExpr createArraysOfFromList(List<String> source) {
-        ObjectCreationExpr toReturn = new ObjectCreationExpr();
+    /**
+     * Create <b>Arrays.asList(String... a)</b> <code>ExpressionStmt</code>
+     *
+     * @param source
+     * @return
+     */
+    public static ExpressionStmt createArraysAsListFromList(List<String> source) {
+        ExpressionStmt toReturn = new ExpressionStmt();
+        MethodCallExpr arraysCallExpression = new MethodCallExpr();
+        SimpleName arraysName = new SimpleName(Arrays.class.getName());
+        arraysCallExpression.setScope(new NameExpr(arraysName));
+        arraysCallExpression.setName(new SimpleName("asList"));
+        NodeList<Expression> arguments = new NodeList<>();
+        source.forEach(value -> arguments.add(new StringLiteralExpr(value)));
+        arraysCallExpression.setArguments(arguments);
+        toReturn.setExpression(arraysCallExpression);
         return toReturn;
     }
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtils.java
@@ -208,6 +208,11 @@ public class CommonCodegenUtils {
         });
     }
 
+    public static ObjectCreationExpr createArraysOfFromList(List<String> source) {
+        ObjectCreationExpr toReturn = new ObjectCreationExpr();
+        return toReturn;
+    }
+
     /**
      * Returns
      * <pre>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtils.java
@@ -187,7 +187,11 @@ public class KiePMMLModelFactoryUtils {
                     Expression opType = oPT != null ?
                             new NameExpr(oPT.getClass().getName() + "." + oPT.name())
                             : new NullLiteralExpr();
-                    toReturn.setArguments(NodeList.nodeList(name, usageType, opType));
+                    DATA_TYPE dtT = miningField.getDataType();
+                    Expression dataType = dtT != null ?
+                            new NameExpr(dtT.getClass().getName() + "." + dtT.name())
+                            : new NullLiteralExpr();
+                    toReturn.setArguments(NodeList.nodeList(name, usageType, opType, dataType));
                     return toReturn;
                 })
                 .collect(Collectors.toList());

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtils.java
@@ -50,6 +50,7 @@ import static org.kie.pmml.commons.Constants.MISSING_CONSTRUCTOR_IN_BODY;
 import static org.kie.pmml.commons.Constants.MISSING_DEFAULT_CONSTRUCTOR;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.addListPopulation;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.addMapPopulation;
+import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.createArraysAsListFromList;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.populateMethodDeclarations;
 import static org.kie.pmml.compiler.commons.utils.DefineFunctionUtils.getDefineFunctionsMethodMap;
 import static org.kie.pmml.compiler.commons.utils.DerivedFieldFunctionUtils.getDerivedFieldsMethodMap;
@@ -194,13 +195,13 @@ public class KiePMMLModelFactoryUtils {
                     Expression missingValueReplacement = miningField.getMissingValueReplacement() != null ?
                             new StringLiteralExpr(miningField.getMissingValueReplacement())
                             : new NullLiteralExpr();
-                    toReturn.setArguments(NodeList.nodeList(name, usageType, opType, dataType, missingValueReplacement));
-//                    Expression allowedValues = miningField.getAllowedValues() != null ?
-//                            new StringLiteralExpr(miningField.getAllowedValues())
-//                            : new NullLiteralExpr();
-
-
-
+                    Expression allowedValues = miningField.getAllowedValues() != null ?
+                            CommonCodegenUtils.createArraysAsListFromList(miningField.getAllowedValues()).getExpression()
+                            : new NullLiteralExpr();
+                    Expression intervals = miningField.getIntervals() != null ?
+                            CommonCodegenUtils.createArraysAsListFromList(miningField.getIntervals()).getExpression()
+                            : new NullLiteralExpr();
+                    toReturn.setArguments(NodeList.nodeList(name, usageType, opType, dataType, missingValueReplacement, allowedValues, intervals));
                     return toReturn;
                 })
                 .collect(Collectors.toList());
@@ -234,7 +235,10 @@ public class KiePMMLModelFactoryUtils {
                     Expression resultFeature = rsltF != null ?
                             new NameExpr(rsltF.getClass().getName() + "." + rsltF.name())
                             : new NullLiteralExpr();
-                    toReturn.setArguments(NodeList.nodeList(name, opType, dataType, targetField, resultFeature));
+                    Expression allowedValues = outputField.getAllowedValues() != null ?
+                            CommonCodegenUtils.createArraysAsListFromList(outputField.getAllowedValues()).getExpression()
+                            : new NullLiteralExpr();
+                    toReturn.setArguments(NodeList.nodeList(name, opType, dataType, targetField, resultFeature, allowedValues));
                     return toReturn;
                 })
                 .collect(Collectors.toList());

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtils.java
@@ -191,7 +191,16 @@ public class KiePMMLModelFactoryUtils {
                     Expression dataType = dtT != null ?
                             new NameExpr(dtT.getClass().getName() + "." + dtT.name())
                             : new NullLiteralExpr();
-                    toReturn.setArguments(NodeList.nodeList(name, usageType, opType, dataType));
+                    Expression missingValueReplacement = miningField.getMissingValueReplacement() != null ?
+                            new StringLiteralExpr(miningField.getMissingValueReplacement())
+                            : new NullLiteralExpr();
+                    toReturn.setArguments(NodeList.nodeList(name, usageType, opType, dataType, missingValueReplacement));
+//                    Expression allowedValues = miningField.getAllowedValues() != null ?
+//                            new StringLiteralExpr(miningField.getAllowedValues())
+//                            : new NullLiteralExpr();
+
+
+
                     return toReturn;
                 })
                 .collect(Collectors.toList());

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtil.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtil.java
@@ -18,13 +18,22 @@ package org.kie.pmml.compiler.commons.utils;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 
+import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.DataField;
+import org.dmg.pmml.DataType;
+import org.dmg.pmml.FieldName;
+import org.dmg.pmml.MiningField;
 import org.dmg.pmml.Model;
+import org.dmg.pmml.OutputField;
 import org.dmg.pmml.PMML;
+import org.dmg.pmml.ResultFeature;
 import org.dmg.pmml.mining.MiningModel;
 import org.dmg.pmml.mining.Segment;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.xml.sax.SAXException;
 
 /**
@@ -62,6 +71,14 @@ public class KiePMMLUtil {
         PMML toReturn = org.jpmml.model.PMMLUtil.unmarshal(is);
         String cleanedFileName = fileName.contains(".") ? fileName.substring(0, fileName.indexOf('.')) : fileName;
         populateMissingNames(toReturn, cleanedFileName);
+        List<DataField> dataFields = toReturn.getDataDictionary().getDataFields();
+        for (Model model : toReturn.getModels()) {
+            if (model.getOutput() != null &&
+                    model.getOutput().getOutputFields() != null) {
+                populateMissingOutputFieldDataType(model.getOutput().getOutputFields(),
+                                                   model.getMiningSchema().getMiningFields(), dataFields);
+            }
+        }
         return toReturn;
     }
 
@@ -69,15 +86,14 @@ public class KiePMMLUtil {
      * Method to provide default generated <b>modelName</b> attributes for models
      * without them.
      * Generated name would be
-     *
+     * <p>
      * fileName + model type + index (inside models list)
-     *
      * @param toPopulate
      * @param fileName
      */
     static void populateMissingNames(final PMML toPopulate, final String fileName) {
         final List<Model> models = toPopulate.getModels();
-        for (int i = 0; i < models.size(); i ++) {
+        for (int i = 0; i < models.size(); i++) {
             Model model = models.get(i);
             if (model.getModelName() == null || model.getModelName().isEmpty()) {
                 String modelName = String.format(MODELNAME_TEMPLATE,
@@ -85,7 +101,6 @@ public class KiePMMLUtil {
                                                  model.getClass().getSimpleName(),
                                                  i);
                 model.setModelName(modelName);
-
             }
             if (model instanceof MiningModel) {
                 populateCorrectMiningModel((MiningModel) model);
@@ -96,18 +111,17 @@ public class KiePMMLUtil {
     /**
      * Recursively populate or correct <code>Segment</code>s with auto generated id,
      * if missing in original model, and auto generated model name, if missing in original model
-     *
      * @param miningModel
      */
     static void populateCorrectMiningModel(final MiningModel miningModel) {
-        final List<Segment> segments =miningModel.getSegmentation().getSegments();
-        for (int i = 0; i < segments.size(); i ++) {
+        final List<Segment> segments = miningModel.getSegmentation().getSegments();
+        for (int i = 0; i < segments.size(); i++) {
             Segment segment = segments.get(i);
             String toSet = null;
             if (segment.getId() == null || segment.getId().isEmpty()) {
                 toSet = String.format(SEGMENTID_TEMPLATE,
-                                             miningModel.getModelName(),
-                                             i);
+                                      miningModel.getModelName(),
+                                      i);
             } else {
                 toSet = getSanitizedId(segment.getId(), miningModel.getModelName());
             }
@@ -123,6 +137,52 @@ public class KiePMMLUtil {
                 populateCorrectMiningModel((MiningModel) segment.getModel());
             }
         }
+    }
+
+    /**
+     * Method to populate the <b>dataType</b> property of <code>OutputField</code>s.
+     * Such property was optional in 4.2.1 spec
+     * @param toPopulate
+     * @param miningFields
+     * @param dataFields
+     */
+    static void populateMissingOutputFieldDataType(List<OutputField> toPopulate, List<MiningField> miningFields,
+                                                   List<DataField> dataFields) {
+        // partial implementation to fix the missing DataType inside OutputField, that were was in 4.2.1 spec
+        List<MiningField> targetFields = miningFields.stream()
+                .filter(miningField -> MiningField.UsageType.PREDICTED.equals(miningField.getUsageType()) ||
+                        MiningField.UsageType.TARGET.equals(miningField.getUsageType()))
+                .collect(Collectors.toList());
+        toPopulate.stream()
+                .filter(outputField -> outputField.getDataType() == null)
+                .forEach(outputField -> {
+                    MiningField referencedField = null;
+                    if (outputField.getTargetField() != null) {
+                        referencedField = targetFields.stream()
+                                .filter(targetField -> outputField.getTargetField().equals(targetField.getName()))
+                                .findFirst()
+                                .orElseThrow(() -> new KiePMMLException("Find to find a target field for OutputField "
+                                                                                + outputField.getName().getValue()));
+                    }
+                    if (referencedField == null && (outputField.getResultFeature() == null || outputField.getResultFeature().equals(ResultFeature.PREDICTED_VALUE))) { // default predictedValue
+                        referencedField = targetFields.stream()
+                                .findFirst()
+                                .orElse(null); //
+                    }
+                    if (referencedField == null && ResultFeature.PROBABILITY.equals(outputField.getResultFeature())) {
+                        outputField.setDataType(DataType.DOUBLE);
+                        return;
+                    }
+                    if (referencedField != null) {
+                        FieldName targetFieldName = referencedField.getName();
+                        DataField dataField = dataFields.stream()
+                                .filter(df -> df.getName().equals(targetFieldName))
+                                .findFirst()
+                                .orElseThrow(() -> new KiePMMLException("Find to find a DataField field for " +
+                                                                                "MiningField " + targetFieldName.toString()));
+                        outputField.setDataType(dataField.getDataType());
+                    }
+                });
     }
 
     static String getSanitizedId(String id, String modelName) {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
@@ -211,6 +211,7 @@ public class ModelUtils {
                 FIELD_USAGE_TYPE.byName(toConvert.getUsageType().value()) : null;
         final OP_TYPE opType = toConvert.getOpType() != null ? OP_TYPE.byName(toConvert.getOpType().value()) : null;
         final DATA_TYPE dataType = dataField.getDataType() != null ? DATA_TYPE.byName(dataField.getDataType().value()) : null;
+
         return new org.kie.pmml.api.models.MiningField(name,
                                                        fieldUsageType,
                                                        opType,

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
@@ -241,22 +241,31 @@ public class ModelUtils {
      * @param toConvert
      * @return
      */
-    public static List<org.kie.pmml.api.models.OutputField> convertToKieOutputFieldList(final Output toConvert) {
+    public static List<org.kie.pmml.api.models.OutputField> convertToKieOutputFieldList(final Output toConvert,
+                                                                                        final DataDictionary dataDictionary) {
         if (toConvert == null) {
             return Collections.emptyList();
         }
         return toConvert.getOutputFields()
                 .stream()
-                .map(ModelUtils::convertToKieOutputField)
+                .map(outputField -> {
+                    DataField dataField = dataDictionary.getDataFields().stream()
+                            .filter(df -> df.getName().equals(outputField.getTargetField()))
+                            .findFirst()
+                            .orElse(null);
+                    return convertToKieOutputField(outputField, dataField);
+                })
                 .collect(Collectors.toList());
     }
 
     /**
      * Return a <code>org.kie.pmml.api.models.OutputField</code> out of a <code>org.dmg.pmml.OutputField</code> one
      * @param toConvert
+     * @param dataField
      * @return
      */
-    public static org.kie.pmml.api.models.OutputField convertToKieOutputField(final OutputField toConvert) {
+    public static org.kie.pmml.api.models.OutputField convertToKieOutputField(final OutputField toConvert,
+                                                                              final DataField dataField) {
         final String name = toConvert.getName() != null ? toConvert.getName().getValue() : null;
         final OP_TYPE opType = toConvert.getOpType() != null ? OP_TYPE.byName(toConvert.getOpType().value()) : null;
         final DATA_TYPE dataType = toConvert.getDataType() != null ?
@@ -264,11 +273,13 @@ public class ModelUtils {
         final String targetField = toConvert.getTargetField() != null ? toConvert.getTargetField().getValue() : null;
         final RESULT_FEATURE resultFeature = toConvert.getResultFeature() != null ?
                 RESULT_FEATURE.byName(toConvert.getResultFeature().value()) : null;
+        final List<String> allowedValues = dataField != null ? convertDataFieldValues(dataField.getValues()) : null;
         return new org.kie.pmml.api.models.OutputField(name,
                                                        opType,
                                                        dataType,
                                                        targetField,
-                                                       resultFeature);
+                                                       resultFeature,
+                                                       allowedValues);
     }
 
     /**

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
@@ -15,7 +15,6 @@
  */
 package org.kie.pmml.compiler.commons.utils;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -225,7 +224,7 @@ public class ModelUtils {
         final String missingValueReplacement = toConvert.getMissingValueReplacement() != null ?
                 toConvert.getMissingValueReplacement().toString() : null;
         final List<String> allowedValues = convertDataFieldValues(dataField.getValues());
-        final List<String> intervals = convertDataFieldIntervals(dataField.getIntervals());
+        final List<org.kie.pmml.api.models.Interval> intervals = convertDataFieldIntervals(dataField.getIntervals());
         return new org.kie.pmml.api.models.MiningField(name,
                                                        fieldUsageType,
                                                        opType,
@@ -313,14 +312,11 @@ public class ModelUtils {
                 .collect(Collectors.toList()) : null;
     }
 
-    static List<String> convertDataFieldIntervals(List<Interval> toConvert) {
+    static List<org.kie.pmml.api.models.Interval> convertDataFieldIntervals(List<Interval> toConvert) {
         return toConvert != null ? toConvert.stream()
-                .map(interval -> {
-                    String leftMargin = interval.getLeftMargin() != null ? interval.getLeftMargin().toString() : "-" + INFINITY_SYMBOL;
-                    String rightMargin = interval.getRightMargin() != null ? interval.getRightMargin().toString() : "+" + INFINITY_SYMBOL;
-                    return String.format("%s-%s", leftMargin, rightMargin);
-                })
+                .map(interval -> new org.kie.pmml.api.models.Interval(interval.getLeftMargin(), interval.getRightMargin()))
                 .collect(Collectors.toList()) : null;
+
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
@@ -252,7 +252,7 @@ public class ModelUtils {
                     DataField dataField = dataDictionary.getDataFields().stream()
                             .filter(df -> df.getName().equals(outputField.getTargetField()))
                             .findFirst()
-                            .orElse(null);
+                            .orElse(null); // expected to be null because OutputField.targetField is not mandatory
                     return convertToKieOutputField(outputField, dataField);
                 })
                 .collect(Collectors.toList());
@@ -261,15 +261,16 @@ public class ModelUtils {
     /**
      * Return a <code>org.kie.pmml.api.models.OutputField</code> out of a <code>org.dmg.pmml.OutputField</code> one
      * @param toConvert
-     * @param dataField
+     * @param dataField - this may be <code>null</code>
      * @return
      */
     public static org.kie.pmml.api.models.OutputField convertToKieOutputField(final OutputField toConvert,
                                                                               final DataField dataField) {
         final String name = toConvert.getName() != null ? toConvert.getName().getValue() : null;
         final OP_TYPE opType = toConvert.getOpType() != null ? OP_TYPE.byName(toConvert.getOpType().value()) : null;
+        final DATA_TYPE dataFieldDataType = dataField != null ? DATA_TYPE.byName(dataField.getDataType().value()) : null;
         final DATA_TYPE dataType = toConvert.getDataType() != null ?
-                DATA_TYPE.byName(toConvert.getDataType().value()) : null;
+                DATA_TYPE.byName(toConvert.getDataType().value()) : dataFieldDataType;
         final String targetField = toConvert.getTargetField() != null ? toConvert.getTargetField().getValue() : null;
         final RESULT_FEATURE resultFeature = toConvert.getResultFeature() != null ?
                 RESULT_FEATURE.byName(toConvert.getResultFeature().value()) : null;

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/implementations/KiePMMLModelRetrieverTest.java
@@ -18,6 +18,8 @@ package org.kie.pmml.compiler.commons.implementations;
 
 import java.util.Optional;
 
+import org.dmg.pmml.DataDictionary;
+import org.dmg.pmml.DataField;
 import org.dmg.pmml.MiningSchema;
 import org.dmg.pmml.Output;
 import org.dmg.pmml.PMML;
@@ -32,7 +34,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndTransformationDictionaryAndModel;
 import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndTransformationDictionaryAndModelWithSources;
+import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getDataField;
 import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getPMMLWithRandomTestModel;
+import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getRandomDataType;
 import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getRandomMiningSchema;
 import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getRandomOutput;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -86,20 +90,25 @@ public class KiePMMLModelRetrieverTest {
         assertTrue(toPopulate.getMiningFields().isEmpty());
         assertTrue(toPopulate.getOutputFields().isEmpty());
         final MiningSchema miningSchema = getRandomMiningSchema();
+        DataDictionary dataDictionary = new DataDictionary();
+        dataDictionary.addDataFields(miningSchema.getMiningFields().stream()
+                                             .map(miningField -> getDataField(miningField.getName().getValue(),
+                                                                              miningField.getOpType(),
+                                                                              getRandomDataType())).toArray(DataField[]::new));
         final Output output = getRandomOutput();
-        KiePMMLTestModel populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, miningSchema, output);
+        KiePMMLTestModel populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, dataDictionary, miningSchema, output);
         assertEquals(miningSchema.getMiningFields().size(), populated.getMiningFields().size());
         assertEquals(output.getOutputFields().size(), populated.getOutputFields().size());
         toPopulate = new KiePMMLTestModel();
-        populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, miningSchema, null);
+        populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, dataDictionary, miningSchema, null);
         assertEquals(miningSchema.getMiningFields().size(), populated.getMiningFields().size());
         assertTrue(populated.getOutputFields().isEmpty());
         toPopulate = new KiePMMLTestModel();
-        populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, null, output);
+        populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, dataDictionary, null, output);
         assertTrue(populated.getMiningFields().isEmpty());
         assertEquals(output.getOutputFields().size(), populated.getOutputFields().size());
         toPopulate = new KiePMMLTestModel();
-        populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, null, null);
+        populated = (KiePMMLTestModel) KiePMMLModelRetriever.getPopulatedWithPMMLModelFields(toPopulate, dataDictionary, null, null);
         assertTrue(populated.getMiningFields().isEmpty());
         assertTrue(populated.getOutputFields().isEmpty());
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/PMMLModelTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/PMMLModelTestUtils.java
@@ -62,8 +62,9 @@ public class PMMLModelTestUtils {
 
     public static PMML getPMMLWithRandomTestModel() {
         PMML toReturn = new PMML();
-        toReturn.setDataDictionary(getRandomDataDictionary());
-        toReturn.addModels(getRandomTestModel());
+        DataDictionary dataDictionary = getRandomDataDictionary();
+        toReturn.setDataDictionary(dataDictionary);
+        toReturn.addModels(getRandomTestModel(dataDictionary));
         return toReturn;
     }
 
@@ -107,10 +108,37 @@ public class PMMLModelTestUtils {
 
     public static TestModel getRandomTestModel() {
         TestModel toReturn = new TestModel();
-
         toReturn.setModelName(RandomStringUtils.random(6, true, false));
         toReturn.setMiningSchema(getRandomMiningSchema());
         toReturn.setOutput(getRandomOutput());
+        return toReturn;
+    }
+
+    public static TestModel getRandomTestModel(DataDictionary dataDictionary) {
+        TestModel toReturn = new TestModel();
+        List<DataField> dataFields = dataDictionary.getDataFields();
+        MiningSchema miningSchema = new MiningSchema();
+        IntStream.range(0, dataFields.size() -1)
+                .forEach(i -> {
+                            DataField dataField = dataFields.get(i);
+                            MiningField miningField = new MiningField();
+                            miningField.setName(dataField.getName());
+                            miningField.setUsageType(MiningField.UsageType.ACTIVE);
+                            miningSchema.addMiningFields(miningField);
+                          });
+        DataField lastDataField = dataFields.get(dataFields.size()-1);
+        MiningField predictedMiningField = new MiningField();
+        predictedMiningField.setName(lastDataField.getName());
+        predictedMiningField.setUsageType(MiningField.UsageType.PREDICTED);
+        miningSchema.addMiningFields(predictedMiningField);
+        Output output = new Output();
+        OutputField outputField = new OutputField();
+        outputField.setName(FieldName.create("OUTPUT_" + lastDataField.getName().getValue()));
+        outputField.setDataType(lastDataField.getDataType());
+        outputField.setOpType(OpType.values()[new Random().nextInt(OpType.values().length)]);
+        toReturn.setModelName(RandomStringUtils.random(6, true, false));
+        toReturn.setMiningSchema(miningSchema);
+        toReturn.setOutput(output);
         return toReturn;
     }
 
@@ -169,6 +197,12 @@ public class PMMLModelTestUtils {
         return toReturn;
     }
 
+    public static DataField getDataField(String fieldName, OpType opType, DataType dataType) {
+        DataField toReturn = getDataField(fieldName, opType);
+        toReturn.setDataType(dataType);
+        return toReturn;
+    }
+
     public static MiningField getMiningField(String fieldName, MiningField.UsageType usageType) {
         MiningField toReturn = new MiningField();
         toReturn.setName(getFieldName(fieldName));
@@ -177,12 +211,15 @@ public class PMMLModelTestUtils {
     }
 
     public static DataField getRandomDataField() {
-        Random random = new Random();
         DataField toReturn = new DataField();
         toReturn.setName(getFieldName(RandomStringUtils.random(6, true, false)));
-        List<DataType> dataTypes = getDataTypes();
-        toReturn.setDataType(dataTypes.get(random.nextInt(dataTypes.size())));
+        toReturn.setDataType(getRandomDataType());
         return toReturn;
+    }
+
+    public static DataType getRandomDataType() {
+        List<DataType> dataTypes = getDataTypes();
+        return dataTypes.get(new Random().nextInt(dataTypes.size()));
     }
 
     public static MiningField getRandomMiningField() {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
@@ -33,8 +33,10 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -205,17 +207,37 @@ public class CommonCodegenUtilsTest {
     }
 
     @Test
+    public void createArraysAsListExpression() {
+        ExpressionStmt retrieved = CommonCodegenUtils.createArraysAsListExpression();
+        assertNotNull(retrieved);
+        String expected = "java.util.Arrays.asList();";
+        String retrievedString = retrieved.toString();
+        assertEquals(expected, retrievedString);
+    }
+
+    @Test
     public void createArraysAsListFromList() {
-        List<String> source = IntStream.range(0, 3)
+        List<String> strings = IntStream.range(0, 3)
                 .mapToObj(i -> "Element" + i)
                 .collect(Collectors.toList());
-        ExpressionStmt retrieved = CommonCodegenUtils.createArraysAsListFromList(source);
+        ExpressionStmt retrieved = CommonCodegenUtils.createArraysAsListFromList(strings);
         assertNotNull(retrieved);
-        String arguments = source.stream()
+        String arguments = strings.stream()
                 .map(string -> "\"" + string + "\"")
                 .collect(Collectors.joining(", "));
         String expected = String.format("java.util.Arrays.asList(%s);", arguments);
         String retrievedString = retrieved.toString();
+        assertEquals(expected, retrievedString);
+        List<Double> doubles = IntStream.range(0, 3)
+                .mapToObj(i ->  i * 0.17)
+                .collect(Collectors.toList());
+        retrieved = CommonCodegenUtils.createArraysAsListFromList(doubles);
+        assertNotNull(retrieved);
+        arguments = doubles.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(", "));
+        expected = String.format("java.util.Arrays.asList(%s);", arguments);
+        retrievedString = retrieved.toString();
         assertEquals(expected, retrievedString);
     }
 
@@ -383,6 +405,46 @@ public class CommonCodegenUtilsTest {
         assertTrue(retrieved.isPresent());
         VariableDeclarator variableDeclarator = retrieved.get();
         assertEquals(variableName, variableDeclarator.getName().asString());
+    }
+
+    @Test
+    public void getExpressionForObject() {
+        String string = "string";
+        Expression retrieved = CommonCodegenUtils.getExpressionForObject(string);
+        assertTrue(retrieved instanceof  StringLiteralExpr);
+        assertEquals("\"string\"", retrieved.toString());
+        int i = 1;
+        retrieved = CommonCodegenUtils.getExpressionForObject(i);
+        assertTrue(retrieved instanceof  IntegerLiteralExpr);
+        assertEquals(i, ((IntegerLiteralExpr)retrieved).asInt());
+        Integer j = 3;
+        retrieved = CommonCodegenUtils.getExpressionForObject(j);
+        assertTrue(retrieved instanceof  IntegerLiteralExpr);
+        assertEquals(j.intValue(), ((IntegerLiteralExpr)retrieved).asInt());
+        double x = 1.12;
+        retrieved = CommonCodegenUtils.getExpressionForObject(x);
+        assertTrue(retrieved instanceof  DoubleLiteralExpr);
+        assertEquals(x, ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        Double y = 3.12;
+        retrieved = CommonCodegenUtils.getExpressionForObject(y);
+        assertTrue(retrieved instanceof  DoubleLiteralExpr);
+        assertEquals(y, ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        float k = 1.12f;
+        retrieved = CommonCodegenUtils.getExpressionForObject(k);
+        assertTrue(retrieved instanceof  DoubleLiteralExpr);
+        assertEquals(1.12, ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        Float z = 3.12f;
+        retrieved = CommonCodegenUtils.getExpressionForObject(z);
+        assertTrue(retrieved instanceof  DoubleLiteralExpr);
+        assertEquals(z.doubleValue(), ((DoubleLiteralExpr)retrieved).asDouble(), 0.001);
+        boolean b = true;
+        retrieved = CommonCodegenUtils.getExpressionForObject(b);
+        assertTrue(retrieved instanceof BooleanLiteralExpr);
+        assertEquals(b, ((BooleanLiteralExpr)retrieved).getValue());
+        Boolean c = false;
+        retrieved = CommonCodegenUtils.getExpressionForObject(c);
+        assertTrue(retrieved instanceof BooleanLiteralExpr);
+        assertEquals(c, ((BooleanLiteralExpr)retrieved).getValue());
     }
 
     private void commonValidateMethodDeclaration(MethodDeclaration toValidate, String methodName) {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/CommonCodegenUtilsTest.java
@@ -205,6 +205,21 @@ public class CommonCodegenUtilsTest {
     }
 
     @Test
+    public void createArraysAsListFromList() {
+        List<String> source = IntStream.range(0, 3)
+                .mapToObj(i -> "Element" + i)
+                .collect(Collectors.toList());
+        ExpressionStmt retrieved = CommonCodegenUtils.createArraysAsListFromList(source);
+        assertNotNull(retrieved);
+        String arguments = source.stream()
+                .map(string -> "\"" + string + "\"")
+                .collect(Collectors.joining(", "));
+        String expected = String.format("java.util.Arrays.asList(%s);", arguments);
+        String retrievedString = retrieved.toString();
+        assertEquals(expected, retrievedString);
+    }
+
+    @Test
     public void getParamMethodDeclaration() {
         String methodName = "METHOD_NAME";
         final Map<String, ClassOrInterfaceType> parameterNameTypeMap = new HashMap<>();

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLModelFactoryUtilsTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -39,10 +40,13 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import org.dmg.pmml.DerivedField;
@@ -51,13 +55,23 @@ import org.dmg.pmml.tree.TreeModel;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.kie.pmml.api.enums.DATA_TYPE;
+import org.kie.pmml.api.enums.FIELD_USAGE_TYPE;
+import org.kie.pmml.api.enums.OP_TYPE;
+import org.kie.pmml.api.models.Interval;
+import org.kie.pmml.api.models.MiningField;
+import org.kie.pmml.api.models.OutputField;
 import org.kie.pmml.commons.model.KiePMMLOutputField;
 import org.kie.pmml.api.enums.RESULT_FEATURE;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getRandomDataField;
+import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getRandomMiningField;
+import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getRandomOutputField;
 import static org.kie.pmml.compiler.commons.utils.DerivedFieldFunctionUtils.getDerivedFieldsMethodMap;
+import static org.kie.pmml.compiler.commons.utils.DerivedFieldFunctionUtils.getDiscretizeMethodDeclaration;
 import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFromFileName;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
 
@@ -69,6 +83,7 @@ public class KiePMMLModelFactoryUtilsTest {
     private static PMML pmmlModel;
     private static TreeModel model;
     private ConstructorDeclaration constructorDeclaration;
+    private ExplicitConstructorInvocationStmt superInvocation;
     private ClassOrInterfaceDeclaration classOrInterfaceDeclaration;
 
     @BeforeClass
@@ -87,8 +102,56 @@ public class KiePMMLModelFactoryUtilsTest {
                 .getDefaultConstructor()
                 .orElseThrow(() -> new RuntimeException("Failed to retrieve default constructor from " + TEMPLATE_SOURCE));
         assertNotNull(constructorDeclaration);
+        assertNotNull(constructorDeclaration.getBody());
+        Optional<ExplicitConstructorInvocationStmt> optSuperInvocation =
+                CommonCodegenUtils.getExplicitConstructorInvocationStmt(constructorDeclaration.getBody());
+        assertTrue(optSuperInvocation.isPresent());
+        superInvocation = optSuperInvocation.get();
+        assertEquals("Template", constructorDeclaration.getName().asString()); // as in the original template
+        assertEquals("super(name, Collections.emptyList(), operator, second);", superInvocation.toString()); // as in
+        // the original template
         assertTrue(compilationUnit.getClassByName(TEMPLATE_CLASS_NAME).isPresent());
         classOrInterfaceDeclaration = compilationUnit.getClassByName(TEMPLATE_CLASS_NAME).get();
+    }
+
+    @Test
+    public void setConstructorSuperNameInvocation() {
+        String generatedClassName = "generatedClassName";
+        String name = "newName";
+        KiePMMLModelFactoryUtils.setConstructorSuperNameInvocation(generatedClassName,
+                                                                   constructorDeclaration,
+                                                                   name);
+        commonVerifySuperInvocation(generatedClassName, name);
+    }
+
+    @Test
+    public void setKiePMMLModelConstructor() {
+        String generatedClassName = "generatedClassName";
+        String name = "newName";
+        List<MiningField> miningFields = IntStream.range(0, 3)
+                .mapToObj(i -> ModelUtils.convertToKieMiningField(getRandomMiningField(),
+                                                                             getRandomDataField()))
+                .collect(Collectors.toList());
+        List<OutputField> outputFields = IntStream.range(0, 2)
+                .mapToObj(i -> ModelUtils.convertToKieOutputField(getRandomOutputField(),
+                                                                             getRandomDataField()))
+                .collect(Collectors.toList());
+        KiePMMLModelFactoryUtils.setKiePMMLModelConstructor(generatedClassName,
+                                                            constructorDeclaration,
+                                                            name,
+                                                            miningFields,
+                                                            outputFields);
+        commonVerifySuperInvocation(generatedClassName, name);
+        List<MethodCallExpr> retrieved = getMethodCallExprList(constructorDeclaration.getBody(), miningFields.size(), "miningFields",
+                                                               "add");
+        MethodCallExpr addMethodCall = retrieved.get(0);
+        NodeList<Expression> arguments = addMethodCall.getArguments();
+        commonVerifyMiningFieldsObjectCreation(arguments, miningFields);
+        retrieved = getMethodCallExprList(constructorDeclaration.getBody(), outputFields.size(), "outputFields",
+                                                               "add");
+        addMethodCall = retrieved.get(0);
+        arguments = addMethodCall.getArguments();
+        commonVerifyOutputFieldsObjectCreation(arguments, outputFields);
     }
 
     @Test
@@ -102,14 +165,15 @@ public class KiePMMLModelFactoryUtilsTest {
                         .build())
                 .collect(Collectors.toList());
         KiePMMLModelFactoryUtils.addKiePMMLOutputFieldsPopulation(blockStmt, outputFields);
-        List<MethodCallExpr> retrieved = getMethodCallExprList(blockStmt, outputFields.size(), "kiePMMLOutputFields", "add");
+        List<MethodCallExpr> retrieved = getMethodCallExprList(blockStmt, outputFields.size(), "kiePMMLOutputFields",
+                                                               "add");
         for (KiePMMLOutputField outputField : outputFields) {
             assertTrue(retrieved.stream()
                                .filter(methodCallExpr -> methodCallExpr.getArguments().size() == 1)
                                .map(methodCallExpr -> methodCallExpr.getArgument(0))
                                .filter(Expression::isMethodCallExpr)
                                .map(expressionArgument -> (MethodCallExpr) expressionArgument)
-                               .anyMatch(methodCallExpr -> evaluateOutputFieldPopulation(methodCallExpr, outputField)));
+                               .anyMatch(methodCallExpr -> evaluateKiePMMLOutputFieldPopulation(methodCallExpr, outputField)));
         }
     }
 
@@ -125,13 +189,146 @@ public class KiePMMLModelFactoryUtilsTest {
     }
 
     @Test
+    public void getMiningFieldsObjectCreations() {
+        List<MiningField> miningFields = IntStream.range(0, 3)
+                .mapToObj(i -> ModelUtils.convertToKieMiningField(getRandomMiningField(),
+                                                                  getRandomDataField()))
+                .collect(Collectors.toList());
+        List retrieved = KiePMMLModelFactoryUtils.getMiningFieldsObjectCreations(miningFields);
+        commonVerifyMiningFieldsObjectCreation(retrieved, miningFields);
+    }
+
+    @Test
+    public void createIntervalsExpression() {
+        List<Interval> intervals = IntStream.range(0, 3)
+                .mapToObj(i -> {
+                    int leftMargin = new Random().nextInt(40);
+                    int rightMargin = leftMargin +13;
+                    return new Interval(leftMargin, rightMargin);
+                })
+                .collect(Collectors.toList());
+        Expression retrieved = KiePMMLModelFactoryUtils.createIntervalsExpression(intervals);
+        assertNotNull(retrieved);
+        assertTrue(retrieved instanceof MethodCallExpr);
+        MethodCallExpr mtdExp = (MethodCallExpr) retrieved;
+        String expected = "java.util.Arrays";
+        assertEquals(expected, mtdExp.getScope().get().asNameExpr().toString());
+        expected = "asList";
+        assertEquals(expected, mtdExp.getName().asString());
+        NodeList<Expression> arguments = mtdExp.getArguments();
+        assertEquals(intervals.size(), arguments.size());
+        arguments.forEach(argument -> {
+            assertTrue(argument instanceof ObjectCreationExpr);
+            ObjectCreationExpr objCrt = (ObjectCreationExpr) argument;
+            assertEquals(Interval.class.getCanonicalName(), objCrt.getType().asString());
+            Optional<Interval> intervalOpt = intervals.stream()
+                    .filter(interval -> String.valueOf(interval.getLeftMargin()).equals(objCrt.getArgument(0).asNameExpr().toString()) &&
+                            String.valueOf(interval.getRightMargin()).equals(objCrt.getArgument(1).asNameExpr().toString()) )
+                    .findFirst();
+            assertTrue(intervalOpt.isPresent());
+        });
+    }
+
+    @Test
+    public void getObjectCreationExprFromInterval() {
+        Interval interval = new Interval(null, -14);
+        ObjectCreationExpr retrieved = KiePMMLModelFactoryUtils.getObjectCreationExprFromInterval(interval);
+        assertNotNull(retrieved);
+        assertEquals(Interval.class.getCanonicalName(), retrieved.getType().asString());
+        NodeList<Expression> arguments = retrieved.getArguments();
+        assertEquals(2, arguments.size());
+        assertTrue(arguments.get(0) instanceof NullLiteralExpr);
+        assertEquals(String.valueOf(interval.getRightMargin()), arguments.get(1).asNameExpr().toString());
+        interval = new Interval(-13, 10);
+        retrieved = KiePMMLModelFactoryUtils.getObjectCreationExprFromInterval(interval);
+        assertNotNull(retrieved);
+        assertEquals(Interval.class.getCanonicalName(), retrieved.getType().asString());
+        arguments = retrieved.getArguments();
+        assertEquals(2, arguments.size());
+        assertEquals(String.valueOf(interval.getLeftMargin()), arguments.get(0).asNameExpr().toString());
+        assertEquals(String.valueOf(interval.getRightMargin()), arguments.get(1).asNameExpr().toString());
+        interval = new Interval(-13, null);
+        retrieved = KiePMMLModelFactoryUtils.getObjectCreationExprFromInterval(interval);
+        assertNotNull(retrieved);
+        assertEquals(Interval.class.getCanonicalName(), retrieved.getType().asString());
+        arguments = retrieved.getArguments();
+        assertEquals(2, arguments.size());
+        assertEquals(String.valueOf(interval.getLeftMargin()), arguments.get(0).asNameExpr().toString());
+        assertTrue(arguments.get(1) instanceof NullLiteralExpr);
+    }
+
+    @Test
+    public void getOutputFieldsObjectCreations() {
+        List<OutputField> outputFields = IntStream.range(0, 2)
+                .mapToObj(i -> ModelUtils.convertToKieOutputField(getRandomOutputField(),
+                                                                  getRandomDataField()))
+                .collect(Collectors.toList());
+        List retrieved = KiePMMLModelFactoryUtils.getOutputFieldsObjectCreations(outputFields);
+        commonVerifyOutputFieldsObjectCreation(retrieved, outputFields);
+    }
+
+    @Test
     public void populateTransformationsInConstructor() {
         final AtomicInteger arityCounter = new AtomicInteger(0);
-        final Map<String, MethodDeclaration> commonDerivedFieldsMethodMap = getDerivedFieldsMethodMap(pmmlModel.getTransformationDictionary().getDerivedFields(), arityCounter);
-        final Map<String, MethodDeclaration> localDerivedFieldsMethodMap = getDerivedFieldsMethodMap(model.getLocalTransformations().getDerivedFields(), arityCounter);
-        KiePMMLModelFactoryUtils.populateTransformationsInConstructor(constructorDeclaration, commonDerivedFieldsMethodMap, localDerivedFieldsMethodMap);
+        final Map<String, MethodDeclaration> commonDerivedFieldsMethodMap =
+                getDerivedFieldsMethodMap(pmmlModel.getTransformationDictionary().getDerivedFields(), arityCounter);
+        final Map<String, MethodDeclaration> localDerivedFieldsMethodMap =
+                getDerivedFieldsMethodMap(model.getLocalTransformations().getDerivedFields(), arityCounter);
+        KiePMMLModelFactoryUtils.populateTransformationsInConstructor(constructorDeclaration,
+                                                                      commonDerivedFieldsMethodMap,
+                                                                      localDerivedFieldsMethodMap);
         pmmlModel.getTransformationDictionary().getDerivedFields().forEach(derivedField -> commonVerifyDerivedFieldTransformation(derivedField, commonDerivedFieldsMethodMap, "commonTransformationsMap"));
         model.getLocalTransformations().getDerivedFields().forEach(derivedField -> commonVerifyDerivedFieldTransformation(derivedField, localDerivedFieldsMethodMap, "localTransformationsMap"));
+    }
+
+    private void commonVerifyMiningFieldsObjectCreation(List <Expression> toVerify, List<MiningField> miningFields) {
+        toVerify.forEach(expression -> {
+            assertTrue(expression instanceof ObjectCreationExpr);
+            ObjectCreationExpr objCrt = (ObjectCreationExpr) expression;
+            assertEquals(MiningField.class.getCanonicalName(), objCrt.getType().asString());
+            Optional<MiningField> miningFieldOpt = miningFields.stream()
+                    .filter(miningField -> miningField.getName().equals(objCrt.getArgument(0).asStringLiteralExpr().asString()))
+                    .findFirst();
+            assertTrue(miningFieldOpt.isPresent());
+            MiningField miningField = miningFieldOpt.get();
+            assertEquals(MiningField.class.getCanonicalName(), objCrt.getType().asString());
+            String expected = FIELD_USAGE_TYPE.class.getCanonicalName() + "." + miningField.getUsageType();
+            assertEquals(expected, objCrt.getArgument(1).asNameExpr().toString());
+            expected = DATA_TYPE.class.getCanonicalName() + "." + miningField.getDataType();
+            assertEquals(expected, objCrt.getArgument(3).asNameExpr().toString());
+            expected = "java.util.Arrays.asList()";
+            assertEquals(expected, objCrt.getArgument(5).asMethodCallExpr().toString());
+            assertEquals(expected, objCrt.getArgument(6).asMethodCallExpr().toString());
+            });
+    }
+
+    private void commonVerifyOutputFieldsObjectCreation(List <Expression> toVerify, List<OutputField> outputFields) {
+        toVerify.forEach(argument -> {
+            assertTrue(argument instanceof ObjectCreationExpr);
+            ObjectCreationExpr objCrt = (ObjectCreationExpr) argument;
+            assertEquals(OutputField.class.getCanonicalName(),  objCrt.getType().asString());
+            Optional<OutputField> outputFieldOpt = outputFields.stream()
+                    .filter(miningField -> miningField.getName().equals(objCrt.getArgument(0).asStringLiteralExpr().asString()))
+                    .findFirst();
+            assertTrue(outputFieldOpt.isPresent());
+            OutputField outputField = outputFieldOpt.get();
+            String expected = OP_TYPE.class.getCanonicalName() + "." + outputField.getOpType();
+            assertEquals(expected, objCrt.getArgument(1).asNameExpr().toString());
+            expected = DATA_TYPE.class.getCanonicalName() + "." + outputField.getDataType();
+            assertEquals(expected, objCrt.getArgument(2).asNameExpr().toString());
+            expected = outputField.getTargetField();
+            assertEquals(expected, objCrt.getArgument(3).asStringLiteralExpr().asString());
+            expected = RESULT_FEATURE.class.getCanonicalName() + "." + outputField.getResultFeature();
+            assertEquals(expected, objCrt.getArgument(4).asNameExpr().toString());
+            expected = "java.util.Arrays.asList()";
+            assertEquals(expected, objCrt.getArgument(5).asMethodCallExpr().toString());
+        });
+    }
+
+    private void commonVerifySuperInvocation(String generatedClassName, String name) {
+        assertEquals(generatedClassName, constructorDeclaration.getName().asString()); // modified by invocation
+        String expected = String.format("super(\"%s\", Collections.emptyList(), operator, second);", name);
+        assertEquals(expected, superInvocation.toString()); // modified by invocation
     }
 
     private void commonVerifyConstructorClass(String mapName) {
@@ -157,12 +354,14 @@ public class KiePMMLModelFactoryUtilsTest {
             MethodCallExpr methodCallExpr = (MethodCallExpr) expressionStmt.getExpression();
             return (MethodReferenceExpr) methodCallExpr.getArgument(1);
         }).forEach(methodReferenceExpr -> assertTrue(methodDeclarations
-                           .stream()
-                           .anyMatch(methodDeclaration ->
-                                             methodDeclaration.getName().asString().equals(methodReferenceExpr.getIdentifier()))));
+                                                             .stream()
+                                                             .anyMatch(methodDeclaration ->
+                                                                               methodDeclaration.getName().asString().equals(methodReferenceExpr.getIdentifier()))));
     }
 
-    private void commonVerifyDerivedFieldTransformation(DerivedField toVerify, Map<String, MethodDeclaration> derivedFieldsMethodMap, String mapToVerify) {
+    private void commonVerifyDerivedFieldTransformation(DerivedField toVerify,
+                                                        Map<String, MethodDeclaration> derivedFieldsMethodMap,
+                                                        String mapToVerify) {
         NodeList<Statement> statements = constructorDeclaration.getBody().getStatements();
         String fieldName = toVerify.getName().getValue();
         if (derivedFieldsMethodMap != null) {
@@ -193,20 +392,25 @@ public class KiePMMLModelFactoryUtilsTest {
             }
             assertTrue(((MethodReferenceExpr) methodCallExpr.getArgument(1)).getScope() instanceof ThisExpr);
             if (derivedFieldsMethodMap != null) {
-                assertEquals(derivedFieldsMethodMap.get(fieldName).getName().asString(), ((MethodReferenceExpr) methodCallExpr.getArgument(1)).getIdentifier());
+                assertEquals(derivedFieldsMethodMap.get(fieldName).getName().asString(),
+                             ((MethodReferenceExpr) methodCallExpr.getArgument(1)).getIdentifier());
             }
             return true;
         }));
     }
 
-    private boolean evaluateOutputFieldPopulation(MethodCallExpr methodCallExpr, KiePMMLOutputField outputField) {
-        boolean toReturn = commonEvaluateMethodCallExpr(methodCallExpr, "build", new NodeList<>(), MethodCallExpr.class);
+    private boolean evaluateKiePMMLOutputFieldPopulation(MethodCallExpr methodCallExpr, KiePMMLOutputField outputField) {
+        boolean toReturn = commonEvaluateMethodCallExpr(methodCallExpr, "build", new NodeList<>(),
+                                                        MethodCallExpr.class);
         MethodCallExpr resultFeatureScopeExpr = (MethodCallExpr) methodCallExpr.getScope().get();
-        NodeList<Expression> expectedArguments = NodeList.nodeList(new NameExpr(RESULT_FEATURE.class.getName() + "." + outputField.getResultFeature().toString()));
-        toReturn &= commonEvaluateMethodCallExpr(resultFeatureScopeExpr, "withResultFeature", expectedArguments, MethodCallExpr.class);
+        NodeList<Expression> expectedArguments =
+                NodeList.nodeList(new NameExpr(RESULT_FEATURE.class.getName() + "." + outputField.getResultFeature().toString()));
+        toReturn &= commonEvaluateMethodCallExpr(resultFeatureScopeExpr, "withResultFeature", expectedArguments,
+                                                 MethodCallExpr.class);
         MethodCallExpr targetFieldScopeExpr = (MethodCallExpr) resultFeatureScopeExpr.getScope().get();
         expectedArguments = NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().get()));
-        toReturn &= commonEvaluateMethodCallExpr(targetFieldScopeExpr, "withTargetField", expectedArguments, MethodCallExpr.class);
+        toReturn &= commonEvaluateMethodCallExpr(targetFieldScopeExpr, "withTargetField", expectedArguments,
+                                                 MethodCallExpr.class);
         MethodCallExpr valueScopeExpr = (MethodCallExpr) targetFieldScopeExpr.getScope().get();
         expectedArguments = NodeList.nodeList(new StringLiteralExpr(outputField.getValue().toString()));
         toReturn &= commonEvaluateMethodCallExpr(valueScopeExpr, "withValue", expectedArguments, MethodCallExpr.class);
@@ -221,7 +425,9 @@ public class KiePMMLModelFactoryUtilsTest {
         return toReturn;
     }
 
-    private boolean commonEvaluateMethodCallExpr(MethodCallExpr toEvaluate, String name, NodeList<Expression> expectedArguments, Class<? extends Expression> expectedScopeType) {
+    private boolean commonEvaluateMethodCallExpr(MethodCallExpr toEvaluate, String name,
+                                                 NodeList<Expression> expectedArguments,
+                                                 Class<? extends Expression> expectedScopeType) {
         boolean toReturn = Objects.equals(new SimpleName(name), toEvaluate.getName());
         toReturn &= expectedArguments.size() == toEvaluate.getArguments().size();
         for (int i = 0; i < expectedArguments.size(); i++) {
@@ -242,8 +448,31 @@ public class KiePMMLModelFactoryUtilsTest {
      * @param method
      * @return
      */
-    private List<MethodCallExpr> getMethodCallExprList(BlockStmt blockStmt, int expectedSize, String scope, String method) {
-        Stream<Statement> statementStream = getStatementStream(blockStmt, expectedSize);
+    private List<MethodCallExpr> getMethodCallExprList(BlockStmt blockStmt, int expectedSize, String scope,
+                                                       String method) {
+        Stream<Statement> statementStream = getStatementStream(blockStmt);
+        List<MethodCallExpr> toReturn =  statementStream
+                .filter(Statement::isExpressionStmt)
+                .map(expressionStmt -> ((ExpressionStmt) expressionStmt).getExpression())
+                .filter(expression -> expression instanceof MethodCallExpr)
+                .map(expression -> (MethodCallExpr) expression)
+                .filter(methodCallExpr -> evaluateMethodCallExpr(methodCallExpr, scope, method))
+                .collect(Collectors.toList());
+        assertEquals(expectedSize, toReturn.size());
+        return toReturn;
+    }
+
+    /**
+     * Return a <code>List&lt;MethodCallExpr&gt;</code> where every element <b>scope' name</b> is <code>scope</code>
+     * and every element <b>name</b> is <code>method</code>
+     * @param blockStmt
+     * @param scope
+     * @param method
+     * @return
+     */
+    private List<MethodCallExpr> getMethodCallExprList(BlockStmt blockStmt, String scope,
+                                                       String method) {
+        Stream<Statement> statementStream = getStatementStream(blockStmt);
         return statementStream
                 .filter(Statement::isExpressionStmt)
                 .map(expressionStmt -> ((ExpressionStmt) expressionStmt).getExpression())
@@ -277,7 +506,16 @@ public class KiePMMLModelFactoryUtilsTest {
                         Spliterator.ORDERED), false);
     }
 
-    private void commonVerifyDerivedFieldMethodMap(DerivedField toVerify, Map<String, MethodDeclaration> derivedFieldsMethodMap) {
+    private Stream<Statement> getStatementStream(BlockStmt blockStmt) {
+        final NodeList<Statement> statements = blockStmt.getStatements();
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                        statements.iterator(),
+                        Spliterator.ORDERED), false);
+    }
+
+    private void commonVerifyDerivedFieldMethodMap(DerivedField toVerify,
+                                                   Map<String, MethodDeclaration> derivedFieldsMethodMap) {
         assertNotNull(derivedFieldsMethodMap);
         assertTrue(derivedFieldsMethodMap.containsKey(toVerify.getName().getValue()));
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/KiePMMLUtilTest.java
@@ -23,11 +23,23 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.xml.bind.JAXBException;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.dmg.pmml.DataField;
+import org.dmg.pmml.DataType;
+import org.dmg.pmml.FieldName;
+import org.dmg.pmml.MiningField;
 import org.dmg.pmml.Model;
+import org.dmg.pmml.OutputField;
 import org.dmg.pmml.PMML;
+import org.dmg.pmml.ResultFeature;
 import org.dmg.pmml.mining.MiningModel;
 import org.dmg.pmml.mining.Segment;
 import org.junit.Test;
@@ -35,6 +47,7 @@ import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.compiler.commons.utils.KiePMMLUtil.SEGMENTID_TEMPLATE;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
@@ -56,6 +69,66 @@ public class KiePMMLUtilTest {
         commonLoadFile(NO_MODELNAME_NO_SEGMENTID_SAMPLE_NAME);
     }
 
+    @Test
+    public void populateMissingOutputFieldDataType() {
+        Random random = new Random();
+        List<String> fieldNames = IntStream.range(0, 6)
+                .mapToObj(i -> RandomStringUtils.random(6, true, false))
+                .collect(Collectors.toList());
+        List<DataField> dataFields = fieldNames.stream()
+                .map(fieldName -> {
+                    DataField toReturn = new DataField();
+                    toReturn.setName(FieldName.create(fieldName));
+                    DataType dataType = DataType.values()[random.nextInt(DataType.values().length)];
+                    toReturn.setDataType(dataType);
+                    return toReturn;
+                })
+                .collect(Collectors.toList());
+        List<MiningField> miningFields = IntStream.range(0, dataFields.size() - 1)
+                .mapToObj(dataFields::get)
+                .map(dataField -> {
+                    MiningField toReturn = new MiningField();
+                    toReturn.setName(FieldName.create(dataField.getName().getValue()));
+                    toReturn.setUsageType(MiningField.UsageType.ACTIVE);
+                    return toReturn;
+                })
+                .collect(Collectors.toList());
+        DataField lastDataField = dataFields.get(dataFields.size() - 1);
+        MiningField targetMiningField = new MiningField();
+        targetMiningField.setName(FieldName.create(lastDataField.getName().getValue()));
+        targetMiningField.setUsageType(MiningField.UsageType.TARGET);
+        miningFields.add(targetMiningField);
+        // Following OutputFields should be populated based on "ResultFeature.PROBABILITY"
+        List<OutputField> outputFields = IntStream.range(0, 3)
+                .mapToObj(i -> {
+                    OutputField toReturn = new OutputField();
+                    toReturn.setName(FieldName.create(RandomStringUtils.random(6, true, false)));
+                    toReturn.setResultFeature(ResultFeature.PROBABILITY);
+                    return toReturn;
+                })
+                .collect(Collectors.toList());
+        // Following OutputField should be populated based on "ResultFeature.PREDICTED_VALUE"
+        OutputField targetOutputField = new OutputField();
+        targetOutputField.setName(FieldName.create(RandomStringUtils.random(6, true, false)));
+        targetOutputField.setResultFeature(ResultFeature.PREDICTED_VALUE);
+        outputFields.add(targetOutputField);
+        // Following OutputField should be populated based on "TargetField" property
+        OutputField targetingOutputField = new OutputField();
+        targetingOutputField.setName(FieldName.create(RandomStringUtils.random(6, true, false)));
+        targetingOutputField.setTargetField(FieldName.create(targetMiningField.getName().getValue()));
+        outputFields.add(targetingOutputField);
+        outputFields.forEach(outputField -> assertNull(outputField.getDataType()));
+        IntStream.range(0, 2)
+                .forEach(i -> {
+                    OutputField toAdd = new OutputField();
+                    toAdd.setName(FieldName.create(RandomStringUtils.random(6, true, false)));
+                    DataType dataType = DataType.values()[random.nextInt(DataType.values().length)];
+                    toAdd.setDataType(dataType);
+                    outputFields.add(toAdd);
+                });
+        KiePMMLUtil.populateMissingOutputFieldDataType(outputFields, miningFields, dataFields);
+        outputFields.forEach(outputField -> assertNotNull(outputField.getDataType()));
+    }
 
     @Test
     public void getSanitizedId() {
@@ -63,16 +136,15 @@ public class KiePMMLUtilTest {
         String id = "2";
         String expected = String.format(SEGMENTID_TEMPLATE, modelName, id);
         String retrieved = KiePMMLUtil.getSanitizedId(id, modelName);
-        assertEquals(expected,retrieved);
+        assertEquals(expected, retrieved);
         id = "34.5";
         expected = String.format(SEGMENTID_TEMPLATE, modelName, id);
         retrieved = KiePMMLUtil.getSanitizedId(id, modelName);
-        assertEquals(expected,retrieved);
+        assertEquals(expected, retrieved);
         id = "3,45";
         expected = String.format(SEGMENTID_TEMPLATE, modelName, id);
         retrieved = KiePMMLUtil.getSanitizedId(id, modelName);
-        assertEquals(expected,retrieved);
-
+        assertEquals(expected, retrieved);
     }
 
     private void commonLoadString(String fileName) throws IOException, JAXBException, SAXException {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/ModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/ModelUtilsTest.java
@@ -87,7 +87,7 @@ public class ModelUtilsTest {
     @Test
     public void convertToKieOutputField() {
         final OutputField toConvert = getRandomOutputField();
-        org.kie.pmml.api.models.OutputField retrieved = ModelUtils.convertToKieOutputField(toConvert);
+        org.kie.pmml.api.models.OutputField retrieved = ModelUtils.convertToKieOutputField(toConvert, null);
         assertNotNull(retrieved);
         assertEquals(toConvert.getName().getValue() , retrieved.getName());
         OP_TYPE expectedOpType = OP_TYPE.byName(toConvert.getOpType().value());
@@ -99,7 +99,7 @@ public class ModelUtilsTest {
         assertEquals(expectedResultFeature, retrieved.getResultFeature());
         toConvert.setOpType(null);
         toConvert.setTargetField(null);
-        retrieved = ModelUtils.convertToKieOutputField(toConvert);
+        retrieved = ModelUtils.convertToKieOutputField(toConvert, null);
         assertNull(retrieved.getOpType());
         assertNull(retrieved.getTargetField());
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/ModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/utils/ModelUtilsTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.dmg.pmml.DataField;
 import org.dmg.pmml.DataType;
 import org.dmg.pmml.MiningField;
 import org.dmg.pmml.OpType;
@@ -35,6 +36,7 @@ import org.kie.pmml.api.enums.RESULT_FEATURE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getDataField;
 import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getDataTypes;
 import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getMiningField;
 import static org.kie.pmml.compiler.commons.testutils.PMMLModelTestUtils.getParameterFields;
@@ -70,13 +72,15 @@ public class ModelUtilsTest {
         final String fieldName =  "fieldName";
         final MiningField.UsageType usageType = MiningField.UsageType.ACTIVE;
         final MiningField toConvert = getMiningField(fieldName, usageType);
-        org.kie.pmml.api.models.MiningField retrieved = ModelUtils.convertToKieMiningField(toConvert);
+        final DataField dataField = getDataField(fieldName, OpType.CATEGORICAL, DataType.STRING);
+        org.kie.pmml.api.models.MiningField retrieved = ModelUtils.convertToKieMiningField(toConvert, dataField);
         assertNotNull(retrieved);
         assertEquals(fieldName, retrieved.getName());
         assertEquals(FIELD_USAGE_TYPE.ACTIVE, retrieved.getUsageType());
+        assertEquals(DATA_TYPE.STRING, retrieved.getDataType());
         assertNull(retrieved.getOpType());
         toConvert.setOpType(OpType.CATEGORICAL);
-        retrieved = ModelUtils.convertToKieMiningField(toConvert);
+        retrieved = ModelUtils.convertToKieMiningField(toConvert, dataField);
         assertEquals(OP_TYPE.CATEGORICAL, retrieved.getOpType());
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -115,7 +115,7 @@ public class KiePMMLScorecardModelFactory {
                                final ConstructorDeclaration constructorDeclaration,
                                final SimpleName modelName) {
         final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(scorecard.getMiningSchema(), dataDictionary);
-        final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(scorecard.getOutput());
+        final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(scorecard.getOutput(), dataDictionary);
         setKiePMMLModelConstructor(modelName.asString(), constructorDeclaration, scorecard.getModelName(), miningFields, outputFields);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/main/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactory.java
@@ -84,7 +84,7 @@ public class KiePMMLScorecardModelFactory {
         ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
                 .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + className));
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, modelTemplate.getName())));
-        setConstructor(model, constructorDeclaration, modelTemplate.getName());
+        setConstructor(model,  dataDictionary, constructorDeclaration, modelTemplate.getName());
         addTransformationsInClassOrInterfaceDeclaration(modelTemplate, transformationDictionary, model.getLocalTransformations());
         Map<String, String> toReturn = new HashMap<>();
         String fullClassName = packageName + "." + className;
@@ -110,8 +110,11 @@ public class KiePMMLScorecardModelFactory {
         return KiePMMLScorecardModelASTFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap, types);
     }
 
-    static void setConstructor(final Scorecard scorecard, final ConstructorDeclaration constructorDeclaration, final SimpleName modelName) {
-        final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(scorecard.getMiningSchema());
+    static void setConstructor(final Scorecard scorecard,
+                               final DataDictionary dataDictionary,
+                               final ConstructorDeclaration constructorDeclaration,
+                               final SimpleName modelName) {
+        final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(scorecard.getMiningSchema(), dataDictionary);
         final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(scorecard.getOutput());
         setKiePMMLModelConstructor(modelName.asString(), constructorDeclaration, scorecard.getModelName(), miningFields, outputFields);
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/src/test/java/org/kie/pmml/models/drools/scorecard/compiler/factories/KiePMMLScorecardModelFactoryTest.java
@@ -115,6 +115,7 @@ public class KiePMMLScorecardModelFactoryTest {
         ConstructorDeclaration constructorDeclaration = classOrInterfaceDeclaration.getDefaultConstructor().get();
         SimpleName simpleName = new SimpleName("SIMPLENAME");
         KiePMMLScorecardModelFactory.setConstructor(scorecardModel,
+                                                    pmml.getDataDictionary(),
                                                     constructorDeclaration,
                                                     simpleName);
         Map<Integer, Expression> superInvocationExpressionsMap = new HashMap<>();

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -92,7 +92,7 @@ public class KiePMMLTreeModelFactory {
         ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
                 .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + className));
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, modelTemplate.getName())));
-        setConstructor(model, constructorDeclaration, modelTemplate.getName());
+        setConstructor(model, dataDictionary, constructorDeclaration, modelTemplate.getName());
         addTransformationsInClassOrInterfaceDeclaration(modelTemplate, transformationDictionary, model.getLocalTransformations());
         Map<String, String> toReturn = new HashMap<>();
         String fullClassName = packageName + "." + className;
@@ -118,8 +118,8 @@ public class KiePMMLTreeModelFactory {
         return KiePMMLTreeModelASTFactory.getKiePMMLDroolsAST(dataDictionary, model, fieldTypeMap, types);
     }
 
-    static void setConstructor(final TreeModel treeModel, final ConstructorDeclaration constructorDeclaration, final SimpleName modelName) {
-        final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(treeModel.getMiningSchema());
+    static void setConstructor(final TreeModel treeModel, final DataDictionary dataDictionary, final ConstructorDeclaration constructorDeclaration, final SimpleName modelName) {
+        final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(treeModel.getMiningSchema(), dataDictionary);
         final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(treeModel.getOutput());
         setKiePMMLModelConstructor(modelName.asString(), constructorDeclaration, treeModel.getModelName(), miningFields, outputFields);
         final BlockStmt body = constructorDeclaration.getBody();

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/main/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -120,7 +120,7 @@ public class KiePMMLTreeModelFactory {
 
     static void setConstructor(final TreeModel treeModel, final DataDictionary dataDictionary, final ConstructorDeclaration constructorDeclaration, final SimpleName modelName) {
         final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(treeModel.getMiningSchema(), dataDictionary);
-        final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(treeModel.getOutput());
+        final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(treeModel.getOutput(), dataDictionary);
         setKiePMMLModelConstructor(modelName.asString(), constructorDeclaration, treeModel.getModelName(), miningFields, outputFields);
         final BlockStmt body = constructorDeclaration.getBody();
         final ExplicitConstructorInvocationStmt superStatement = CommonCodegenUtils.getExplicitConstructorInvocationStmt(body)

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/src/test/java/org/kie/pmml/models/drools/tree/compiler/factories/KiePMMLTreeModelFactoryTest.java
@@ -118,6 +118,7 @@ public class KiePMMLTreeModelFactoryTest {
         ConstructorDeclaration constructorDeclaration = classOrInterfaceDeclaration.getDefaultConstructor().get();
         SimpleName simpleName = new SimpleName("SIMPLENAME");
         KiePMMLTreeModelFactory.setConstructor(treeModel,
+                                               pmml.getDataDictionary(),
                                                constructorDeclaration,
                                                simpleName);
         Map<Integer, Expression> superInvocationExpressionsMap = new HashMap<>();

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactory.java
@@ -145,7 +145,7 @@ public class KiePMMLMiningModelFactory {
         final List<org.kie.pmml.api.models.MiningField> miningFields =
                 ModelUtils.convertToKieMiningFieldList(miningModel.getMiningSchema(), dataDictionary);
         final List<org.kie.pmml.api.models.OutputField> outputFields =
-                ModelUtils.convertToKieOutputFieldList(miningModel.getOutput());
+                ModelUtils.convertToKieOutputFieldList(miningModel.getOutput(), dataDictionary);
         setKiePMMLModelConstructor(getSanitizedClassName(miningModel.getModelName()), constructorDeclaration,
                                    miningModel.getModelName(), miningFields, outputFields);
         Expression miningFunctionExpression;

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/main/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactory.java
@@ -126,6 +126,7 @@ public class KiePMMLMiningModelFactory {
         final ConstructorDeclaration constructorDeclaration =
                 modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, modelTemplate.getName())));
         setConstructor(model,
+                       dataDictionary,
                        constructorDeclaration,
                        targetFieldName,
                        segmentationClass);
@@ -137,11 +138,12 @@ public class KiePMMLMiningModelFactory {
     }
 
     static void setConstructor(final MiningModel miningModel,
+                               final DataDictionary dataDictionary,
                                final ConstructorDeclaration constructorDeclaration,
                                final String targetField,
                                final String segmentationClass) {
         final List<org.kie.pmml.api.models.MiningField> miningFields =
-                ModelUtils.convertToKieMiningFieldList(miningModel.getMiningSchema());
+                ModelUtils.convertToKieMiningFieldList(miningModel.getMiningSchema(), dataDictionary);
         final List<org.kie.pmml.api.models.OutputField> outputFields =
                 ModelUtils.convertToKieOutputFieldList(miningModel.getOutput());
         setKiePMMLModelConstructor(getSanitizedClassName(miningModel.getModelName()), constructorDeclaration,

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/src/test/java/org/kie/pmml/models/mining/compiler/factories/KiePMMLMiningModelFactoryTest.java
@@ -33,6 +33,7 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.MiningFunction;
 import org.dmg.pmml.mining.MiningModel;
 import org.junit.BeforeClass;
@@ -108,6 +109,7 @@ public class KiePMMLMiningModelFactoryTest extends AbstractKiePMMLFactoryTest {
         MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(model.getMiningFunction().value());
         String segmentationClass = "SEGMENTATIONCLASS";
         KiePMMLMiningModelFactory.setConstructor(model,
+                                                 new DataDictionary(),
                                                  constructorDeclaration,
                                                  targetField,
                                                  segmentationClass);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
@@ -148,7 +148,7 @@ public class KiePMMLRegressionModelFactory {
                                final ConstructorDeclaration constructorDeclaration,
                                final String targetField) {
         final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(regressionModel.getMiningSchema(), dataDictionary);
-        final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(regressionModel.getOutput());
+        final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(regressionModel.getOutput(), dataDictionary);
         setKiePMMLModelConstructor( getSanitizedClassName(regressionModel.getModelName()), constructorDeclaration, regressionModel.getModelName(), miningFields, outputFields);
 
         MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(regressionModel.getMiningFunction().value());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactory.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.Constants.MISSING_DEFAULT_CONSTRUCTOR;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
-import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageName;
 import static org.kie.pmml.compiler.commons.factories.KiePMMLOutputFieldFactory.getOutputFields;
 import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.MAIN_CLASS_NOT_FOUND;
 import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFullClassName;
@@ -107,7 +106,7 @@ public class KiePMMLRegressionModelFactory {
                         .findFirst()
                         .orElseThrow(() -> new KiePMMLException("Failed to find expected KiePMMLRegressionTableClassification"));
         final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, modelTemplate.getName())));
-        setConstructor(model, nestedTable, constructorDeclaration, targetFieldName);
+        setConstructor(model, dataDictionary, nestedTable, constructorDeclaration, targetFieldName);
         addTransformationsInClassOrInterfaceDeclaration(modelTemplate, transformationDictionary, model.getLocalTransformations());
         Map<String, String> toReturn = tablesSourceMap.entrySet()
                 .stream()
@@ -144,10 +143,11 @@ public class KiePMMLRegressionModelFactory {
     }
 
     static void setConstructor(final RegressionModel regressionModel,
+                               final DataDictionary dataDictionary,
                                final String nestedTable,
                                final ConstructorDeclaration constructorDeclaration,
                                final String targetField) {
-        final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(regressionModel.getMiningSchema());
+        final List<org.kie.pmml.api.models.MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(regressionModel.getMiningSchema(), dataDictionary);
         final List<org.kie.pmml.api.models.OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(regressionModel.getOutput());
         setKiePMMLModelConstructor( getSanitizedClassName(regressionModel.getModelName()), constructorDeclaration, regressionModel.getModelName(), miningFields, outputFields);
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
@@ -186,6 +186,7 @@ public class KiePMMLRegressionModelFactoryTest {
         String targetField = "targetField";
         MINING_FUNCTION miningFunction = MINING_FUNCTION.byName(regressionModel.getMiningFunction().value());
         KiePMMLRegressionModelFactory.setConstructor(regressionModel,
+                                                     dataDictionary,
                                                      nestedTable,
                                                      constructorDeclaration,
                                                      targetField);


### PR DESCRIPTION

@danielezonca @mariofusco @jiripetrlik

Scope of this PR is to propagate additional information inside MiningField/OutputField, to be used by OpenAPI.

This required modification to

1) beans itself
2) propagation of DataDictionary
3) modification of codegeneration

see https://issues.redhat.com/browse/DROOLS-5968