### PR TITLE
[DROOLS-6041] "RHS doesn't have a type" error when a semicolon is mis…

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -925,4 +925,28 @@ public class MvelDialectTest extends BaseModelTest {
 
         assertTrue(result.contains("R"));
     }
+
+    @Test
+    public void testLineBreakAtTheEndOfStatementWithoutSemicolon() {
+        final String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                           "\n" +
+                           "rule R\n" +
+                           "dialect \"mvel\"\n" +
+                           "when\n" +
+                           "  Person(name == \"Mario\")\n" +
+                           "then\n" +
+                           "  Person p2 = new Person(\"John\");\n" +
+                           "  p2.age = 30\n" + // a line break at the end of the statement without a semicolon
+                           "  insert(p2);\n" +
+                           "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person p = new Person("Mario", 40);
+        ksession.insert(p);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
+    }
 }

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -91,6 +91,7 @@ import com.github.javaparser.JavaToken;
 @Generated("JavaCC")
 public final class GeneratedMvelParser extends GeneratedMvelParserBase {
     private boolean optionalSemicolon = true;
+    private int nestedBlocks = 0;
     private boolean isWithOrModify = false;
 
     public void setOptionalSemicolon(boolean optionalSemicolon) {
@@ -110,14 +111,16 @@ public final class GeneratedMvelParser extends GeneratedMvelParserBase {
 
     }
 
-    public boolean doesCrossLineBreak(Token token) {
-        if (token.specialToken == null) {
-            return false;
-        }
-        if (token.specialToken.kind == UNIX_EOL || token.specialToken.kind == WINDOWS_EOL) {
-            return true;
-        }
-        return doesCrossLineBreak(token.specialToken);
+    public boolean inBlock() {
+        return nestedBlocks > 0;
+    }
+
+    public void enterBlock() {
+        this.nestedBlocks++;
+    }
+
+    public void leaveBlock() {
+        this.nestedBlocks--;
     }
 
     /* Returns the JavaParser specific token type of the last matched token */
@@ -2247,6 +2250,7 @@ BlockStmt Block():
 {
 	NodeList<Statement> stmts = emptyList();
 	JavaToken begin;
+	this.enterBlock();
 }
 {
     "{" {begin=token();}
@@ -2259,6 +2263,8 @@ BlockStmt Block():
         BlockStmt block = new BlockStmt(range(begin, token()), new NodeList<Statement>());
         block.setParsed(UNPARSABLE);
         return block;
+    } finally {
+        this.leaveBlock();
     }
 }
 
@@ -3294,7 +3300,9 @@ Expression PointFreeExpr():
         (
             left = PrimaryExpression()
             {
-                if (doesCrossLineBreak(token.next)) {
+                // if we are in a Block {} we short-circuit;
+                // a PointFreeExpr is invalid in that case
+                if (this.inBlock()) {
                     return left;
                 }
                 begin=token();

--- a/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
+++ b/drools-model/drools-mvel-parser/src/main/javacc/mvel.jj
@@ -110,6 +110,16 @@ public final class GeneratedMvelParser extends GeneratedMvelParserBase {
 
     }
 
+    public boolean doesCrossLineBreak(Token token) {
+        if (token.specialToken == null) {
+            return false;
+        }
+        if (token.specialToken.kind == UNIX_EOL || token.specialToken.kind == WINDOWS_EOL) {
+            return true;
+        }
+        return doesCrossLineBreak(token.specialToken);
+    }
+
     /* Returns the JavaParser specific token type of the last matched token */
     JavaToken token() {
         if(token.toString() == null) {
@@ -3282,7 +3292,13 @@ Expression PointFreeExpr():
 {
     (
         (
-            left = PrimaryExpression() { begin=token(); }
+            left = PrimaryExpression()
+            {
+                if (doesCrossLineBreak(token.next)) {
+                    return left;
+                }
+                begin=token();
+            }
             (
                           <NOT>
                           { negated = true; }

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -1019,6 +1019,20 @@ public class DroolsMvelParserTest {
         assertFalse("Parsing should break at newline", r.isSuccessful());
     }
 
+        @Test
+        public void testLineBreakAtTheEndOfStatementWithoutSemicolon() {
+            String expr =
+                    "{  Person p2 = new Person(\"John\");\n" +
+                    "  p2.age = 30\n" + // a line break at the end of the statement without a semicolon
+                    "insert(p2);\n }";
+
+            MvelParser mvelParser = new MvelParser(new ParserConfiguration(), true);
+            ParseResult<BlockStmt> r = mvelParser.parse(GeneratedMvelParser::BlockParseStart, new StringProvider(expr));
+            BlockStmt blockStmt = r.getResult().get();
+            assertEquals("Should parse 3 statements", 3, blockStmt.getStatements().size());
+
+        }
+
     private void testMvelSquareOperator(String wholeExpression, String operator, String left, String right, boolean isNegated) {
         String expr = wholeExpression;
         Expression expression = parseExpression(parser, expr ).getExpr();


### PR DESCRIPTION
…sing with exec-model and mvel dialect

- WIP : just to spot the issue

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6041

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
