### PR TITLE
[DROOLS-6065] add logs for kiemodules and kiebases creation

### DIFF
--- a/drools-alphanetwork-compiler/src/test/resources/logback-test.xml
+++ b/drools-alphanetwork-compiler/src/test/resources/logback-test.xml
@@ -7,11 +7,11 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <logger name="org.drools.ancompiler" level="info"/>
 
-  <logger name="org.drools" level="info"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-beliefs/src/test/resources/logback-test.xml
+++ b/drools-beliefs/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModuleProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModuleProvider.java
@@ -22,6 +22,8 @@ import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.internal.utils.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface InternalKieModuleProvider {
 
@@ -35,13 +37,17 @@ public interface InternalKieModuleProvider {
 
     class DrlBasedKieModuleProvider implements InternalKieModuleProvider {
 
+        private static final Logger log = LoggerFactory.getLogger( InternalKieModuleProvider.class );
+
         @Override
         public InternalKieModule createKieModule( ReleaseId releaseId, KieModuleModel kieProject, File file ) {
+            log.info( "Creating KieModule for artifact " + releaseId );
             return file.isDirectory() ? new FileKieModule( releaseId, kieProject, file ) : new ZipKieModule( releaseId, kieProject, file );
         }
 
         @Override
         public InternalKieModule createKieModule( ReleaseId releaseId, KieModuleModel kieProject, MemoryFileSystem mfs ) {
+            log.info( "Creating in memory KieModule for artifact " + releaseId );
             return new MemoryKieModule(releaseId, kieProject, mfs);
         }
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModuleProvider.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModuleProvider.java
@@ -41,13 +41,17 @@ public interface InternalKieModuleProvider {
 
         @Override
         public InternalKieModule createKieModule( ReleaseId releaseId, KieModuleModel kieProject, File file ) {
-            log.info( "Creating KieModule for artifact " + releaseId );
+            if (log.isInfoEnabled()) {
+                log.info( "Creating KieModule for artifact " + releaseId );
+            }
             return file.isDirectory() ? new FileKieModule( releaseId, kieProject, file ) : new ZipKieModule( releaseId, kieProject, file );
         }
 
         @Override
         public InternalKieModule createKieModule( ReleaseId releaseId, KieModuleModel kieProject, MemoryFileSystem mfs ) {
-            log.info( "Creating in memory KieModule for artifact " + releaseId );
+            if (log.isInfoEnabled()) {
+                log.info( "Creating in memory KieModule for artifact " + releaseId );
+            }
             return new MemoryKieModule(releaseId, kieProject, mfs);
         }
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -466,6 +466,8 @@ public class KieContainerImpl
     }
 
     private KieBase createKieBase(KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf) {
+        log.info( "Start creation of KieBase: " + kBaseModel.getName() );
+
         InternalKieModule kModule = kieProject.getKieModuleForKBase( kBaseModel.getName() );
         InternalKnowledgeBase kBase = kModule.createKieBase(kBaseModel, kieProject, messages, conf);
         kModule.afterKieBaseCreationUpdate(kBaseModel.getName(), kBase);
@@ -477,6 +479,8 @@ public class KieContainerImpl
         kBase.setContainerId(containerId);
         kBase.setKieContainer(this);
         kBase.initMBeans();
+
+        log.info( "End creation of KieBase: " + kBaseModel.getName() );
 
         return kBase;
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -466,7 +466,9 @@ public class KieContainerImpl
     }
 
     private KieBase createKieBase(KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf) {
-        log.info( "Start creation of KieBase: " + kBaseModel.getName() );
+        if (log.isInfoEnabled()) {
+            log.info( "Start creation of KieBase: " + kBaseModel.getName() );
+        }
 
         InternalKieModule kModule = kieProject.getKieModuleForKBase( kBaseModel.getName() );
         InternalKnowledgeBase kBase = kModule.createKieBase(kBaseModel, kieProject, messages, conf);
@@ -480,7 +482,9 @@ public class KieContainerImpl
         kBase.setKieContainer(this);
         kBase.initMBeans();
 
-        log.info( "End creation of KieBase: " + kBaseModel.getName() );
+        if (log.isInfoEnabled()) {
+            log.info( "End creation of KieBase: " + kBaseModel.getName() );
+        }
 
         return kBase;
     }

--- a/drools-compiler/src/test/resources/logback-test.xml
+++ b/drools-compiler/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   
   <logger name="org.drools.core.management" level="debug"/>
   <!--<logger name="org.drools.ancompiler" level="debug"/>-->

--- a/drools-core/src/test/resources/logback-test.xml
+++ b/drools-core/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-decisiontables/src/test/resources/logback-test.xml
+++ b/drools-decisiontables/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-examples-api/default-kiesession-from-file/src/main/resources/logback.xml
+++ b/drools-examples-api/default-kiesession-from-file/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>

--- a/drools-examples-api/default-kiesession/src/main/resources/logback.xml
+++ b/drools-examples-api/default-kiesession/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>

--- a/drools-examples-api/kie-module-from-multiple-files/src/main/resources/logback.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.drools" level="debug"/>
 
   <root level="warn">

--- a/drools-examples-api/kiebase-inclusion/src/main/resources/logback.xml
+++ b/drools-examples-api/kiebase-inclusion/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="warn">

--- a/drools-examples-api/kiecontainer-from-kierepo/src/main/resources/logback.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="warn">

--- a/drools-examples-api/kiefilesystem-example/src/main/resources/logback.xml
+++ b/drools-examples-api/kiefilesystem-example/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="warn">

--- a/drools-examples-api/kiemodulemodel-example/src/main/resources/logback.xml
+++ b/drools-examples-api/kiemodulemodel-example/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="warn">

--- a/drools-examples-api/multiple-kbases/src/main/resources/logback.xml
+++ b/drools-examples-api/multiple-kbases/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="info">

--- a/drools-examples-api/named-kiesession-from-file/src/main/resources/logback.xml
+++ b/drools-examples-api/named-kiesession-from-file/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.kie" level="info"/>
+    <logger name="org.kie" level="warn"/>
     <logger name="org.jboss.weld" level="info"/>
 
     <root level="info"><!-- TODO We probably want to set default level to warn instead -->

--- a/drools-examples-api/named-kiesession/src/main/resources/logback.xml
+++ b/drools-examples-api/named-kiesession/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>

--- a/drools-examples-api/reactive-kiesession/src/main/resources/logback.xml
+++ b/drools-examples-api/reactive-kiesession/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>

--- a/drools-examples-api/ruleunit/src/main/resources/logback.xml
+++ b/drools-examples-api/ruleunit/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender"/>

--- a/drools-examples-cdi/cdi-example-with-inclusion/src/main/resources/META-INF/logback.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/src/main/resources/META-INF/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="warn">

--- a/drools-examples-cdi/cdi-example/src/main/resources/META-INF/logback.xml
+++ b/drools-examples-cdi/cdi-example/src/main/resources/META-INF/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   <logger name="org.jboss.weld" level="info"/>
 
   <root level="warn">

--- a/drools-examples/src/main/resources/logback.xml
+++ b/drools-examples/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-impact-analysis/drools-impact-analysis-itests/src/test/resources/logback-test.xml
+++ b/drools-impact-analysis/drools-impact-analysis-itests/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-metric/src/test/resources/logback-test.xml
+++ b/drools-metric/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
 <!--   <logger name="org.drools.metric.util.MetricLogUtils" level="trace"/> -->
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleProvider.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleProvider.java
@@ -44,10 +44,14 @@ public class CanonicalKieModuleProvider extends InternalKieModuleProvider.DrlBas
 
     private InternalKieModule createCanonicalKieModule( InternalKieModule internalKieModule ) {
         if (internalKieModule.hasResource(getModelFileWithGAV(internalKieModule.getReleaseId()))) {
-            log.info( "Artifact " + internalKieModule.getReleaseId() + " has executable model");
+            if (log.isInfoEnabled()) {
+                log.info( "Artifact " + internalKieModule.getReleaseId() + " has executable model" );
+            }
             return new CanonicalKieModule(internalKieModule);
         } else {
-            log.info( "No executable model found for artifact " + internalKieModule.getReleaseId() + ". Falling back to resources parsing.");
+            if (log.isInfoEnabled()) {
+                log.info( "No executable model found for artifact " + internalKieModule.getReleaseId() + ". Falling back to resources parsing." );
+            }
             return internalKieModule;
         }
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleProvider.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModuleProvider.java
@@ -23,10 +23,14 @@ import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.InternalKieModuleProvider;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.drools.modelcompiler.CanonicalKieModule.getModelFileWithGAV;
 
 public class CanonicalKieModuleProvider extends InternalKieModuleProvider.DrlBasedKieModuleProvider implements InternalKieModuleProvider {
+
+    private static final Logger log = LoggerFactory.getLogger( CanonicalKieModuleProvider.class );
 
     @Override
     public InternalKieModule createKieModule( ReleaseId releaseId, KieModuleModel kieProject, File file ) {
@@ -40,8 +44,10 @@ public class CanonicalKieModuleProvider extends InternalKieModuleProvider.DrlBas
 
     private InternalKieModule createCanonicalKieModule( InternalKieModule internalKieModule ) {
         if (internalKieModule.hasResource(getModelFileWithGAV(internalKieModule.getReleaseId()))) {
+            log.info( "Artifact " + internalKieModule.getReleaseId() + " has executable model");
             return new CanonicalKieModule(internalKieModule);
         } else {
+            log.info( "No executable model found for artifact " + internalKieModule.getReleaseId() + ". Falling back to resources parsing.");
             return internalKieModule;
         }
     }

--- a/drools-model/drools-model-compiler/src/test/resources/logback-test.xml
+++ b/drools-model/drools-model-compiler/src/test/resources/logback-test.xml
@@ -7,13 +7,13 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <!--<logger name="org.drools.modelcompiler.builder.generator.expressiontyper" level="debug"/>-->
 <!--  <logger name="org.drools.modelcompiler.builder" level="debug"/>-->
   <logger name="org.drools.ancompiler" level="info"/>
 
-  <logger name="org.drools" level="info"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-model/drools-mvel-compiler/src/test/resources/logback-test.xml
+++ b/drools-model/drools-mvel-compiler/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-mvel/src/test/resources/logback-test.xml
+++ b/drools-mvel/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   
   <logger name="org.drools.core.management" level="debug"/>
   <!--<logger name="org.drools.ancompiler" level="debug"/>-->

--- a/drools-persistence/drools-persistence-jpa/src/test/resources/logback-test.xml
+++ b/drools-persistence/drools-persistence-jpa/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/logback-test.xml
@@ -23,8 +23,8 @@
         </encoder>
     </appender>
 
-    <logger name="org.kie" level="info"/>
-    <logger name="org.drools" level="info"/>
+    <logger name="org.kie" level="warn"/>
+    <logger name="org.drools" level="warn"/>
 
     <logger name="org.drools.core.management" level="debug"/>
 <!--    <logger name="org.drools.modelcompiler.builder" level="debug"/>-->

--- a/drools-test-coverage/test-suite/src/test/resources/logback-test.xml
+++ b/drools-test-coverage/test-suite/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
   <!--<logger name="org.drools.modelcompiler.builder" level="debug"/>-->

--- a/drools-traits/src/test/resources/logback-test.xml
+++ b/drools-traits/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
   
   <logger name="org.drools.core.management" level="debug"/>
   <logger name="org.kie.api.internal.utils" level="debug"/>

--- a/kie-ci/src/test/resources/logback-test.xml
+++ b/kie-ci/src/test/resources/logback-test.xml
@@ -7,8 +7,8 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
-  <logger name="org.drools" level="info"/>
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/kie-dmn/kie-dmn-core/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-core/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.kie.dmn.core.compiler.execmodelbased" level="info"/> <!-- useful default when moving generic org.kie to <info -->
   <logger name="org.kie.dmn.feel.codegen" level="info"/> <!-- useful default when moving generic org.kie to <info -->
 

--- a/kie-dmn/kie-dmn-feel/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-feel/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.kie.dmn.feel.codegen" level="info"/> <!-- useful default when moving generic org.kie to <info -->
 
   <root level="warn">

--- a/kie-dmn/kie-dmn-legacy-tests/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-legacy-tests/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.kie.dmn.legacy.tests.core.v1_1" level="info"/> 
   
   <root level="warn">

--- a/kie-dmn/kie-dmn-model/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-model/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/kie-dmn/kie-dmn-openapi/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-openapi/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/kie-dmn/kie-dmn-signavio/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-signavio/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />

--- a/kie-dmn/kie-dmn-validation/src/test/resources/logback.xml
+++ b/kie-dmn/kie-dmn-validation/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.kie.dmn.validation.dtanalysis" level="info"/> 
   <logger name="org.kie.dmn.validation.dtanalysis.mcdc" level="info"/> 
 

--- a/kie-test-util/src/test/resources/logback-test.xml
+++ b/kie-test-util/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie" level="info"/>
+  <logger name="org.kie" level="warn"/>
   <logger name="org.drools" level="debug"/>
 
   <root level="warn">


### PR DESCRIPTION
Example of KieModule/KieBase creation with executble model

```
14:14:58.398 [main] INFO  o.d.c.k.b.i.InternalKieModuleProvider$DrlBasedKieModuleProvider.createKieModule:44 - Creating KieModule for artifact com.provisioning.voip:voip-am-uber:1.0.0-SNAPSHOT
14:14:58.936 [main] INFO  o.d.m.CanonicalKieModuleProvider.createCanonicalKieModule:47 - Artifact com.provisioning.voip:voip-am-uber:1.0.0-SNAPSHOT has executable model
14:15:21.752 [main] INFO  o.d.c.k.b.impl.KieContainerImpl.createKieBase:469 - Start creation of KieBase: defaultKieBase
14:15:27.471 [main] INFO  o.d.c.k.b.impl.KieContainerImpl.createKieBase:483 - End creation of KieBase: defaultKieBase
```

and without it

```
14:02:51.678 [main] INFO  o.d.c.k.b.i.InternalKieModuleProvider$DrlBasedKieModuleProvider.createKieModule:44 - Creating KieModule for artifact com.provisioning.voip:voip-am-uber:2.0.0-SNAPSHOT
14:02:51.919 [main] INFO  o.d.m.CanonicalKieModuleProvider.createCanonicalKieModule:50 - No executable model found for artifact com.provisioning.voip:voip-am-uber:2.0.0-SNAPSHOT. Falling back to resources parsing.
14:03:09.841 [main] INFO  o.d.c.k.b.impl.KieContainerImpl.createKieBase:469 - Start creation of KieBase: defaultKieBase
14:03:27.798 [main] INFO  o.d.c.k.b.impl.KieContainerImpl.createKieBase:483 - End creation of KieBase: defaultKieBase
```