### PR TITLE
DROOLS-6004 improve SonarCloud metrics

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ResultCollectorAlphaSink.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ResultCollectorAlphaSink.java
@@ -26,13 +26,17 @@ import org.drools.core.spi.PropagationContext;
 
 public class ResultCollectorAlphaSink extends LeftInputAdapterNode {
 
-    private final Object result;
-    private final ResultCollector resultCollector;
+    private Object result;
+    private ResultCollector resultCollector;
 
     public ResultCollectorAlphaSink(int id, ObjectSource source, BuildContext context, Object result, ResultCollector resultCollector) {
         super(id, source, context);
         this.result = result;
         this.resultCollector = resultCollector;
+    }
+
+    public ResultCollectorAlphaSink() {
+        super(); // java:S2060
     }
 
     @Override


### PR DESCRIPTION
"Externalizable" classes should have no-arguments constructors
java:S2060

all NetworkNode seems to be Externalizable and follow the no-args
constructor convention too.

**JIRA**: https://issues.redhat.com/browse/DROOLS-6004

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
