### PR TITLE
BAQE-1696 - Change revapi to check against 7.48.0.Final

### DIFF
--- a/drools-core/src/build/revapi-config.json
+++ b/drools-core/src/build/revapi-config.json
@@ -43,8 +43,19 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.44.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
+      "ignore": [
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.kie.api.pmml.PMML4Result org.drools.core.command.runtime.pmml.ApplyPmmlModelCommand::executePMMLTrusty()",
+          "new": "method org.kie.api.pmml.PMML4Result org.drools.core.command.runtime.pmml.ApplyPmmlModelCommand::executePMMLTrusty(org.kie.api.runtime.Context)",
+          "package": "org.drools.core.command.runtime.pmml",
+          "classSimpleName": "ApplyPmmlModelCommand",
+          "methodName": "executePMMLTrusty",
+          "elementKind": "method",
+          "justification": "[DROOLS-5861] Fixing KieBase/Classloader usage"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
**JIRA:** [BAQE-1696](https://issues.redhat.com/browse/BAQE-1696)

depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1585