### PR TITLE
[DROOLS-5974] TemporalOperatorTest.testComparisonWithLocalDateAndLite…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -96,6 +96,8 @@ public class PackageModel {
 
     public static final String DATE_TIME_FORMATTER_FIELD = "DATE_TIME_FORMATTER";
     public static final String STRING_TO_DATE_METHOD = "string_2_date";
+    public static final String STRING_TO_LOCAL_DATE_METHOD = "string_2_localDate";
+    public static final String STRING_TO_LOCAL_DATE_TIME_METHOD = "string_2_localDateTime";
 
     private static final String RULES_FILE_NAME = "Rules";
 
@@ -468,10 +470,22 @@ public class PackageModel {
 
         BodyDeclaration<?> getNameMethod = parseBodyDeclaration(
                 "    public static java.util.Date " + STRING_TO_DATE_METHOD + "(String s) {\n" +
-                "        return java.util.GregorianCalendar.from(java.time.LocalDate.parse(s, DATE_TIME_FORMATTER).atStartOfDay(java.time.ZoneId.systemDefault())).getTime();\n" +
+                "        return java.util.GregorianCalendar.from(" + STRING_TO_LOCAL_DATE_METHOD + "(s).atStartOfDay(java.time.ZoneId.systemDefault())).getTime();\n" +
                 "    }\n"
                 );
         rulesClass.addMember(getNameMethod);
+
+        BodyDeclaration<?> string2localDateMethod = parseBodyDeclaration(
+                "    public static java.time.LocalDate " + STRING_TO_LOCAL_DATE_METHOD + "(String s) {\n" +
+                "        return java.time.LocalDate.parse(s, DATE_TIME_FORMATTER);\n" +
+                "    }\n");
+        rulesClass.addMember(string2localDateMethod);
+
+        BodyDeclaration<?> string2localDateTimeMethod = parseBodyDeclaration(
+                "    public static java.time.LocalDateTime " + STRING_TO_LOCAL_DATE_TIME_METHOD + "(String s) {\n" +
+                "        return " + STRING_TO_LOCAL_DATE_METHOD + "(s).atStartOfDay();\n" +
+                "    }\n");
+        rulesClass.addMember(string2localDateTimeMethod);
 
         String entryPointsBuilder = entryPoints.isEmpty() ?
                 "java.util.Collections.emptyList()" :

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpression.java
@@ -18,6 +18,8 @@
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -45,6 +47,8 @@ import org.drools.modelcompiler.builder.generator.UnificationTypedExpression;
 import org.drools.modelcompiler.util.ClassUtil;
 
 import static org.drools.modelcompiler.builder.PackageModel.STRING_TO_DATE_METHOD;
+import static org.drools.modelcompiler.builder.PackageModel.STRING_TO_LOCAL_DATE_METHOD;
+import static org.drools.modelcompiler.builder.PackageModel.STRING_TO_LOCAL_DATE_TIME_METHOD;
 import static org.drools.modelcompiler.util.ClassUtil.toNonPrimitiveType;
 import static org.drools.modelcompiler.util.JavaParserUtil.toJavaParserType;
 
@@ -108,6 +112,10 @@ public class CoercedExpression {
             coercedRight = right.cloneWithNewExpression(new CastExpr(PrimitiveType.longType(), right.getExpression()));
         } else if (leftClass == Date.class && rightClass == String.class) {
             coercedRight = coerceToDate(right);
+        } else if (leftClass == LocalDate.class && rightClass == String.class) {
+            coercedRight = coerceToLocalDate(right);
+        } else if (leftClass == LocalDateTime.class && rightClass == String.class) {
+            coercedRight = coerceToLocalDateTime(right);
         } else if (shouldCoerceBToMap()) {
             coercedRight = castToClass(toNonPrimitiveType(leftClass));
         } else if (isBoolean(leftClass) && !isBoolean(rightClass)) {
@@ -175,6 +183,18 @@ public class CoercedExpression {
         MethodCallExpr methodCallExpr = new MethodCallExpr(null, STRING_TO_DATE_METHOD);
         methodCallExpr.addArgument(typedExpression.getExpression());
         return new TypedExpression(methodCallExpr, Date.class);
+    }
+
+    private static TypedExpression coerceToLocalDate(TypedExpression typedExpression) {
+        MethodCallExpr methodCallExpr = new MethodCallExpr(null, STRING_TO_LOCAL_DATE_METHOD);
+        methodCallExpr.addArgument(typedExpression.getExpression());
+        return new TypedExpression(methodCallExpr, LocalDate.class);
+    }
+
+    private static TypedExpression coerceToLocalDateTime(TypedExpression typedExpression) {
+        MethodCallExpr methodCallExpr = new MethodCallExpr(null, STRING_TO_LOCAL_DATE_TIME_METHOD);
+        methodCallExpr.addArgument(typedExpression.getExpression());
+        return new TypedExpression(methodCallExpr, LocalDateTime.class);
     }
 
     private static TypedExpression coerceBoolean(TypedExpression typedExpression) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -232,7 +232,15 @@ public abstract class AbstractExpressionBuilder {
     }
 
     protected boolean isStringToDateExpression(Expression expression) {
-        return expression instanceof MethodCallExpr && ((MethodCallExpr) expression).getNameAsString().equals(PackageModel.STRING_TO_DATE_METHOD);
+        if (expression instanceof MethodCallExpr) {
+            String methodName = ((MethodCallExpr) expression).getNameAsString();
+            if (methodName.equals(PackageModel.STRING_TO_DATE_METHOD)
+                    || methodName.equals(PackageModel.STRING_TO_LOCAL_DATE_METHOD)
+                    || methodName.equals(PackageModel.STRING_TO_LOCAL_DATE_TIME_METHOD)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static AbstractExpressionBuilder getExpressionBuilder(RuleContext context) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/TypeCoercionTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/TypeCoercionTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.modelcompiler;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -23,6 +24,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.drools.modelcompiler.domain.ChildFactWithObject;
+import org.drools.modelcompiler.domain.DateTimeHolder;
 import org.drools.modelcompiler.domain.Person;
 import org.drools.modelcompiler.domain.Result;
 import org.junit.Test;
@@ -484,5 +486,53 @@ public class TypeCoercionTest extends BaseModelTest {
         ksession.insert( new ClassWithIntProperty( 3 ) );
 
         assertEquals( 0, ksession.fireAllRules() );
+    }
+
+    @Test
+    public void testCompareDateLiteral() throws Exception {
+        String str =
+                "import " + DateTimeHolder.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "    DateTimeHolder( date > \"01-Jan-1970\" )\n" +
+                     "then\n" +
+                     "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert(new DateTimeHolder(ZonedDateTime.now()));
+
+        assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testCompareLocalDateLiteral() throws Exception {
+        String str =
+                "import " + DateTimeHolder.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "    DateTimeHolder( localDate > \"01-Jan-1970\" )\n" +
+                     "then\n" +
+                     "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert(new DateTimeHolder(ZonedDateTime.now()));
+
+        assertEquals(1, ksession.fireAllRules());
+    }
+
+    @Test
+    public void testCompareLocalDateTimeLiteral() throws Exception {
+        String str =
+                "import " + DateTimeHolder.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "    DateTimeHolder( localDateTime > \"01-Jan-1970\" )\n" +
+                     "then\n" +
+                     "end\n";
+
+        KieSession ksession = getKieSession(str);
+
+        ksession.insert(new DateTimeHolder(ZonedDateTime.now()));
+
+        assertEquals(1, ksession.fireAllRules());
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/DateTimeHolder.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/DateTimeHolder.java
@@ -16,7 +16,10 @@
 
 package org.drools.modelcompiler.domain;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.Date;
 
 public class DateTimeHolder {
 
@@ -34,4 +37,15 @@ public class DateTimeHolder {
         this.zonedDateTime = zonedDateTime;
     }
 
+    public LocalDateTime getLocalDateTime() {
+        return zonedDateTime.toLocalDateTime();
+    }
+
+    public LocalDate getLocalDate() {
+        return zonedDateTime.toLocalDate();
+    }
+
+    public Date getDate() {
+        return Date.from(zonedDateTime.toInstant());
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TemporalOperatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TemporalOperatorTest.java
@@ -50,8 +50,7 @@ public class TemporalOperatorTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-     // TODO: EM failed with testAfterWithZonedDateTime. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @Test
@@ -140,55 +139,55 @@ public class TemporalOperatorTest {
 
     @Test
     public void testAfterWithConstant() {
-        checkConstantTemporalConstraint( "date after \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "date after \"01-Jan-1970\"" );
     }
 
     @Test
     public void testAfterWithConstantUsingOR() {
         // RHBRMS-2799
-        checkConstantTemporalConstraint( "date == null || date after \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "date == null || date after \"01-Jan-1970\"" );
     }
 
     @Test
     public void testAfterWithLocalDateTimeUsingOr() {
         // RHBRMS-2799
-        checkConstantTemporalConstraint( "localDateTime == null || localDateTime after \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "localDateTime == null || localDateTime after \"01-Jan-1970\"" );
     }
 
     @Test
     public void testAfterWithLocalDateTimeWithLiteral() {
         // RHBRMS-2799
-        checkConstantTemporalConstraint( "localDateTime after \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "localDateTime after \"01-Jan-1970\"" );
     }
 
     @Test
     public void testDateAfterWithLiteral() {
-        checkConstantTemporalConstraint( "date after \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "date after \"01-Jan-1970\"" );
     }
 
     @Test
     public void testAfterWithLocalDateWithLiteral() {
-        checkConstantTemporalConstraint( "localDate after \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "localDate after \"01-Jan-1970\"" );
     }
 
     @Test
     public void testComparisonWithLocalDateTimeAndLiteral() {
-        checkConstantTemporalConstraint( "localDate > \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "localDate > \"01-Jan-1970\"" );
     }
 
     @Test
     public void testComparisonWithLocalDate() {
-        checkConstantTemporalConstraint( "localDate > org.drools.mvel.integrationtests.TemporalOperatorTest.parseDateAsLocal(\"1-Jan-1970\")" );
+        checkConstantTemporalConstraint( "localDate > org.drools.mvel.integrationtests.TemporalOperatorTest.parseDateAsLocal(\"01-Jan-1970\")" );
     }
 
     @Test
     public void testComparisonWithLocalDateAndLiteral() {
-        checkConstantTemporalConstraint( "localDateTime > \"1-Jan-1970\"" );
+        checkConstantTemporalConstraint( "localDateTime > \"01-Jan-1970\"" );
     }
 
     @Test
     public void testComparisonWithLocalDateTime() {
-        checkConstantTemporalConstraint( "localDateTime > org.drools.mvel.integrationtests.TemporalOperatorTest.parseTimeAsLocal(\"1-Jan-1970\")" );
+        checkConstantTemporalConstraint( "localDateTime > org.drools.mvel.integrationtests.TemporalOperatorTest.parseTimeAsLocal(\"01-Jan-1970\")" );
     }
 
     public void checkConstantTemporalConstraint(String constraint) {


### PR DESCRIPTION
…ral error with exec-model

Added LocalDate, LocalDateTime support.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-5974

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
