### PR TITLE
[DROOLS-5866] Move back core tests from drools-mvel

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/phreak/A.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/phreak/A.java
@@ -27,15 +27,15 @@ public class A {
         this.object = object;
     }
     
-    public static A a(Integer object) {
-        return new A( object );
+    public static org.drools.mvel.integrationtests.phreak.A a(Integer object) {
+        return new org.drools.mvel.integrationtests.phreak.A(object );
     }
 
-    public static A[] a(Integer... objects) {
-        A[] as = new A[objects.length];
+    public static org.drools.mvel.integrationtests.phreak.A[] a(Integer... objects) {
+        org.drools.mvel.integrationtests.phreak.A[] as = new org.drools.mvel.integrationtests.phreak.A[objects.length];
         int i = 0;
         for ( Integer object : objects ) {
-            as[i++] = new A( object );
+            as[i++] = new org.drools.mvel.integrationtests.phreak.A(object );
         }
         return as;
     }        
@@ -61,10 +61,10 @@ public class A {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        A other = (A) obj;
+        org.drools.mvel.integrationtests.phreak.A other = (org.drools.mvel.integrationtests.phreak.A) obj;
         if ( object == null ) {
-            if ( other.object != null ) return false;
-        } else if ( !object.equals( other.object ) ) return false;
+            if ( other.getObject() != null ) return false;
+        } else if ( !object.equals( other.getObject() ) ) return false;
         return true;
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/A.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/A.java
@@ -13,38 +13,38 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 
-public class C {
+public class A {
 
     @Position(0)
-    Object object;
+    Integer object;
 
-    public C(Object object) {
+    public A(Integer object) {
         super();
         this.object = object;
     }
-
-    public static C b(Object object) {
-        return new C( object );
+    
+    public static A a(Integer object) {
+        return new A( object );
     }
 
-    public static C[] b(Object... objects) {
-        C[] bs = new C[objects.length];
+    public static A[] a(Integer... objects) {
+        A[] as = new A[objects.length];
         int i = 0;
-        for ( Object object : objects ) {
-            bs[i++] = new C( object );
+        for ( Integer object : objects ) {
+            as[i++] = new A( object );
         }
-        return bs;
+        return as;
     }        
 
     public Object getObject() {
         return object;
     }
 
-    public void setObject(Object object) {
+    public void setObject(Integer object) {
         this.object = object;
     }
 
@@ -61,7 +61,7 @@ public class C {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        C other = (C) obj;
+        A other = (A) obj;
         if ( object == null ) {
             if ( other.object != null ) return false;
         } else if ( !object.equals( other.object ) ) return false;
@@ -70,7 +70,7 @@ public class C {
 
     @Override
     public String toString() {
-        return "C [" + object + "]";
+        return "A[" + object + "]";
     }
 
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/AddRuleTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.common.InternalWorkingMemory;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/B.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/B.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BaseLeftTuplesBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BaseLeftTuplesBuilder.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BetaNodeBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/BetaNodeBuilder.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.base.ClassFieldAccessorStore;
 import org.drools.core.base.ClassObjectType;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/C.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/C.java
@@ -13,38 +13,38 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 
-public class A {
+public class C {
 
     @Position(0)
-    Integer object;
+    Object object;
 
-    public A(Integer object) {
+    public C(Object object) {
         super();
         this.object = object;
     }
-    
-    public static A a(Integer object) {
-        return new A( object );
+
+    public static C b(Object object) {
+        return new C( object );
     }
 
-    public static A[] a(Integer... objects) {
-        A[] as = new A[objects.length];
+    public static C[] b(Object... objects) {
+        C[] bs = new C[objects.length];
         int i = 0;
-        for ( Integer object : objects ) {
-            as[i++] = new A( object );
+        for ( Object object : objects ) {
+            bs[i++] = new C( object );
         }
-        return as;
+        return bs;
     }        
 
     public Object getObject() {
         return object;
     }
 
-    public void setObject(Integer object) {
+    public void setObject(Object object) {
         this.object = object;
     }
 
@@ -61,7 +61,7 @@ public class A {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        A other = (A) obj;
+        C other = (C) obj;
         if ( object == null ) {
             if ( other.object != null ) return false;
         } else if ( !object.equals( other.object ) ) return false;
@@ -70,7 +70,7 @@ public class A {
 
     @Override
     public String toString() {
-        return "A[" + object + "]";
+        return "C [" + object + "]";
     }
 
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/D.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/D.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/E.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/E.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftBuilder.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftMemory.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/LeftMemory.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.InternalWorkingMemory;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/MVELConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/MVELConstraintTestUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020. Red Hat, Inc. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvel.integrationtests.phreak;
+
+import java.util.ArrayList;
+
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.rule.Declaration;
+import org.drools.core.spi.FieldValue;
+import org.drools.core.spi.InternalReadAccessor;
+import org.drools.core.test.model.Cheese;
+import org.drools.core.util.index.IndexUtil;
+import org.drools.mvel.MVELConstraint;
+import org.mvel2.MVEL;
+import org.mvel2.ParserConfiguration;
+
+public class MVELConstraintTestUtil extends MVELConstraint {
+
+    static {
+        MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL = true;
+        MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING = true;
+        MVEL.COMPILER_OPT_ALLOW_RESOLVE_INNERCLASSES_WITH_DOTNOTATION = true;
+        MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS = true;
+    }
+
+    public MVELConstraintTestUtil(String expression, FieldValue fieldValue, InternalReadAccessor extractor) {
+        super(null, expression, null, findConstraintTypeForExpression(expression), fieldValue, extractor, null);
+    }
+
+    public MVELConstraintTestUtil(String expression, Declaration declaration, InternalReadAccessor extractor) {
+        super(new ArrayList<String>(), expression, new Declaration[] { declaration }, null, null, findConstraintTypeForExpression(expression), declaration, extractor, expression.contains(":="));
+    }
+
+    public MVELConstraintTestUtil(String expression, String operator, Declaration declaration, InternalReadAccessor extractor) {
+        this(expression, IndexUtil.ConstraintType.decode(operator), declaration, extractor);
+    }
+
+    public MVELConstraintTestUtil(String expression, IndexUtil.ConstraintType constraintType, Declaration declaration, InternalReadAccessor extractor) {
+        super(new ArrayList<String>(), expression, new Declaration[] { declaration }, null, null, constraintType, declaration, extractor, expression.contains(":="));
+    }
+
+    @Override
+    protected ParserConfiguration getParserConfiguration(InternalWorkingMemory workingMemory) {
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.addImport(Cheese.class);
+        return parserConfiguration;
+    }
+
+    private static IndexUtil.ConstraintType findConstraintTypeForExpression(String expression) {
+        if (expression.contains("==")) {
+            return IndexUtil.ConstraintType.EQUAL;
+        }
+        if (expression.contains("!=")) {
+            return IndexUtil.ConstraintType.NOT_EQUAL;
+        }
+        if (expression.contains(">")) {
+            return IndexUtil.ConstraintType.GREATER_THAN;
+        }
+        if (expression.contains(">=")) {
+            return IndexUtil.ConstraintType.GREATER_OR_EQUAL;
+        }
+        if (expression.contains("<")) {
+            return IndexUtil.ConstraintType.LESS_THAN;
+        }
+        if (expression.contains("<=")) {
+            return IndexUtil.ConstraintType.LESS_OR_EQUAL;
+        }
+        return IndexUtil.ConstraintType.UNKNOWN;
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Pair.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Pair.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 public class Pair {
     private Object o1;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import static org.drools.mvel.integrationtests.phreak.Pair.t;
 
+// TODO: EM Need to migrate this to executable model
 public class PhreakJoinNodeTest {
     BuildContext          buildContext;
     JoinNode              joinNode;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakJoinNodeTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.InternalFactHandle;
@@ -33,7 +33,7 @@ import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.junit.Test;
 
-import static org.drools.mvel.compiler.phreak.Pair.t;
+import static org.drools.mvel.integrationtests.phreak.Pair.t;
 
 public class PhreakJoinNodeTest {
     BuildContext          buildContext;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakLiaNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakLiaNodeTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.impl.InternalKnowledgeBase;
@@ -24,7 +24,6 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 public class PhreakLiaNodeTest {
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakLiaNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakLiaNodeTest.java
@@ -25,6 +25,7 @@ import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
+// TODO: EM Need to migrate this to executable model
 public class PhreakLiaNodeTest {
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import static org.drools.mvel.integrationtests.phreak.A.a;
 import static org.drools.mvel.integrationtests.phreak.B.b;
 
+// TODO: EM Need to migrate this to executable model
 public class PhreakNotNodeTest {
 
     BuildContext          buildContext;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/PhreakNotNodeTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.InternalWorkingMemory;
@@ -33,8 +33,8 @@ import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.junit.Test;
 
-import static org.drools.mvel.compiler.phreak.A.a;
-import static org.drools.mvel.compiler.phreak.B.b;
+import static org.drools.mvel.integrationtests.phreak.A.a;
+import static org.drools.mvel.integrationtests.phreak.B.b;
 
 public class PhreakNotNodeTest {
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/RemoveRuleTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+// TODO: EM Need to migrate this to executable model
 public class RemoveRuleTest {
 
     @Test
@@ -62,13 +63,13 @@ public class RemoveRuleTest {
         wm.insert(new B(1));
         wm.insert(new C(1));
         wm.insert(new C(2));
-        wm.insert(new D(1));
+        wm.insert(new X(1));
         wm.insert(new E(1));
 
         wm.fireAllRules();
 
 
-        kbase.addPackages( buildKnowledgePackage("r1", "   A() B() C(object == 2) D() E()\n") );
+        kbase.addPackages( buildKnowledgePackage("r1", "   A() B() C(object == 2) X() E()\n") );
         List list = new ArrayList();
         wm.setGlobal("list", list);
 
@@ -109,14 +110,14 @@ public class RemoveRuleTest {
 
         wm.insert(new A(1));
         wm.insert(new A(2));
-        wm.insert(new D(1));
+        wm.insert(new X(1));
         wm.insert(new E(1));
 
         wm.insert(new C(2));
         wm.fireAllRules();
 
 
-        kbase.addPackages( buildKnowledgePackage("r1", "   A() not( B() and C() ) D() E()\n") );
+        kbase.addPackages( buildKnowledgePackage("r1", "   A() not( B() and C() ) X() E()\n") );
         List list = new ArrayList();
         wm.setGlobal("list", list);
 
@@ -144,7 +145,7 @@ public class RemoveRuleTest {
 
     @Test
     public void testPopulatedRuleMidwayShare() throws Exception {
-        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A() B() C(1;) D() E()\n");
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A() B() C(1;) X() E()\n");
 
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
         List list = new ArrayList();
@@ -156,13 +157,13 @@ public class RemoveRuleTest {
         wm.insert(new B(1));
         wm.insert(new C(1));
         wm.insert(new C(2));
-        wm.insert(new D(1));
+        wm.insert(new X(1));
         wm.insert(new E(1));
         wm.fireAllRules();
 
         assertEquals( 7, countNodeMemories(wm.getNodeMemories()));
 
-        kbase1.addPackages( buildKnowledgePackage("r2", "   a : A() B() C(2;) D() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   a : A() B() C(2;) X() E()\n") );
         wm.fireAllRules();
 
         ObjectTypeNode aotn = getObjectTypeNode(kbase1, A.class );
@@ -216,7 +217,7 @@ public class RemoveRuleTest {
         wm.insert(new B(1));
         wm.insert(new C(1));
         wm.insert(new C(2));
-        wm.insert(new D(1));
+        wm.insert(new X(1));
         wm.insert(new E(1));
         wm.fireAllRules();
 
@@ -267,7 +268,7 @@ public class RemoveRuleTest {
 
     @Test
     public void testPopulatedSharedLiaNode() throws Exception {
-        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A() B(1;) C() D() E()\n");
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A() B(1;) C() X() E()\n");
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
         List list = new ArrayList();
         wm.setGlobal("list", list);
@@ -278,14 +279,14 @@ public class RemoveRuleTest {
         wm.insert(new B(1));
         wm.insert(new B(2));
         wm.insert(new C(1));
-        wm.insert(new D(1));
+        wm.insert(new X(1));
         wm.insert(new E(1));
 
         wm.fireAllRules();
         assertEquals( 3, list.size() );
         assertEquals( 7, countNodeMemories(wm.getNodeMemories()));
 
-        kbase1.addPackages( buildKnowledgePackage("r2", "   a : A() B(2;) C() D() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   a : A() B(2;) C() X() E()\n") );
         wm.fireAllRules();
         assertEquals( 17, countNodeMemories(wm.getNodeMemories()));
 
@@ -371,7 +372,7 @@ public class RemoveRuleTest {
 
     @Test
     public void testPopulatedSharedToRtn() throws Exception {
-        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A() B() C() D() E()\n");
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A() B() C() X() E()\n");
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
         List list = new ArrayList();
         wm.setGlobal("list", list);
@@ -380,14 +381,14 @@ public class RemoveRuleTest {
         wm.insert(new A(2));
         wm.insert(new B(1));
         wm.insert(new C(1));
-        wm.insert(new D(1));
+        wm.insert(new X(1));
         wm.insert(new E(1));
 
         wm.fireAllRules();
         assertEquals( 2, list.size() );
         assertEquals( 7, countNodeMemories(wm.getNodeMemories()));
 
-        kbase1.addPackages( buildKnowledgePackage("r2", "   A() B() C() D() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   A() B() C() X() E()\n") );
         wm.fireAllRules();
         assertEquals( 8, countNodeMemories(wm.getNodeMemories()));
         assertEquals(4, list.size() );
@@ -433,7 +434,7 @@ public class RemoveRuleTest {
 
     @Test
          public void testPopulatedMultipleSharesRemoveFirst() throws Exception {
-        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) D() E()\n" );
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) X() E()\n" );
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
         List list = new ArrayList();
         wm.setGlobal("list", list);
@@ -446,14 +447,14 @@ public class RemoveRuleTest {
         InternalFactHandle fh6 =  (InternalFactHandle) wm.insert(new B(2));
         InternalFactHandle fh7 =  (InternalFactHandle) wm.insert(new C(1));
         InternalFactHandle fh8 =  (InternalFactHandle) wm.insert(new C(2));
-        InternalFactHandle fh9 =  (InternalFactHandle) wm.insert(new D(1));
+        InternalFactHandle fh9 =  (InternalFactHandle) wm.insert(new X(1));
         InternalFactHandle fh10 =  (InternalFactHandle) wm.insert(new E(1));
 
         wm.fireAllRules();
         assertEquals( 2, list.size() );
 
-        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(2;) D() E()\n") );
-        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(3;) B(1;) B(2;) C(2;) D() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(2;) X() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(3;) B(1;) B(2;) C(2;) X() E()\n") );
 
         wm.fireAllRules();
         assertEquals( 5, list.size() );
@@ -479,7 +480,7 @@ public class RemoveRuleTest {
 
     @Test
     public void testPopulatedMultipleSharesRemoveMid() throws Exception {
-        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) D() E()\n" );
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) X() E()\n" );
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
         List list = new ArrayList();
         wm.setGlobal("list", list);
@@ -492,14 +493,14 @@ public class RemoveRuleTest {
         InternalFactHandle fh6 =  (InternalFactHandle) wm.insert(new B(2));
         InternalFactHandle fh7 =  (InternalFactHandle) wm.insert(new C(1));
         InternalFactHandle fh8 =  (InternalFactHandle) wm.insert(new C(2));
-        InternalFactHandle fh9 =  (InternalFactHandle) wm.insert(new D(1));
+        InternalFactHandle fh9 =  (InternalFactHandle) wm.insert(new X(1));
         InternalFactHandle fh10 =  (InternalFactHandle) wm.insert(new E(1));
 
         wm.fireAllRules();
         assertEquals( 2, list.size() );
 
-        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(2;) D() E()\n") );
-        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(3;) B(1;) B(2;) C(2;) D() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(2;) X() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(3;) B(1;) B(2;) C(2;) X() E()\n") );
 
         wm.fireAllRules();
         assertEquals( 5, list.size() );
@@ -525,7 +526,7 @@ public class RemoveRuleTest {
 
     @Test
     public void testPopulatedMultipleSharesRemoveLast() throws Exception {
-        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) D() E()\n" );
+        InternalKnowledgeBase kbase1 = buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) X() E()\n" );
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
         List list = new ArrayList();
         wm.setGlobal("list", list);
@@ -538,14 +539,14 @@ public class RemoveRuleTest {
         InternalFactHandle fh6 =  (InternalFactHandle) wm.insert(new B(2));
         InternalFactHandle fh7 =  (InternalFactHandle) wm.insert(new C(1));
         InternalFactHandle fh8 =  (InternalFactHandle) wm.insert(new C(2));
-        InternalFactHandle fh9 =  (InternalFactHandle) wm.insert(new D(1));
+        InternalFactHandle fh9 =  (InternalFactHandle) wm.insert(new X(1));
         InternalFactHandle fh10 =  (InternalFactHandle) wm.insert(new E(1));
 
         wm.fireAllRules();
         assertEquals( 2, list.size() );
 
-        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(2;) D() E()\n") );
-        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(3;) B(1;) B(2;) C(2;) D() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(2;) X() E()\n") );
+        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(3;) B(1;) B(2;) C(2;) X() E()\n") );
 
         wm.fireAllRules();
         assertEquals( 5, list.size() );
@@ -611,9 +612,9 @@ public class RemoveRuleTest {
 
     @Test
     public void testSplitTwoBeforeCreatedSegment() throws Exception {
-        InternalKnowledgeBase kbase1 =          buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) D(1;) D(2;) E(1;) E(2;)\n" );
-        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) D(1;) D(2;) E(1;) E(2;)\n") );
-        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) D(1;) D(2;)\n") );
+        InternalKnowledgeBase kbase1 =          buildKnowledgeBase("r1", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) X(1;) X(2;) E(1;) E(2;)\n" );
+        kbase1.addPackages( buildKnowledgePackage("r2", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) X(1;) X(2;) E(1;) E(2;)\n") );
+        kbase1.addPackages( buildKnowledgePackage("r3", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) X(1;) X(2;)\n") );
         kbase1.addPackages( buildKnowledgePackage("r4", "   A(1;)  A(2;) B(1;) B(2;) C(1;) C(2;) \n") );
 
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase1.newKieSession());
@@ -671,7 +672,7 @@ public class RemoveRuleTest {
         str += "import " + A.class.getCanonicalName() + "\n" ;
         str += "import " + B.class.getCanonicalName() + "\n" ;
         str += "import " + C.class.getCanonicalName() + "\n" ;
-        str += "import " + D.class.getCanonicalName() + "\n" ;
+        str += "import " + X.class.getCanonicalName() + "\n" ;
         str += "import " + E.class.getCanonicalName() + "\n" ;
         str += "global java.util.List list \n";
 
@@ -700,7 +701,7 @@ public class RemoveRuleTest {
         str += "import " + A.class.getCanonicalName() + "\n" ;
         str += "import " + B.class.getCanonicalName() + "\n" ;
         str += "import " + C.class.getCanonicalName() + "\n" ;
-        str += "import " + D.class.getCanonicalName() + "\n" ;
+        str += "import " + X.class.getCanonicalName() + "\n" ;
         str += "import " + E.class.getCanonicalName() + "\n" ;
         str += "global java.util.List list \n";
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ReteTesterHelper.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ReteTesterHelper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +37,6 @@ import org.drools.core.spi.BetaNodeFieldConstraint;
 import org.drools.core.spi.Evaluator;
 import org.drools.core.spi.FieldValue;
 import org.drools.core.spi.InternalReadAccessor;
-import org.drools.mvel.MVELConstraintTestUtil;
 
 public class ReteTesterHelper {
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/Scenario.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.common.TupleSets;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
@@ -37,6 +37,7 @@ import static org.drools.mvel.integrationtests.phreak.Pair.t;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+// TODO: EM Need to migrate this to executable model
 public class ScenarioTest {
     BuildContext          buildContext;
     JoinNode              joinNode;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/ScenarioTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.InternalWorkingMemory;
@@ -32,8 +32,8 @@ import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.junit.Test;
 
-import static org.drools.mvel.compiler.phreak.B.b;
-import static org.drools.mvel.compiler.phreak.Pair.t;
+import static org.drools.mvel.integrationtests.phreak.B.b;
+import static org.drools.mvel.integrationtests.phreak.Pair.t;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import static org.drools.mvel.integrationtests.phreak.Pair.t;
 
+// TODO: EM Need to migrate this to executable model
 public class SegmentPropagationTest {
     
     BuildContext          buildContext;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.common.InternalWorkingMemory;
@@ -32,7 +32,7 @@ import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.junit.Test;
 
-import static org.drools.mvel.compiler.phreak.Pair.t;
+import static org.drools.mvel.integrationtests.phreak.Pair.t;
 
 public class SegmentPropagationTest {
     

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/StagedBuilder.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/StagedBuilder.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.drools.mvel.compiler.phreak;
+package org.drools.mvel.integrationtests.phreak;
 
 import org.drools.core.common.TupleSetsImpl;
 import org.drools.core.reteoo.LeftTuple;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/X.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/X.java
@@ -17,25 +17,25 @@ package org.drools.mvel.integrationtests.phreak;
 
 import org.kie.api.definition.type.Position;
 
-public class D {
+public class X {
 
     @Position(0)
     Object object;
 
-    public D(Object object) {
+    public X(Object object) {
         super();
         this.object = object;
     }
 
-    public static D b(Object object) {
-        return new D( object );
+    public static X b(Object object) {
+        return new X(object );
     }
 
-    public static D[] b(Object... objects) {
-        D[] bs = new D[objects.length];
+    public static X[] b(Object... objects) {
+        X[] bs = new X[objects.length];
         int i = 0;
         for ( Object object : objects ) {
-            bs[i++] = new D( object );
+            bs[i++] = new X(object );
         }
         return bs;
     }        
@@ -61,7 +61,7 @@ public class D {
         if ( this == obj ) return true;
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
-        D other = (D) obj;
+        X other = (X) obj;
         if ( object == null ) {
             if ( other.object != null ) return false;
         } else if ( !object.equals( other.object ) ) return false;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/sequential/SequentialTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/sequential/SequentialTest.java
@@ -26,7 +26,7 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.mvel.compiler.Cheese;
 import org.drools.mvel.compiler.Message;
 import org.drools.mvel.compiler.Person;
-import org.drools.mvel.compiler.phreak.A;
+import org.drools.mvel.integrationtests.phreak.A;
 import org.drools.mvel.integrationtests.DynamicRulesTest;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;


### PR DESCRIPTION
Moved 

`org/drools/mvel/compiler/phreak`

and

`org/drools/mvel/integrationtest`

to `test-compiler-integration`.

Most of the test aren't using the executable model, to do so we need to enable it explicitly by parametrising the test. 

I've started migrating the `AddRuleTest` but it's using the old `.addPacakge` API, so I migrated some of the tests to the new incremental compilation API. As I couldn't migrate the others easily I added a comment and stopped migrating.

I also added a comment to other tests that aren't parametrized. I used the TODO EM: placeholder

I'm not sure if this is correct but this will preserve the test if we remove the `drools-mvel` module and we can work on migrating it afterwards. Can you check @tkobayas?

Sorry the works seems to be mixed, I migrated some tests and some not, but I think it could be useful to push the already migrated tests as a blueprint.

Thank you

https://issues.redhat.com/browse/DROOLS-5866

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
