### PR TITLE
[7.48.x] DROOLS-5848 : CallMethod with ActionFieldFunctions does not compile  

### DIFF
--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/GuidedDTDRLPersistence.java
@@ -489,6 +489,7 @@ public class GuidedDTDRLPersistence {
             update.setFieldValues(old.getFieldValues());
             a.action = update;
         }
+
         ActionSetField asf = (ActionSetField) a.action;
         ActionFieldValue val = new ActionFieldValue(sf.getFactField(),
                                                     cell,
@@ -534,7 +535,9 @@ public class GuidedDTDRLPersistence {
         for (LabelledAction labelledAction : actions) {
             IAction action = labelledAction.action;
             if (action instanceof ActionFieldList) {
-                if (labelledAction.boundName.equals(boundName) && labelledAction.isUpdate == isUpdate) {
+                if (labelledAction.boundName.equals(boundName)
+                        && labelledAction.isUpdate == isUpdate
+                        && !(labelledAction.action instanceof ActionCallMethod)) {
                     return labelledAction;
                 }
             }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 
 import org.assertj.core.api.Assertions;
 import org.drools.workbench.models.datamodel.rule.ActionCallMethod;
+import org.drools.workbench.models.datamodel.rule.ActionFieldFunction;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
 import org.drools.workbench.models.datamodel.rule.ActionSetField;
@@ -1221,6 +1222,119 @@ public class BRLRuleModelTest {
                 "  x : Context( )\n" +
                 "then\n" +
                 "  x.clear( );\n" +
+                "end\n";
+
+        assertEqualsIgnoreWhitespace(expected,
+                                     drl);
+    }
+
+    @Test
+    /**
+     * DROOLS-5848
+     */
+    public void testActionCallMethodWithActionFieldFunction() {
+        final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+
+        final Pattern52 p1 = new Pattern52();
+        p1.setBoundName("x");
+        p1.setFactType("Context");
+
+        final ConditionCol52 c = new ConditionCol52();
+        c.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        p1.getChildColumns().add(c);
+        dt.getConditions().add(p1);
+
+        final BRLActionColumn brlAction1 = new BRLActionColumn();
+        final ActionCallMethod actionCallMethod = new ActionCallMethod("x");
+        actionCallMethod.setState(ActionCallMethod.TYPE_DEFINED);
+        actionCallMethod.setMethodName("add");
+        actionCallMethod.addFieldValue(new ActionFieldFunction("name",
+                                                               "Toni",
+                                                               DataType.TYPE_STRING));
+
+        brlAction1.getDefinition().add(actionCallMethod);
+        brlAction1.getChildColumns().add(new BRLActionVariableColumn("",
+                                                                     DataType.TYPE_BOOLEAN,
+                                                                     null,
+                                                                     null));
+        dt.getActionCols().add(brlAction1);
+        ActionSetFieldCol52 set = new ActionSetFieldCol52();
+        set.setBoundName("x");
+        set.setFactField("name");
+
+        dt.getActionCols().add(set);
+
+        dt.setData(DataUtilities.makeDataLists(new Object[][]{
+                new Object[]{"1", "", "desc", "x", true, "ToniR"}
+        }));
+        final String drl = GuidedDTDRLPersistence.getInstance().marshal(dt);
+        final String expected = "//from row number: 1\n" +
+                "//desc\n" +
+                "rule \"Row 1 null\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  x : Context( )\n" +
+                "then\n" +
+                "  x.add( \"Toni\" );\n" +
+                "  x.setName( \"ToniR\" );\n" +
+                "end\n";
+
+        assertEqualsIgnoreWhitespace(expected,
+                                     drl);
+    }
+
+    @Test
+    /**
+     * DROOLS-5848
+     */
+    public void testBrlActionCallMethodWithBeforeModify() {
+        final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+
+        final Pattern52 p1 = new Pattern52();
+        p1.setBoundName("x");
+        p1.setFactType("Context");
+
+        final ConditionCol52 c = new ConditionCol52();
+        c.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        p1.getChildColumns().add(c);
+        dt.getConditions().add(p1);
+
+        final BRLActionColumn brlAction1 = new BRLActionColumn();
+        final ActionCallMethod actionCallMethod = new ActionCallMethod("x");
+        actionCallMethod.setState(ActionCallMethod.TYPE_DEFINED);
+        actionCallMethod.setMethodName("add");
+        actionCallMethod.addFieldValue(new ActionFieldFunction("name",
+                                                               "Toni",
+                                                               DataType.TYPE_STRING));
+
+        brlAction1.getDefinition().add(actionCallMethod);
+        brlAction1.getChildColumns().add(new BRLActionVariableColumn("",
+                                                                     DataType.TYPE_BOOLEAN,
+                                                                     null,
+                                                                     null));
+        dt.getActionCols().add(brlAction1);
+        ActionSetFieldCol52 set = new ActionSetFieldCol52();
+        set.setBoundName("x");
+        set.setFactField("name");
+        set.setUpdate(true);
+
+        dt.getActionCols().add(set);
+
+        dt.setData(DataUtilities.makeDataLists(new Object[][]{
+                new Object[]{"1", "", "desc", "x", true, "ToniR"}
+        }));
+        final String drl = GuidedDTDRLPersistence.getInstance().marshal(dt);
+        final String expected = "//from row number: 1\n" +
+                "//desc\n" +
+                "rule \"Row 1 null\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  x : Context( )\n" +
+                "then\n" +
+                "  x.add( \"Toni\" );\n" +
+                "  modify( x ) {\n" +
+                "    setName( \"ToniR\" )\n" +
+                "}\n" +
                 "end\n";
 
         assertEqualsIgnoreWhitespace(expected,


### PR DESCRIPTION


* DROOLS-5848 : CallMethod with ActionFieldFunctions does not compile

* DROOLS-5848: Extend coverage

(cherry picked from commit 00c9b28010aced286f5b1db3fbec77f148310806)

**Thank you for submitting this pull request**

**JIRA**:  

[DROOLS-5848](https://issues.redhat.com/browse/DROOLS-5848)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
