### PR TITLE
[DROOLS-6053] Reduce unnecessary classloading by parent classloader

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -193,9 +194,9 @@ public interface InternalKieModule extends KieModule, Serializable {
         }
     }
 
-    default void updateKieModule(InternalKieModule newKM) {
+    default void updateKieModule(InternalKieModule newKM) {}
 
-    }
+    default void addGeneratedClassNames(Set<String> classNames) {}
 
     class CompilationCache implements Serializable {
         private static final long serialVersionUID = 3812243055974412935L;

--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -103,6 +103,14 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
         }
 
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (projectClassLoader.containsInStore(ClassUtils.convertClassToResourcePath(name))) {
+                Class<?> clazz = findLoadedClass(name); // skip parent classloader
+                if (clazz != null) {
+                    return clazz;
+                }
+                // if the class is stored in projectClassLoader, go straight to defineType
+                return projectClassLoader.tryDefineType(name, null);
+            }
             try {
                 return loadType(name, resolve);
             } catch (ClassNotFoundException cnfe) {

--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -103,12 +103,12 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
         }
 
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-            if (projectClassLoader.containsInStore(ClassUtils.convertClassToResourcePath(name))) {
+            if (projectClassLoader.getGeneratedClassNames().contains(name)) {
                 Class<?> clazz = findLoadedClass(name); // skip parent classloader
                 if (clazz != null) {
                     return clazz;
                 }
-                // if the class is stored in projectClassLoader, go straight to defineType
+                // if generated class, go straight to defineType
                 return projectClassLoader.tryDefineType(name, null);
             }
             try {

--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -126,6 +126,10 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
             return super.loadClass(name, resolve);
         }
 
+        public Class<?> findLoadedClassWithoutParent( String name ) {
+            return findLoadedClass(name);
+        }
+
         @Override
         public URL getResource(String name) {
             return projectClassLoader.getResource(name);

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -122,11 +122,18 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         if (cls != null) {
             return cls;
         }
-        try {
-            cls = internalLoadClass(name, resolve);
-        } catch (ClassNotFoundException e2) {
+
+        if (containsInStore(ClassUtils.convertClassToResourcePath(name))) {
+            Class<?> clazz = findLoadedClass(name); // skip parent classloader
+            if (clazz != null) {
+                return clazz;
+            }
+            // if the class is stored in projectClassLoader, go straight to defineType
             cls = loadType(name, resolve);
+        } else {
+            cls = internalLoadClass(name, resolve);
         }
+
         loadedClasses.put(name, cls);
         return cls;
     }
@@ -145,7 +152,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         try {
             return super.loadClass(name, resolve);
         } catch (ClassNotFoundException e) {
-            return Class.forName(name, resolve, getParent());
+            try {
+                return Class.forName(name, resolve, getParent());
+            } catch (ClassNotFoundException e1) {
+                if (CACHE_NON_EXISTING_CLASSES) {
+                    nonExistingClasses.add(name);
+                }
+                throw e1;
+            }
         }
     }
 
@@ -329,6 +343,10 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
 
     public byte[] getBytecode(String resourceName) {
         return store == null ? null : store.get(resourceName);
+    }
+
+    public boolean containsInStore(String resourceName) {
+        return store == null ? false : store.containsKey(resourceName);
     }
 
     @Override

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -128,8 +128,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
             if (clazz != null) {
                 return clazz;
             }
+            if (typesClassLoader != null) {
+                clazz = typesClassLoader.findLoadedClassWithoutParent(name);
+                if (clazz != null) {
+                    return clazz;
+                }
+            }
             // if the class is stored in projectClassLoader, go straight to defineType
-            cls = loadType(name, resolve);
+            cls = tryDefineType(name, null);
         } else {
             cls = internalLoadClass(name, resolve);
         }
@@ -161,18 +167,6 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
                 throw e1;
             }
         }
-    }
-
-    private Class<?> loadType(String name, boolean resolve) throws ClassNotFoundException {
-        ClassNotFoundException cnfe = null;
-        if (typesClassLoader != null) {
-            try {
-                return typesClassLoader.loadType(name, resolve);
-            } catch (ClassNotFoundException e) {
-                cnfe = e;
-            }
-        }
-        return tryDefineType(name, cnfe);
     }
 
     // This method has to be public because is also used by the android ClassLoader
@@ -406,6 +400,7 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
     public interface InternalTypesClassLoader extends KieTypeResolver {
         Class<?> defineClass( String name, byte[] bytecode );
         Class<?> loadType( String name, boolean resolve ) throws ClassNotFoundException;
+        Class<?> findLoadedClassWithoutParent( String name );
     }
 
     public synchronized List<String> reinitTypes() {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/CanonicalKieModule.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -97,7 +98,6 @@ import org.kie.internal.builder.conf.AlphaNetworkCompilerOption;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-
 import static org.drools.compiler.kie.builder.impl.AbstractKieModule.checkStreamMode;
 import static org.drools.model.impl.ModelComponent.areEqualInModel;
 import static org.drools.modelcompiler.builder.ModelSourceClass.getProjectModelClassNameNameWithReleaseId;
@@ -122,6 +122,7 @@ public class CanonicalKieModule implements InternalKieModule {
     private final Map<String, Model> models = new HashMap<>();
     private Collection<String> ruleClassesNames;
     private boolean incrementalUpdate = false;
+    private Set<String> generatedClassNames = new HashSet<>();
 
     private ProjectClassLoader moduleClassLoader;
 
@@ -197,6 +198,11 @@ public class CanonicalKieModule implements InternalKieModule {
     @Override
     public Map<String, byte[]> getClassesMap() {
         return internalKieModule.getClassesMap();
+    }
+
+    @Override
+    public void addGeneratedClassNames(Set<String> classNames) {
+        generatedClassNames.addAll(classNames);
     }
 
     @Override
@@ -372,6 +378,7 @@ public class CanonicalKieModule implements InternalKieModule {
         if (moduleClassLoader == null) {
             moduleClassLoader = createModuleClassLoader(null);
             moduleClassLoader.storeClasses(getClassesMap());
+            moduleClassLoader.setGeneratedClassNames(generatedClassNames);
         }
         return moduleClassLoader;
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelKieProject.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelKieProject.java
@@ -16,23 +16,27 @@
 
 package org.drools.modelcompiler.builder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
-import org.drools.compiler.kie.builder.impl.CompilationProblemAdapter;
 import org.drools.compiler.compiler.io.File;
 import org.drools.compiler.compiler.io.memory.MemoryFile;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.kie.builder.impl.CompilationProblemAdapter;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
 import org.drools.compiler.kie.builder.impl.ResultsImpl;
 import org.drools.compiler.kproject.models.KieBaseModelImpl;
+import org.drools.core.util.ClassUtils;
 import org.drools.modelcompiler.CanonicalKieModule;
 import org.kie.api.builder.Message;
 import org.kie.internal.builder.KnowledgeBuilder;
@@ -40,7 +44,6 @@ import org.kie.memorycompiler.CompilationProblem;
 import org.kie.memorycompiler.CompilationResult;
 
 import static java.util.stream.Collectors.groupingBy;
-
 import static org.drools.modelcompiler.builder.JavaParserCompiler.getCompiler;
 
 public class CanonicalModelKieProject extends KieModuleKieProject {
@@ -95,6 +98,8 @@ public class CanonicalModelKieProject extends KieModuleKieProject {
         srcMfs.write(projectSourcePath, modelSourceClass.generate().getBytes());
         sourceFiles.add( projectSourcePath );
 
+        Set<String> origFileNames = new HashSet<>(trgMfs.getFileNames());
+
         String[] sources = sourceFiles.toArray(new String[sourceFiles.size()]);
         if (sources.length != 0) {
             CompilationResult res = getCompiler().compile(sources, srcMfs, trgMfs, getClassLoader());
@@ -113,6 +118,11 @@ public class CanonicalModelKieProject extends KieModuleKieProject {
                 messages.addMessage(new CompilationProblemAdapter(problem));
             }
         }
+
+        Set<String> generatedClassPaths = new HashSet<>(trgMfs.getFileNames());
+        generatedClassPaths.removeAll(origFileNames);
+        Set<String> generatedClassNames = generatedClassPaths.stream().map(path -> ClassUtils.convertResourceToClassName(path)).collect(Collectors.toSet());
+        kieModule.addGeneratedClassNames(generatedClassNames);
 
         modelWriter.writeModelFile(modelFiles, trgMfs, getInternalKieModule().getReleaseId());
     }


### PR DESCRIPTION
This version:

- In case of exec-model, collect generated class names during `CanonicalModelKieProject.writeProjectOutput()`. Then, store the generated class names to `ProjectClassloader.generatedClassNames`.
- At `ProjectClassloader.loadClass()` and `DynamicProjectClassLoader$DefaultInternalTypesClassLoader.loadClass()`, if it's a generated class name, go straight to `tryDefineType()`.
- Note: This "skip" is only available when you build exec-model in the same process. In case of kjar loading, we will need to add metadata in kjar.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6053

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
