### PR TITLE
[DROOLS-6055] Enable exec-model for moved tests in drools-test-covera…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NestedAccessorsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/NestedAccessorsTest.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.drools.mvel.CommonTestMethodBase;
-import org.drools.mvel.integrationtests.SerializationHelper;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
@@ -145,7 +144,6 @@ public class NestedAccessorsTest extends CommonTestMethodBase {
 
     @Test
     public void testNestedAccessors() throws Exception {
-        //final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_NestedAccessors.drl"));
         KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "test_NestedAccessors.drl");
         final KieSession ksession = createKnowledgeSession(kbase);
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/abductive/AbductionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/beliefsystem/abductive/AbductionTest.java
@@ -73,7 +73,7 @@ public class AbductionTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-     // TODO: EM failed with testBindNonAbductiveQueryError etc. File JIRAs
+        // Abduction is experimental. And not supported for exec-model
         return TestParametersUtil.getKieBaseCloudConfigurations(false, true);
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/compiler/TypeDeclarationTest.java
@@ -158,9 +158,6 @@ public class TypeDeclarationTest {
 
     @Test
     public void testNoAnnotationUpdateIfError(){
-        // Note: Didn't applied new APIs because kieModule.getKnowledgePackagesForKieBase("defaultKieBase").size() returns 2.
-        // TODO: File a JIRA to revisit and write a valid test for new APIs and exec-model
-
         String str1 = "";
         str1 += "package org.drools.mvel.compiler \n" +
         		"declare org.drools.EventA \n" +
@@ -194,6 +191,19 @@ public class TypeDeclarationTest {
 
         //just 1 package was created
         assertEquals(0, kbuilder.getKnowledgePackages().size());
+
+        // TODO: Odd behavior with new APIs (an error found for single test method. But no error for running the test class or parameterized)
+        // File a JIRA to revisit and write a valid test for new APIs and exec-model
+
+//        final Resource drlResource1 = KieServices.Factory.get().getResources().newReaderResource(new StringReader(str1));
+//        drlResource1.setSourcePath(TestConstants.TEST_RESOURCES_FOLDER + "rule1x.drl");
+//        final Resource drlResource2 = KieServices.Factory.get().getResources().newReaderResource(new StringReader(str2));
+//        drlResource2.setSourcePath(TestConstants.TEST_RESOURCES_FOLDER + "rule2x.drl");
+//
+//        KieBuilder kieBuilder = KieUtil.getKieBuilderFromResources(kieBaseTestConfiguration, false, drlResource1, drlResource2);
+//        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+//        System.out.println(errors);
+//        assertFalse("Errors Expected", errors.isEmpty());
     }
 
     /**
@@ -612,7 +622,7 @@ public class TypeDeclarationTest {
 
         KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str1);
         List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
-        assertFalse("Should fail", errors.isEmpty());
+        assertFalse("Should have an error", errors.isEmpty());
     }
 
     @Test
@@ -627,7 +637,7 @@ public class TypeDeclarationTest {
 
         KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str1);
         List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
-        assertFalse("Should fail", errors.isEmpty());
+        assertFalse("Should have an error", errors.isEmpty());
     }
 
     @Test
@@ -704,7 +714,7 @@ public class TypeDeclarationTest {
         assertTrue(errors.toString(), errors.isEmpty());
 
         InternalKieModule kieModule = (InternalKieModule)kieBuilder.getKieModule();
-        KnowledgeBuilderImpl kbuilder = (KnowledgeBuilderImpl)kieModule.getKnowledgeBuilderForKieBase("defaultKieBase");
+        KnowledgeBuilderImpl kbuilder = (KnowledgeBuilderImpl)kieModule.getKnowledgeBuilderForKieBase(KieBaseTestConfiguration.KIE_BASE_MODEL_NAME);
 
         for( KiePackage kp : kbuilder.getKnowledgePackages() ) {
             if ( kp.getName().equals( "org.drools" ) ) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/definitions/KnowledgePackageMetaDataTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/definitions/KnowledgePackageMetaDataTest.java
@@ -17,26 +17,40 @@
 package org.drools.mvel.compiler.definitions;
 
 
+import java.util.Collection;
+
+import org.drools.core.definitions.rule.impl.GlobalImpl;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.definition.rule.Query;
+import org.kie.api.definition.type.FactField;
+import org.kie.api.definition.type.FactType;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.drools.core.definitions.rule.impl.GlobalImpl;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
-import org.drools.core.io.impl.ByteArrayResource;
-import org.junit.Test;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.api.definition.KiePackage;
-import org.kie.api.definition.rule.Query;
-import org.kie.api.definition.type.FactField;
-import org.kie.api.definition.type.FactType;
-import org.kie.api.io.ResourceType;
-
+@RunWith(Parameterized.class)
 public class KnowledgePackageMetaDataTest {
 
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KnowledgePackageMetaDataTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        // TODO: EM failed with testMetaData. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     private String drl ="" +
             "package org.drools.mvel.compiler.test.definitions \n" +
@@ -78,15 +92,8 @@ public class KnowledgePackageMetaDataTest {
 
     @Test
     public void testMetaData() {
-        KnowledgeBuilder kBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kBuilder.add( new ByteArrayResource( drl.getBytes() ), ResourceType.DRL );
-        if ( kBuilder.hasErrors() ) {
-            fail( kBuilder.getErrors().toString() );
-        }
-
-        InternalKnowledgeBase kBase = KnowledgeBaseFactory.newKnowledgeBase();
-        kBase.addPackages( kBuilder.getKnowledgePackages() );
-        KiePackage pack = kBase.getPackage( "org.drools.mvel.compiler.test.definitions" );
+        KieBase kBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KiePackage pack = kBase.getKiePackage( "org.drools.mvel.compiler.test.definitions" );
 
         assertNotNull( pack );
 
@@ -117,7 +124,6 @@ public class KnowledgePackageMetaDataTest {
             }
         }
 
-
         assertEquals( 2, pack.getQueries().size() );
         for ( Query q : pack.getQueries() ) {
             assertTrue( q.getName().equals( "qry1" ) || q.getName().equals( "qry2" ) );
@@ -125,8 +131,5 @@ public class KnowledgePackageMetaDataTest {
 
         assertEquals( 4, pack.getRules().size() );
         assertTrue( pack.getRules().containsAll( pack.getQueries() ) );
-
     }
-
-
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/DslExpansionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/DslExpansionTest.java
@@ -15,9 +15,15 @@
 
 package org.drools.mvel.compiler.kie.builder;
 
+import java.util.Collection;
 import java.util.List;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -32,7 +38,19 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for DSL expansion with KieBuilder
  */
+@RunWith(Parameterized.class)
 public class DslExpansionTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public DslExpansionTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testDSLExpansion_MessageImplNPE() throws Exception {
@@ -46,8 +64,8 @@ public class DslExpansionTest {
                 .write( "src/main/resources/KBase1/test-dsl.dsl", createDSL() )
                 .write( "src/main/resources/KBase1/test-rule.dslr", createDRL() );
 
-        final KieBuilder kieBuilder = ks.newKieBuilder( kfs );
-        final List<Message> messages = kieBuilder.buildAll().getResults().getMessages();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        final List<Message> messages = kieBuilder.getResults().getMessages();
         if ( !messages.isEmpty() ) {
             for ( final Message m : messages ) {
                 System.out.println( m.getText() );
@@ -68,8 +86,8 @@ public class DslExpansionTest {
                 .write( "src/main/resources/KBase1/test-dsl.dsl", createDSL() )
                 .write( "src/main/resources/KBase1/test-rule.drl", createDRL() );
 
-        final KieBuilder kieBuilder = ks.newKieBuilder( kfs );
-        final List<Message> messages = kieBuilder.buildAll().getResults().getMessages();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        final List<Message> messages = kieBuilder.getResults().getMessages();
         if ( !messages.isEmpty() ) {
             for ( final Message m : messages ) {
                 System.out.println( m.getText() );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireChannelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireChannelTest.java
@@ -18,9 +18,15 @@ package org.drools.mvel.compiler.kie.builder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -35,7 +41,20 @@ import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.generatePomXml
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class WireChannelTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public WireChannelTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with testWireChannel. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     private static final List<Object> channelMessages = new ArrayList<Object>();
     
@@ -66,8 +85,8 @@ public class WireChannelTest {
            .writePomXML( generatePomXml(releaseId) )
            .write("src/main/resources/KBase1/rules.drl", createDRL());
 
-        KieBuilder kieBuilder = ks.newKieBuilder(kfs);
-        assertTrue(kieBuilder.buildAll().getResults().getMessages().isEmpty());
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        assertTrue(kieBuilder.getResults().getMessages().isEmpty());
     }
 
     private String createDRL() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireListenerTest.java
@@ -17,9 +17,15 @@ package org.drools.mvel.compiler.kie.builder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -38,7 +44,20 @@ import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.generatePomXml
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class WireListenerTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public WireListenerTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with testWireListener. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     private static final List<ObjectInsertedEvent> insertEvents = new ArrayList<ObjectInsertedEvent>();
     private static final List<ObjectUpdatedEvent> updateEvents = new ArrayList<ObjectUpdatedEvent>();
@@ -72,8 +91,8 @@ public class WireListenerTest {
            .writePomXML( generatePomXml(releaseId) )
            .write("src/main/resources/KBase1/rules.drl", createDRL());
 
-        KieBuilder kieBuilder = ks.newKieBuilder(kfs);
-        assertTrue(kieBuilder.buildAll().getResults().getMessages().isEmpty());
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        assertTrue(kieBuilder.getResults().getMessages().isEmpty());
     }
 
     private String createDRL() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieBuilderSetImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieBuilderSetImplTest.java
@@ -16,11 +16,18 @@
 
 package org.drools.mvel.compiler.kie.builder.impl;
 
+import java.util.Collection;
+
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieBuilderSetImpl;
 import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -30,7 +37,19 @@ import org.kie.internal.io.ResourceFactory;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(Parameterized.class)
 public class KieBuilderSetImplTest extends CommonTestMethodBase {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieBuilderSetImplTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testBuild() throws Exception {
@@ -84,10 +103,7 @@ public class KieBuilderSetImplTest extends CommonTestMethodBase {
 
     private KieBuilderImpl kieBuilder( final KieServices ks,
                                        final KieFileSystem kfs ) {
-        final KieBuilder kieBuilder = ks.newKieBuilder( kfs );
-
-        kieBuilder.buildAll();
-
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, true);
         return (KieBuilderImpl) kieBuilder;
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathAccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathAccumulateTest.java
@@ -17,15 +17,33 @@
 package org.drools.mvel.compiler.oopath;
 
 import java.util.Collection;
+
 import org.assertj.core.api.Assertions;
 import org.drools.mvel.compiler.oopath.model.Child;
 import org.drools.mvel.compiler.oopath.model.Man;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
+@RunWith(Parameterized.class)
 public class OOPathAccumulateTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathAccumulateTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with testAccumulateAverage, testAccumulateMax, testAccumulateMin, testAccumulateSum. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testAccumulateAverage() {
@@ -74,9 +92,8 @@ public class OOPathAccumulateTest {
                         "  kcontext.getKieRuntime().setGlobal(\"globalVar\", $accumulateResult);\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Man bob = new Man( "Bob", 40 );
         bob.addChild( new Child( "Charles", 12 ) );
@@ -104,9 +121,8 @@ public class OOPathAccumulateTest {
                         "  kcontext.getKieRuntime().setGlobal(\"globalVar\", $accumulateResult);\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Man bob = new Man( "Bob", 40 );
         bob.addChild( new Child( "Charles", 12 ) );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBenchmarkTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBenchmarkTest.java
@@ -31,7 +31,7 @@ import org.kie.internal.utils.KieHelper;
 public class OOPathBenchmarkTest {
 
     private static final String RELATIONAL_DRL =
-            "import org.drools.compiler.oopath.model.*;\n" +
+            "import org.drools.mvel.compiler.oopath.model.*;\n" +
             "global java.util.List list\n" +
             "\n" +
             "rule R when\n" +
@@ -44,7 +44,7 @@ public class OOPathBenchmarkTest {
             "end\n";
 
     private static final String FROM_DRL =
-            "import org.drools.compiler.oopath.model.*;\n" +
+            "import org.drools.mvel.compiler.oopath.model.*;\n" +
             "global java.util.List list\n" +
             "\n" +
             "rule R when\n" +
@@ -56,7 +56,7 @@ public class OOPathBenchmarkTest {
             "end\n";
 
     private static final String OOPATH_DRL =
-            "import org.drools.compiler.oopath.model.*;\n" +
+            "import org.drools.mvel.compiler.oopath.model.*;\n" +
             "global java.util.List list\n" +
             "\n" +
             "rule R when\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBindTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathBindTest.java
@@ -17,22 +17,41 @@
 package org.drools.mvel.compiler.oopath;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
 import org.assertj.core.api.Assertions;
 import org.drools.mvel.compiler.oopath.model.Child;
 import org.drools.mvel.compiler.oopath.model.Man;
 import org.drools.mvel.compiler.oopath.model.Toy;
 import org.drools.mvel.compiler.oopath.model.Woman;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
+@RunWith(Parameterized.class)
 public class OOPathBindTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathBindTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with testBindIntegerFireAllRules, testBindIntegerFireUntilHalt, testBindListWithConstraint, testBindListWithConstraint etc. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testBindIntegerFireAllRules() throws InterruptedException, ExecutionException {
@@ -55,9 +74,8 @@ public class OOPathBindTest {
                         "  list.add( $age );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         Future fireUntilHaltFuture = null;
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -159,9 +177,8 @@ public class OOPathBindTest {
     }
 
     private void testScenarioBindString(final String drl, final String... expectedResults) {
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -188,9 +205,8 @@ public class OOPathBindTest {
                         "  list.add( $child.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -217,9 +233,8 @@ public class OOPathBindTest {
                         "  list.add( $toys.size() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -255,9 +270,8 @@ public class OOPathBindTest {
                         "  list.add( $toys.size() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Integer> list = new ArrayList<>();
         ksession.setGlobal( "list", list );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathCastTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathCastTest.java
@@ -17,6 +17,7 @@
 package org.drools.mvel.compiler.oopath;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -25,18 +26,34 @@ import org.drools.mvel.compiler.oopath.model.BabyGirl;
 import org.drools.mvel.compiler.oopath.model.Man;
 import org.drools.mvel.compiler.oopath.model.Toy;
 import org.drools.mvel.compiler.oopath.model.Woman;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieFileSystem;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.Message;
-import org.kie.api.builder.Results;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
+@RunWith(Parameterized.class)
 public class OOPathCastTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathCastTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testInlineCast() {
@@ -50,9 +67,8 @@ public class OOPathCastTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -88,10 +104,9 @@ public class OOPathCastTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieServices ks = KieServices.Factory.get();
-        final KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
-        final Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
-        assertTrue( results.hasMessages( Message.Level.ERROR ) );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertFalse("Should have an error", errors.isEmpty());
     }
 
     @Test
@@ -106,9 +121,8 @@ public class OOPathCastTest {
                         "  list.add( $name );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathMultilevelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathMultilevelTest.java
@@ -17,18 +17,36 @@
 package org.drools.mvel.compiler.oopath;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.drools.mvel.compiler.oopath.model.Child;
 import org.drools.mvel.compiler.oopath.model.Man;
 import org.drools.mvel.compiler.oopath.model.Toy;
 import org.drools.mvel.compiler.oopath.model.Woman;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
+@RunWith(Parameterized.class)
 public class OOPathMultilevelTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathMultilevelTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testClassTwoLevelPath() {
@@ -42,9 +60,8 @@ public class OOPathMultilevelTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -80,9 +97,8 @@ public class OOPathMultilevelTest {
                         "  list.add( $toyName );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -134,9 +150,8 @@ public class OOPathMultilevelTest {
     }
 
     private void testScenarioTwoLevelPathWithConstraint(final String drl) {
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathQueriesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathQueriesTest.java
@@ -16,6 +16,7 @@
 package org.drools.mvel.compiler.oopath;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -23,16 +24,33 @@ import java.util.stream.StreamSupport;
 import org.drools.mvel.compiler.oopath.model.Room;
 import org.drools.mvel.compiler.oopath.model.SensorEvent;
 import org.drools.mvel.compiler.oopath.model.Thing;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.Variable;
-import org.kie.internal.utils.KieHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(Parameterized.class)
 public class OOPathQueriesTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathQueriesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testQueryFromCode() {
@@ -48,9 +66,8 @@ public class OOPathQueriesTest {
         final List<String> itemList = Arrays.asList(new String[] { "display", "keyboard", "processor" });
         itemList.stream().map(item -> new Thing(item)).forEach((thing) -> smartphone.addChild(thing));
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
         ksession.insert(smartphone);
 
         final QueryResults queryResults = ksession.getQueryResults("isContainedIn", new Object[] { smartphone, Variable.v });
@@ -97,9 +114,8 @@ public class OOPathQueriesTest {
         room.getTemperatureSensor().setValue(15);
         room.getHeating().setOn(false);
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
         ksession.insert(room);
         ksession.insert(room.getTemperatureSensor());
         ksession.insert(room.getHeating());
@@ -149,9 +165,8 @@ public class OOPathQueriesTest {
         room.getTemperatureSensor().setValue(15);
         room.getHeating().setOn(false);
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
         ksession.insert(room);
         ksession.insert(room.getTemperatureSensor());
         ksession.insert(room.getHeating());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathReactiveTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathReactiveTest.java
@@ -17,6 +17,7 @@
 package org.drools.mvel.compiler.oopath;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -40,15 +41,17 @@ import org.drools.mvel.compiler.oopath.model.School;
 import org.drools.mvel.compiler.oopath.model.Toy;
 import org.drools.mvel.compiler.oopath.model.Woman;
 import org.drools.mvel.integrationtests.SerializationHelper;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.Message;
-import org.kie.api.builder.Results;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
 import static org.drools.mvel.compiler.oopath.model.BodyMeasurement.CHEST;
 import static org.drools.mvel.compiler.oopath.model.BodyMeasurement.RIGHT_FOREARM;
@@ -56,7 +59,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(Parameterized.class)
 public class OOPathReactiveTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathReactiveTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testReactiveOnLia() {
@@ -70,9 +86,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -114,8 +129,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieBase kbase = new KieHelper().addContent( drl, ResourceType.DRL ).build();
-        final KieSession ksession = kbase.newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final EntryPointNode epn = ( (InternalKnowledgeBase) ksession.getKieBase() ).getRete().getEntryPointNodes().values().iterator().next();
         final ObjectTypeNode otn = epn.getObjectTypeNodes().get( new ClassObjectType(Man.class) );
@@ -180,9 +195,8 @@ public class OOPathReactiveTest {
                         "  insertLogical( $child );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Child charlie = new Child( "Charles", 15 );
         final Child debbie = new Child( "Debbie", 19 );
@@ -227,9 +241,8 @@ public class OOPathReactiveTest {
                         "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Adult ada = new Adult("Ada", 19);
         final Adult bea = new Adult("Bea", 19);
@@ -275,9 +288,8 @@ public class OOPathReactiveTest {
                         "  insertLogical( $disease );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent(drl, ResourceType.DRL)
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Disease flu = new Disease("flu");
         final Disease asthma = new Disease("asthma");
@@ -347,9 +359,8 @@ public class OOPathReactiveTest {
                         "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                         "end\n";
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         try {
             ksession = SerializationHelper.getSerialisedStatefulKnowledgeSession( ksession, true, false );
@@ -404,9 +415,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -456,9 +466,8 @@ public class OOPathReactiveTest {
                         "  teenagers.add( $child.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> toyList = new ArrayList<>();
         ksession.setGlobal( "toyList", toyList );
@@ -510,9 +519,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -554,9 +562,8 @@ public class OOPathReactiveTest {
                         "  list.add( $disease.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal("list", list);
@@ -596,9 +603,8 @@ public class OOPathReactiveTest {
                         "  list.add( $bodyMeasurement.getValue() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Integer> list = new ArrayList<>();
         ksession.setGlobal("list", list);
@@ -630,9 +636,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -674,9 +679,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -718,10 +722,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy.getName() );\n" +
                         "end\n";
 
-        final KieServices ks = KieServices.Factory.get();
-        final KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
-        final Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
-        assertTrue( results.hasMessages( Message.Level.ERROR ) );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        assertTrue(kieBuilder.getResults().hasMessages(Message.Level.ERROR));
     }
 
     @Test
@@ -737,8 +739,8 @@ public class OOPathReactiveTest {
                         "  list.add( $toy );\n" +
                         "end\n";
 
-        final KieBase kbase = new KieHelper().addContent( drl, ResourceType.DRL ).build();
-        final KieSession ksession = kbase.newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -783,9 +785,8 @@ public class OOPathReactiveTest {
                         "$child.setAge(12);" +
                         "end\n";
 
-        final KieSession ksession = new KieHelper().addContent(drl, ResourceType.DRL)
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Man bob = new Man("Bob", 40);
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathTest.java
@@ -17,12 +17,15 @@ package org.drools.mvel.compiler.oopath;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 
 import org.assertj.core.api.Assertions;
+import org.drools.core.phreak.AbstractReactiveObject;
+import org.drools.core.phreak.ReactiveSet;
 import org.drools.mvel.compiler.oopath.model.Adult;
 import org.drools.mvel.compiler.oopath.model.Child;
 import org.drools.mvel.compiler.oopath.model.Group;
@@ -35,25 +38,41 @@ import org.drools.mvel.compiler.oopath.model.TMFileWithParentObj;
 import org.drools.mvel.compiler.oopath.model.Thing;
 import org.drools.mvel.compiler.oopath.model.Toy;
 import org.drools.mvel.compiler.oopath.model.Woman;
-import org.drools.core.phreak.AbstractReactiveObject;
-import org.drools.core.phreak.ReactiveSet;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieFileSystem;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.Message;
-import org.kie.api.builder.Results;
 import org.kie.api.event.rule.DefaultRuleRuntimeEventListener;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.ObjectInsertedEvent;
 import org.kie.api.event.rule.ObjectUpdatedEvent;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
 import static org.drools.mvel.compiler.TestUtil.assertDrlHasCompilationError;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class OOPathTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testInvalidOOPath() {
@@ -86,10 +105,8 @@ public class OOPathTest {
     }
 
     private void testInvalid(final String drl) {
-        final KieServices ks = KieServices.Factory.get();
-        final KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
-        final Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
-        assertTrue( results.hasMessages( Message.Level.ERROR ) );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        assertTrue(kieBuilder.getResults().hasMessages(Message.Level.ERROR));
     }
 
     @Test
@@ -104,9 +121,8 @@ public class OOPathTest {
                 "  list.add( $toy.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -172,9 +188,8 @@ public class OOPathTest {
         final Thing key = new Thing( "key" );
         draw.addChild( key );
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -206,9 +221,8 @@ public class OOPathTest {
                 "  list.add( $toy.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -246,9 +260,8 @@ public class OOPathTest {
                 "  list.add( $x );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -276,10 +289,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
  
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         final Group x = new Group("X");
         final Group y = new Group("Y");
         ksession.insert( x );
@@ -326,10 +338,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
  
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         final Adult ada = new Adult("Ada", 20);
         final Adult bea = new Adult("Bea", 20);
         final Group x = new Group("X");
@@ -369,10 +380,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         final Group x = new Group("X");
         final Group y = new Group("Y");
         ksession.fireAllRules();
@@ -422,10 +432,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         final TMDirectory x = new TMDirectory("X");
         final TMDirectory y = new TMDirectory("Y");
         ksession.insert( x );
@@ -504,10 +513,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         final TMDirectory x = new TMDirectory("X");
         final TMDirectory y = new TMDirectory("Y");
         final TMFile file0 = new TMFile("File0", 999);
@@ -571,10 +579,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         ksession.addEventListener(new DefaultRuleRuntimeEventListener() {
             @Override
             public void objectDeleted(ObjectDeletedEvent event) {
@@ -677,10 +684,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         ksession.addEventListener(new DefaultRuleRuntimeEventListener() {
             @Override
             public void objectDeleted(ObjectDeletedEvent event) {
@@ -779,10 +785,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         ksession.addEventListener(new DefaultRuleRuntimeEventListener() {
             @Override
             public void objectDeleted(ObjectDeletedEvent event) {
@@ -850,10 +855,9 @@ public class OOPathTest {
                 "  insertLogical(      $id + \".\" + $p.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
-        
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
+
         final TMFileSet x = new TMFileSet("X");
         final TMFileSet y = new TMFileSet("Y");
         ksession.insert( x );
@@ -924,9 +928,8 @@ public class OOPathTest {
                 "  duplicateNames.add( $ic1.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Set<String> duplicateNames = new HashSet<>();
         ksession.setGlobal("duplicateNames", duplicateNames);
@@ -959,9 +962,8 @@ public class OOPathTest {
                 "  duplicateNames.add( $ic1.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Set<String> duplicateNames = new HashSet<>();
         ksession.setGlobal("duplicateNames", duplicateNames);
@@ -994,9 +996,8 @@ public class OOPathTest {
                 "  duplicateNames.add( $ic1.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Set<String> duplicateNames = new HashSet<>();
         ksession.setGlobal("duplicateNames", duplicateNames);
@@ -1045,9 +1046,8 @@ public class OOPathTest {
                 "  duplicateNames.add( $ic1.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Set<String> duplicateNames = new HashSet<>();
         ksession.setGlobal("duplicateNames", duplicateNames);
@@ -1098,9 +1098,8 @@ public class OOPathTest {
                 "  duplicateNames.add( $ic1.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final Set duplicateNames = new HashSet();
         ksession.setGlobal("duplicateNames", duplicateNames);
@@ -1155,10 +1154,8 @@ public class OOPathTest {
                 "  list.add($m.getName());\n" +
                 "end\n\n";
 
-        final KieSession ksession = new KieHelper()
-                .addContent( header + drl1 + drl2 + drl3, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, header + drl1 + drl2 + drl3);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -1205,10 +1202,8 @@ public class OOPathTest {
                 "  list.add(\"Found\");\n" +
                 "end\n\n";
 
-        final KieSession ksession = new KieHelper()
-                .addContent( header + drl1, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, header + drl1);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -1245,7 +1240,8 @@ public class OOPathTest {
                 "  insert($a.getName());\n" +
                 "end\n\n";
 
-        KieSession ksession = new KieHelper().addContent( drl1, ResourceType.DRL ).build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl1);
+        KieSession ksession = kbase.newKieSession();
 
         List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );
@@ -1272,9 +1268,8 @@ public class OOPathTest {
                 "  list.add( $child.getName() );\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         List<String> list = new ArrayList<>();
         ksession.setGlobal( "list", list );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/OOPathOnGraphTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/graph/OOPathOnGraphTest.java
@@ -17,18 +17,36 @@
 package org.drools.mvel.compiler.oopath.graph;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.phreak.AbstractReactiveObject;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class OOPathOnGraphTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public OOPathOnGraphTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testOOPathOnGraph() {
@@ -45,9 +63,8 @@ public class OOPathOnGraphTest {
                 "  list.add( $a.getName() );\n" +
                 "end\n";
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         List<String> list = new ArrayList<String>();
         ksession.setGlobal( "list", list );
@@ -84,9 +101,8 @@ public class OOPathOnGraphTest {
                 "  list.add( $a.getName() );\n" +
                 "end\n";
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         List<String> list = new ArrayList<String>();
         ksession.setGlobal( "list", list );
@@ -123,9 +139,8 @@ public class OOPathOnGraphTest {
                 "  list.add( ((Person)$v.getIt()).getName() );\n" +
                 "end\n";
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         List<String> list = new ArrayList<String>();
         ksession.setGlobal( "list", list );
@@ -162,9 +177,8 @@ public class OOPathOnGraphTest {
                 "  list.add( ((Person)$v.getIt()).getName() );\n" +
                 "end\n";
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         List<String> list = new ArrayList<String>();
         ksession.setGlobal( "list", list );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectBinaryEqualityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectBinaryEqualityTest.java
@@ -16,12 +16,11 @@
 package org.drools.mvel.compiler.rule.builder.dialect.java;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.rule.impl.RuleImpl;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.rule.EvalCondition;
 import org.drools.core.rule.Pattern;
 import org.drools.core.rule.PredicateConstraint;
@@ -29,23 +28,37 @@ import org.drools.core.spi.Constraint;
 import org.drools.core.spi.EvalExpression;
 import org.drools.core.spi.PredicateExpression;
 import org.drools.mvel.compiler.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.definition.KiePackage;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.fail;
 
 
+@RunWith(Parameterized.class)
 public class JavaDialectBinaryEqualityTest{
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public JavaDialectBinaryEqualityTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs. Probably need to modify test code e.g. getPredicateConstraint()
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
     
     @Test
     public void test1() {
@@ -135,16 +148,8 @@ public class JavaDialectBinaryEqualityTest{
         str += "then\n";
         str += "   list.add( $p );\n";
         str += "end\n";
-        
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ), ResourceType.DRL );
-        
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         
         List<Person> list = new ArrayList<Person>();
         KieSession ksession = kbase.newKieSession();
@@ -154,7 +159,8 @@ public class JavaDialectBinaryEqualityTest{
         
         assertEquals( new Person( "darth", 34 ), list.get( 0 ) );
         
-        return kbase.getPackage( "org.drools.mvel.compiler.test" );
+        return kbase.getKiePackage( "org.drools.mvel.compiler.test" );
+
     }
     
     public KiePackage getKnowledgePackage2() {
@@ -172,16 +178,9 @@ public class JavaDialectBinaryEqualityTest{
         str += "   list.add( $p );\n";
         str += "end\n";
         
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource(str.getBytes()), ResourceType.DRL );
-        
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-        
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+
         List<Person> list = new ArrayList<Person>();
         KieSession ksession = kbase.newKieSession();
         ksession.setGlobal( "list", list );
@@ -190,6 +189,6 @@ public class JavaDialectBinaryEqualityTest{
         
         assertEquals( new Person( "darth", 36 ), list.get( 0 ) );
 
-        return kbase.getPackage( "org.drools.mvel.compiler.test" );
+        return kbase.getKiePackage( "org.drools.mvel.compiler.test" );
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectTest.java
@@ -15,12 +15,10 @@
 
 package org.drools.mvel.compiler.rule.builder.dialect.java;
 
-import java.io.StringReader;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.base.ClassObjectType;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.BetaNode;
@@ -33,19 +31,31 @@ import org.drools.core.spi.FieldValue;
 import org.drools.core.spi.PredicateExpression;
 import org.drools.mvel.MVELConstraint;
 import org.drools.mvel.compiler.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderErrors;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+@RunWith(Parameterized.class)
 public class JavaDialectTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public JavaDialectTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs. Probably need to modify test code e.g. PredicateConstraint vs LambdaConstraint
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
     
     @Test
     public void testEvalDetectionInAlphaNode() {
@@ -60,18 +70,8 @@ public class JavaDialectTest {
         drl += "then\n";
         drl += "end\n";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource(new StringReader(drl)),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        assertFalse( kbuilder.hasErrors() );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-        
         List<ObjectTypeNode> nodes = ((KnowledgeBaseImpl)kbase).getRete().getObjectTypeNodes();
         ObjectTypeNode node = null;
         for ( ObjectTypeNode n : nodes ) {
@@ -111,18 +111,8 @@ public class JavaDialectTest {
         drl += "then\n";
         drl += "end\n";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newReaderResource( new StringReader( drl ) ),
-                      ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        assertFalse( kbuilder.hasErrors() );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-        
         List<ObjectTypeNode> nodes = ((KnowledgeBaseImpl)kbase).getRete().getObjectTypeNodes();
         ObjectTypeNode node = null;
         for ( ObjectTypeNode n : nodes ) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/runtime/pipeline/impl/DroolsJaxbHelperXSDInKJARTest.java
@@ -15,11 +15,17 @@
  */
 package org.drools.mvel.compiler.runtime.pipeline.impl;
 
+import java.util.Collection;
 import java.util.List;
 
 import com.sun.tools.xjc.Language;
 import com.sun.tools.xjc.Options;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -38,7 +44,19 @@ import static org.junit.Assert.fail;
 /**
  * DROOLS-5803 RHDM-851
  */
+@RunWith(Parameterized.class)
 public class DroolsJaxbHelperXSDInKJARTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public DroolsJaxbHelperXSDInKJARTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(DroolsJaxbHelperXSDInKJARTest.class);
 
@@ -65,7 +83,7 @@ public class DroolsJaxbHelperXSDInKJARTest {
         JaxbConfiguration jaxbConfiguration = KnowledgeBuilderFactory.newJaxbConfiguration(xjcOpts, "xsd");
         kfs.write(kieResources.newClassPathResource(simpleXsdRelativePath, getClass()).setResourceType(ResourceType.XSD).setConfiguration(jaxbConfiguration));
 
-        KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
         if (!errors.isEmpty()) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DeclarativeAgendaTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DeclarativeAgendaTest.java
@@ -15,14 +15,23 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieModule;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.conf.DeclarativeAgendaOption;
@@ -39,15 +48,24 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.Match;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class DeclarativeAgendaTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class DeclarativeAgendaTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public DeclarativeAgendaTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        // Declarative Agenda is experimental. Not supported by exec-model
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
     
     @Test(timeout=10000)
     public void testSimpleBlockingUsingForall() {
@@ -71,10 +89,10 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    list.add( kcontext.rule.name + ':' + $s ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
+
         List list = new ArrayList();
         ksession.setGlobal( "list",
                             list );
@@ -123,10 +141,10 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.blockMatch( $i ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
+
         List list = new ArrayList();
         ksession.setGlobal( "list",
                             list );
@@ -333,10 +351,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.blockMatch( $i ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
 
         return ksession;
     }
@@ -383,10 +400,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.blockMatch( $i ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
         List list = new ArrayList();
         ksession.setGlobal( "list",
                             list );
@@ -475,10 +491,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.unblockAllMatches( $i ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
         List list = new ArrayList();
         ksession.setGlobal( "list",
                             list );
@@ -549,10 +564,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.blockMatch( $i ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
         List list = new ArrayList();
         ksession.setGlobal( "list",
                             list );
@@ -676,10 +690,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.cancelMatch( $i ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
 
         final List cancelled = new ArrayList();
 
@@ -768,10 +781,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
         str += "    kcontext.halt( ); \n";
         str += "end \n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
 
         List list = new ArrayList();
         ksession.setGlobal( "list",
@@ -816,10 +828,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
                 "    kcontext.cancelMatch($i);\n" +
                 "end";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
 
         List list = new ArrayList();
         ksession.setGlobal( "list", list );
@@ -860,10 +871,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
                 "    kcontext.cancelMatch($i);\n" +
                 "end";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, str );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, str);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
 
         List list = new ArrayList();
         ksession.setGlobal( "list", list );
@@ -931,7 +941,7 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
 
         kfs.writeKModuleXML(kmodule.toXML());
         kfs.write("src/main/resources/block_rule.drl", drl);
-        KieBuilder kieBuilder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         assertEquals( 0, kieBuilder.getResults().getMessages( org.kie.api.builder.Message.Level.ERROR ).size() );
 
         KieSession ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
@@ -1051,10 +1061,9 @@ public class DeclarativeAgendaTest extends CommonTestMethodBase {
                      "\n" +
                      "\n";
 
-        KieBaseConfiguration kconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kconf.setOption( DeclarativeAgendaOption.ENABLED );
-        KieBase kbase = loadKnowledgeBaseFromString( kconf, drl );
-        KieSession ksession = createKnowledgeSession(kbase);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, DeclarativeAgendaOption.ENABLED);
+        KieSession ksession = kbase.newKieSession();
 
         List list = new ArrayList();
         ksession.setGlobal( "list", list );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsFromRHSTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsFromRHSTest.java
@@ -17,21 +17,38 @@
 package org.drools.mvel.integrationtests;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 
-public class DroolsFromRHSTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class DroolsFromRHSTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public DroolsFromRHSTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testHalt() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject( loadKnowledgeBase( "test_halt.drl" ) );
-        final KieSession ksession = createKnowledgeSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "test_halt.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List results = new ArrayList();
         ksession.setGlobal( "results",
@@ -48,8 +65,8 @@ public class DroolsFromRHSTest extends CommonTestMethodBase {
 
     @Test
     public void testFireLimit() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_fireLimit.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(this.getClass(), kieBaseTestConfiguration, "test_fireLimit.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List results = new ArrayList();
         ksession.setGlobal("results", results);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DroolsTest.java
@@ -16,13 +16,30 @@
 package org.drools.mvel.integrationtests;
 
 import java.io.Serializable;
+import java.util.Collection;
 
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
-public class DroolsTest extends CommonTestMethodBase  {
+@RunWith(Parameterized.class)
+public class DroolsTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public DroolsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
     private final static int NUM_FACTS = 20;
 
     private static int       counter;
@@ -67,9 +84,8 @@ public class DroolsTest extends CommonTestMethodBase  {
 
         counter = 0;
 
-        KieBase kbase = loadKnowledgeBaseFromString(str);
-
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession wm = kbase.newKieSession();
 
         for ( int i = 0; i < NUM_FACTS; i++ ) {
             wm.insert( new Foo( i ) );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicEvalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicEvalTest.java
@@ -41,6 +41,10 @@ import java.util.Collection;
 import static org.junit.Assert.assertTrue;
 
 public class DynamicEvalTest {
+
+    // KieBuilder doesn't have addPackage(). So we don't re-write this test at the moment.
+    // If needed, we may test it with KieContainer.updateToVersion()
+
     KieBase kbase;
     KieSession session;
     SessionPseudoClock clock;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRuleRemovalTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/DynamicRuleRemovalTest.java
@@ -15,20 +15,40 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieSession;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class DynamicRuleRemovalTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class DynamicRuleRemovalTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public DynamicRuleRemovalTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testDynamicRuleRemoval() throws Exception {
@@ -61,7 +81,9 @@ public class DynamicRuleRemovalTest extends CommonTestMethodBase {
 
     private void addRule(InternalKnowledgeBase kbase, String ruleName) {
         String rule = createDRL(ruleName);
-        kbase.addPackages(loadKnowledgePackagesFromString(rule));
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, true, rule);
+        Collection<KiePackage> pkgs = KieBaseUtil.getDefaultKieBaseFromKieBuilder(kieBuilder).getKiePackages();
+        kbase.addPackages(pkgs);
     }
 
     private void removeRule(InternalKnowledgeBase kbase, String ruleName) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
@@ -32,15 +32,11 @@ import org.drools.core.time.impl.PseudoClockScheduler;
 import org.drools.mvel.integrationtests.facts.BasicEvent;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.builder.KieModule;
-import org.kie.api.conf.EqualityBehaviorOption;
-import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.definition.type.Expires;
 import org.kie.api.definition.type.Role;
 import org.kie.api.runtime.KieSession;
@@ -62,7 +58,7 @@ public class ExpirationTest {
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
         // TODO: EM failed with testBeta, testEvalExpired, testEvalNotExpired. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseStreamConfigurations(false);
     }
 
     @Test
@@ -80,8 +76,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
@@ -119,8 +114,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler sessionClock = ksession.getSessionClock();
@@ -160,8 +154,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler sessionClock = ksession.getSessionClock();
@@ -197,8 +190,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler sessionClock = ksession.getSessionClock();
@@ -237,8 +229,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler sessionClock = ksession.getSessionClock();
@@ -339,8 +330,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler clock = ksession.getSessionClock();
@@ -404,8 +394,7 @@ public class ExpirationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler clock = ksession.getSessionClock();
@@ -493,8 +482,7 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler clock = kieSession.getSessionClock();
@@ -563,8 +551,7 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler clock = kieSession.getSessionClock();
@@ -740,8 +727,7 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler clock = kieSession.getSessionClock();
@@ -785,8 +771,8 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = new SessionConfigurationImpl();
         sessionConfig.setOption(ClockTypeOption.get(ClockType.PSEUDO_CLOCK.getId()));
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EqualityBehaviorOption.EQUALITY, EventProcessingOption.STREAM);
+        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession kieSession = kieBase.newKieSession(sessionConfig, null);
 
         //clock init to current time
@@ -873,8 +859,7 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = new SessionConfigurationImpl();
         sessionConfig.setOption(ClockTypeOption.get(ClockType.PSEUDO_CLOCK.getId()));
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         final KieSession kieSession = kieBase.newKieSession(sessionConfig, null);
 
@@ -970,8 +955,7 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = new SessionConfigurationImpl();
         sessionConfig.setOption(ClockTypeOption.get(ClockType.PSEUDO_CLOCK.getId()));
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession kieSession = kieBase.newKieSession(sessionConfig, null);
 
         //clock init to current time
@@ -1024,8 +1008,7 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession kieSession = kieBase.newKieSession( sessionConfig, null );
 
         PseudoClockScheduler clock = kieSession.getSessionClock();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireAllRulesCommandTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireAllRulesCommandTest.java
@@ -15,28 +15,39 @@
 
 package org.drools.mvel.integrationtests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import org.drools.mvel.compiler.Cheese;
 import org.drools.core.command.runtime.rule.FireAllRulesCommand;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.mvel.compiler.Cheese;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.command.Command;
-import org.kie.internal.command.CommandFactory;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.runtime.StatelessKnowledgeSession;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.StatelessKieSession;
+import org.kie.internal.command.CommandFactory;
 
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
 public class FireAllRulesCommandTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public FireAllRulesCommandTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
     @Test
     public void oneRuleFiredTest() {
         String str = "";
@@ -166,18 +177,7 @@ public class FireAllRulesCommandTest {
     }
 
     private StatelessKieSession getSession(String drl) {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-
-        kbuilder.add(ResourceFactory.newByteArrayResource(drl.getBytes()), ResourceType.DRL);
-
-        if (kbuilder.hasErrors()) {
-            System.err.println(kbuilder.getErrors());
-        }
-        assertFalse(kbuilder.hasErrors());
-
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages(kbuilder.getKnowledgePackages());
-
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         return kbase.newStatelessKieSession();
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireUntilHaltAccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FireUntilHaltAccumulateTest.java
@@ -15,29 +15,28 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.core.ClockType;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
-import org.kie.api.time.SessionPseudoClock;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.kie.api.KieBase;
-import org.kie.api.KieBaseConfiguration;
-import org.kie.api.conf.EventProcessingOption;
-import org.kie.api.definition.type.FactType;
-import org.kie.api.io.ResourceType;
-import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.KieSessionConfiguration;
-import org.kie.api.runtime.conf.ClockTypeOption;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
-
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import org.drools.core.ClockType;
+import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.definition.type.FactType;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.api.time.SessionPseudoClock;
 
 
 /**
@@ -45,7 +44,19 @@ import java.util.concurrent.TimeUnit;
  * fed into the engine by thread A while the engine had been started by
  * fireUntilHalt by thread B.
  */
+@RunWith(Parameterized.class)
 public class FireUntilHaltAccumulateTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public FireUntilHaltAccumulateTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
+    }
 
     private KieSession statefulSession;
 
@@ -72,18 +83,7 @@ public class FireUntilHaltAccumulateTest {
 
     @Before
     public void setUp() {
-        final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource( drl.getBytes() ), ResourceType.DRL);
-
-        if (kbuilder.hasErrors()) {
-            System.err.println(kbuilder.getErrors().toString());
-        }
-        final KieBaseConfiguration config =
-                KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        config.setOption( EventProcessingOption.STREAM);
-
-        final InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase(config);
-        kbase.addPackages(kbuilder.getKnowledgePackages());
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         final KieSessionConfiguration sessionConfig =
                 KnowledgeBaseFactory.newKnowledgeSessionConfiguration();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FirstOrderLogicTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FirstOrderLogicTest.java
@@ -22,9 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.drools.core.ClockType;
 import org.drools.core.audit.WorkingMemoryConsoleLogger;
-import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Address;
 import org.drools.mvel.compiler.Cheese;
 import org.drools.mvel.compiler.Cheesery;
@@ -40,28 +38,28 @@ import org.drools.mvel.compiler.SpecialString;
 import org.drools.mvel.compiler.State;
 import org.drools.mvel.compiler.StockTick;
 import org.drools.mvel.compiler.Triangle;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.KieBaseConfiguration;
+import org.kie.api.builder.KieModule;
 import org.kie.api.conf.RemoveIdentitiesOption;
-import org.kie.api.definition.KiePackage;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.AgendaEventListener;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.time.SessionClock;
 import org.kie.api.time.SessionPseudoClock;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,20 +67,29 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class FirstOrderLogicTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class FirstOrderLogicTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public FirstOrderLogicTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     private static Logger logger = LoggerFactory.getLogger(FirstOrderLogicTest.class);
 
-    protected KieSession createKnowledgeSession(KieBase kbase) { 
-        return kbase.newKieSession();
-    }
-    
     @Test
     public void testCollect() throws Exception {
         List results = new ArrayList();
 
-        KieBase kbase = loadKnowledgeBase("test_Collect.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Collect.drl");
+        KieSession wm = kbase.newKieSession();
 
         wm.setGlobal( "results",
                       results );
@@ -124,8 +131,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectNodeSharing() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_collectNodeSharing.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_collectNodeSharing.drl");
+        KieSession wm = kbase.newKieSession();
 
         List results = new ArrayList();
         wm.setGlobal( "results",
@@ -156,8 +163,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectModify() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_Collect.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Collect.drl");
+        KieSession wm = kbase.newKieSession();
 
         List results = new ArrayList();
 
@@ -225,8 +232,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectResultConstraints() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_CollectResultConstraints.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectResultConstraints.drl");
+        KieSession wm = kbase.newKieSession();
         List results = new ArrayList();
 
         wm.setGlobal( "results",
@@ -264,8 +271,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testExistsWithBinding() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_ExistsWithBindings.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ExistsWithBindings.drl");
+        KieSession wm = kbase.newKieSession();
 
         final List list = new ArrayList();
         wm.setGlobal( "results",
@@ -286,8 +293,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testNot() throws Exception {
-        KieBase kbase = loadKnowledgeBase("not_rule_test.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "not_rule_test.drl");
+        KieSession wm = kbase.newKieSession();
 
         final List list = new ArrayList();
         wm.setGlobal( "list", list );
@@ -317,8 +324,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testNotWithBindings() throws Exception {
-        KieBase kbase = loadKnowledgeBase("not_with_bindings_rule_test.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "not_with_bindings_rule_test.drl");
+        KieSession wm = kbase.newKieSession();
 
         final List list = new ArrayList();
         wm.setGlobal( "list",
@@ -350,8 +357,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testExists() throws Exception {
-        KieBase kbase = loadKnowledgeBase("exists_rule_test.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "exists_rule_test.drl");
+        KieSession wm = kbase.newKieSession();
 
         final List list = new ArrayList();
         wm.setGlobal( "list", list );
@@ -383,8 +390,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testExists2() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_exists.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_exists.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "list",
@@ -422,8 +429,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testExists3() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_Exists_JBRULES_2810.drl");
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Exists_JBRULES_2810.drl");
+        KieSession ksession = kbase.newKieSession();
 
         WorkingMemoryConsoleLogger logger = new WorkingMemoryConsoleLogger( ksession );
         ksession.fireAllRules();
@@ -432,8 +439,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testForall() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_Forall.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Forall.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -462,8 +469,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testForall2() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_Forall2.drl");
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Forall2.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
         ksession.setGlobal( "results",
@@ -497,12 +504,10 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testRemoveIdentitiesSubNetwork() throws Exception {
-        KieBaseConfiguration conf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        conf.setOption(RemoveIdentitiesOption.YES);
-
-        KieBase kbase = loadKnowledgeBase(conf, "test_removeIdentitiesSubNetwork.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
-
+        KieModule kieModule = KieUtil.getKieModuleFromClasspathResources("test", getClass(), kieBaseTestConfiguration, "test_removeIdentitiesSubNetwork.drl");
+        KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, RemoveIdentitiesOption.YES);
+        KieSession workingMemory = kbase.newKieSession();
+        
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
                                  list );
@@ -545,8 +550,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectWithNestedFromWithParams() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_CollectWithNestedFrom.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectWithNestedFrom.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List results = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -586,8 +591,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectModifyAlphaRestriction() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_CollectAlphaRestriction.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectAlphaRestriction.drl");
+        KieSession wm = kbase.newKieSession();
 
         final List results = new ArrayList();
 
@@ -634,8 +639,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testForallSinglePattern() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_ForallSinglePattern.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ForallSinglePattern.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -690,8 +695,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testForallSinglePattern2() throws Exception {
-        final KieBase kbase = loadKnowledgeBase( "test_ForallSinglePattern2.drl" );
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ForallSinglePattern2.drl");
+        KieSession ksession = kbase.newKieSession();
 
         ksession.insert( new Triangle( 3,
                                        3,
@@ -710,8 +715,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testMVELCollect() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_MVELCollect.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_MVELCollect.drl");
+        KieSession wm = kbase.newKieSession();
 
         final List results = new ArrayList();
 
@@ -745,8 +750,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testNestedCorelatedRulesWithForall() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_NestedCorrelatedRulesWithForall.drl");
-        KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_NestedCorrelatedRulesWithForall.drl");
+        KieSession session = kbase.newKieSession();
 
         List list1 = new ArrayList();
         List list2 = new ArrayList();
@@ -805,8 +810,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testFromInsideNotAndExists() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_FromInsideNotAndExists.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_FromInsideNotAndExists.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -839,8 +844,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testOr() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_OrNesting.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_OrNesting.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -868,21 +873,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
     // JBRULES-2482 
     @Test
     public void testOrWithVariableResolution() throws Exception {
-//        KieBase kbase = loadKnowledgeBase( "test_OrCEFollowedByMultipleEval.drl");
-//        KieSession workingMemory = createKnowledgeSession(kbase);
-
-        final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newClassPathResource( "test_OrCEFollowedByMultipleEval.drl",
-                                                            FirstOrderLogicTest.class ),
-                      ResourceType.DRL );
-
-        assertFalse( kbuilder.getErrors().toString(),
-                     kbuilder.hasErrors() );
-
-        final InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_OrCEFollowedByMultipleEval.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final AgendaEventListener al = mock( AgendaEventListener.class );
         ksession.addEventListener( al );
@@ -899,21 +891,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
     // JBRULES-2526 
     @Test
     public void testOrWithVariableResolution2() throws Exception {
-        //        KieBase kbase = loadKnowledgeBase( "test_OrCEFollowedByMultipleEval.drl");
-        //        KieSession workingMemory = createKnowledgeSession(kbase);
-
-        final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newClassPathResource( "test_OrCEFollowedByMultipleEval2.drl",
-                                                            FirstOrderLogicTest.class ),
-                      ResourceType.DRL );
-
-        assertFalse( kbuilder.getErrors().toString(),
-                     kbuilder.hasErrors() );
-
-        final InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_OrCEFollowedByMultipleEval2.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final AgendaEventListener al = mock( AgendaEventListener.class );
         ksession.addEventListener( al );
@@ -929,8 +908,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectWithMemberOfOperators() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_CollectMemberOfOperator.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectMemberOfOperator.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -982,8 +961,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectWithContainsOperators() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_CollectContainsOperator.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectContainsOperator.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -1035,8 +1014,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testForallSinglePatternWithExists() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_ForallSinglePatternWithExists.drl");
-        KieSession workingMemory = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ForallSinglePatternWithExists.drl");
+        KieSession workingMemory = kbase.newKieSession();
 
         final List list = new ArrayList();
         workingMemory.setGlobal( "results",
@@ -1064,8 +1043,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectResultBetaConstraint() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_CollectResultsBetaConstraint.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectResultsBetaConstraint.drl");
+        KieSession wm = kbase.newKieSession();
 
         List results = new ArrayList();
 
@@ -1094,8 +1073,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testFromWithOr() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_FromWithOr.drl");
-        KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_FromWithOr.drl");
+        KieSession session = kbase.newKieSession();
 
         final List<Address> results = new ArrayList<Address>();
         session.setGlobal( "results",
@@ -1128,8 +1107,9 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
         final KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        KieBase kbase = loadKnowledgeBase( "test_ForallSlidingWindow.drl");
-        KieSession ksession = createKnowledgeSession(kbase, conf);
+        kieBaseTestConfiguration.setStreamMode(true);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ForallSlidingWindow.drl");
+        KieSession ksession = kbase.newKieSession(conf, null);
 
         final SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();
         List<String> results = new ArrayList<String>();
@@ -1219,8 +1199,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectFromMVELAfterOr() throws Exception {
-        KieBase kbase = loadKnowledgeBase( "test_CollectFromMVELAfterOr.drl");
-        KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CollectFromMVELAfterOr.drl");
+        KieSession wm = kbase.newKieSession();
 
         List results = new ArrayList();
 
@@ -1252,11 +1232,8 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
 
     @Test
     public void testCollectAfterOrCE() throws Exception {
-        Collection<KiePackage> pkgs = loadKnowledgePackages("test_OrCEFollowedByCollect.drl");
-
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages(pkgs);
-        KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_OrCEFollowedByCollect.drl");
+        KieSession session = kbase.newKieSession();
 
         //Set up facts
         final Cheesery bonFromage = new Cheesery();
@@ -1268,19 +1245,6 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
         int rules = session.fireAllRules();
         assertEquals( 2,
                       rules );
-
-        //Serialize and test again
-        pkgs = SerializationHelper.serializeObject(pkgs);
-        kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( pkgs );
-        
-        session = createKnowledgeSession(kbase);
-        session.insert( bonFromage );
-
-        rules = session.fireAllRules();
-        assertEquals( 2,
-                      rules );
-
     }
     
     @Test 
@@ -1338,9 +1302,9 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
                 "end";
         
         logger.info( str );
-        
-        KieBase kbase = loadKnowledgeBaseFromString( str );
-        KieSession ksession = createKnowledgeSession(kbase);
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
              
         ksession.insert(new Field("t", "Y"));
         ksession.insert(new Field("a", "b"));
@@ -1361,9 +1325,9 @@ public class FirstOrderLogicTest extends CommonTestMethodBase {
                 "        Message( !fired ) or eval( !false )\n" + 
                 "    then\n" + 
                 "end\n";
-        
-        KieBase kbase = loadKnowledgeBaseFromString( str );
-        KieSession ksession = createKnowledgeSession(kbase);
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
         
         ksession.insert( new Message( "test" ) );
         int rules = ksession.fireAllRules();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/HelloWorldTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/HelloWorldTest.java
@@ -16,22 +16,21 @@
 package org.drools.mvel.integrationtests;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Message;
 import org.drools.mvel.expr.MVELDebugHandler;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
 import org.kie.api.logger.KieRuntimeLogger;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.logger.KnowledgeRuntimeLoggerFactory;
 import org.mvel2.MVELRuntime;
 import org.mvel2.debug.Debugger;
@@ -39,18 +38,30 @@ import org.mvel2.debug.Frame;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This is a sample class to launch a rule.
  */
-public class HelloWorldTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class HelloWorldTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public HelloWorldTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        // not for exec-model
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testHelloWorld() throws Exception {
         // load up the knowledge base
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         File testTmpDir = new File("target/test-tmp/");
         testTmpDir.mkdirs();
         KieRuntimeLogger logger = KnowledgeRuntimeLoggerFactory.newFileLogger( ksession, "target/test-tmp/testHelloWorld" );
@@ -82,7 +93,7 @@ public class HelloWorldTest extends CommonTestMethodBase {
         MVELRuntime.registerBreakpoint(source, 1);
         // load up the knowledge base
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         File testTmpDir = new File("target/test-tmp/");
         testTmpDir.mkdirs();
         KieRuntimeLogger logger = KnowledgeRuntimeLoggerFactory.newFileLogger( ksession, "target/test-tmp/testHelloWorldDebug" );
@@ -104,16 +115,7 @@ public class HelloWorldTest extends CommonTestMethodBase {
     }
 
     private KieBase readKnowledgeBase() throws Exception {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add(
-            ResourceFactory.newClassPathResource("Sample.drl", HelloWorldTest.class),
-            ResourceType.DRL);
-        if (kbuilder.hasErrors()) {
-           fail( kbuilder.getErrors().toString() );
-        }
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages(kbuilder.getKnowledgePackages());
-        return kbase;
+        return KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "Sample.drl");
     }
 
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/IntegrationInterfacesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/IntegrationInterfacesTest.java
@@ -15,76 +15,52 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.drools.mvel.compiler.Cheese;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.Channel;
+import org.kie.api.runtime.KieSession;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
+@RunWith(Parameterized.class)
+public class IntegrationInterfacesTest {
 
-import org.drools.mvel.compiler.Cheese;
-import org.drools.mvel.CommonTestMethodBase;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
-import org.junit.Test;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
-import org.kie.api.runtime.Channel;
-import org.kie.api.runtime.KieSession;
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
-public class IntegrationInterfacesTest extends CommonTestMethodBase {
-
-    private KieBase getKnowledgeBase(final String resourceName) throws IOException,
-                                                                     ClassNotFoundException {
-        final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newClassPathResource( resourceName,
-                                                            getClass() ),
-                      ResourceType.DRL );
-
-        assertFalse( kbuilder.getErrors().toString(),
-                     kbuilder.hasErrors() );
-
-        KieBase kbase = getKnowledgeBase( kbuilder );
-
-        return kbase;
+    public IntegrationInterfacesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
-    private KieBase getKnowledgeBase(final Reader[] readers) throws IOException,
-                                                                  ClassNotFoundException {
-        final KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        for ( Reader reader : readers ) {
-            kbuilder.add( ResourceFactory.newReaderResource(reader),
-                          ResourceType.DRL );
-        }
-        assertFalse( kbuilder.getErrors().toString(),
-                     kbuilder.hasErrors() );
-        KieBase kbase = getKnowledgeBase( kbuilder );
-        return kbase;
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
-    private KieBase getKnowledgeBase(final KnowledgeBuilder kbuilder) throws IOException,
-                                                                           ClassNotFoundException {
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-        kbase = SerializationHelper.serializeObject( kbase );
-        return kbase;
+    private KieBase getKnowledgeBase(final String resourceName) {
+        return KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, resourceName);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testGlobals() throws Exception {
         final KieBase kbase = getKnowledgeBase( "globals_rule_test.drl" );
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Object> list = mock( List.class );
         ksession.setGlobal( "list",
@@ -108,7 +84,7 @@ public class IntegrationInterfacesTest extends CommonTestMethodBase {
     @Test
     public void testGlobals2() throws Exception {
         final KieBase kbase = getKnowledgeBase( "test_globalsAsConstraints.drl" );
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Object> results = mock( List.class );
         ksession.setGlobal( "results",
@@ -162,12 +138,8 @@ public class IntegrationInterfacesTest extends CommonTestMethodBase {
                        "        l.add( \"rule 2 executed \" + str);\n" + 
                        "end\n";
 
-        StringReader[] readers = new StringReader[2];
-        readers[0] = new StringReader( rule1 );
-        readers[1] = new StringReader( rule2 );
-
-        final KieBase kbase = getKnowledgeBase( readers );
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule1, rule2);
+        KieSession ksession = kbase.newKieSession();
 
         ksession.setGlobal( "str",
                             "boo" );
@@ -183,7 +155,7 @@ public class IntegrationInterfacesTest extends CommonTestMethodBase {
     @Test
     public void testChannels() throws IOException, ClassNotFoundException {
         KieBase kbase = getKnowledgeBase( "test_Channels.drl" );
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         
         Channel someChannel = mock( Channel.class );
         ksession.registerChannel( "someChannel", someChannel );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/JittingTest.java
@@ -16,24 +16,44 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.integrationtests.facts.AnEnum;
 import org.drools.mvel.integrationtests.facts.FactWithEnum;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
+import org.kie.api.builder.KieModule;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.conf.ConstraintJittingThresholdOption;
-import org.kie.internal.utils.KieHelper;
 
 import static org.junit.Assert.assertEquals;
 
-public class JittingTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class JittingTest {
+
+    // This test is basically written for Mvel Jitting. But it has good edge cases which are useful for testing even with exec-model.
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public JittingTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testJitConstraintInvokingConstructor() {
@@ -44,7 +64,7 @@ public class JittingTest extends CommonTestMethodBase {
                 "then\n" +
                 "end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         ksession.insert(new Person("Mario", 38));
@@ -78,7 +98,7 @@ public class JittingTest extends CommonTestMethodBase {
     }
 
     private void testJitting(final String drl) {
-        final KieBase kbase = loadKnowledgeBaseFromString(drl);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession ksession = kbase.newKieSession();
 
         ksession.insert(new Person("mark", 37));
@@ -97,9 +117,8 @@ public class JittingTest extends CommonTestMethodBase {
                 " then \n" +
                 " end ";
 
-        final KieHelper kieHelper = new KieHelper();
-        kieHelper.addContent( drl, ResourceType.DRL );
-        final KieBase kieBase = kieHelper.build(ConstraintJittingThresholdOption.get(0));
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
         final KieSession kieSession = kieBase.newKieSession();
 
         kieSession.insert(AnEnum.FIRST);
@@ -116,9 +135,8 @@ public class JittingTest extends CommonTestMethodBase {
                 " then \n" +
                 " end ";
 
-        final KieHelper kieHelper = new KieHelper();
-        kieHelper.addContent( drl, ResourceType.DRL );
-        final KieBase kieBase = kieHelper.build(ConstraintJittingThresholdOption.get(0));
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
 
         final KieSession kieSession = kieBase.newKieSession();
         kieSession.insert(new FactWithEnum(AnEnum.FIRST));
@@ -134,7 +152,9 @@ public class JittingTest extends CommonTestMethodBase {
                 + "  Person( name == \"Paul\", age > ((2*$age1)/3) )\n"
                 + "then end\n";
 
-        KieSession ksession = new KieHelper().addContent(drl, ResourceType.DRL).build(ConstraintJittingThresholdOption.get(0)).newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
+        final KieSession ksession = kieBase.newKieSession();
 
         Person john = new Person("John", 20);
         ksession.insert(john);
@@ -178,7 +198,9 @@ public class JittingTest extends CommonTestMethodBase {
                 "  then\n" +
                 "end";
 
-        KieSession ksession = new KieHelper().addContent(drl, ResourceType.DRL).build(ConstraintJittingThresholdOption.get(0)).newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
+        final KieSession ksession = kieBase.newKieSession();
 
         int fired = ksession.fireAllRules();
 
@@ -216,7 +238,9 @@ public class JittingTest extends CommonTestMethodBase {
                 "then\n" +
                 "end";
 
-        KieSession ksession = new KieHelper().addContent(drl, ResourceType.DRL).build(ConstraintJittingThresholdOption.get(0)).newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, ConstraintJittingThresholdOption.get(0));
+        final KieSession ksession = kieBase.newKieSession();
 
         Map<String, Object> valueMap = new HashMap<>();
         valueMap.put("key", useInt ? 5 : "a");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
@@ -18,8 +18,12 @@ package org.drools.mvel.integrationtests;
 
 import java.util.Collection;
 
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -31,7 +35,19 @@ import org.kie.api.runtime.KieContainer;
 import static org.junit.Assert.assertEquals;
 
 // DROOLS-1044
-public class KieBaseIncludesTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class KieBaseIncludesTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieBaseIncludesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     /**
      * Test the inclusion of a KieBase defined in one KJAR into the KieBase of another KJAR.
@@ -100,7 +116,7 @@ public class KieBaseIncludesTest extends CommonTestMethodBase {
                                .write("src/main/resources/rules2/rules.drl", drl2)
                                .writeKModuleXML(kmoduleContent2);
 
-        ks.newKieBuilder(kfs2).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs2, true);
 
         KieFileSystem kfs1 = ks.newKieFileSystem()
                                //.generateAndWritePomXML(releaseId1)
@@ -108,7 +124,7 @@ public class KieBaseIncludesTest extends CommonTestMethodBase {
                                .write("src/main/resources/rules/rules.drl", drl1)
                                .writeKModuleXML(kmoduleContent1);
 
-        ks.newKieBuilder(kfs1).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs1, true);
 
         KieContainer kc = ks.newKieContainer( releaseId1 );
         KieBase kieBase = kc.getKieBase();
@@ -187,7 +203,7 @@ public class KieBaseIncludesTest extends CommonTestMethodBase {
                                .write("src/main/resources/rules/rules.drl", drl2)
                                .writeKModuleXML(kmoduleContent2);
 
-        ks.newKieBuilder(kfs2).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs2, true);
 
         KieFileSystem kfs1 = ks.newKieFileSystem()
                                //.generateAndWritePomXML(releaseId1)
@@ -195,7 +211,7 @@ public class KieBaseIncludesTest extends CommonTestMethodBase {
                                .write("src/main/resources/rules/rules.drl", drl1)
                                .writeKModuleXML(kmoduleContent1);
 
-        ks.newKieBuilder(kfs1).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs1, true);
 
         KieContainer kc = ks.newKieContainer(releaseId1);
         KieBase kieBase = kc.getKieBase();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieCompilationCacheTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieCompilationCacheTest.java
@@ -15,15 +15,22 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
+
 import org.drools.compiler.compiler.io.File;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Message;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.KieModule;
 import org.kie.api.builder.ReleaseId;
@@ -42,7 +49,20 @@ import static org.junit.Assert.assertNotNull;
 /**
  * This is a sample class to launch a rule.
  */
-public class KieCompilationCacheTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class KieCompilationCacheTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieCompilationCacheTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testCompilationCache() throws Exception {
@@ -58,7 +78,7 @@ public class KieCompilationCacheTest extends CommonTestMethodBase {
         KieServices ks = KieServices.Factory.get();
 
         KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
-        ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         
         ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
         InternalKieModule kieModule = (InternalKieModule) ks.getRepository().getKieModule( releaseId );
@@ -118,7 +138,7 @@ public class KieCompilationCacheTest extends CommonTestMethodBase {
                 .write("src/main/resources/KBase1/org/pkg1/r1.drl", drl1)
                 .write("src/main/resources/KBase1/org/pkg2/r2.drl", drl2)
                 .writeKModuleXML(createKieProjectWithPackagesAnd2KieBases(ks).toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         
         InternalKieModule kieModule = (InternalKieModule) ks.getRepository().getKieModule( releaseId );
         byte[] jar = kieModule.getBytes();
@@ -177,7 +197,7 @@ public class KieCompilationCacheTest extends CommonTestMethodBase {
                 .generateAndWritePomXML(releaseId)
                 .write("src/main/resources/KBase1/org/pkg1/r1.drl", drl1)
                 .writeKModuleXML(createKieProjectWithPackagesAnd2KieBases(ks).toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         
         InternalKieModule kieModule = (InternalKieModule) ks.getRepository().getKieModule( releaseId );
         byte[] jar = kieModule.getBytes();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieDefaultPackageTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieDefaultPackageTest.java
@@ -15,9 +15,15 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -27,7 +33,19 @@ import static org.junit.Assert.assertEquals;
 /**
  * Testing use of default Package.
  */
-public class KieDefaultPackageTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class KieDefaultPackageTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieDefaultPackageTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testAllInDefaultPackage() throws Exception {
@@ -50,7 +68,7 @@ public class KieDefaultPackageTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem();
         kfs.write( "src/main/resources/model.drl", model_drl );
         kfs.write( "src/main/resources/drl.drl", drl );
-        KieBuilder builder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 0,
                       builder.getResults().getMessages().size() );
@@ -68,7 +86,7 @@ public class KieDefaultPackageTest extends CommonTestMethodBase {
 
         KieFileSystem kfs = ks.newKieFileSystem();
         kfs.write( "src/test/java/org/jbpm/Test.java", javaClass );
-        KieBuilder builder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 0,
                       builder.getResults().getMessages().size() );
@@ -99,7 +117,7 @@ public class KieDefaultPackageTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem();
         kfs.write( "src/main/resources/model.drl", model_drl );
         kfs.write( "src/main/resources/drl.drl", drl );
-        KieBuilder builder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 0,
                       builder.getResults().getMessages().size() );
@@ -128,7 +146,7 @@ public class KieDefaultPackageTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem();
         kfs.write( "src/main/resources/model.drl", model_drl );
         kfs.write( "src/main/resources/drl.drl", drl );
-        KieBuilder builder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 0,
                       builder.getResults().getMessages().size() );
@@ -157,7 +175,7 @@ public class KieDefaultPackageTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem();
         kfs.write( "src/main/resources/model.drl", model_drl );
         kfs.write( "src/main/resources/drl.drl", drl );
-        KieBuilder builder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 0,
                       builder.getResults().getMessages().size() );
@@ -187,7 +205,7 @@ public class KieDefaultPackageTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem();
         kfs.write( "src/main/resources/model.drl", model_drl );
         kfs.write( "src/main/resources/drl.drl", drl );
-        KieBuilder builder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 0,
                       builder.getResults().getMessages().size() );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieHelloWorldTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieHelloWorldTest.java
@@ -21,15 +21,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieProject;
 import org.drools.compiler.kie.builder.impl.ResultsImpl;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Message;
 import org.drools.reflective.classloader.ProjectClassLoader;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -57,14 +62,27 @@ import static org.junit.Assert.fail;
 /**
  * This is a sample class to launch a rule.
  */
-public class KieHelloWorldTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class KieHelloWorldTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieHelloWorldTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testHelloWorld() throws Exception {
         KieServices ks = KieServices.Factory.get();
 
         KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", createDrl( "R1" ) );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
         ksession.insert(new Message("Hello World"));
@@ -81,7 +99,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         KieServices ks = KieServices.Factory.get();
 
         KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieContainer kcontainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
 
@@ -104,7 +122,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                   .newReaderResource( new StringReader( createDrl( "R1" ) ) )
                   .setResourceType( ResourceType.DRL )
                   .setSourcePath( "src/main/resources/r1.txt" ) );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
         ksession.insert(new Message("Hello World"));
@@ -123,7 +141,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem()
                 .write("src/main/resources/r1.drl", drl)
                 .write( "src/main/resources/empty.drl", ks.getResources().newInputStreamResource( new ByteArrayInputStream( new byte[0] ) ) );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer( ks.getRepository().getDefaultReleaseId() ).newKieSession();
         ksession.insert(new Message("Hello World"));
@@ -145,8 +163,8 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         KieServices ks = KieServices.Factory.get();
 
         KieFileSystem kfs = ks.newKieFileSystem().write("src/main/resources/r1.drl", drl);
-        
-        KieBuilder kb = ks.newKieBuilder( kfs ).buildAll();
+
+        KieBuilder kb = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 1, kb.getResults().getMessages().size() );
     }
@@ -183,7 +201,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         includingBase.newKieSessionModel("includingKSession").setDefault(false);
 
         kfs.writeKModuleXML(module.toXML());
-        KieBuilder kb = ks.newKieBuilder( kfs ).buildAll();
+        KieBuilder kb = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         assertEquals( 0, kb.getResults().getMessages().size() );
 
         KieSession ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
@@ -206,7 +224,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .write( "src/main/resources/KBase1/org/pkg1/r1.drl", createDrl( "org.pkg1", "R1" ) )
                 .write( "src/main/resources/KBase1/org/pkg2/r2.drl", createDrl( "org.pkg2", "R2" ) )
                 .writeKModuleXML( createKieProjectWithPackages( ks, "org.pkg1" ).toXML() );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(releaseId).newKieSession("KSession1");
         ksession.insert(new Message("Hello World"));
@@ -235,7 +253,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .write("src/main/resources/KBase1/r1_2.drl", createDrl("org.pkg1", "R1"))
                 .write("src/main/resources/KBase1/r2.drl", createDrl("org.pkg2", "R2"))
                 .writeKModuleXML(createKieProjectWithPackages(ks, "org.pkg1").toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(releaseId).newKieSession("KSession1");
         ksession.insert( new Message( "Hello World" ) );
@@ -264,7 +282,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .writeKModuleXML( createKieProjectWithPackages( ks, "org.pkg1" )
                         .setConfigurationProperty( "drools.groupDRLsInKieBasesByFolder", "true" )
                         .toXML() );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer( releaseId ).newKieSession( "KSession1" );
         ksession.insert( new Message( "Hello World" ) );
@@ -282,7 +300,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .write( "src/main/resources/org/pkg1/test/r1.drl", createDrlWithGlobal( "org.pkg1.test", "R1" ) )
                 .write( "src/main/resources/org/pkg2/test/r2.drl", createDrlWithGlobal( "org.pkg2.test", "R2" ) )
                 .writeKModuleXML( createKieProjectWithPackages( ks, "org.pkg1.*" ).toXML() );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(releaseId).newKieSession("KSession1");
         ksession.insert(new Message("Hello World"));
@@ -310,7 +328,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .write("src/main/resources/tests/tests.drl", createDrlWithGlobal("tests", "R6"))
                 .write("src/main/resources/rules2/rules2.drl", createDrlWithGlobal("rules2", "R7"))
                 .writeKModuleXML( createKieProjectWithPackages(ks, "rules.*").toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, true);
 
         KieSession ksession = ks.newKieContainer(releaseId).newKieSession("KSession1");
         ksession.insert(new Message("Hello World"));
@@ -433,7 +451,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .generateAndWritePomXML(releaseId)
                 .write("src/main/resources/KBase1/org/pkg1/r1.drl", drl)
                 .writeKModuleXML(createKieProjectWithPackages(ks, "*").toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
     }
 
     @Test
@@ -469,7 +487,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .write("src/main/resources/KBase1/org/pkg1/r1.drl", drl1)
                 .write("src/main/resources/KBase1/org/pkg2/r2.drl", drl2)
                 .writeKModuleXML(createKieProjectWithPackagesAnd2KieBases(ks).toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(releaseId).newKieSession("KSession1");
         ksession.insert(new Message("Hello World"));
@@ -550,7 +568,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                               .write( "src/main/resources/myrules/r2.drl", drl2 )
                               .writeKModuleXML( kproj.toXML() );
 
-        KieBuilder kieBuilder = ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         KieSession ksession = ks.newKieContainer( releaseId ).newKieSession( );
 
         List<String> results = new ArrayList<String>();
@@ -578,7 +596,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", createDrl( "R1" ) );
         kfs.writeKModuleXML(kmodule);
 
-        KieBuilder kb = ks.newKieBuilder( kfs ).buildAll();
+        KieBuilder kb = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         assertEquals( 1, kb.getResults().getMessages().size() );
         assertTrue( kb.getResults().getMessages().get(0).toString().contains( "ABC" ) );
@@ -603,8 +621,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
 
         fs.write( ResourceFactory.newUrlResource("file:/tmp/t%20tt/one.drl"));
 
-        KieBuilder kieBuilder = kieServices.newKieBuilder(fs);
-        kieBuilder.buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, fs, false);
         KieModule kieModule = kieBuilder.getKieModule();
 
         KieSession ksession = kieServices.newKieContainer(kieModule.getReleaseId()).newKieSession();
@@ -621,7 +638,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
         KieServices ks = KieServices.Factory.get();
 
         KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", createDrl( "R1" ) );
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
         try {
@@ -698,7 +715,7 @@ public class KieHelloWorldTest extends CommonTestMethodBase {
                 .write("src/main/java/org/mypackage/WeekendCalendar.java", weekendCalendarSource)
                 .write("src/main/java/org/mypackage/WeekdayCalendar.java", weekdayCalendarSource)
                 .writeKModuleXML(kproj.toXML());
-        ks.newKieBuilder( kfs ).buildAll();
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
 
         KieSession ksession = ks.newKieContainer(releaseId).newKieSession("KSession1");
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieLoggersTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieLoggersTest.java
@@ -16,9 +16,15 @@
 package org.drools.mvel.integrationtests;
 
 import java.io.File;
+import java.util.Collection;
 
 import org.drools.mvel.compiler.Message;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -37,11 +43,23 @@ import org.kie.internal.io.ResourceFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@RunWith(Parameterized.class)
 public class KieLoggersTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieLoggersTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testKieConsoleLogger() throws Exception {
@@ -85,7 +103,8 @@ public class KieLoggersTest {
         kfs.writeKModuleXML(kproj.toXML());
         kfs.write("src/main/resources/KBase1/rule.drl", drl);
 
-        KieModule kieModule = ks.newKieBuilder(kfs).buildAll().getKieModule();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        KieModule kieModule = kieBuilder.getKieModule();
         KieContainer kieContainer = ks.newKieContainer(kieModule.getReleaseId());
 
         KieSession ksession = kieContainer.newKieSession("KSession1");
@@ -146,7 +165,8 @@ public class KieLoggersTest {
         kfs.writeKModuleXML(kproj.toXML());
         kfs.write("src/main/resources/KBase1/rule.drl", drl);
 
-        KieModule kieModule = ks.newKieBuilder(kfs).buildAll().getKieModule();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        KieModule kieModule = kieBuilder.getKieModule();
         KieContainer kieContainer = ks.newKieContainer(kieModule.getReleaseId());
 
         StatelessKieSession ksession = kieContainer.newStatelessKieSession("KSession1");
@@ -255,7 +275,8 @@ public class KieLoggersTest {
         kfs.writeKModuleXML(kproj.toXML());
         kfs.write("src/main/resources/KBase1/rule.drl", drl);
 
-        KieModule kieModule = ks.newKieBuilder(kfs).buildAll().getKieModule();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        KieModule kieModule = kieBuilder.getKieModule();
         KieContainer kieContainer = ks.newKieContainer(kieModule.getReleaseId());
 
         KieSession ksession = kieContainer.newKieSession("KSession1");
@@ -292,7 +313,7 @@ public class KieLoggersTest {
         KieServices ks = KieServices.Factory.get();
 
         KieFileSystem kfs = ks.newKieFileSystem().write( dt );
-        KieBuilder kb = ks.newKieBuilder( kfs ).buildAll();
+        KieBuilder kb = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         assertTrue( kb.getResults().getMessages().isEmpty() );
         return ks;
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PolymorphismTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PolymorphismTest.java
@@ -20,14 +20,11 @@ import java.util.Collection;
 
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.builder.KieModule;
-import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
@@ -44,7 +41,7 @@ public class PolymorphismTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
     }
 
     @Test
@@ -63,8 +60,7 @@ public class PolymorphismTest {
                      "then\n" +
                      "end";
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession ksession = kieBase.newKieSession();
 
         ksession.insert(1);
@@ -104,8 +100,7 @@ public class PolymorphismTest {
                      "    modify($d) { setId($id+1) };\n" +
                      "end";
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession ksession = kieBase.newKieSession();
 
         ksession.insert( new X(0) );
@@ -145,8 +140,7 @@ public class PolymorphismTest {
                      "    delete($a);\n" +
                      "end";
 
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kieBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         final KieSession ksession = kieBase.newKieSession();
 
         FactHandle fh = ksession.insert( new X(0) );

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
@@ -233,8 +233,8 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
 
     private static List<KieBaseOption> additionalKieBaseOptions = Collections.emptyList();
 
-    private final boolean identity;
-    private final boolean streamMode;
+    private boolean identity;
+    private boolean streamMode;
     private final boolean alphaNetworkCompiler;
     private final Class<? extends KieBuilder.ProjectType> executableModelProjectClass;
 
@@ -250,6 +250,7 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
         this.executableModelProjectClass = executableModelProjectClass;
     }
 
+    // additionalKieBaseOptions is only used by getKieBaseConfiguration(), not by getKieBaseModel(). Little confusing
     @Override
     public void setAdditionalKieBaseOptions(final KieBaseOption... options) {
         additionalKieBaseOptions = Arrays.asList(options);
@@ -260,9 +261,19 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
         return identity;
     }
 
+    // identity is mutable for test convenience but basically we don't need to use this (One test class should focus on identity or equality)
+    public void setIdentity(boolean identity) {
+        this.identity = identity;
+    }
+
     @Override
     public boolean isStreamMode() {
         return streamMode;
+    }
+
+    // streamMode is mutable for test convenience but basically we don't need to use this (One test class should focus on cloud or stream)
+    public void setStreamMode(boolean streamMode) {
+        this.streamMode = streamMode;
     }
 
     @Override

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
@@ -17,6 +17,7 @@
 package org.drools.testcoverage.common.util;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -24,13 +25,13 @@ import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.KieModule;
 import org.kie.api.builder.ReleaseId;
-import org.kie.api.conf.DeclarativeAgendaOption;
+import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.conf.KieBaseOption;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.KieContainer;
-import org.kie.api.runtime.KieSession;
 
 /**
  * Util class that provides various methods related to KieBase.
@@ -125,12 +126,39 @@ public final class KieBaseUtil {
         return getKieBaseFromKieModuleFromResources(KieUtil.generateReleaseId(moduleGroupId), kieBaseTestConfiguration, resources.toArray(new Resource[]{}));
     }
 
+    public static KieBase getKieBaseFromClasspathResources(final String moduleGroupId,
+                                                           final Class<?> classLoaderFromClass,
+                                                           final KieBaseTestConfiguration kieBaseTestConfiguration,
+                                                           final String... classpathResources) {
+        final List<Resource> resources = KieUtil.getClasspathResources(classLoaderFromClass, classpathResources);
+        return getKieBaseFromKieModuleFromResources(KieUtil.generateReleaseId(moduleGroupId), kieBaseTestConfiguration, resources.toArray(new Resource[]{}));
+    }
+
+    public static KieBase getKieBaseFromClasspathResourcesWithClassLoaderForKieBuilder(final String moduleGroupId,
+                                                           final Class<?> classLoaderFromClass,
+                                                           final ClassLoader classLoaderForKieBuilder,
+                                                           final KieBaseTestConfiguration kieBaseTestConfiguration,
+                                                           final String... classpathResources) {
+        final List<Resource> resources = KieUtil.getClasspathResources(classLoaderFromClass, classpathResources);
+        KieModuleModel kieModuleModel = KieUtil.getKieModuleModel(kieBaseTestConfiguration, KieSessionTestConfiguration.STATEFUL_REALTIME, new HashMap<>());
+        KieFileSystem kfs = KieUtil.getKieFileSystemWithKieModule(kieModuleModel, KieUtil.generateReleaseId(moduleGroupId), resources.toArray(new Resource[]{}));
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false, classLoaderForKieBuilder);
+        final KieModule kieModule = kieBuilder.getKieModule();
+        KieServices.Factory.get().getRepository().addKieModule(kieModule);
+        return getDefaultKieBaseFromReleaseId(kieModule.getReleaseId());
+    }
+
     public static KieBase newKieBaseFromKieModuleWithAdditionalOptions(final KieModule kieModule,
                                                          final KieBaseTestConfiguration kieBaseTestConfiguration, final KieBaseOption... options) {
         final KieContainer kieContainer = KieServices.get().newKieContainer(kieModule.getReleaseId());
         final KieBaseConfiguration kieBaseConfiguration = kieBaseTestConfiguration.getKieBaseConfiguration();
         Arrays.stream(options).forEach(kieBaseConfiguration::setOption);
         return kieContainer.newKieBase(kieBaseConfiguration);
+    }
+
+    public static KieBase newKieBaseFromReleaseId(final ReleaseId id, final KieBaseConfiguration kbaseConf) {
+        final KieContainer container = KieServices.Factory.get().newKieContainer(id);
+        return container.newKieBase(kbaseConf);
     }
 
     private KieBaseUtil() {


### PR DESCRIPTION
…ge : 2nd round

For this PR, I reviewed/modified tests until org/drools/mvel/integrationtests/KieLoggersTest.java
- Enabled KieBaseUtil/KieUtil test API
- Enabled exec-model if possible. If exec-model fails, disabled. Will raise JIRAs later.
- If tests are more internal unit tests (= doesn't require build), just left them

I'll continue with another JIRAs.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6055

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
