### PR TITLE
[DROOLS-6053] Reduce unnecessary classloading by parent classloader

### DIFF
--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -103,6 +103,14 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
         }
 
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (projectClassLoader.containsInStore(ClassUtils.convertClassToResourcePath(name))) {
+                Class<?> clazz = findLoadedClass(name); // skip parent classloader
+                if (clazz != null) {
+                    return clazz;
+                }
+                // if the class is stored in projectClassLoader, go straight to defineType
+                return projectClassLoader.tryDefineType(name, null);
+            }
             try {
                 return loadType(name, resolve);
             } catch (ClassNotFoundException cnfe) {

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -145,7 +145,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         try {
             return super.loadClass(name, resolve);
         } catch (ClassNotFoundException e) {
-            return Class.forName(name, resolve, getParent());
+            try {
+                return Class.forName(name, resolve, getParent());
+            } catch (ClassNotFoundException e1) {
+                if (CACHE_NON_EXISTING_CLASSES) {
+                    nonExistingClasses.add(name);
+                }
+                throw e1;
+            }
         }
     }
 
@@ -329,6 +336,10 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
 
     public byte[] getBytecode(String resourceName) {
         return store == null ? null : store.get(resourceName);
+    }
+
+    public boolean containsInStore(String resourceName) {
+        return store == null ? false : store.containsKey(resourceName);
     }
 
     @Override


### PR DESCRIPTION
**JIRA**:

https://issues.redhat.com/browse/DROOLS-6053

**referenced Pull Requests**: 

Another alternative of https://github.com/kiegroup/drools/pull/3412

This time, go straight to defineType if the class is stored in projectClassLoader

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
