### PR TITLE
[DROOLS-6053] Reduce unnecessary classloading by parent classloader

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -193,9 +194,9 @@ public interface InternalKieModule extends KieModule, Serializable {
         }
     }
 
-    default void updateKieModule(InternalKieModule newKM) {
+    default void updateKieModule(InternalKieModule newKM) {}
 
-    }
+    default void addGeneratedClassPaths(Set<String> classPaths) {}
 
     class CompilationCache implements Serializable {
         private static final long serialVersionUID = 3812243055974412935L;

--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -103,6 +103,14 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
         }
 
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (projectClassLoader.containsInStore(ClassUtils.convertClassToResourcePath(name))) {
+                Class<?> clazz = findLoadedClass(name); // skip parent classloader
+                if (clazz != null) {
+                    return clazz;
+                }
+                // if the class is stored in projectClassLoader, go straight to defineType
+                return projectClassLoader.tryDefineType(name, null);
+            }
             try {
                 return loadType(name, resolve);
             } catch (ClassNotFoundException cnfe) {

--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -126,6 +126,10 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
             return super.loadClass(name, resolve);
         }
 
+        public Class<?> findLoadedClassWithoutParent( String name ) {
+            return findLoadedClass(name);
+        }
+
         @Override
         public URL getResource(String name) {
             return projectClassLoader.getResource(name);

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -122,11 +122,18 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         if (cls != null) {
             return cls;
         }
-        try {
-            cls = internalLoadClass(name, resolve);
-        } catch (ClassNotFoundException e2) {
+
+        if (containsInStore(ClassUtils.convertClassToResourcePath(name))) {
+            Class<?> clazz = findLoadedClass(name); // skip parent classloader
+            if (clazz != null) {
+                return clazz;
+            }
+            // if the class is stored in projectClassLoader, go straight to defineType
             cls = loadType(name, resolve);
+        } else {
+            cls = internalLoadClass(name, resolve);
         }
+
         loadedClasses.put(name, cls);
         return cls;
     }
@@ -145,7 +152,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         try {
             return super.loadClass(name, resolve);
         } catch (ClassNotFoundException e) {
-            return Class.forName(name, resolve, getParent());
+            try {
+                return Class.forName(name, resolve, getParent());
+            } catch (ClassNotFoundException e1) {
+                if (CACHE_NON_EXISTING_CLASSES) {
+                    nonExistingClasses.add(name);
+                }
+                throw e1;
+            }
         }
     }
 
@@ -329,6 +343,10 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
 
     public byte[] getBytecode(String resourceName) {
         return store == null ? null : store.get(resourceName);
+    }
+
+    public boolean containsInStore(String resourceName) {
+        return store == null ? false : store.containsKey(resourceName);
     }
 
     @Override

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -128,8 +128,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
             if (clazz != null) {
                 return clazz;
             }
+            if (typesClassLoader != null) {
+                clazz = typesClassLoader.findLoadedClassWithoutParent(name);
+                if (clazz != null) {
+                    return clazz;
+                }
+            }
             // if the class is stored in projectClassLoader, go straight to defineType
-            cls = loadType(name, resolve);
+            cls = tryDefineType(name, null);
         } else {
             cls = internalLoadClass(name, resolve);
         }
@@ -161,18 +167,6 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
                 throw e1;
             }
         }
-    }
-
-    private Class<?> loadType(String name, boolean resolve) throws ClassNotFoundException {
-        ClassNotFoundException cnfe = null;
-        if (typesClassLoader != null) {
-            try {
-                return typesClassLoader.loadType(name, resolve);
-            } catch (ClassNotFoundException e) {
-                cnfe = e;
-            }
-        }
-        return tryDefineType(name, cnfe);
     }
 
     // This method has to be public because is also used by the android ClassLoader
@@ -406,6 +400,7 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
     public interface InternalTypesClassLoader extends KieTypeResolver {
         Class<?> defineClass( String name, byte[] bytecode );
         Class<?> loadType( String name, boolean resolve ) throws ClassNotFoundException;
+        Class<?> findLoadedClassWithoutParent( String name );
     }
 
     public synchronized List<String> reinitTypes() {


### PR DESCRIPTION
This time:
- at `ProjectClassLoader.storeClass()`, firstly check if the class is found in parent classloader. If found, don't store the class.
- In case of exec-model, collect class resource paths of generated classes during `CanonicalModelKieProject.writeProjectOutput()`.  Then, for generated classes, skip the parent classloader check at  `ProjectClassLoader.storeClass()`

- Note: This "skip" is only available when you build exec-model in the same process. In case of kjar loading, we will need to add metadata in kjar.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6053

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
