### PR TITLE
DROOLS-6084 DMN maintenance corners JP usage in -feel

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.antlr.v4.runtime.CommonToken;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMessage;
@@ -55,6 +53,9 @@ import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.kie.dmn.model.api.DMNElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 
 public class DMNFEELHelper {
 
@@ -300,7 +301,7 @@ public class DMNFEELHelper {
 
     public ClassOrInterfaceDeclaration generateFeelExpressionSource(String input, CompilerContext compilerContext1) {
 
-        CompilationUnit compilationUnit = ((FEELImpl) feel).generateExpressionSource(input, compilerContext1);
+        CompilationUnit compilationUnit = ((FEELImpl) feel).compileExpression(input, compilerContext1).getSourceCode();
         return compilationUnit.getType(0)
                 .asClassOrInterfaceDeclaration()
                 .setStatic(true);

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.github.javaparser.ast.CompilationUnit;
 import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
 import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
@@ -112,12 +111,12 @@ public class FEELImpl
                 profiles).getResult();
     }
 
-    public CompilationUnit generateExpressionSource(String expression, CompilerContext ctx) {
+    public ProcessedExpression compileExpression(String expression, CompilerContext ctx) {
         return new ProcessedExpression(
                 expression,
                 ctx,
                 ProcessedFEELUnit.DefaultMode.of(doCompile || ctx.isDoCompile()),
-                profiles).getSourceCode();
+                profiles);
     }
 
     @Override


### PR DESCRIPTION
Corners JavaParser usages in kie-dmn-feel

Carve out from `org.kie.dmn.feel.lang.impl`
To be used only in the related package: `org.kie.dmn.feel.codegen.feel11`
being related to codegen

**JIRA**: https://issues.redhat.com/browse/DROOLS-6084

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
