### PR TITLE
[DROOLS-5998] integerToShort casting issue when we call function in the expression

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewrite.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewrite.java
@@ -4,15 +4,18 @@ import java.util.Optional;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyper;
 import org.drools.modelcompiler.builder.generator.expressiontyper.TypedExpressionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.javaparser.ast.NodeList.nodeList;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.unEncloseExpr;
 
 public class PrimitiveTypeConsequenceRewrite {
@@ -57,7 +60,8 @@ public class PrimitiveTypeConsequenceRewrite {
             ) {
                 Expression unenclosedExpression = unEncloseExpr(typedExpression.getExpression());
                 Expression scope = StaticJavaParser.parseExpression(unenclosedExpression.toString());
-                MethodCallExpr shortValue = new MethodCallExpr(scope, "shortValue");
+                MethodCallExpr integerValueOf = new MethodCallExpr(new NameExpr(Integer.class.getCanonicalName()), "valueOf", nodeList(scope));
+                MethodCallExpr shortValue = new MethodCallExpr(integerValueOf, "shortValue");
                 ce.replace(shortValue);
             }
         });

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 public class PrimitiveTypeConsequenceRewriteTest {
 
     @Test
-    public void shouldConvertCastOfShortToShortValue() {
+    public void shouldConvertCastOfShortToIntegerToShortValue() {
         RuleContext context = createContext();
         context.addDeclaration("$interimVar", int.class);
 
@@ -21,7 +21,18 @@ public class PrimitiveTypeConsequenceRewriteTest {
                 .rewrite("{ $address.setShortNumber((short)$interimVar); }");
 
         assertThat(rewritten,
-                   equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.shortValue()); }"));
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber(java.lang.Integer.valueOf($interimVar).shortValue()); }"));
+    }
+
+    @Test
+    public void shouldConvertCastOfShortNegativeValueToIntegerToShortValue() {
+        RuleContext context = createContext();
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{ $address.setShortNumber((short)-2); }");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber(java.lang.Integer.valueOf(-2).shortValue()); }"));
     }
 
     @Test
@@ -44,7 +55,7 @@ public class PrimitiveTypeConsequenceRewriteTest {
                 .rewrite("{ $address.setShortNumber((short)($interimVar)); }");
 
         assertThat(rewritten,
-                   equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.shortValue()); }"));
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber(java.lang.Integer.valueOf($interimVar).shortValue()); }"));
     }
 
     public static class WithIntegerField {
@@ -71,7 +82,7 @@ public class PrimitiveTypeConsequenceRewriteTest {
                 .rewrite("{ $address.setShortNumber((short)($interimVar.unboxed())); }");
 
         assertThat(rewritten,
-                   equalToIgnoringWhiteSpace("{ $address.setShortNumber($interimVar.unboxed().shortValue()); }"));
+                   equalToIgnoringWhiteSpace("{ $address.setShortNumber(java.lang.Integer.valueOf($interimVar.unboxed()).shortValue()); }"));
     }
 
 


### PR DESCRIPTION
- Improved existing testCastingIntegerToShort test
- Reproducer: it fails to rewrite consequence using PrimitiveTypeConsequenceRewrite
- Fix: always box Integer before calling shortValue
- Added test to PrimitiveTypeConsequenceRewriteTest

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[https://issues.redhat.com/browse/DROOLS-5998]

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
