### PR TITLE
[DROOLS-6048] Enforcing before rules/after rules semantic

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/AbstractAssemblerService.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/AbstractAssemblerService.java
@@ -47,7 +47,7 @@ public abstract class AbstractAssemblerService<T extends ResourceTypePackage<U>,
     protected abstract ResourceProcessor<U> createResourceProcessor(Resource resource);
 
     @Override
-    public final void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+    public final void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
         AssemblerContext kb = (AssemblerContext) kbuilder;
         ResourceProcessor<U> processor = createResourceProcessor(resource);
         processor.process();

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
@@ -111,7 +111,7 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
             kBuilder.buildPackagesWithoutRules(packages);
         }
         buildProcesses();
-        buildAssemblersAfterRules();
+        buildAssemblerResourcesAfterRules();
         kBuilder.postBuild();
         resourcesByType.clear();
         if (buildException != null) {
@@ -153,19 +153,6 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
                     kBuilder.setAssetFilter(null);
                 }
             }
-        }
-    }
-
-    private void buildAssemblersAfterRules() {
-        try {
-            for (Map.Entry<ResourceType, List<ResourceDescr>> entry : resourcesByType.entrySet()) {
-                List<ResourceWithConfiguration> rds = entry.getValue().stream().map(CompositeKnowledgeBuilderImpl::descrToResourceWithConfiguration).collect(Collectors.toList());
-                kBuilder.addPackageForExternalType(entry.getKey(), rds);
-            }
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException( e );
         }
     }
 
@@ -215,6 +202,19 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
         }
     }
 
+    private void buildAssemblerResourcesAfterRules() {
+        KieAssemblers assemblers = ServiceRegistry.getService(KieAssemblers.class);
+        try {
+            for (Map.Entry<ResourceType, List<ResourceDescr>> entry : resourcesByType.entrySet()) {
+                List<ResourceWithConfiguration> rds = entry.getValue().stream().map(CompositeKnowledgeBuilderImpl::descrToResourceWithConfiguration).collect(Collectors.toList());
+                assemblers.addResourcesAfterRules(kBuilder, rds, entry.getKey());
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private void buildResource(Map<String, CompositePackageDescr> packages, ResourceType resourceType, ResourceToPkgDescrMapper mapper) {
         List<ResourceDescr> resourcesByType = this.resourcesByType.remove(resourceType);

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/CompositeKnowledgeBuilderImpl.java
@@ -111,7 +111,7 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
             kBuilder.buildPackagesWithoutRules(packages);
         }
         buildProcesses();
-        buildAssemblersAfterRules();
+        buildAssemblerResourcesAfterRules();
         kBuilder.postBuild();
         resourcesByType.clear();
         if (buildException != null) {
@@ -156,16 +156,35 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
         }
     }
 
-    private void buildAssemblersAfterRules() {
+    private void buildAssemblerResourcesAfterRules() {
+        KieAssemblers assemblers = ServiceRegistry.getService(KieAssemblers.class);
         try {
             for (Map.Entry<ResourceType, List<ResourceDescr>> entry : resourcesByType.entrySet()) {
-                List<ResourceWithConfiguration> rds = entry.getValue().stream().map(CompositeKnowledgeBuilderImpl::descrToResourceWithConfiguration).collect(Collectors.toList());
-                kBuilder.addPackageForExternalType(entry.getKey(), rds);
+                List<ResourceWithConfiguration> resources = entry.getValue().stream().map(CompositeKnowledgeBuilderImpl::descrToResourceWithConfiguration).collect(Collectors.toList());
+                assemblers.addResourcesAfterRules(kBuilder, resources, entry.getKey());
             }
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException( e );
+        }
+    }
+
+    private void buildAssemblerResourcesBeforeRules() {
+        KieAssemblers assemblers = ServiceRegistry.getService(KieAssemblers.class);
+        try {
+            for (Map.Entry<ResourceType, List<ResourceDescr>> entry : resourcesByType.entrySet()) {
+                List<ResourceWithConfiguration> resources = entry.getValue().stream().map(CompositeKnowledgeBuilderImpl::descrToResourceWithConfiguration).collect(Collectors.toList());
+                assemblers.addResourcesBeforeRules(kBuilder, resources, entry.getKey());
+            }
+        } catch (RuntimeException e) {
+            if (buildException == null) {
+                buildException = e;
+            }
+        } catch (Exception e) {
+            if (buildException == null) {
+                buildException = new RuntimeException(e);
+            }
         }
     }
 
@@ -193,28 +212,6 @@ public class CompositeKnowledgeBuilderImpl implements CompositeKnowledgeBuilder 
 
         return packages.values();
     }
-
-    private void buildAssemblerResourcesBeforeRules() {
-        KieAssemblers assemblers = ServiceRegistry.getService(KieAssemblers.class);
-        try {
-            for (Map.Entry<ResourceType, List<ResourceDescr>> resourceTypeListEntry : resourcesByType.entrySet()) {
-                ResourceType type = resourceTypeListEntry.getKey();
-                List<ResourceDescr> descrs = resourceTypeListEntry.getValue();
-                for (ResourceDescr descr : descrs) {
-                    assemblers.addResourceBeforeRules(this.kBuilder, descr.resource, type, descr.configuration);
-                }
-            }
-        } catch (RuntimeException e) {
-            if (buildException == null) {
-                buildException = e;
-            }
-        } catch (Exception e) {
-            if (buildException == null) {
-                buildException = new RuntimeException(e);
-            }
-        }
-    }
-
 
     private void buildResource(Map<String, CompositePackageDescr> packages, ResourceType resourceType, ResourceToPkgDescrMapper mapper) {
         List<ResourceDescr> resourcesByType = this.resourcesByType.remove(resourceType);

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.drools.compiler.builder.impl;
 
@@ -780,17 +780,17 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
                                    ResourceConfiguration configuration) throws Exception {
         KieAssemblers assemblers = ServiceRegistry.getService(KieAssemblers.class);
 
-        assemblers.addResource(this,
-                              resource,
-                              type,
-                              configuration);
+        assemblers.addResourceAfterRules(this,
+                               resource,
+                               type,
+                               configuration);
     }
 
     @Deprecated
     void addPackageForExternalType(ResourceType type, List<ResourceWithConfiguration> resources) throws Exception {
         KieAssemblers assemblers = ServiceRegistry.getService(KieAssemblers.class);
 
-        assemblers.addResources(this, resources, type);
+        assemblers.addResourcesAfterRules(this, resources, type);
     }
 
     void addPackageFromXSD(Resource resource, ResourceConfiguration configuration) throws IOException {
@@ -1129,19 +1129,19 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
             Map<String, RuleBuildContext> ruleCxts = new ConcurrentHashMap<>();
             try {
                 ForkJoinPoolHolder.COMPILER_POOL.submit(() ->
-                rules.stream().parallel()
-                        .filter(ruleDescr -> filterAccepts(ResourceChange.Type.RULE, ruleDescr.getNamespace(), ruleDescr.getName()))
-                        .forEach(ruleDescr -> {
-                            initRuleDescr(packageDescr, pkgRegistry, ruleDescr);
-                            RuleBuildContext context = buildRuleBuilderContext(pkgRegistry, ruleDescr);
-                            ruleCxts.put(ruleDescr.getName(), context);
-                            List<? extends KnowledgeBuilderResult> results = addRule(context);
-                            if (!results.isEmpty()) {
-                            synchronized (this.results) {
-                                    this.results.addAll(results);
-                                }
-                            }
-                        })
+                                                                rules.stream().parallel()
+                                                                        .filter(ruleDescr -> filterAccepts(ResourceChange.Type.RULE, ruleDescr.getNamespace(), ruleDescr.getName()))
+                                                                        .forEach(ruleDescr -> {
+                                                                            initRuleDescr(packageDescr, pkgRegistry, ruleDescr);
+                                                                            RuleBuildContext context = buildRuleBuilderContext(pkgRegistry, ruleDescr);
+                                                                            ruleCxts.put(ruleDescr.getName(), context);
+                                                                            List<? extends KnowledgeBuilderResult> results = addRule(context);
+                                                                            if (!results.isEmpty()) {
+                                                                                synchronized (this.results) {
+                                                                                    this.results.addAll(results);
+                                                                                }
+                                                                            }
+                                                                        })
                 ).get();
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException("Rules compilation failed or interrupted", e);
@@ -1699,7 +1699,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
     }
 
     protected void processAccumulateFunctions(PackageRegistry pkgRegistry,
-                                            PackageDescr packageDescr) {
+                                              PackageDescr packageDescr) {
         for (final AccumulateImportDescr aid : packageDescr.getAccumulateImports()) {
             AccumulateFunction af = loadAccumulateFunction(pkgRegistry,
                                                            aid.getFunctionName(),
@@ -1728,7 +1728,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
     }
 
     protected void processFunctions(PackageRegistry pkgRegistry,
-                                  PackageDescr packageDescr) {
+                                    PackageDescr packageDescr) {
         for (FunctionDescr function : packageDescr.getFunctions()) {
             Function existingFunc = pkgRegistry.getPackage().getFunctions().get(function.getName());
             if (existingFunc != null && function.getNamespace().equals(existingFunc.getNamespace())) {
@@ -1766,7 +1766,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
     }
 
     protected void processWindowDeclarations(PackageRegistry pkgRegistry,
-                                           PackageDescr packageDescr) {
+                                             PackageDescr packageDescr) {
         for (WindowDeclarationDescr wd : packageDescr.getWindowDeclarations()) {
             WindowDeclaration window = new WindowDeclaration(wd.getName(), packageDescr.getName());
             // TODO: process annotations

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/drlx/DrlxAssembler.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/drlx/DrlxAssembler.java
@@ -23,4 +23,8 @@ public class DrlxAssembler implements KieAssemblerService {
         kBuilder.updateResults(drlxCompiler.getResults());
     }
 
+    @Override
+    public void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/drlx/DrlxAssembler.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/drlx/DrlxAssembler.java
@@ -23,8 +23,4 @@ public class DrlxAssembler implements KieAssemblerService {
         kBuilder.updateResults(drlxCompiler.getResults());
     }
 
-    @Override
-    public void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
-
-    }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/assembler/TestAssembler.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/assembler/TestAssembler.java
@@ -1,7 +1,6 @@
 package org.drools.modelcompiler.assembler;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
-import org.drools.compiler.compiler.BaseKnowledgeBuilderResultImpl;
 import org.drools.compiler.compiler.DroolsError;
 import org.drools.compiler.lang.descr.FunctionDescr;
 import org.drools.compiler.lang.descr.PackageDescr;
@@ -29,7 +28,7 @@ public class TestAssembler implements KieAssemblerService {
     }
 
     @Override
-    public void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+    public void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
         KnowledgeBuilderImpl kb = (KnowledgeBuilderImpl) kbuilder;
         PackageDescr fakEpkg = new PackageDescr("FAKEpkg");
         fakEpkg.addFunction(new FunctionDescr("INVALID", "INVALID"));

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -85,7 +85,7 @@ public class DMNAssemblerService implements KieAssemblerService {
     }
 
     @Override
-    public void addResources(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+    public void addResourcesAfterRules(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
         EvalHelper.clearGenericAccessorCache();
         KnowledgeBuilderImpl kbuilderImpl = (KnowledgeBuilderImpl) kbuilder;
         DMNCompilerImpl dmnCompiler = (DMNCompilerImpl) kbuilderImpl.getCachedOrCreate(DMN_COMPILER_CACHE_KEY, () -> getCompiler(kbuilderImpl));
@@ -152,8 +152,8 @@ public class DMNAssemblerService implements KieAssemblerService {
     }
 
     @Override
-    public void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
-        logger.warn("invoked legacy addResource (no control on the order of the assembler compilation): " + resource.getSourcePath());
+    public void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+        logger.warn("invoked legacy addResourceAfterRules (no control on the order of the assembler compilation): {}", resource.getSourcePath());
         KnowledgeBuilderImpl kbuilderImpl = (KnowledgeBuilderImpl) kbuilder;
         DMNCompiler dmnCompiler = kbuilderImpl.getCachedOrCreate( DMN_COMPILER_CACHE_KEY, () -> getCompiler( kbuilderImpl ) );
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuntimeFactoryInternal.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuntimeFactoryInternal.java
@@ -181,7 +181,7 @@ public class PMMLRuntimeFactoryInternal {
 
     protected static PMMLRuntime getPMMLRuntime(File pmmlFile, KnowledgeBuilderImpl kbuilderImpl) {
         FileSystemResource fileSystemResource = new FileSystemResource(pmmlFile);
-        new PMMLAssemblerService().addResource(kbuilderImpl, fileSystemResource, ResourceType.PMML, null);
+        new PMMLAssemblerService().addResourceAfterRules(kbuilderImpl, fileSystemResource, ResourceType.PMML, null);
         KieBase kieBase = createKieBase(kbuilderImpl);
         return getPMMLRuntime(kieBase);
     }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerService.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerService.java
@@ -79,7 +79,7 @@ public class PMMLAssemblerService implements KieAssemblerService {
     }
 
     @Override
-    public void addResources(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) {
+    public void addResourcesAfterRules(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) {
         KnowledgeBuilderImpl kbuilderImpl = (KnowledgeBuilderImpl) kbuilder;
         if (isjPMMLAvailableToClassLoader(kbuilderImpl.getRootClassLoader())) {
             return;
@@ -96,8 +96,8 @@ public class PMMLAssemblerService implements KieAssemblerService {
     }
 
     @Override
-    public void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) {
-        logger.warn("invoked legacy addResource (no control on the order of the assembler compilation): {}", resource.getSourcePath());
+    public void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) {
+        logger.warn("invoked legacy addResourceAfterRules (no control on the order of the assembler compilation): {}", resource.getSourcePath());
         KnowledgeBuilderImpl kbuilderImpl = (KnowledgeBuilderImpl) kbuilder;
         if (isjPMMLAvailableToClassLoader(kbuilderImpl.getRootClassLoader())) {
             return;

--- a/kie-pmml/src/main/java/org/kie/pmml/assembler/PMMLAssemblerService.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/assembler/PMMLAssemblerService.java
@@ -73,7 +73,7 @@ public class PMMLAssemblerService implements KieAssemblerService {
     }
 
     @Override
-    public synchronized void addResource(Object kbuilder, Resource resource, ResourceType type,
+    public synchronized void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type,
                                          ResourceConfiguration configuration) throws Exception {
         this.kbuilder = (KnowledgeBuilderImpl) kbuilder;
         this.configuration = this.kbuilder.getBuilderConfiguration();
@@ -84,13 +84,13 @@ public class PMMLAssemblerService implements KieAssemblerService {
     }
 
     @Override
-    public synchronized void addResources(Object kbuilder, Collection<ResourceWithConfiguration> resources,
+    public synchronized void addResourcesAfterRules(Object kbuilder, Collection<ResourceWithConfiguration> resources,
             ResourceType type) throws Exception {
         for (ResourceWithConfiguration rd : resources) {
             if (rd.getBeforeAdd() != null) {
                 rd.getBeforeAdd().accept(kbuilder);
             }
-            addResource(kbuilder, rd.getResource(), type, rd.getResourceConfiguration());
+            addResourceAfterRules(kbuilder, rd.getResource(), type, rd.getResourceConfiguration());
             if (rd.getAfterAdd() != null) {
                 rd.getAfterAdd().accept(kbuilder);
             }


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik

See https://issues.redhat.com/browse/DROOLS-6048

Scope of this PR is to enforce/clarify the "before rules/after rules" semantic introduced by DROOLS-5950.
In detail:

1. renamed some methods for consistency
2. uniformed methods
3. replaced addResource/addResources with addResourceAfterRules / addResourcesAfterRules

@tarilabs @evacchi FYI

Depends on https://github.com/kiegroup/droolsjbpm-knowledge/pull/503
