### PR TITLE
[DROOLS-6053] Reduce unnecessary classloading by parent classloader

### DIFF
--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -145,7 +145,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         try {
             return super.loadClass(name, resolve);
         } catch (ClassNotFoundException e) {
-            return Class.forName(name, resolve, getParent());
+            try {
+                return Class.forName(name, resolve, getParent());
+            } catch (ClassNotFoundException e1) {
+                if (CACHE_NON_EXISTING_CLASSES) {
+                    nonExistingClasses.add(name);
+                }
+                throw e1;
+            }
         }
     }
 


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6053

**referenced Pull Requests**: 
This is an alternative fix of https://github.com/kiegroup/drools/pull/3411

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
