### PR TITLE
DROOLS-6044 DRLX parser: update condition/consequence syntax

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/drlx/DrlxVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/drlx/DrlxVisitor.java
@@ -64,7 +64,7 @@ public class DrlxVisitor implements DrlVoidVisitor<Void> {
                 }
             } else if (item instanceof RuleConsequence) {
                 RuleConsequence c = (RuleConsequence) item;
-                ruleDescrBuilder.rhs(c.getBlock().toString());
+                ruleDescrBuilder.rhs(c.getStatement().toString());
             } else {
                 throw new IllegalArgumentException(item.getClass().getCanonicalName());
             }

--- a/drools-model/drools-model-compiler/src/test/resources/drlx1/Example.drlx
+++ b/drools-model/drools-model-compiler/src/test/resources/drlx1/Example.drlx
@@ -7,27 +7,27 @@ import java.time.Month;
 
 unit Example;
 
-rule year2020
-when {
-    LocalDate foo = /dates[ year > 2020 ];
-} do {
-    System.out.println("finally " + foo);
-    int a = 1
-    + 1;
+rule year2020 {
+    LocalDate foo : /dates[ year > 2020 ],
+    do {
+        System.out.println("finally " + foo);
+        int a = 1
+        + 1;
+    }
 }
 
-rule newyear2020
-when {
-    LocalDate foo = /dates[ year == 2021, dayOfMonth == 1, month == Month.JANUARY ];
-} do {
-    System.out.println("Happy new year 🎉 " + foo);
+rule newyear2020 {
+    LocalDate foo : /dates[ year == 2021, dayOfMonth == 1, month == Month.JANUARY ],
+    do {
+        System.out.println("Happy new year 🎉 " + foo);
+    }
 }
 
-rule join
-when {
-    LocalDate a = /dates[ year == 2021 ];
-    LocalDate b = /dates[ year == a.year, dayOfMonth == 1, month == Month.JANUARY ];
-} do {
-    // silly match;
-    System.out.println("Happy new year 🎉 " + b);
+rule join {
+    LocalDate a : /dates[ year == 2021 ],
+    LocalDate b : /dates[ year == a.year, dayOfMonth == 1, month == Month.JANUARY ],
+    do {
+        // silly match;
+        System.out.println("Happy new year 🎉 " + b);
+    }
 }

--- a/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleConsequence.java
+++ b/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/RuleConsequence.java
@@ -20,6 +20,7 @@ package org.drools.mvel.parser.ast.expr;
 
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
 import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
 import org.drools.mvel.parser.ast.visitor.DrlVoidVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -27,15 +28,15 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 
 public class RuleConsequence extends RuleItem {
 
-    private final BlockStmt block;
+    private final Statement statement;
 
-    public RuleConsequence(TokenRange range, BlockStmt block ) {
+    public RuleConsequence(TokenRange range, Statement statement) {
         super( range );
-        this.block = block;
+        this.statement = statement;
     }
 
-    public BlockStmt getBlock() {
-        return block;
+    public Statement getStatement() {
+        return statement;
     }
 
     @Override

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -3110,15 +3110,14 @@ NodeList<RuleItem> RuleItems():
     RuleConsequence consequnce;
 }
 {
-  (
-      <WHEN> "{"
-      (
-    item = RulePattern() { items.add(item); }
-      )*
-      "}"
-      <DO>
-    item = RuleConsequence() { items.add(item); }
-  )+
+
+    "{"
+    (
+        item = RulePattern() { items.add(item); }
+      | <DO> item = RuleConsequence() { items.add(item); }
+    )*
+    "}"
+
     { return items; }
 }
 
@@ -3132,9 +3131,9 @@ RulePattern RulePattern():
 {
   type = SimpleName() { begin=token(); }
   bind = SimpleName()
-  "="
+  ("=" | ":") // need to differentiate in the Pattern kind
   expr = OOPathExpr()
-  ";"
+  ","
 
     { return new RulePattern(range(begin, token()), type, bind, expr); }
 }
@@ -3142,13 +3141,13 @@ RulePattern RulePattern():
 RuleConsequence RuleConsequence():
 {
     JavaToken begin;
-    BlockStmt block;
+    Statement statement;
 }
 {
   { begin=token(); }
-  block = Block()
+  statement = Statement()
 
-    { return new RuleConsequence(range(begin, token()), block); }
+    { return new RuleConsequence(range(begin, token()), statement); }
 }
 
 OOPathExpr OOPathExpr():

--- a/drools-model/drools-mvel-parser/src/test/resources/org/drools/mvel/parser/Example.drlx
+++ b/drools-model/drools-mvel-parser/src/test/resources/org/drools/mvel/parser/Example.drlx
@@ -4,15 +4,17 @@ import blah.*;
 
 unit Example;
 
-rule fooBar
-when {
-    Foo foo = /blah/baz[x == "test"];
-    Bar bar = /blah/baz[y];
-} do {
-    System.out.println("hello");
-} when {
-    Blah blah = /a/b/c;
-} do {
-    System.out.println("more hello");
+rule fooBar {
+    Foo foo : /blah/baz[x == "test"],
+    var whatever : /blah/baz[y],
+    do System.out.println("hello");
+
+    Blah blah = /a/b/c,
+    do {
+        System.out.println("more hello");
+    }
+
+    var xx : /blah/baz[y],
+
 }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6044

Further iterative updates to the parser. The following syntax is now accepted.

```java
unit Example;

rule fooBar {
    Foo foo : /blah/baz[x == "test"],
    var whatever : /blah/baz[y],
    do System.out.println("hello");

    Blah blah = /a/b/c,
    do {
        System.out.println("still hello");
    }

    var xx : /blah/baz[y],

}
```