### PR TITLE
[DROOLS-6074] Enable exec-model for moved tests in drools-test-covera…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/TestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/TestUtil.java
@@ -16,19 +16,19 @@
 
 package org.drools.mvel.compiler;
 
-import org.drools.compiler.kie.builder.impl.DrlProject;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieFileSystem;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.Results;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestUtil {
 
-    public static void assertDrlHasCompilationError( String str, int errorNr ) {
-        KieServices ks = KieServices.Factory.get();
-        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", str );
-        org.kie.api.builder.Results results = ks.newKieBuilder( kfs ).buildAll( DrlProject.class).getResults();
+    public static void assertDrlHasCompilationError( String str, int errorNr, KieBaseTestConfiguration kieBaseTestConfiguration ) {
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
+        Results results = kieBuilder.getResults();
         if ( errorNr > 0 ) {
             assertEquals( errorNr, results.getMessages().size() );
         } else {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireChannelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireChannelTest.java
@@ -60,6 +60,8 @@ public class WireChannelTest {
     
     @Test
     public void testWireChannel() throws Exception {
+        channelMessages.clear();
+
         KieServices ks = KieServices.Factory.get();
 
         ReleaseId releaseId = ks.newReleaseId("org.kie", "listener-test", "1.0");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireListenerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/WireListenerTest.java
@@ -65,6 +65,10 @@ public class WireListenerTest {
 
     @Test
     public void testWireListener() throws Exception {
+        insertEvents.clear();
+        updateEvents.clear();
+        retractEvents.clear();
+
         KieServices ks = KieServices.Factory.get();
 
         ReleaseId releaseId = ks.newReleaseId("org.kie", "listener-test", "1.0");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/oopath/OOPathTest.java
@@ -1028,7 +1028,7 @@ public class OOPathTest {
                 "  duplicateNames.add( $ic1.getName() );\n" +
                 "end\n";
 
-        assertDrlHasCompilationError( drl, 1 );
+        assertDrlHasCompilationError( drl, 1, kieBaseTestConfiguration );
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieContainerTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieContainerTest.java
@@ -30,7 +30,6 @@ import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.compiler.kie.builder.impl.MemoryKieModule;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.drools.core.impl.InternalKieContainer;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
@@ -55,7 +54,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
-public class KieContainerTest extends CommonTestMethodBase {
+public class KieContainerTest {
 
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
 
@@ -99,6 +98,11 @@ public class KieContainerTest extends CommonTestMethodBase {
     public void testReleaseIdGetters() {
         KieServices ks = KieServices.Factory.get();
         ReleaseId releaseId = ks.newReleaseId("org.kie", "test-delete-v", "1.0.1");
+        ReleaseId newReleaseId = ks.newReleaseId("org.kie", "test-delete-v", "1.0.2");
+
+        ks.getRepository().removeKieModule(releaseId);
+        ks.getRepository().removeKieModule(newReleaseId);
+
         KieUtil.getKieModuleFromDrls(releaseId, kieBaseTestConfiguration, createDRL("ruleA"));
 
         ReleaseId configuredReleaseId = ks.newReleaseId("org.kie", "test-delete-v", "RELEASE");
@@ -110,8 +114,7 @@ public class KieContainerTest extends CommonTestMethodBase {
         assertEquals(releaseId, iKieContainer.getReleaseId());
         // demonstrate internal API behavior, in the future shall this be enforced?
         assertEquals(configuredReleaseId, iKieContainer.getContainerReleaseId());
-        
-        ReleaseId newReleaseId = ks.newReleaseId("org.kie", "test-delete-v", "1.0.2");
+
         KieUtil.getKieModuleFromDrls(newReleaseId, kieBaseTestConfiguration, createDRL("ruleA"));
         iKieContainer.updateToVersion(newReleaseId);
         

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieRuntimeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieRuntimeTest.java
@@ -17,13 +17,32 @@
 package org.drools.mvel.integrationtests;
 
 import java.io.IOException;
+import java.util.Collection;
+
 import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Message;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
+@RunWith(Parameterized.class)
 public class KieRuntimeTest extends CommonTestMethodBase {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieRuntimeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testKieRuntimeAccess() throws IOException, ClassNotFoundException {
@@ -37,9 +56,8 @@ public class KieRuntimeTest extends CommonTestMethodBase {
         str += "    System.out.println( drools.getKieRuntime() );\n";
         str += "end\n";
 
-        KieBase kbase = loadKnowledgeBaseFromString( str );
-        kbase = SerializationHelper.serializeObject( kbase );
-        final KieSession ksession = createKnowledgeSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         ksession.insert( new Message( "help" ) );
         ksession.fireAllRules();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieServicesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieServicesTest.java
@@ -1,19 +1,38 @@
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
+
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieServicesImpl;
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieModule;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieContainer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class KieServicesTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class KieServicesTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public KieServicesTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 	
 	private KieServices ks;
 
@@ -61,8 +80,8 @@ public class KieServicesTest extends CommonTestMethodBase {
 	@Test
 	public void testNewKieContainerIDs() {
 		ReleaseId releaseId = ks.newReleaseId("org.kie", "test-delete", "1.0.0");
-        createAndDeployJar( ks, releaseId, createDRL("ruleA") );
-        
+        KieModule km = KieUtil.getKieModuleFromDrls(releaseId, kieBaseTestConfiguration, createDRL("ruleA"));
+
 		KieContainer c1 = ks.newKieContainer("id1", releaseId);
 		KieContainer c2 = ks.newKieClasspathContainer("id2");
 		try {
@@ -82,8 +101,8 @@ public class KieServicesTest extends CommonTestMethodBase {
 	@Test
 	public void testDisposeClearTheIDReference() {
 		ReleaseId releaseId = ks.newReleaseId("org.kie", "test-delete", "1.0.0");
-        createAndDeployJar( ks, releaseId, createDRL("ruleA") );
-        
+        KieModule km = KieUtil.getKieModuleFromDrls(releaseId, kieBaseTestConfiguration, createDRL("ruleA"));
+
 		KieContainer c1 = ks.newKieContainer("id1", releaseId);
 		try {
 			ks.newKieClasspathContainer("id1");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieSessionIterationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieSessionIterationTest.java
@@ -15,7 +15,9 @@
  */
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,15 +25,12 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import static org.junit.Assert.assertTrue;
 
 /**
  * Tests iteration through the list of KieSessions of a KieBase.
  */
-public class KieSessionIterationTest extends CommonTestMethodBase {
+public class KieSessionIterationTest {
 
     private KieBase kieBase;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LifecycleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/LifecycleTest.java
@@ -15,12 +15,18 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import org.drools.mvel.compiler.StockTick;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -40,7 +46,19 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests updating events using API.
  */
+@RunWith(Parameterized.class)
 public class LifecycleTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public LifecycleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     private KieSession kieSession;
     
@@ -74,11 +92,11 @@ public class LifecycleTest {
         
         kfs.writeKModuleXML(kmoduleModel.toXML());
         
-        KieBuilder builder = ks.newKieBuilder(kfs).buildAll();
-        assertEquals(0, builder.getResults().getMessages().size());
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
+        assertEquals(0, kieBuilder.getResults().getMessages().size());
 
         this.kieSession = ks.newKieContainer(ks.getRepository()
-                .getDefaultReleaseId()).newKieSession();        
+                .getDefaultReleaseId()).newKieSession();
     }
 
     @After

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ListenersTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ListenersTest.java
@@ -16,9 +16,17 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -36,16 +44,25 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.StatelessKieSession;
 import org.kie.internal.io.ResourceFactory;
 
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Tests stateful/stateless KieSession listeners registration - DROOLS-818.
  */
+@RunWith(Parameterized.class)
 public class ListenersTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ListenersTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     private static final ReleaseId RELEASE_ID = KieServices.Factory.get()
             .newReleaseId("org.drools.mvel.compiler.test", "listeners-test", "1.0.0");
@@ -156,7 +173,7 @@ public class ListenersTest {
         kfs.write("src/main/resources/" + PACKAGE_PATH + "/test.drl",
                 ResourceFactory.newByteArrayResource(DRL.getBytes()));
 
-        KieBuilder builder = ks.newKieBuilder(kfs).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         assertEquals("Unexpected compilation errors", 0, builder.getResults().getMessages().size());
 
         ks.getRepository().addKieModule(builder.getKieModule());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MessageImplTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MessageImplTest.java
@@ -15,7 +15,14 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
@@ -23,12 +30,24 @@ import org.kie.api.builder.Results;
 import org.kie.internal.builder.IncrementalResults;
 import org.kie.internal.builder.InternalKieBuilder;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for MessageImpl
  */
+@RunWith(Parameterized.class)
 public class MessageImplTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public MessageImplTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     //See DROOLS-193 (KnowledgeBuilderResult does not always contain a Resource)
@@ -50,7 +69,7 @@ public class MessageImplTest {
                 .write( "src/main/resources/dsl.dsl", dsl )
                 .write( "src/main/resources/drl.dslr", drl );
 
-        KieBuilder kieBuilder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         Results results = kieBuilder.getResults();
 
         assertEquals( 3,
@@ -82,7 +101,7 @@ public class MessageImplTest {
                 .write( "src/main/resources/dsl.dsl", dsl1 )
                 .write( "src/main/resources/drl.dslr", drl1 );
 
-        KieBuilder kieBuilder = ks.newKieBuilder( kfs ).buildAll();
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         Results fullBuildResults = kieBuilder.getResults();
         assertEquals( 3,
                       fullBuildResults.getMessages().size() );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullTest.java
@@ -18,17 +18,22 @@ package org.drools.mvel.integrationtests;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.impl.KnowledgeBaseFactory;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Attribute;
+import org.drools.mvel.compiler.Cheese;
 import org.drools.mvel.compiler.Message;
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.compiler.PersonInterface;
 import org.drools.mvel.compiler.Primitives;
-import org.drools.mvel.compiler.Cheese;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieBaseConfiguration;
 import org.kie.api.conf.EqualityBehaviorOption;
@@ -37,12 +42,25 @@ import org.kie.api.runtime.KieSession;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class NullTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class NullTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public NullTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testNullValuesIndexing() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_NullValuesIndexing.drl"));
-        final KieSession ksession = kbase.newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_NullValuesIndexing.drl");
+        KieSession ksession = kbase.newKieSession();
 
         // Adding person with null name and likes attributes
         final PersonInterface bob = new Person(null, null);
@@ -60,7 +78,7 @@ public class NullTest extends CommonTestMethodBase {
 
     @Test
     public void testNullBehaviour() throws Exception {
-        final KieBase kbase = loadKnowledgeBase("null_behaviour.drl");
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "null_behaviour.drl");
         KieSession session = kbase.newKieSession();
 
         final PersonInterface p1 = new Person("michael", "food", 40);
@@ -74,7 +92,7 @@ public class NullTest extends CommonTestMethodBase {
 
     @Test
     public void testNullConstraint() throws Exception {
-        final KieBase kbase = loadKnowledgeBase("null_constraint.drl");
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "null_constraint.drl");
         KieSession session = kbase.newKieSession();
 
         final List foo = new ArrayList();
@@ -94,8 +112,8 @@ public class NullTest extends CommonTestMethodBase {
 
     @Test
     public void testNullBinding() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_nullBindings.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_nullBindings.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List list = new ArrayList();
         ksession.setGlobal("results", list);
@@ -119,8 +137,8 @@ public class NullTest extends CommonTestMethodBase {
                 "then\n" +
                 "end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
-        final KieSession ksession = kbase.newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         ksession.insert(new Person(null));
         ksession.insert(new Person("Mark"));
@@ -131,9 +149,9 @@ public class NullTest extends CommonTestMethodBase {
 
     @Test
     public void testNullFieldOnCompositeSink() throws Exception {
-        final KieBase kbase = loadKnowledgeBase("test_NullFieldOnCompositeSink.drl");
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_NullFieldOnCompositeSink.drl");
+        KieSession ksession = kbase.newKieSession();
 
-        KieSession ksession = createKnowledgeSession(kbase);
         final List list = new ArrayList();
         ksession.setGlobal("list", list);
 
@@ -148,8 +166,8 @@ public class NullTest extends CommonTestMethodBase {
 
     @Test
     public void testNullHandling() throws Exception {
-        final KieBase kbase = loadKnowledgeBase("test_NullHandling.drl");
-        KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_NullHandling.drl");
+        KieSession session = kbase.newKieSession();
 
         final List list = new ArrayList();
         session.setGlobal("list", list);
@@ -180,8 +198,8 @@ public class NullTest extends CommonTestMethodBase {
 
     @Test
     public void testNullHashing() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_NullHashing.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_NullHashing.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List results = new ArrayList();
         ksession.setGlobal("results", results);
@@ -222,11 +240,9 @@ public class NullTest extends CommonTestMethodBase {
                 "  list.add( \"OK\" ); \n" +
                 "end";
 
-        final KieBaseConfiguration kbConf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
-        kbConf.setOption(EqualityBehaviorOption.EQUALITY);
-
-        final KieBase kbase = loadKnowledgeBaseFromString(kbConf, str);
-        final KieSession ksession = kbase.newKieSession();
+        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         final java.util.List list = new java.util.ArrayList();
         ksession.setGlobal("list", list);
@@ -246,8 +262,8 @@ public class NullTest extends CommonTestMethodBase {
                 "then\n" +
                 "end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
-        final KieSession ksession = kbase.newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         ksession.insert(new PrimitiveBean(0.9, 1.1));
         ksession.insert(new PrimitiveBean(0.9, null));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ObjectTypeNodeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ObjectTypeNodeTest.java
@@ -16,12 +16,30 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
-public class ObjectTypeNodeTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class ObjectTypeNodeTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ObjectTypeNodeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testDeterministicOTNOrdering() throws Exception {
@@ -73,8 +91,7 @@ public class ObjectTypeNodeTest extends CommonTestMethodBase {
                         "   modify($criteria) { setProcessed(true) }\n" +
                         "end";
 
-        KieBase kbase = loadKnowledgeBaseFromString(str);
-        kbase = SerializationHelper.serializeObject(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         KieSession ksession = kbase.newKieSession();
 
         ksession.fireAllRules();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelBuildTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelBuildTest.java
@@ -16,17 +16,35 @@
 
 package org.drools.mvel.integrationtests;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.Message;
 
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
 public class ParallelBuildTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ParallelBuildTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     private final List<Class<?>> classes = Arrays.asList(
             java.util.List.class,
@@ -45,8 +63,6 @@ public class ParallelBuildTest {
 
     @Test
     public void testParallelBuild() {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-
         StringBuilder sb = new StringBuilder();
         int rc = 0;
         for (Class<?> c : classes) {
@@ -59,7 +75,9 @@ public class ParallelBuildTest {
             sb.append("\n");
         }
 
-        kbuilder.add(ResourceFactory.newByteArrayResource(sb.toString().getBytes(StandardCharsets.UTF_8)), ResourceType.DRL);
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, sb.toString());
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertTrue(errors.toString(), errors.isEmpty());
     }
 
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelCompilationTest.java
@@ -15,33 +15,44 @@
 
 package org.drools.mvel.integrationtests;
 
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.io.Resource;
-import org.kie.api.io.ResourceType;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderConfiguration;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 
+@RunWith(Parameterized.class)
 public class ParallelCompilationTest {
+
     private static final int PARALLEL_THREADS = 5;
     private static final String DRL_FILE = "parallel_compilation.drl";
 
     private ExecutorService executor;
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ParallelCompilationTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -55,7 +66,7 @@ public class ParallelCompilationTest {
 
     @Test(timeout=10000)
     public void testConcurrentRuleAdditions() throws Exception {
-        parallelExecute(BuildExecutor.getSolvers());
+        parallelExecute(BuildExecutor.getSolvers(kieBaseTestConfiguration));
     }
 
     private void parallelExecute(Collection<Callable<KieBase>> solvers) throws Exception {
@@ -70,32 +81,26 @@ public class ParallelCompilationTest {
 
     public static class BuildExecutor implements Callable<KieBase> {
 
+        private KieBaseTestConfiguration myKieBaseTestConfiguration;
+
+        public BuildExecutor(KieBaseTestConfiguration kieBaseTestConfiguration) {
+            this.myKieBaseTestConfiguration = kieBaseTestConfiguration;
+        }
+
         public KieBase call() throws Exception {
-            final Reader source = new InputStreamReader(ParallelCompilationTest.class.getResourceAsStream(DRL_FILE));
-
-            final Properties props = new Properties();
-            props.setProperty("drools.dialect.java.compiler.lnglevel", "1.6");
-            KieBase result;
-
-            final KnowledgeBuilderConfiguration configuration = KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration(props, ParallelCompilationTest.class.getClass().getClassLoader());
-            final KnowledgeBuilder builder = KnowledgeBuilderFactory.newKnowledgeBuilder(configuration);
-
             Thread.sleep(Math.round(Math.random()*250));
 
-            Resource newReaderResource = ResourceFactory.newReaderResource(source);
-            //synchronized (RuleUtil.class)
-            {
-                builder.add(newReaderResource, ResourceType.DRL);
-            }
-            result = builder.newKieBase();
+            Map<String, String> kieModuleConfigurationProperties = new HashMap<>();
+            kieModuleConfigurationProperties.put("drools.dialect.java.compiler.lnglevel", "1.6");
+            KieBase result = KieBaseUtil.getKieBaseFromClasspathResourcesWithClassLoaderForKieBuilder("test", getClass(), ParallelCompilationTest.class.getClass().getClassLoader(), myKieBaseTestConfiguration, kieModuleConfigurationProperties, DRL_FILE);
 
             return result;
         }
 
-        public static Collection<Callable<KieBase>> getSolvers() {
+        public static Collection<Callable<KieBase>> getSolvers(KieBaseTestConfiguration kieBaseTestConfiguration) {
             Collection<Callable<KieBase>> solvers = new ArrayList<Callable<KieBase>>();
             for (int i = 0; i < PARALLEL_THREADS; ++i) {
-                solvers.add(new BuildExecutor());
+                solvers.add(new BuildExecutor(kieBaseTestConfiguration));
             }
             return solvers;
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
@@ -18,6 +18,7 @@ package org.drools.mvel.integrationtests;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -29,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.drools.mvel.compiler.util.debug.DebugList;
 import org.drools.core.ClockType;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.common.InternalWorkingMemory;
@@ -41,24 +41,42 @@ import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.rule.EntryPointId;
 import org.drools.core.time.impl.PseudoClockScheduler;
+import org.drools.mvel.compiler.util.debug.DebugList;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.conf.EventProcessingOption;
-import org.kie.api.io.ResourceType;
+import org.kie.api.builder.KieModule;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.conf.MultithreadEvaluationOption;
-import org.kie.internal.utils.KieHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class ParallelEvaluationTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ParallelEvaluationTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test(timeout = 40000L)
     public void test() {
@@ -68,8 +86,8 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "" ) );
         }
 
-        KieBase kbase = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                       .build( MultithreadEvaluationOption.YES );
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         EntryPointNode epn = ((InternalKnowledgeBase) kbase).getRete().getEntryPointNode( EntryPointId.DEFAULT );
         ObjectTypeNode otn = epn.getObjectTypeNodes().get( new ClassObjectType( Integer.class ) );
@@ -101,9 +119,9 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "insert( $i + 10 );\ninsert( \"\" + ($i + 10) );\n" ) );
         }
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -131,9 +149,9 @@ public class ParallelEvaluationTest {
             sb.append( getNotRule( i ) );
         }
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -160,9 +178,9 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "insertAsync( $i + 10 );\ninsertAsync( \"\" + ($i + 10) );\n" ) );
         }
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -212,9 +230,9 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "" ) );
         }
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -264,8 +282,8 @@ public class ParallelEvaluationTest {
             drl += getFireUntilHaltRule(fireNr, i);
         }
 
-        KieBase kbase = new KieHelper().addContent( drl, ResourceType.DRL )
-                                       .build( MultithreadEvaluationOption.YES );
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         for (int loop = 0; loop < 10; loop++) {
             System.out.println("Starting loop " + loop);
@@ -359,9 +377,9 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "" ) );
         }
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -412,9 +430,9 @@ public class ParallelEvaluationTest {
                 "    String( length < $i )\n" +
                 "then end \n";
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         InternalWorkingMemory session = (InternalWorkingMemory) ksession;
 
@@ -435,9 +453,10 @@ public class ParallelEvaluationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( EventProcessingOption.STREAM, MultithreadEvaluationOption.YES )
-                                             .newKieSession( sessionConfig, null );
+        kieBaseTestConfiguration.setStreamMode(true);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -477,9 +496,10 @@ public class ParallelEvaluationTest {
 
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( EventProcessingOption.STREAM, MultithreadEvaluationOption.YES )
-                                             .newKieSession( sessionConfig, null );
+        kieBaseTestConfiguration.setStreamMode(true);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -554,9 +574,10 @@ public class ParallelEvaluationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( EventProcessingOption.STREAM, MultithreadEvaluationOption.YES )
-                                             .newKieSession( sessionConfig, null );
+        kieBaseTestConfiguration.setStreamMode(true);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -663,9 +684,10 @@ public class ParallelEvaluationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        KieSession ksession = new KieHelper().addContent( drl, ResourceType.DRL )
-                                             .build( EventProcessingOption.STREAM, MultithreadEvaluationOption.YES )
-                                             .newKieSession( sessionConfig, null );
+        kieBaseTestConfiguration.setStreamMode(true);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         try {
             assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
@@ -703,9 +725,9 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "" ) );
         }
 
-        KieSession ksession = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                             .build( MultithreadEvaluationOption.YES )
-                                             .newKieSession();
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieSession ksession = kbase.newKieSession();
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
 
@@ -745,8 +767,8 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "", "agenda-group \"agenda\"" ) );
         }
 
-        KieBase kbase = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                       .build( MultithreadEvaluationOption.YES );
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         KieSession ksession = kbase.newKieSession();
 
@@ -774,8 +796,8 @@ public class ParallelEvaluationTest {
             sb.append( getRule( i, "", "salience " + i ) );
         }
 
-        KieBase kbase = new KieHelper().addContent( sb.toString(), ResourceType.DRL )
-                                       .build( MultithreadEvaluationOption.YES );
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         KieSession ksession = kbase.newKieSession();
 
@@ -808,8 +830,9 @@ public class ParallelEvaluationTest {
         for (int i = 0; i < ruleNr; i++) {
             sb.append(getRule(i, "insert( $i + 10 );\ninsert( \"\" + ($i + 10) );\n"));
         }
-        KieBase kBase = new KieHelper().addContent(sb.toString(), ResourceType.DRL)
-                .build(MultithreadEvaluationOption.YES);
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         /* Create parallel tasks */
         List<Callable<Void>> tasks = new ArrayList<>();
@@ -849,8 +872,9 @@ public class ParallelEvaluationTest {
         for (int i = 0; i < 10; i++) {
             sb.append( getRule( i, "" ) );
         }
-        KieBase kBase = new KieHelper().addContent(sb.toString(), ResourceType.DRL)
-                .build(MultithreadEvaluationOption.YES);
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kBase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         /* Create parallel tasks */
         List<Callable<Void>> tasks = new ArrayList<>();
@@ -904,8 +928,9 @@ public class ParallelEvaluationTest {
         for (int i = 1; i < 11; i++) {
             sb.append(getNotRule(i));
         }
-        KieBase kbase = new KieHelper().addContent(sb.toString(), ResourceType.DRL)
-                .build(MultithreadEvaluationOption.YES);
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         List<Callable<Void>> tasks = new ArrayList<>();
         for (int i = 0; i < NUMBER_OF_PARALLEL_SESSIONS; i++) {
@@ -946,8 +971,9 @@ public class ParallelEvaluationTest {
         for (int i = 0; i < 10; i++) {
             sb.append(getRule(i, ""));
         }
-        KieBase kbase = new KieHelper().addContent(sb.toString(), ResourceType.DRL)
-                .build(MultithreadEvaluationOption.YES);
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         List<Callable<Void>> tasks = new ArrayList<>();
         for (int i = 0; i < NUMBER_OF_PARALLEL_SESSIONS; i++) {
@@ -1007,8 +1033,9 @@ public class ParallelEvaluationTest {
         for (int i = 0; i < 10; i++) {
             sb.append(getRule(i, ""));
         }
-        KieBase kbase = new KieHelper().addContent(sb.toString(), ResourceType.DRL)
-                .build(MultithreadEvaluationOption.YES);
+
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
 
         /* Create parallel tasks */
         List<Callable<Void>> tasks = new ArrayList<>();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParserTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParserTest.java
@@ -21,9 +21,7 @@ import java.io.InputStreamReader;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.compiler.DescrBuildError;
 import org.drools.compiler.compiler.DrlParser;
-import org.kie.memorycompiler.JavaConfiguration;
 import org.drools.compiler.compiler.ParserError;
-import org.drools.mvel.CommonTestMethodBase;
 import org.junit.Test;
 import org.kie.api.io.ResourceType;
 import org.kie.internal.builder.KnowledgeBuilder;
@@ -31,6 +29,7 @@ import org.kie.internal.builder.KnowledgeBuilderError;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.builder.conf.LanguageLevelOption;
 import org.kie.internal.io.ResourceFactory;
+import org.kie.memorycompiler.JavaConfiguration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,8 +37,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ParserTest extends CommonTestMethodBase {
+public class ParserTest {
 
+    // not for exec-model
+    
     @Test
     public void testErrorLineNumbers() throws Exception {
         // this test aims to test semantic errors

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PhreakConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PhreakConcurrencyTest.java
@@ -55,6 +55,8 @@ import static org.junit.Assert.fail;
 @Ignore
 public class PhreakConcurrencyTest extends CommonTestMethodBase {
 
+    // This test already fails with standard-drl (probably not maintained) so not enhanced for exec-model
+
     @Test
     public void testMultipleConcurrentEPs() {
         final boolean PARALLEL = true;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertyReactivityTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertyReactivityTest.java
@@ -18,33 +18,47 @@ package org.drools.mvel.integrationtests;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
+import org.drools.core.impl.StatefulKnowledgeSessionImpl;
 import org.drools.mvel.compiler.Address;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.compiler.State;
-import org.drools.core.impl.StatefulKnowledgeSessionImpl;
-import org.drools.core.io.impl.ByteArrayResource;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.Message;
 import org.kie.api.definition.type.Modifies;
 import org.kie.api.definition.type.PropertyReactive;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.builder.conf.PropertySpecificOption;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.utils.KieHelper;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class PropertyReactivityTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class PropertyReactivityTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public PropertyReactivityTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test(timeout=10000)
     public void testComposedConstraint() {
@@ -59,7 +73,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 " modify($k2) { setD(1) }\n" +
                 "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final Klass2 k2 = new Klass2(0, 0, 0, 0);
@@ -115,7 +129,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 " list.add( \"React\" );\n" +
                 " end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -298,7 +312,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add( $id + \"@I2\" );\n" +
                 "end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -350,7 +364,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add( $o.getClass().getSimpleName() );\n" +
                 "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -405,8 +419,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 " insert( new SampleBean( 1L ) ); \n" +
                 " end";
 
-
-        final KieBase kbase = loadKnowledgeBaseFromString( str1 );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
         final KieSession ksession = kbase.newKieSession();
         final ArrayList list = new ArrayList();
         ksession.setGlobal( "list", list );
@@ -500,8 +513,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                       " list.add( 0 );\n" +
                       "end";
 
-
-        final KieBase kbase = loadKnowledgeBaseFromString( str1 );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
         final KieSession ksession = kbase.newKieSession();
         final ArrayList list = new ArrayList();
         ksession.setGlobal( "list", list );
@@ -571,8 +583,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "";
 
-
-        final KieBase kbase = loadKnowledgeBaseFromString( str1 );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
         final KieSession ksession = kbase.newKieSession();
         final ArrayList list = new ArrayList();
         ksession.setGlobal( "list", list );
@@ -626,7 +637,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -677,7 +688,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -726,7 +737,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -777,7 +788,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -827,7 +838,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -877,7 +888,7 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "end\n" +
                 "\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
@@ -908,11 +919,9 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add( $fullName );\n" +
                 "end\n";
 
-        final KnowledgeBuilder knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        knowledgeBuilder.add( new ByteArrayResource( str.getBytes() ), ResourceType.DRL );
-
-        System.out.println( knowledgeBuilder.getErrors() );
-        assertTrue( knowledgeBuilder.hasErrors() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertFalse("Should have an error", errors.isEmpty());
     }
 
     @Test(timeout=10000)
@@ -932,11 +941,9 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        final KnowledgeBuilder knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        knowledgeBuilder.add( new ByteArrayResource( str.getBytes() ), ResourceType.DRL );
-
-        System.out.println( knowledgeBuilder.getErrors() );
-        assertTrue( knowledgeBuilder.hasErrors() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, str);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertFalse("Should have an error", errors.isEmpty());
     }
 
     @Test(timeout=10000)
@@ -971,9 +978,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add( 3 );\n" +
                 "end";
 
-        final KieHelper helper = new KieHelper();
-        helper.addContent(rule1, ResourceType.DRL);
-        final KieSession ksession = helper.build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule1);
+        KieSession ksession = kbase.newKieSession();
 
         final List list = new ArrayList();
         ksession.setGlobal("list", list);
@@ -1098,9 +1104,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "    modify( $m ) { setValue(\"3\"), setData(\"y\") };\n" +
                 "end";
 
-        final KieHelper helper = new KieHelper();
-        helper.addContent(rule1, ResourceType.DRL);
-        final KieSession ksession = helper.build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule1);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
         ksession.setGlobal("list", list);
@@ -1137,9 +1142,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "       modify($p){getAddress().setStreet(\"foo\");}\n" +
                 "end";
 
-        final KieHelper helper = new KieHelper();
-        helper.addContent(rule1, ResourceType.DRL);
-        final KieSession ksession = helper.build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule1);
+        KieSession ksession = kbase.newKieSession();
 
         final Person p = new Person();
         p.setAddress(new Address());
@@ -1174,9 +1178,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add(1);\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent(str, ResourceType.DRL)
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Integer> list = new ArrayList<Integer>();
         ksession.setGlobal("list", list);
@@ -1208,9 +1211,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add(1);\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent(str, ResourceType.DRL)
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Integer> list = new ArrayList<Integer>();
         ksession.setGlobal("list", list);
@@ -1242,9 +1244,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add(1);\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent(str, ResourceType.DRL)
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         final List<Integer> list = new ArrayList<Integer>();
         ksession.setGlobal("list", list);
@@ -1280,9 +1281,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "       System.out.println(\"Rule fired.\");\n" +
                 "end\n";
 
-        final KieBase kbase = new KieHelper().addContent(str1, "a.drl")
-                                       .addContent(str2, "rules.drl")
-                                       .build();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1, str2);
+
     }
 
     public static class Event1 {
@@ -1391,9 +1391,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "        System.out.println(\"RG_TEST_3 fired\");\n" +
                 "end";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         ksession.insert(new DummyBean("1"));
         ksession.fireAllRules();
@@ -1414,9 +1413,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "  list.add(\"fired\");\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                                             .build()
-                                             .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         final List<String> list = new ArrayList<String>();
         ksession.setGlobal( "list", list );
@@ -1443,7 +1441,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                      + "rule R when\n"
                      + "    $b : BaseFact( $n : name, name != null )\n"
                      + "then end\n";
-        final KieSession ksession = new KieHelper().addContent(drl, ResourceType.DRL).build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
 
         final MyFact f = new MyFact();
         final FactHandle fh = ksession.insert(f);
@@ -1522,7 +1521,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                      + "        Shuttle(destination == $destination)\n"
                      + "    then\n"
                      + "end";
-        final KieSession kieSession = new KieHelper().addContent(drl, ResourceType.DRL).build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession kieSession = kbase.newKieSession();
 
         final BusStop busStop = new BusStop();
         final Shuttle shuttle = new Shuttle();
@@ -1564,10 +1564,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "    modify($p1) { setAge(35); } \n" +
                 "end\n";
 
-        // making the default explicit:
-        final KieSession ksession = new KieHelper(PropertySpecificOption.ALWAYS).addContent(drl, ResourceType.DRL)
-                                                                          .build()
-                                                                          .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl); // default PropertySpecificOption.ALWAYS
+        KieSession ksession = kbase.newKieSession();
         final List<String> list = new ArrayList<String>();
         ksession.setGlobal("list", list);
 
@@ -1598,10 +1596,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "    modify($p1) { setAge(35); } \n" +
                 "end\n";
 
-        // making the default explicit:
-        final KieSession ksession = new KieHelper(PropertySpecificOption.ALWAYS).addContent(drl, ResourceType.DRL)
-                                                                          .build()
-                                                                          .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl); // default PropertySpecificOption.ALWAYS
+        KieSession ksession = kbase.newKieSession();
         final List<String> list = new ArrayList<String>();
         ksession.setGlobal("list", list);
 
@@ -1632,10 +1628,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "    modify($p1) { setAge(35); } \n" +
                 "end\n";
 
-        // making the default explicit:
-        final KieSession ksession = new KieHelper(PropertySpecificOption.ALWAYS).addContent(drl, ResourceType.DRL)
-                                                                          .build()
-                                                                          .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl); // default PropertySpecificOption.ALWAYS
+        KieSession ksession = kbase.newKieSession();
         final List<String> list = new ArrayList<String>();
         ksession.setGlobal("list", list);
 
@@ -1650,8 +1644,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
 
     @Test
     public void testPropertyChangeSupportNewAPI() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_PropertyChangeTypeDecl.drl"));
-        final KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_PropertyChangeTypeDecl.drl");
+        KieSession session = kbase.newKieSession();
 
         final List list = new ArrayList();
         session.setGlobal("list", list);
@@ -1695,11 +1689,9 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                      "              )\n" +
                      "then end\n";
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource( drl.getBytes() ), ResourceType.DRL );
-        kbuilder.newKieBase().newKieSession();
-
-        assertTrue( kbuilder.getErrors().isEmpty() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertTrue(errors.toString(), errors.isEmpty());
     }
 
     @Test
@@ -1712,9 +1704,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         final Klass bean = new Klass( 1, 2, 3, 4, 5, 6 );
         final FactHandle fh = ksession.insert( bean );
@@ -1744,9 +1735,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "        modify($o) { setPrice(10) }\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         Order order = new Order( Arrays.asList(new OrderLine( 9 ), new OrderLine( 8 )), 12 );
         ksession.insert( order );
@@ -1826,9 +1816,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "        modify($s) { setAnother(10) }\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         StrangeGetter bean = new StrangeGetter();
         bean.setValue( 1 );
@@ -1848,9 +1837,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "        modify($s) { setAnother(10) }\n" +
                 "end\n";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         StrangeGetter bean = new StrangeGetter();
         bean.setValue( 1 );
@@ -1884,9 +1872,8 @@ public class PropertyReactivityTest extends CommonTestMethodBase {
                 "    update($c);\n" +
                 "end\n\n";
 
-        final KieSession ksession = new KieHelper().addContent( str1, ResourceType.DRL )
-                .build()
-                .newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str1);
+        KieSession ksession = kbase.newKieSession();
 
         assertEquals( 2, ksession.fireAllRules() );
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PseudoClockEventsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PseudoClockEventsTest.java
@@ -26,14 +26,11 @@ import org.drools.mvel.compiler.StockTick;
 import org.drools.mvel.compiler.StockTickInterface;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.builder.KieModule;
-import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.AgendaEventListener;
 import org.kie.api.runtime.KieSession;
@@ -60,7 +57,7 @@ public class PseudoClockEventsTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
     }
 
     private static final String evalFirePseudoClockDeclaration =
@@ -134,8 +131,7 @@ public class PseudoClockEventsTest {
 
     private int processStocks(int stockCount, AgendaEventListener agendaEventListener, String drlContentString)
             throws Exception {
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drlContentString);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, EventProcessingOption.STREAM);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drlContentString);
 
         KieSessionConfiguration ksessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         ksessionConfig.setOption(ClockTypeOption.PSEUDO);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query2Test.java
@@ -15,21 +15,32 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
+import java.util.Collection;
+
 import org.drools.mvel.compiler.Order;
 import org.drools.mvel.compiler.OrderItem;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
-import static org.junit.Assert.fail;
+@RunWith(Parameterized.class)
+public class Query2Test {
 
-public class Query2Test extends CommonTestMethodBase {
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public Query2Test(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
     
     @Test
     public void testEvalRewrite() throws Exception {
@@ -44,14 +55,10 @@ public class Query2Test extends CommonTestMethodBase {
         "    then\n" +
         "        System.out.println( $o1 + \":\" + $o2 );\n" +
         "end        \n";
-        
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource(str.getBytes()), ResourceType.DRL );
-        
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        
+
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
+
         final Order order1 = new Order( 11,
                                         "Bob" );
         final OrderItem item11 = new OrderItem( order1,
@@ -59,15 +66,10 @@ public class Query2Test extends CommonTestMethodBase {
         final OrderItem item12 = new OrderItem( order1,
                                                 2 );
 
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-        KieSession ksession = createKnowledgeSession(kbase);
         ksession.insert( order1 );
         ksession.insert( item11 );
         ksession.insert( item12 );
         
         ksession.fireAllRules();
-        
-
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query3Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Query3Test.java
@@ -16,23 +16,37 @@
 package org.drools.mvel.integrationtests;
 
 
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Before;
 import org.junit.Test;
-import org.kie.api.io.ResourceType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.QueryResults;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
+@RunWith(Parameterized.class)
 public class Query3Test {
 
-    private InternalKnowledgeBase knowledgeBase;
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public Query3Test(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+    private KieBase knowledgeBase;
 
     /**
      * @throws java.lang.Exception
@@ -57,12 +71,7 @@ public class Query3Test {
         text += "    foo2 : Foo2(id == foo.id);\n";
         text += "end\n";
 
-        KnowledgeBuilder knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        knowledgeBuilder.add( ResourceFactory.newByteArrayResource(text.getBytes()),
-                              ResourceType.DRL );
-        assertFalse( knowledgeBuilder.hasErrors() );
-        knowledgeBase = KnowledgeBaseFactory.newKnowledgeBase();
-        knowledgeBase.addPackages( knowledgeBuilder.getKnowledgePackages() );
+        knowledgeBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, text);
     }
 
     private void doIt(Object o1,

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepFireUntilHaltTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepFireUntilHaltTest.java
@@ -15,15 +15,21 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.kie.api.time.SessionPseudoClock;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
@@ -32,12 +38,24 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.QueryResults;
+import org.kie.api.time.SessionPseudoClock;
 import org.kie.internal.io.ResourceFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class QueryCepFireUntilHaltTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public QueryCepFireUntilHaltTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
+    }
 
     private KieSession ksession;
     
@@ -77,7 +95,7 @@ public class QueryCepFireUntilHaltTest {
         kfs.write( ResourceFactory.newByteArrayResource(drl.getBytes())
                                   .setTargetPath("org/drools/compiler/integrationtests/queries.drl") );
 
-        assertTrue(ks.newKieBuilder(kfs).buildAll().getResults().getMessages().isEmpty());
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, true);
         ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
         
         firstEntryPoint = ksession.getEntryPoint("FirstStream");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryCepTest.java
@@ -15,13 +15,19 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import org.kie.api.time.SessionPseudoClock;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
@@ -30,12 +36,24 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.rule.EntryPoint;
 import org.kie.api.runtime.rule.QueryResults;
+import org.kie.api.time.SessionPseudoClock;
 import org.kie.internal.io.ResourceFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class QueryCepTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public QueryCepTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
+    }
     
     private KieSession ksession;
     
@@ -73,7 +91,7 @@ public class QueryCepTest {
         kfs.write( ResourceFactory.newByteArrayResource(drl.getBytes())
                                   .setTargetPath("org/drools/compiler/integrationtests/queries.drl") );
 
-        assertTrue(ks.newKieBuilder(kfs).buildAll().getResults().getMessages().isEmpty());
+        final KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, true);
         ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
         
         firstEntryPoint = ksession.getEntryPoint("FirstStream");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
@@ -29,14 +29,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import javax.xml.bind.JAXBContext;
-import org.drools.mvel.compiler.Address;
-import org.drools.mvel.compiler.Cheese;
-import org.drools.mvel.CommonTestMethodBase;
-import org.drools.mvel.compiler.DomainObject;
-import org.drools.mvel.compiler.InsertedObject;
-import org.drools.mvel.compiler.Interval;
-import org.drools.mvel.compiler.Person;
-import org.drools.mvel.compiler.Worker;
+
 import org.drools.core.QueryResultsImpl;
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.base.DroolsQuery;
@@ -47,15 +40,25 @@ import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ObjectTypeNode.ObjectTypeNodeMemory;
 import org.drools.core.runtime.rule.impl.FlatQueryResults;
 import org.drools.core.spi.ObjectType;
+import org.drools.mvel.compiler.Address;
+import org.drools.mvel.compiler.Cheese;
+import org.drools.mvel.compiler.DomainObject;
+import org.drools.mvel.compiler.InsertedObject;
+import org.drools.mvel.compiler.Interval;
+import org.drools.mvel.compiler.Person;
+import org.drools.mvel.compiler.Worker;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.Message;
-import org.kie.api.builder.Results;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.conf.QueryListenerOption;
 import org.kie.api.runtime.rule.FactHandle;
@@ -65,7 +68,6 @@ import org.kie.api.runtime.rule.QueryResultsRow;
 import org.kie.api.runtime.rule.Row;
 import org.kie.api.runtime.rule.Variable;
 import org.kie.api.runtime.rule.ViewChangedEventListener;
-import org.kie.internal.utils.KieHelper;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -74,7 +76,20 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-public class QueryTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class QueryTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public QueryTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @org.junit.Rule
     public TestName testName = new TestName();
@@ -160,8 +175,8 @@ public class QueryTest extends CommonTestMethodBase {
 
     @Test
     public void testQuery2() throws Exception {
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_Query.drl"));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Query.drl");
+        KieSession session = kbase.newKieSession();
 
         session.fireAllRules();
 
@@ -174,8 +189,8 @@ public class QueryTest extends CommonTestMethodBase {
 
     @Test
     public void testQueryWithParams() throws Exception {
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_QueryWithParams.drl"));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_QueryWithParams.drl");
+        KieSession session = kbase.newKieSession();
 
         session.fireAllRules();
 
@@ -222,8 +237,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    cheddar : Cheese(type == 'cheddar', price == stilton.price) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession session = kbase.newKieSession();
 
 
         Cheese stilton1 = new Cheese( "stilton", 1 );
@@ -287,8 +302,8 @@ public class QueryTest extends CommonTestMethodBase {
     public void testTwoQuerries() throws Exception {
         // @see JBRULES-410 More than one Query definition causes an incorrect
         // Rete network to be built.
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_TwoQuerries.drl"));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_TwoQuerries.drl");
+        KieSession session = kbase.newKieSession();
 
         final Cheese stilton = new Cheese( "stinky",
                                            5 );
@@ -314,8 +329,8 @@ public class QueryTest extends CommonTestMethodBase {
 
     @Test
     public void testDoubleQueryWithExists() throws Exception {
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_DoubleQueryWithExists.drl"));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_DoubleQueryWithExists.drl");
+        KieSession session = kbase.newKieSession();
 
         final Person p1 = new Person( "p1",
                                       "stilton",
@@ -395,8 +410,8 @@ public class QueryTest extends CommonTestMethodBase {
 
     @Test
     public void testQueryWithCollect() throws Exception {
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_Query.drl"));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_Query.drl");
+        KieSession session = kbase.newKieSession();
         session.fireAllRules();
 
         QueryResults results = getQueryResults( session, "collect objects" );
@@ -412,8 +427,7 @@ public class QueryTest extends CommonTestMethodBase {
 
     @Test
     public void testDroolsQueryCleanup() throws Exception {
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_QueryMemoryLeak.drl"));
-        KieSession session = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_QueryMemoryLeak.drl");
 
         KieSession ksession = kbase.newKieSession();
 
@@ -464,8 +478,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    $p : Person( $name := name, $likes := likes, $age := age ) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         Person p1 = new Person( "darth",
                                 "stilton",
@@ -555,8 +569,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    $p := Person( $name := name, $likes := likes, $age := age ) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         Person p1 = new Person( "darth",
                                 "stilton",
@@ -613,8 +627,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    $p : Person( $name := name, $likes := likes, $street := address.street ) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         Person p1 = new Person( "darth",
                                 "stilton",
@@ -659,8 +673,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    cheddar : Cheese(type == $type2, $cprice : price == stilton.price) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         Cheese stilton1 = new Cheese( "stilton",
                                       1 );
@@ -866,8 +880,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    $cheese : Cheese(type == $type) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase, option );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         // insert some data into the session
         for ( int i = 0; i < 10000; i++ ) {
@@ -900,8 +914,8 @@ public class QueryTest extends CommonTestMethodBase {
                      "    not DomainObject( id == $do.id, eval(interval.isAfter($do.getInterval())))\n" +
                      "end";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         DomainObject do1 = new DomainObject();
         do1.setId( 1 );
@@ -936,11 +950,9 @@ public class QueryTest extends CommonTestMethodBase {
                      "then\n" +
                      "end";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( drl, ResourceType.DRL );
-        Results results = helper.verify();
-        assertTrue( results.hasMessages( Message.Level.ERROR ) );
-        assertEquals( 2, results.getMessages( Message.Level.ERROR ).size() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertEquals(2, errors.size());
     }
 
     @Test
@@ -956,11 +968,9 @@ public class QueryTest extends CommonTestMethodBase {
                      "then\n" +
                      "end";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( drl, ResourceType.DRL );
-        Results results = helper.verify();
-        assertTrue( results.hasMessages( Message.Level.ERROR ) );
-        assertEquals( 1, results.getMessages( Message.Level.ERROR ).size() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertEquals(1, errors.size());
     }
 
     @Test
@@ -977,11 +987,9 @@ public class QueryTest extends CommonTestMethodBase {
                     "then\n" +
                      "end";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( drl, ResourceType.DRL );
-        Results results = helper.verify();
-        assertTrue( results.hasMessages( Message.Level.ERROR ) );
-        assertEquals( 1, results.getMessages( Message.Level.ERROR ).size() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertEquals(1, errors.size());
     }
 
 
@@ -1019,9 +1027,8 @@ public class QueryTest extends CommonTestMethodBase {
                      "         list.add( AString + \" World\" );\n" +
                      "end\n";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( drl, ResourceType.DRL );
-        KieSession ks = helper.build(  ).newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ks = kbase.newKieSession();
 
         ArrayList list = new ArrayList();
         ks.setGlobal( "AString", "Hello" );
@@ -1063,9 +1070,8 @@ public class QueryTest extends CommonTestMethodBase {
                      "end";
 
         List list = new ArrayList(  );
-        KieHelper helper = new KieHelper();
-        helper.addContent( drl, ResourceType.DRL );
-        KieSession ks = helper.build(  ).newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ks = kbase.newKieSession();
         ks.setGlobal( "list", list );
         ks.fireAllRules();
 
@@ -1091,9 +1097,8 @@ public class QueryTest extends CommonTestMethodBase {
                      "    list.add( $s );\n" +
                      "end\n";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( drl, ResourceType.DRL );
-        KieSession ks = helper.build(  ).newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ks = kbase.newKieSession();
 
         ArrayList list = new ArrayList();
         ks.setGlobal( "list", list );
@@ -1125,9 +1130,8 @@ public class QueryTest extends CommonTestMethodBase {
                 "    persons.add( $p );\n" +
                 "end\n";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( str, ResourceType.DRL );
-        KieSession ksession = helper.build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         List<Person> personsWithA = new ArrayList<Person>();
         ksession.setGlobal("persons", personsWithA);
@@ -1165,9 +1169,7 @@ public class QueryTest extends CommonTestMethodBase {
                 "    persons.add( $p );\n" +
                 "end\n";
 
-        KieHelper helper = new KieHelper();
-        helper.addContent( str, ResourceType.DRL );
-        KieBase kbase = SerializationHelper.serializeObject(helper.build());
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         KieSession ksession = kbase.newKieSession();
 
         List<Person> list = new ArrayList<Person>();
@@ -1208,10 +1210,9 @@ public class QueryTest extends CommonTestMethodBase {
                 "    persons.add( $p );\n" +
                 "end\n";
 
-        KieServices ks = KieServices.Factory.get();
-        KieFileSystem kfs = ks.newKieFileSystem().write( "src/main/resources/r1.drl", drl );
-        Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
-        assertFalse( results.getMessages().isEmpty() );
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        assertFalse("Should have an error", errors.isEmpty());
     }
 
     @Test
@@ -1230,7 +1231,8 @@ public class QueryTest extends CommonTestMethodBase {
                      "then\n" +
                      "end\n\n";
 
-        KieSession ksession = new KieHelper().addContent( str, ResourceType.DRL ).build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         FactHandle iFH = ksession.insert( 1 );
         FactHandle sFH = ksession.insert( "" );
@@ -1254,8 +1256,8 @@ public class QueryTest extends CommonTestMethodBase {
         str += "    cheddar : Cheese(type == 'cheddar', price == stilton.price) \n";
         str += "end\n";
 
-        KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(str));
-        KieSession ksession = createKieSession( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         Cheese stilton1 = new Cheese( "stilton", 1 );
         Cheese cheddar1 = new Cheese( "cheddar", 1 );
@@ -1382,7 +1384,8 @@ public class QueryTest extends CommonTestMethodBase {
                 "    $visible: QuestionVisible(question == $question) or not QuestionVisible(question == $question)\n" +
                 "end\n";
 
-        KieSession ksession = new KieHelper().addContent( str, ResourceType.DRL ).build().newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
         Question question = new Question();
         ksession.insert( question );
         QueryResults results = ksession.getQueryResults("QuestionsKnowledge");

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleMetadataTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/RuleMetadataTest.java
@@ -15,18 +15,37 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.mvel.CommonTestMethodBase;
+import java.util.Collection;
+
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.rule.ConsequenceMetaData;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class RuleMetadataTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class RuleMetadataTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public RuleMetadataTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs. This test may not be necessary for exec-model
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testModify() {
@@ -222,7 +241,7 @@ public class RuleMetadataTest extends CommonTestMethodBase {
                     "\nend\n";
         }
 
-        return loadKnowledgeBaseFromString( rule );
+        return KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule);
     }
 
     private RuleImpl getRule(KieBase kbase, String ruleName) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SecurityPolicyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SecurityPolicyTest.java
@@ -16,13 +16,18 @@
 package org.drools.mvel.integrationtests;
 
 import java.security.Policy;
+import java.util.Collection;
 
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -37,7 +42,20 @@ import org.mvel2.PropertyAccessException;
  * This is a sample class to launch a rule.
  */
 @Ignore( "This test causes problems to surefire, so it will be disabled for now. It works when executed by itself.")
-public class SecurityPolicyTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class SecurityPolicyTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public SecurityPolicyTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Before
     public void init() {
@@ -65,15 +83,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end\n";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (ShouldHavePrevented e) {
@@ -92,15 +103,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end\n";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (ShouldHavePrevented e) {
@@ -112,6 +116,7 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
     
     @Test
     public void testSerializationUntrustedMvelConsequence() {
+     // kbase serialization is not supported. But leave it for standard-drl.
         String drl = "package org.foo.bar\n" +
                 "rule R1 dialect \"mvel\" when\n" +
                 "then\n" +
@@ -146,15 +151,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end\n";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (ShouldHavePrevented e) {
@@ -174,15 +172,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end\n";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (PropertyAccessException e) {
@@ -209,15 +200,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (ShouldHavePrevented e) {
@@ -241,15 +225,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (PropertyAccessException e) {
@@ -280,15 +257,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.insert("foo");
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
@@ -320,15 +290,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.insert("foo");
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
@@ -358,15 +321,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end\n";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (ShouldHavePrevented e) {
@@ -386,15 +342,8 @@ public class SecurityPolicyTest extends CommonTestMethodBase {
                 "end\n";
 
         try {
-            KieServices ks = KieServices.Factory.get();
-            KieFileSystem kfs = ks.newKieFileSystem().write(ResourceFactory.newByteArrayResource(drl.getBytes())
-                    .setSourcePath("org/foo/bar/r1.drl"));
-            ks.newKieBuilder(kfs).buildAll();
-
-            ReleaseId releaseId = ks.getRepository().getDefaultReleaseId();
-            KieContainer kc = ks.newKieContainer(releaseId);
-
-            KieSession ksession = kc.newKieSession();
+            KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+            KieSession ksession = kbase.newKieSession();
             ksession.fireAllRules();
             Assert.fail("The security policy for the rule should have prevented this from executing...");
         } catch (PropertyAccessException e) {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentCreationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentCreationTest.java
@@ -15,12 +15,11 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.common.InternalWorkingMemory;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.reteoo.BetaMemory;
 import org.drools.core.reteoo.ConditionalBranchNode;
@@ -35,20 +34,34 @@ import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.SegmentMemory;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.rule.FactHandle;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class SegmentCreationTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public SegmentCreationTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
     
     @Test
     public void testSingleEmptyLhs() throws Exception {
@@ -162,13 +175,13 @@ public class SegmentCreationTest {
     
     @Test
     public void testMultiSharedPattern() throws Exception {
-        KieBase kbase = buildKnowledgeBase( " D() A() \n",
-                                                  "  D()  A() B() \n",
-                                                  "  D() A() B() C() \n");
+        KieBase kbase = buildKnowledgeBase( " X() A() \n",
+                                                  "  X()  A() B() \n",
+                                                  "  X() A() B() C() \n");
 
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase.newKieSession());
         
-        ObjectTypeNode dotn = getObjectTypeNode(kbase, LinkingTest.D.class );
+        ObjectTypeNode dotn = getObjectTypeNode(kbase, LinkingTest.X.class );
         ObjectTypeNode aotn = getObjectTypeNode(kbase, LinkingTest.A.class );
 
         LeftInputAdapterNode lian = (LeftInputAdapterNode) dotn.getObjectSinkPropagator().getSinks()[0];
@@ -181,7 +194,7 @@ public class SegmentCreationTest {
         JoinNode cNode = ( JoinNode ) bNode.getSinkPropagator().getSinks()[1];
         RuleTerminalNode rtn3 = ( RuleTerminalNode) cNode.getSinkPropagator().getSinks()[0];        
                 
-        wm.insert( new LinkingTest.D() );
+        wm.insert( new LinkingTest.X() );
         wm.insert( new LinkingTest.A() );
         wm.insert( new LinkingTest.B() );
         wm.insert(new LinkingTest.C());
@@ -262,13 +275,13 @@ public class SegmentCreationTest {
     
     @Test
     public void tesSubnetworkAfterShare() throws Exception {
-        KieBase kbase = buildKnowledgeBase( "  D() A() \n",
-                                                  "   D() A()  not ( B() and C() ) \n" );
+        KieBase kbase = buildKnowledgeBase( "  X() A() \n",
+                                                  "   X() A()  not ( B() and C() ) \n" );
 
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase.newKieSession());
         
         ObjectTypeNode aotn = getObjectTypeNode(kbase, LinkingTest.A.class );
-        ObjectTypeNode dotn = getObjectTypeNode(kbase, LinkingTest.D.class );
+        ObjectTypeNode dotn = getObjectTypeNode(kbase, LinkingTest.X.class );
 
         LeftInputAdapterNode lian = (LeftInputAdapterNode) dotn.getObjectSinkPropagator().getSinks()[0];
 
@@ -282,7 +295,7 @@ public class SegmentCreationTest {
         NotNode notNode = ( NotNode ) joinNode.getSinkPropagator().getSinks()[2];
         RuleTerminalNode rtn2 = ( RuleTerminalNode) notNode.getSinkPropagator().getSinks()[0];
                
-        wm.insert( new LinkingTest.D() );
+        wm.insert( new LinkingTest.X() );
         wm.insert( new LinkingTest.A() );
         wm.insert( new LinkingTest.B() );
         wm.insert( new LinkingTest.C() );
@@ -311,14 +324,14 @@ public class SegmentCreationTest {
     
     @Test
     public void tesShareInSubnetwork() throws Exception {
-        KieBase kbase = buildKnowledgeBase( "  D() A() \n",
-                                                  "   D() A() B() C() \n",
-                                                  "   D() A()  not ( B() and C() ) \n" );
+        KieBase kbase = buildKnowledgeBase( "  X() A() \n",
+                                                  "   X() A() B() C() \n",
+                                                  "   X() A()  not ( B() and C() ) \n" );
 
         InternalWorkingMemory wm = ((InternalWorkingMemory)kbase.newKieSession());
         
         ObjectTypeNode aotn = getObjectTypeNode(kbase, LinkingTest.A.class );
-        ObjectTypeNode dotn = getObjectTypeNode(kbase, LinkingTest.D.class );
+        ObjectTypeNode dotn = getObjectTypeNode(kbase, LinkingTest.X.class );
 
         LeftInputAdapterNode lian = (LeftInputAdapterNode) dotn.getObjectSinkPropagator().getSinks()[0];
 
@@ -333,7 +346,7 @@ public class SegmentCreationTest {
         NotNode notNode = ( NotNode ) beta.getSinkPropagator().getSinks()[2];
         RuleTerminalNode rtn3 = ( RuleTerminalNode) notNode.getSinkPropagator().getSinks()[0];
                
-        wm.insert( new LinkingTest.D() );
+        wm.insert( new LinkingTest.X() );
         wm.insert( new LinkingTest.A() );
         wm.insert( new LinkingTest.B() );
         wm.insert( new LinkingTest.C() );
@@ -419,11 +432,11 @@ public class SegmentCreationTest {
 
     @Test
     public void testBranchCEMultipleSegments() throws Exception {
-        KieBase kbase = buildKnowledgeBase( "  D() $a : A() \n", // r1
-                                                  "  D()  $a : A() \n" +
+        KieBase kbase = buildKnowledgeBase( "  X() $a : A() \n", // r1
+                                                  "  X()  $a : A() \n" +
                                                   "   if ( $a != null ) do[t1] \n" +
                                                   "   B() \n", // r2
-                                                  "  D() $a : A() \n"+
+                                                  "  X() $a : A() \n"+
                                                   "   if ( $a != null ) do[t1] \n" +
                                                   "   B() \n" +
                                                   "   C() \n" // r3
@@ -468,7 +481,7 @@ public class SegmentCreationTest {
         assertEquals( 1, cNodeSmem.getAllLinkedMaskTest() );
         assertEquals( 1, cNodeSmem.getLinkedNodeMask() );
 
-        wm.insert(new LinkingTest.D());
+        wm.insert(new LinkingTest.X());
         wm.insert(new LinkingTest.A());
         wm.flushPropagations();
 
@@ -492,7 +505,7 @@ public class SegmentCreationTest {
         str += "import " + LinkingTest.A.class.getCanonicalName() + "\n" ;
         str += "import " + LinkingTest.B.class.getCanonicalName() + "\n" ;
         str += "import " + LinkingTest.C.class.getCanonicalName() + "\n" ;
-        str += "import " + LinkingTest.D.class.getCanonicalName() + "\n" ;
+        str += "import " + LinkingTest.X.class.getCanonicalName() + "\n" ;
         str += "global java.util.List list \n";
 
         int i = 0;
@@ -503,16 +516,8 @@ public class SegmentCreationTest {
             str += "then[t1] \n";
             str += "end \n";            
         }
-        
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
 
-        kbuilder.add( ResourceFactory.newByteArrayResource(str.getBytes()),
-                      ResourceType.DRL );
-
-        assertFalse( kbuilder.getErrors().toString(), kbuilder.hasErrors() );
-
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         return kbase;
     }      
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentMemoryPrototypeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SegmentMemoryPrototypeTest.java
@@ -16,39 +16,51 @@
 package org.drools.mvel.integrationtests;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import org.drools.mvel.compiler.Address;
-import org.drools.mvel.compiler.Person;
-import org.drools.mvel.integrationtests.DynamicRulesChangesTest.Fire;
-import org.drools.mvel.integrationtests.DynamicRulesChangesTest.Room;
-import org.drools.mvel.integrationtests.DynamicRulesChangesTest.Sprinkler;
-import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.impl.StatefulKnowledgeSessionImpl;
 import org.drools.core.reteoo.PathMemory;
 import org.drools.core.reteoo.ReteDumper;
 import org.drools.core.reteoo.TerminalNode;
+import org.drools.mvel.compiler.Address;
+import org.drools.mvel.compiler.Person;
+import org.drools.mvel.integrationtests.DynamicRulesChangesTest.Fire;
+import org.drools.mvel.integrationtests.DynamicRulesChangesTest.Room;
+import org.drools.mvel.integrationtests.DynamicRulesChangesTest.Sprinkler;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.rule.FactHandle;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.conf.ForceEagerActivationOption;
-import org.kie.internal.utils.KieHelper;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class SegmentMemoryPrototypeTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public SegmentMemoryPrototypeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
     private static final String DRL =
             "import " +  DynamicRulesChangesTest.class.getCanonicalName() + "\n " +
             "global java.util.List events\n" +
@@ -99,13 +111,7 @@ public class SegmentMemoryPrototypeTest {
 
     @Test
     public void testSegmentMemoryPrototype() {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource(DRL.getBytes()),
-                      ResourceType.DRL );
-
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
-
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, DRL);
         KieSession ksession = kbase.newKieSession();
         try {
             checkKieSession(ksession);
@@ -124,12 +130,7 @@ public class SegmentMemoryPrototypeTest {
 
     @Test
     public void testSessionCache() {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource(DRL.getBytes()),
-                      ResourceType.DRL );
-
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, DRL);
 
         StatefulKnowledgeSessionImpl ksession = (StatefulKnowledgeSessionImpl)kbase.newKieSession();
         try {
@@ -189,7 +190,7 @@ public class SegmentMemoryPrototypeTest {
                 "    String(  )\n" +
                 "then end";
 
-        KieBase kbase = new KieHelper().addContent( str, ResourceType.DRL ).build();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
 
         KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ForceEagerActivationOption.YES );
@@ -230,7 +231,7 @@ public class SegmentMemoryPrototypeTest {
                 "    Boolean()\n" +
                 "then end";
 
-        KieBase kbase = new KieHelper().addContent( str, ResourceType.DRL ).build();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
 
         List<TerminalNode> terminalNodes = ReteDumper.collectRete( kbase ).stream()
                 .filter( TerminalNode.class::isInstance )

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializationSecurityPolicyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializationSecurityPolicyTest.java
@@ -58,6 +58,7 @@ public class SerializationSecurityPolicyTest extends CommonTestMethodBase {
 
     @Test
     public void testSerialization() throws IOException, ClassNotFoundException {
+     // kpackage serialization is not supported. But leave it for standard-drl.
         final String rule =
                 " rule R " +
                 " when " +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTest.java
@@ -48,6 +48,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class SerializedPackageMergeTest {
+
+    // kpackage serialization is not supported. But leave it for standard-drl.
+
     private static final DateFormat DF   = new SimpleDateFormat( "dd-MMM-yyyy", Locale.UK );
     private static final String[]   DRLs = {"drl/HelloWorld.drl","test_Serialization1.drl"};
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps1Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps1Test.java
@@ -29,6 +29,9 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 
 public class SerializedPackageMergeTwoSteps1Test {
+
+    // kpackage serialization is not supported. But leave it for standard-drl.
+
 	public static final String[] BINPKG = { System.getProperty( "java.io.tmpdir" ) + File.separator + "SerializedPackageMergeTwoSteps_1.bin", 
 			System.getProperty( "java.io.tmpdir" ) + File.separator + "SerializedPackageMergeTwoSteps_2.bin" };
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SerializedPackageMergeTwoSteps2Test.java
@@ -40,6 +40,8 @@ import static org.junit.Assert.assertEquals;
 
 public class SerializedPackageMergeTwoSteps2Test {
 
+    // kpackage serialization is not supported. But leave it for standard-drl.
+
     @Test @Ignore("DROOLS-5620 - test failed randomly and it doesn't reproduce the original issue (DROOLS-2224) scenario on CI."+
                   "It can be tested manually")
     public void testBuildAndSerializePackagesInTwoSteps2() throws IOException, ClassNotFoundException    {        

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SeveralKieSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/SeveralKieSessionsTest.java
@@ -17,9 +17,16 @@ package org.drools.mvel.integrationtests;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -29,10 +36,10 @@ import org.kie.api.builder.model.KieBaseModel;
 import org.kie.api.builder.model.KieModuleModel;
 import org.kie.api.command.Command;
 import org.kie.api.definition.type.FactType;
-import org.kie.internal.io.ResourceFactory;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.command.CommandFactory;
+import org.kie.internal.io.ResourceFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,7 +49,20 @@ import static org.junit.Assert.assertTrue;
  * Tests evaluation of a backward chaining family relationships example using
  * several KieSessions.
  */
+@RunWith(Parameterized.class)
 public class SeveralKieSessionsTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public SeveralKieSessionsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     // DROOLS-145
 
@@ -101,7 +121,7 @@ public class SeveralKieSessionsTest {
         kfs.write("src/main/resources/" + PACKAGE_PATH + "/" + DRL_FILE_NAME,
                   ResourceFactory.newClassPathResource(DRL_FILE_NAME, this.getClass()));
 
-        KieBuilder builder = ks.newKieBuilder(kfs).buildAll();
+        final KieBuilder builder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false);
         assertEquals(0, builder.getResults().getMessages().size());
 
         ks.getRepository().addKieModule(builder.getKieModule());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ShadowProxyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ShadowProxyTest.java
@@ -17,24 +17,42 @@
 package org.drools.mvel.integrationtests;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
 import org.drools.mvel.compiler.Cheesery;
 import org.drools.mvel.compiler.Child;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.MockPersistentSet;
 import org.drools.mvel.compiler.ObjectWithSet;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 
-public class ShadowProxyTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class ShadowProxyTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ShadowProxyTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testShadowProxyInHierarchies() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_ShadowProxyInHierarchies.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ShadowProxyInHierarchies.drl");
+        KieSession ksession = kbase.newKieSession();
         try {
             ksession.insert(new Child("gp"));
             ksession.fireAllRules();
@@ -45,8 +63,8 @@ public class ShadowProxyTest extends CommonTestMethodBase {
 
     @Test
     public void testShadowProxyOnCollections() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_ShadowProxyOnCollections.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ShadowProxyOnCollections.drl");
+        KieSession ksession = kbase.newKieSession();
         try {
             final List results = new ArrayList();
             ksession.setGlobal("results", results);
@@ -65,8 +83,8 @@ public class ShadowProxyTest extends CommonTestMethodBase {
 
     @Test
     public void testShadowProxyOnCollections2() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_ShadowProxyOnCollections2.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ShadowProxyOnCollections2.drl");
+        KieSession ksession = kbase.newKieSession();
         try {
             final List results = new ArrayList();
             ksession.setGlobal("results", results);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StatelessStressTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StatelessStressTest.java
@@ -15,16 +15,18 @@
 
 package org.drools.mvel.integrationtests;
 
-import static org.junit.Assert.assertFalse;
-
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.mvel.compiler.Address;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.StatelessKieSession;
 
@@ -32,12 +34,26 @@ import org.kie.api.runtime.StatelessKieSession;
  * This is for testing possible PermSpace issues (leaking) when spawning lots of sessions in concurrent threads.
  * Normally this test will be XXX'ed out, as when running it will not terminate.
  */
-public class StatelessStressTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class StatelessStressTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public StatelessStressTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        Collection<Object[]> parameters = new ArrayList<>();
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN}); // choose config
+        return parameters;
+    }
 
     @Ignore
     @Test
     public void testLotsOfStateless() throws Exception {
-        final KieBase kbase = loadKnowledgeBase("thread_class_test.drl");
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "thread_class_test.drl");
 
         int numThreads = 100;
         Thread[] ts = new Thread[numThreads];
@@ -52,11 +68,12 @@ public class StatelessStressTest extends CommonTestMethodBase {
                     while (true) {
                         start = System.currentTimeMillis();
                         StatelessKieSession sess = kbase.newStatelessKieSession();
-                        try {
-                            sess    = SerializationHelper.serializeObject(sess);
-                        } catch (Exception ex) {
-                            throw new RuntimeException(ex);
-                        }
+                        // StatelessKieSession is not serializable
+//                        try {
+//                            sess    = SerializationHelper.serializeObject(sess);
+//                        } catch (Exception ex) {
+//                            throw new RuntimeException(ex);
+//                        }
                         Person p = new Person();
                         p.setName( "Michael" );
                         Address add1 = new Address();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StrEvaluatorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/StrEvaluatorTest.java
@@ -16,32 +16,42 @@
 package org.drools.mvel.integrationtests;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.compiler.RoutingMessage;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderError;
-import org.kie.internal.builder.KnowledgeBuilderErrors;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class StrEvaluatorTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class StrEvaluatorTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public StrEvaluatorTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testStrStartsWith() {
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         try {
             List list = new ArrayList();
             ksession.setGlobal( "list", list );
@@ -65,7 +75,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
     @Test
     public void testStrEndsWith() {
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         try {
             List list = new ArrayList();
             ksession.setGlobal( "list", list );
@@ -89,7 +99,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
     @Test
     public void testStrLengthEquals() {
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         try {
             List list = new ArrayList();
             ksession.setGlobal( "list", list );
@@ -109,7 +119,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
     @Test
     public void testStrNotStartsWith() {
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         try {
             List list = new ArrayList();
             ksession.setGlobal( "list", list );
@@ -129,7 +139,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
     @Test
     public void testStrNotEndsWith() {
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         try {
             List list = new ArrayList();
             ksession.setGlobal( "list", list );
@@ -151,7 +161,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
     @Test
     public void testStrLengthNoEquals() {
         KieBase kbase = readKnowledgeBase();
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieSession ksession = kbase.newKieSession();
         try {
             List list = new ArrayList();
             ksession.setGlobal( "list", list );
@@ -180,7 +190,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
                      + " RoutingMessage( routingValue == \"R2\" || routingValue str[startsWith] \"R1\" )\n"
                      + " then\n"
                      + "end\n";
-        KieBase kbase = loadKnowledgeBaseFromString( drl );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         KieSession ksession = kbase.newKieSession();
         try {
@@ -205,7 +215,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
                      " Object( this#" + Person.class.getName() + ".name str[startsWith] \"M\" ) " +
                      " then " +
                      "end ";
-        KieBase kbase = loadKnowledgeBaseFromString(drl);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         KieSession ksession = kbase.newKieSession();
         try {
@@ -225,7 +235,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
                      " Object( this#String str[startsWith] \"M\" ) " +
                      " then " +
                      "end ";
-        KieBase kbase = loadKnowledgeBaseFromString(drl);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         KieSession ksession = kbase.newKieSession();
         try {
@@ -238,18 +248,7 @@ public class StrEvaluatorTest extends CommonTestMethodBase {
     }
 
     private KieBase readKnowledgeBase() {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newInputStreamResource(getClass().getResourceAsStream("strevaluator_test.drl")),
-                ResourceType.DRL );
-        KnowledgeBuilderErrors errors = kbuilder.getErrors();
-        if (errors.size() > 0) {
-            for (KnowledgeBuilderError error: errors) {
-                System.err.println(error);
-            }
-            throw new IllegalArgumentException("Could not parse knowledge." + errors.toArray());
-        }
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages(kbuilder.getKnowledgePackages());
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "strevaluator_test.drl");
         return kbase;
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TreeTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/TreeTest.java
@@ -16,20 +16,38 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.util.Collection;
+
 import org.drools.mvel.compiler.Cheese;
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 
-public class TreeTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class TreeTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public TreeTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testUnbalancedTrees() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_UnbalancedTrees.drl"));
-        final KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_UnbalancedTrees.drl");
+        KieSession wm = kbase.newKieSession();
         try {
             wm.insert(new Cheese("a", 10));
             wm.insert(new Cheese("b", 10));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/UnlinkingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/UnlinkingTest.java
@@ -16,24 +16,41 @@
 package org.drools.mvel.integrationtests;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import org.drools.mvel.CommonTestMethodBase;
-import org.drools.mvel.compiler.Person;
 import org.drools.core.common.InternalFactHandle;
+import org.drools.mvel.compiler.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class UnlinkingTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class UnlinkingTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public UnlinkingTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void multipleJoinsUsingSameOTN() throws Exception {
-        KieBase kbase = loadKnowledgeBase("test_LRUnlinking.drl");
-        kbase = SerializationHelper.serializeObject( kbase );
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_LRUnlinking.drl");
 
         final KieSession wmOne = kbase.newKieSession();
         final KieSession wmTwo = kbase.newKieSession();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WindowTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WindowTest.java
@@ -17,30 +17,41 @@ package org.drools.mvel.integrationtests;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.kie.api.time.SessionPseudoClock;
 import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.KieBaseConfiguration;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.KieFileSystem;
-import org.kie.api.builder.Message;
-import org.kie.api.builder.Message.Level;
-import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.rule.EntryPoint;
+import org.kie.api.time.SessionPseudoClock;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(Parameterized.class)
 public class WindowTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public WindowTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
+    }
 
     private KieSession ksession;
 
@@ -121,26 +132,7 @@ public class WindowTest {
 
     @Before
     public void initialization() {
-        KieFileSystem kfs = KieServices.Factory.get().newKieFileSystem();
-
-        kfs.write("src/main/resources/kbase1/window_test.drl", drl);
-
-        KieBuilder kbuilder = KieServices.Factory.get().newKieBuilder(kfs);
-
-        kbuilder.buildAll();
-
-        List<Message> res = kbuilder.getResults().getMessages(Level.ERROR);
-
-        assertEquals(res.toString(), 0, res.size());
-
-        KieBaseConfiguration kbconf = KnowledgeBaseFactory
-                .newKnowledgeBaseConfiguration();
-
-        kbconf.setOption(EventProcessingOption.STREAM);
-
-        KieBase kbase = KieServices.Factory.get()
-                                   .newKieContainer(kbuilder.getKieModule().getReleaseId())
-                                   .newKieBase(kbconf);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         KieSessionConfiguration ksconfig = KnowledgeBaseFactory
                 .newKnowledgeSessionConfiguration();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WorkingMemoryActionsSerializationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/WorkingMemoryActionsSerializationTest.java
@@ -15,32 +15,44 @@
 
 package org.drools.mvel.integrationtests;
 
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.DefaultAgendaEventListener;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.io.ResourceFactory;
-
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.fail;
 
 @Ignore
+@RunWith(Parameterized.class)
 public class WorkingMemoryActionsSerializationTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public WorkingMemoryActionsSerializationTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
     private static final List<String> RULES = Arrays.asList("enableRecording", "saveRecord", "processEvent", "ignoreEvent"); //rules expected to be executed
     private KieSession ksession;
     private KieBase kbase;
@@ -97,13 +109,7 @@ public class WorkingMemoryActionsSerializationTest {
     public void before() {
         ruleCalls.clear();
 
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add( ResourceFactory.newByteArrayResource(drl.getBytes()), ResourceType.DRL);
-        if ( kbuilder.hasErrors() ) {
-            fail( kbuilder.getErrors().toString() );
-        }
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase( );
-        kbase.addPackages( kbuilder.getKnowledgePackages() );
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         ksession = kbase.newKieSession();
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/XSDResourceTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/XSDResourceTest.java
@@ -16,7 +16,6 @@
 package org.drools.mvel.integrationtests;
 
 import org.assertj.core.api.Assertions;
-import org.drools.mvel.CommonTestMethodBase;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -26,7 +25,7 @@ import org.kie.api.runtime.KieContainer;
  * Tests KIE package compilation when there is a XSD resource (BZ 1120972) - manifests only when using
  * KieClasspathContainer.
  */
-public class XSDResourceTest extends CommonTestMethodBase {
+public class XSDResourceTest {
 
     @Test
     public void testXSDResourceNotBreakingCompilation() {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/AbstractConcurrentInsertionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/AbstractConcurrentInsertionsTest.java
@@ -24,17 +24,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Assertions;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.kie.api.KieBase;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.utils.KieHelper;
 
 public abstract class AbstractConcurrentInsertionsTest {
 
     protected void testConcurrentInsertions(final String drl, final int objectCount, final int threadCount,
-                                          final boolean newSessionForEachThread, final boolean updateFacts) throws InterruptedException {
+                                          final boolean newSessionForEachThread, final boolean updateFacts, KieBaseTestConfiguration kieBaseTestConfiguration) throws InterruptedException {
 
-        final KieBase kieBase = new KieHelper().addContent(drl, ResourceType.DRL).build();
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
 
         final ExecutorService executor = Executors.newFixedThreadPool(threadCount, r -> {
             final Thread t = new Thread(r);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/BasicConcurrentInsertionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/BasicConcurrentInsertionsTest.java
@@ -16,15 +16,32 @@
 
 package org.drools.mvel.integrationtests.concurrency;
 
+import java.util.Collection;
 import java.util.concurrent.Callable;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
+@RunWith(Parameterized.class)
 public class BasicConcurrentInsertionsTest extends AbstractConcurrentInsertionsTest {
 
-    @Test(timeout = 10000)
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public BasicConcurrentInsertionsTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+    @Test(timeout = 20000)
     public void testConcurrentInsertionsFewObjectsManyThreads() throws InterruptedException {
         final String drl = "import " + Bean.class.getCanonicalName() + ";\n" +
                 "\n" +
@@ -33,10 +50,10 @@ public class BasicConcurrentInsertionsTest extends AbstractConcurrentInsertionsT
                 "    $a : Bean( seed != 1 )\n" +
                 "then\n" +
                 "end";
-        testConcurrentInsertions(drl, 1, 1000, false, false);
+        testConcurrentInsertions(drl, 1, 1000, false, false, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void testConcurrentInsertionsManyObjectsFewThreads() throws InterruptedException {
         final String drl = "import " + Bean.class.getCanonicalName() + ";\n" +
                 "\n" +
@@ -45,10 +62,10 @@ public class BasicConcurrentInsertionsTest extends AbstractConcurrentInsertionsT
                 "    $a : Bean( seed != 1 )\n" +
                 "then\n" +
                 "end";
-        testConcurrentInsertions(drl, 1000, 4, false, false);
+        testConcurrentInsertions(drl, 1000, 4, false, false, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void testConcurrentInsertionsNewSessionEachThreadUpdateFacts() throws InterruptedException {
         // This tests also ObjectTypeNode concurrency
         final String drl = "import " + Bean.class.getCanonicalName() + ";\n" +
@@ -67,10 +84,10 @@ public class BasicConcurrentInsertionsTest extends AbstractConcurrentInsertionsT
                 "    $a: Bean( seed != 1 )\n" +
                 "then\n" +
                 "end\n";
-        testConcurrentInsertions(drl, 10, 1000, true, true);
+        testConcurrentInsertions(drl, 10, 1000, true, true, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void testConcurrentInsertionsNewSessionEachThread() throws InterruptedException {
         final String drl = "import " + Bean.class.getCanonicalName() + ";\n" +
                 " query existsBeanSeed5More() \n" +
@@ -99,7 +116,7 @@ public class BasicConcurrentInsertionsTest extends AbstractConcurrentInsertionsT
                 "    $e: Bean( seed != 7 )\n" +
                 "then\n" +
                 "end";
-        testConcurrentInsertions(drl, 10, 1000, true, false);
+        testConcurrentInsertions(drl, 10, 1000, true, false, kieBaseTestConfiguration);
     }
 
     protected Callable<Boolean> getTask(

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/ConcurrentBasesParallelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/ConcurrentBasesParallelTest.java
@@ -18,12 +18,15 @@ package org.drools.mvel.integrationtests.concurrency;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
 import org.drools.mvel.integrationtests.facts.BeanA;
 import org.drools.mvel.integrationtests.facts.BeanB;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,22 +41,34 @@ import org.kie.api.runtime.rule.QueryResultsRow;
 @RunWith(Parameterized.class)
 public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
 
-    @Parameterized.Parameters(name = "Enforced jitting={0}, Serialize KieBase={1}")
-    public static List<Boolean[]> getTestParameters() {
-        return Arrays.asList(
-                new Boolean[] {false, false},
-                new Boolean[] {false, true},
-                new Boolean[] {true, false},
-                new Boolean[] {true, true});
+    @Parameterized.Parameters(name = "Enforced jitting={0}, KieBase type={1}")
+    public static List<Object[]> getTestParameters() {
+        List<Boolean[]> baseParams = Arrays.asList(
+                                                   new Boolean[]{false},
+                                                   new Boolean[]{true});
+
+        Collection<Object[]> kbParams = TestParametersUtil.getKieBaseCloudConfigurations(true);
+        // combine
+        List<Object[]> params = new ArrayList<>();
+        for (Boolean[] baseParam : baseParams) {
+            for (Object[] kbParam : kbParams) {
+                if (baseParam[0] == true && ((KieBaseTestConfiguration) kbParam[0]).isExecutabelModel()) {
+                    // jitting & exec-model test is not required
+                } else {
+                    params.add(new Object[]{baseParam[0], kbParam[0]});
+                }
+            }
+        }
+        return params;
     }
 
     private static final Integer NUMBER_OF_THREADS = 10;
 
-    public ConcurrentBasesParallelTest(final boolean enforcedJitting, final boolean serializeKieBase) {
-        super(enforcedJitting, serializeKieBase, false, false);
+    public ConcurrentBasesParallelTest(final boolean enforcedJitting, final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        super(enforcedJitting, false, false, false, kieBaseTestConfiguration);
     };
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testOneOfAllFactsMatches() throws InterruptedException {
         final int numberOfObjects = 100;
 
@@ -81,7 +96,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testNoFactMatches() throws InterruptedException {
         final TestExecutor exec = counter -> {
             final String rule = "import " + BeanA.class.getCanonicalName() + ";\n" +
@@ -110,7 +125,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testFireAndGlobalSeparation() throws InterruptedException {
         final TestExecutor exec = counter -> {
             final String rule = "import " + BeanA.class.getCanonicalName() + ";\n" +
@@ -140,7 +155,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testFireAndGlobalSeparation2() throws InterruptedException {
         final String ruleTemplate = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "import " + BeanB.class.getCanonicalName() + ";\n" +
@@ -179,7 +194,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testNonMatchingFact() throws InterruptedException {
         final String ruleTemplate = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "import " + BeanB.class.getCanonicalName() + ";\n" +
@@ -213,7 +228,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testMatchingFact() throws InterruptedException {
         final String ruleTemplate = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "import " + BeanB.class.getCanonicalName() + ";\n" +
@@ -247,7 +262,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testNot() throws InterruptedException {
         final String ruleTemplate = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "import " + BeanB.class.getCanonicalName() + ";\n" +
@@ -282,7 +297,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testExists() throws InterruptedException {
         final String ruleTemplate = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "import " + BeanB.class.getCanonicalName() + ";\n" +
@@ -318,7 +333,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testSubnetwork() throws InterruptedException {
         final String ruleTemplate = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "import " + BeanB.class.getCanonicalName() + ";\n" +
@@ -365,7 +380,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testAccumulatesMatchOnlyBeanA() throws InterruptedException {
         final String ruleA = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "rule RuleA " +
@@ -403,7 +418,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testAccumulatesMatchBoth() throws InterruptedException {
         final String ruleA = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "rule RuleA " +
@@ -436,7 +451,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testAccumulatesMatchOnlyOne() throws InterruptedException {
         final String ruleA = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "rule RuleA " +
@@ -473,7 +488,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testNotsMatchOnlyOne() throws InterruptedException {
         final String ruleA = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "rule RuleNotA " +
@@ -510,7 +525,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testNotsMatchBoth() throws InterruptedException {
         final String ruleA = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "rule RuleNotA " +
@@ -547,7 +562,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testFunctions() throws InterruptedException {
         final String rule = "import " + BeanA.class.getCanonicalName() + ";\n" +
             "global java.util.List list;" +
@@ -584,7 +599,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testFunctions2() throws InterruptedException {
         final int objectCount = 100;
 
@@ -633,7 +648,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testQueries() throws InterruptedException {
         final int numberOfObjects = 100;
 
@@ -668,7 +683,7 @@ public class ConcurrentBasesParallelTest extends AbstractConcurrentTest {
         parallelTest(NUMBER_OF_THREADS, exec);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testQueries2() throws InterruptedException {
         final int numberOfObjects = 100;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/DataTypeEvaluationConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/DataTypeEvaluationConcurrentSessionsTest.java
@@ -17,7 +17,9 @@
 package org.drools.mvel.integrationtests.concurrency;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -34,6 +36,8 @@ import org.drools.mvel.integrationtests.facts.FactWithInteger;
 import org.drools.mvel.integrationtests.facts.FactWithLong;
 import org.drools.mvel.integrationtests.facts.FactWithShort;
 import org.drools.mvel.integrationtests.facts.FactWithString;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,124 +48,130 @@ public class DataTypeEvaluationConcurrentSessionsTest extends AbstractConcurrent
     private static final Integer NUMBER_OF_THREADS = 10;
     private static final Integer NUMBER_OF_REPETITIONS = 1;
 
-    @Parameterized.Parameters(name = "Enforced jitting={0}, Serialize KieBase={1}, Share KieBase={2}, Share KieSession={3}")
-    public static List<Boolean[]> getTestParameters() {
-        return Arrays.asList(
-                new Boolean[]{false, false, false, false},
-                new Boolean[]{false, true, false, false},
-                new Boolean[]{true, false, false, false},
-                new Boolean[]{true, true, false, false},
-                new Boolean[]{false, false, true, false},
-                new Boolean[]{false, true, true, false},
-                new Boolean[]{true, false, true, false},
-                new Boolean[]{true, true, true, false},
+    @Parameterized.Parameters(name = "Enforced jitting={0}, Share KieBase={1}, Share KieSession={2}, KieBase type={3}")
+    public static List<Object[]> getTestParameters() {
+        List<Boolean[]> baseParams = Arrays.asList(
+                                                   new Boolean[]{false, false, false},
+                                                   new Boolean[]{true, false, false},
+                                                   new Boolean[]{false, true, false},
+                                                   new Boolean[]{true, true, false},
 
-                new Boolean[]{false, false, false, true},
-                new Boolean[]{false, true, false, true},
-                new Boolean[]{true, false, false, true},
-                new Boolean[]{true, true, false, true},
-                new Boolean[]{false, false, true, true},
-                new Boolean[]{false, true, true, true},
-                new Boolean[]{true, false, true, true},
-                new Boolean[]{true, true, true, true});
+                                                   new Boolean[]{false, false, true},
+                                                   new Boolean[]{true, false, true},
+                                                   new Boolean[]{false, true, true},
+                                                   new Boolean[]{true, true, true});
+        // TODO: EM failed with some tests. File JIRAs
+        Collection<Object[]> kbParams = TestParametersUtil.getKieBaseCloudConfigurations(false);
+        // combine
+        List<Object[]> params = new ArrayList<>();
+        for (Boolean[] baseParam : baseParams) {
+            for (Object[] kbParam : kbParams) {
+                if (baseParam[0] == true && ((KieBaseTestConfiguration) kbParam[0]).isExecutabelModel()) {
+                    // jitting & exec-model test is not required
+                } else {
+                    params.add(new Object[]{baseParam[0], baseParam[1], baseParam[2], kbParam[0]});
+                }
+            }
+        }
+        return params;
     }
 
-    public DataTypeEvaluationConcurrentSessionsTest(final boolean enforcedJitting, final boolean serializeKieBase,
-                                                       final boolean sharedKieBase, final boolean sharedKieSession) {
-        super(enforcedJitting, serializeKieBase, sharedKieBase, sharedKieSession);
+    public DataTypeEvaluationConcurrentSessionsTest(final boolean enforcedJitting,
+                                                       final boolean sharedKieBase, final boolean sharedKieSession, final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        super(enforcedJitting, false, sharedKieBase, sharedKieSession, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testBooleanPrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithBoolean: FactWithBoolean(booleanValue == false) \n", new FactWithBoolean(false));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testBoolean() throws InterruptedException {
         testFactAttributeType("    $factWithBoolean: FactWithBoolean(booleanObjectValue == false) \n", new FactWithBoolean(false));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testBytePrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithByte: FactWithByte(byteValue == 15) \n", new FactWithByte((byte) 15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testByte() throws InterruptedException {
         testFactAttributeType("    $factWithByte: FactWithByte(byteObjectValue == 15) \n", new FactWithByte((byte) 15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testShortPrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithShort: FactWithShort(shortValue == 15) \n", new FactWithShort((short) 15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testShort() throws InterruptedException {
         testFactAttributeType("    $factWithShort: FactWithShort(shortObjectValue == 15) \n", new FactWithShort((short) 15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testIntPrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithInt: FactWithInteger(intValue == 15) \n", new FactWithInteger(15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testInteger() throws InterruptedException {
         testFactAttributeType("    $factWithInteger: FactWithInteger(integerValue == 15) \n", new FactWithInteger(15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testLongPrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithLong: FactWithLong(longValue == 15) \n", new FactWithLong(15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testLong() throws InterruptedException {
         testFactAttributeType("    $factWithLong: FactWithLong(longObjectValue == 15) \n", new FactWithLong(15));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testFloatPrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithFloat: FactWithFloat(floatValue == 15.1) \n", new FactWithFloat(15.1f));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testFloat() throws InterruptedException {
         testFactAttributeType("    $factWithFloat: FactWithFloat(floatObjectValue == 15.1) \n", new FactWithFloat(15.1f));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testDoublePrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithDouble: FactWithDouble(doubleValue == 15.1) \n", new FactWithDouble(15.1d));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testDouble() throws InterruptedException {
         testFactAttributeType("    $factWithDouble: FactWithDouble(doubleObjectValue == 15.1) \n", new FactWithDouble(15.1d));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testBigDecimal() throws InterruptedException {
         testFactAttributeType("    $factWithBigDecimal: FactWithBigDecimal(bigDecimalValue == 10) \n", new FactWithBigDecimal(BigDecimal.TEN));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testCharPrimitive() throws InterruptedException {
         testFactAttributeType("    $factWithChar: FactWithCharacter(charValue == 'a') \n", new FactWithCharacter('a'));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testCharacter() throws InterruptedException {
         testFactAttributeType("    $factWithChar: FactWithCharacter(characterValue == 'a') \n", new FactWithCharacter('a'));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testString() throws InterruptedException {
         testFactAttributeType("    $factWithString: FactWithString(stringValue == \"test\") \n", new FactWithString("test"));
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void testEnum() throws InterruptedException {
         testFactAttributeType("    $factWithEnum: FactWithEnum(enumValue == AnEnum.FIRST) \n", new FactWithEnum(AnEnum.FIRST));
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/JoinsConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/JoinsConcurrentSessionsTest.java
@@ -18,6 +18,7 @@ package org.drools.mvel.integrationtests.concurrency;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.mvel.integrationtests.facts.AnEnum;
@@ -26,6 +27,8 @@ import org.drools.mvel.integrationtests.facts.ChildFact2;
 import org.drools.mvel.integrationtests.facts.ChildFact3WithEnum;
 import org.drools.mvel.integrationtests.facts.ChildFact4WithFirings;
 import org.drools.mvel.integrationtests.facts.RootFact;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,25 +39,35 @@ public class JoinsConcurrentSessionsTest extends AbstractConcurrentTest {
     private static final Integer NUMBER_OF_THREADS = 10;
     private static final Integer NUMBER_OF_REPETITIONS = 1;
 
-    @Parameterized.Parameters(name = "Enforced jitting={0}, Serialize KieBase={1}, Share KieBase={2}")
-    public static List<Boolean[]> getTestParameters() {
-        return Arrays.asList(
-                new Boolean[]{false, false, false},
-                new Boolean[]{false, true, false},
-                new Boolean[]{true, false, false},
-                new Boolean[]{true, true, false},
-                new Boolean[]{false, false, true},
-                new Boolean[]{false, true, true},
-                new Boolean[]{true, false, true},
-                new Boolean[]{true, true, true});
+    @Parameterized.Parameters(name = "Enforced jitting={0}, Share KieBase={1}, KieBase type={2}")
+    public static List<Object[]> getTestParameters() {
+        List<Boolean[]> baseParams = Arrays.asList(
+                                                   new Boolean[]{false, false},
+                                                   new Boolean[]{true, false},
+                                                   new Boolean[]{false, true},
+                                                   new Boolean[]{true, true});
+
+        Collection<Object[]> kbParams = TestParametersUtil.getKieBaseCloudConfigurations(true);
+        // combine
+        List<Object[]> params = new ArrayList<>();
+        for (Boolean[] baseParam : baseParams) {
+            for (Object[] kbParam : kbParams) {
+                if (baseParam[0] == true && ((KieBaseTestConfiguration) kbParam[0]).isExecutabelModel()) {
+                    // jitting & exec-model test is not required
+                } else {
+                    params.add(new Object[]{baseParam[0], baseParam[1], kbParam[0]});
+                }
+            }
+        }
+        return params;
     }
 
-    public JoinsConcurrentSessionsTest(final boolean enforcedJitting, final boolean serializeKieBase,
-                                       final boolean sharedKieBase) {
-        super(enforcedJitting, serializeKieBase, sharedKieBase, false);
+    public JoinsConcurrentSessionsTest(final boolean enforcedJitting,
+                                       final boolean sharedKieBase, final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        super(enforcedJitting, false, sharedKieBase, false, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 40000)
     public void test5() throws InterruptedException {
         final String drlTemplate =
                 " import org.drools.mvel.integrationtests.facts.*;\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SubnetworkConcurrentSessionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SubnetworkConcurrentSessionsTest.java
@@ -16,10 +16,14 @@
 
 package org.drools.mvel.integrationtests.concurrency;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.mvel.integrationtests.facts.Product;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,26 +34,36 @@ public class SubnetworkConcurrentSessionsTest extends AbstractConcurrentTest {
     private static final Integer NUMBER_OF_THREADS = 10;
     private static final Integer NUMBER_OF_REPETITIONS = 1;
 
+    @Parameterized.Parameters(name = "Enforced jitting={0}, Share KieBase={1}, KieBase type={2}")
+    public static List<Object[]> getTestParameters() {
+        List<Boolean[]> baseParams = Arrays.asList(
+                new Boolean[]{false, false},
+                new Boolean[]{true, false},
+                new Boolean[]{false, true},
+                new Boolean[]{true, true}
+                );
 
-    @Parameterized.Parameters(name = "Enforced jitting={0}, Serialize KieBase={1}, Share KieBase={2}")
-    public static List<Boolean[]> getTestParameters() {
-        return Arrays.asList(
-                new Boolean[]{false, false, false},
-                new Boolean[]{false, true, false},
-                new Boolean[]{true, false, false},
-                new Boolean[]{true, true, false},
-                new Boolean[]{false, false, true},
-                new Boolean[]{false, true, true},
-                new Boolean[]{true, false, true},
-                new Boolean[]{true, true, true});
+        Collection<Object[]> kbParams = TestParametersUtil.getKieBaseCloudConfigurations(true);
+        // combine
+        List<Object[]> params = new ArrayList<>();
+        for (Boolean[] baseParam : baseParams) {
+            for (Object[] kbParam : kbParams) {
+                if (baseParam[0] == true && ((KieBaseTestConfiguration) kbParam[0]).isExecutabelModel()) {
+                    // jitting & exec-model test is not required
+                } else {
+                    params.add(new Object[] {baseParam[0], baseParam[1], kbParam[0]});
+                }
+            }
+        }
+        return params;
     }
 
-    public SubnetworkConcurrentSessionsTest(final boolean enforcedJitting, final boolean serializeKieBase,
-                                            final boolean sharedKieBase) {
-        super(enforcedJitting, serializeKieBase, sharedKieBase, false);
+    public SubnetworkConcurrentSessionsTest(final boolean enforcedJitting,
+                                            final boolean sharedKieBase,  final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        super(enforcedJitting, false, sharedKieBase, false, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 80000)
     public void test1() throws InterruptedException {
         final String drl = "rule R when String() then end";
 
@@ -59,13 +73,13 @@ public class SubnetworkConcurrentSessionsTest extends AbstractConcurrentTest {
         }, null, null, drl );
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 80000)
     public void test2NoSubnetwork() throws InterruptedException {
         test2(getRule("R1", "this == \"odd\"", false, false, "Number( intValue > 0 )"),
                 getRule("R2", "this == \"pair\"", false, false, "Number( intValue < 10000 )"));
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 80000)
     public void test2WithSubnetwork() throws InterruptedException {
         test2(getRule("R1", "this == \"odd\"", false, true, "Number( intValue > 0 )"),
                 getRule("R2", "this == \"pair\"", false, true, "Number( intValue < 10000 )"));
@@ -95,19 +109,19 @@ public class SubnetworkConcurrentSessionsTest extends AbstractConcurrentTest {
         }, null, null, drls );
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 80000)
     public void test3NoSubnetwork() throws InterruptedException {
         test3(getRule("R1", "this == \"odd\"", false, false, "Number( intValue > 0 )"),
                 getRule("R2", "this == \"pair\"", false, false, "Number( intValue < 10000 )"));
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 80000)
     public void test3WithSubnetwork() throws InterruptedException {
         test3(getRule("R1", "this == \"odd\"", false, true, "Number( intValue > 0 )"),
                 getRule("R2", "this == \"pair\"", false, true, "Number( intValue < 10000 )"));
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 80000)
     public void test3WithSharedSubnetwork() throws InterruptedException {
         final String ruleTemplate = "import " + Product.class.getCanonicalName() + ";\n" +
                 "rule ${ruleName} when\n" +
@@ -169,13 +183,13 @@ public class SubnetworkConcurrentSessionsTest extends AbstractConcurrentTest {
         }, null, null, drls );
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void test4NoSharing() throws InterruptedException {
         test4(getRule("R1", "", false, true, "Number( intValue > 5 )"),
                 getRule("R2", "", false, true, "Number( intValue < 5 )"));
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void test4WithSharing() throws InterruptedException {
         test4(getRule("R1", "", true, true, "Number( intValue > 5 )"),
                 getRule("R2", "", true, true, "Number( intValue < 5 )"));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventGeneratorTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/eventgenerator/SimpleEventGeneratorTest.java
@@ -16,24 +16,41 @@
 package org.drools.mvel.integrationtests.eventgenerator;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import org.drools.compiler.compiler.DroolsParserException;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.integrationtests.eventgenerator.Event.EventType;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class SimpleEventGeneratorTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class SimpleEventGeneratorTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public SimpleEventGeneratorTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     private final static String TEST_RULE_FILE = "test_eventGenerator.drl";
 
     @Test
     public void testEventGenerationMaxItems() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -46,7 +63,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationMaxTime() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -59,7 +76,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationMaxTimeAndMaxItems() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -73,7 +90,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationDelayedMaxItems() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -86,7 +103,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationDelayedMaxTime() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -99,7 +116,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationDelayedMaxTimeAndMaxItems() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -113,7 +130,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationGlobalMaxTime() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator
@@ -127,7 +144,7 @@ public class SimpleEventGeneratorTest extends CommonTestMethodBase {
 
     @Test
     public void testEventGenerationMultipleSources() throws DroolsParserException, IOException, Exception{
-        KieBase kbase = loadKnowledgeBase(TEST_RULE_FILE);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, TEST_RULE_FILE);
         KieSession ksession = kbase.newKieSession();
 
         // create unrestricted event generator

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/marshalling/MarshallingIssuesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/marshalling/MarshallingIssuesTest.java
@@ -37,6 +37,8 @@ import static org.junit.Assert.fail;
 
 public class MarshallingIssuesTest extends CommonTestMethodBase  {
 
+    // kbase serialization is not supported. But leave it for standard-drl
+
     @Test
     public void testJBRULES_1946() {
         KieBase kbase = loadKnowledgeBase("../Sample.drl" );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/AgendaFilterTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/AgendaFilterTest.java
@@ -16,24 +16,42 @@
 
 package org.drools.mvel.integrationtests.session;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import java.util.Collection;
 
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.core.base.RuleNameEndsWithAgendaFilter;
 import org.drools.core.base.RuleNameEqualsAgendaFilter;
 import org.drools.core.base.RuleNameMatchesAgendaFilter;
 import org.drools.core.base.RuleNameStartsWithAgendaFilter;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.AgendaFilter;
 import org.mockito.ArgumentCaptor;
 
-public class AgendaFilterTest extends CommonTestMethodBase {
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class AgendaFilterTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public AgendaFilterTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testAgendaFilterRuleNameStartsWith() {
@@ -60,8 +78,8 @@ public class AgendaFilterTest extends CommonTestMethodBase {
                 "rule Aaa when then end\n" +
                 "rule Bbb when then end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         final org.kie.api.event.rule.AgendaEventListener ael = mock(org.kie.api.event.rule.AgendaEventListener.class);
         ksession.addEventListener(ael);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/BasicUpdateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/BasicUpdateTest.java
@@ -18,28 +18,41 @@ package org.drools.mvel.integrationtests.session;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.test.model.Cheese;
 import org.drools.core.test.model.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.KieFileSystem;
-import org.kie.api.builder.Message;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.QueryResultsRow;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 
+@RunWith(Parameterized.class)
 public class BasicUpdateTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public BasicUpdateTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     private static final String UPDATE_TEST_DRL = "org/drools/mvel/integrationtests/session/update_test.drl";
 
@@ -47,23 +60,7 @@ public class BasicUpdateTest {
 
     @Before
     public void setUp() {
-        final KieFileSystem kfs = KieServices.Factory.get().newKieFileSystem();
-
-        kfs.write(KieServices.Factory.get().getResources()
-                .newClassPathResource(UPDATE_TEST_DRL, BasicUpdateTest.class));
-
-        final KieBuilder kbuilder = KieServices.Factory.get().newKieBuilder(kfs);
-
-        kbuilder.buildAll();
-
-        final List<Message> res = kbuilder.getResults().getMessages(Message.Level.ERROR);
-
-        assertEquals(res.toString(), 0, res.size());
-
-        final KieBase kbase = KieServices.Factory.get()
-                .newKieContainer(kbuilder.getKieModule().getReleaseId())
-                .getKieBase();
-
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, UPDATE_TEST_DRL);
         ksession = kbase.newKieSession();
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/CrossProductTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/CrossProductTest.java
@@ -18,23 +18,40 @@ package org.drools.mvel.integrationtests.session;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.drools.mvel.CommonTestMethodBase;
+
 import org.drools.mvel.compiler.SpecialString;
-import org.drools.mvel.integrationtests.SerializationHelper;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 
-public class CrossProductTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class CrossProductTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public CrossProductTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testCrossProductRemovingIdentityEquals() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_CrossProductRemovingIdentityEquals.drl"));
-        final KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_CrossProductRemovingIdentityEquals.drl");
+        KieSession session = kbase.newKieSession();
 
         final List list1 = new ArrayList();
         session.setGlobal("list1", list1);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/EntryPointTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/EntryPointTest.java
@@ -17,15 +17,33 @@
 package org.drools.mvel.integrationtests.session;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import org.drools.mvel.CommonTestMethodBase;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertTrue;
 
-public class EntryPointTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class EntryPointTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public EntryPointTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testEntryPointWithVarIN() {
@@ -47,7 +65,7 @@ public class EntryPointTest extends CommonTestMethodBase {
                 "   list.add( $i );\n" +
                 "end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         ksession.insert(10);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/FieldAccessTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/FieldAccessTest.java
@@ -16,20 +16,38 @@
 
 package org.drools.mvel.integrationtests.session;
 
+import java.util.Collection;
+
 import org.drools.mvel.compiler.Address;
 import org.drools.mvel.compiler.Cat;
 import org.drools.mvel.compiler.Cheese;
-import org.drools.mvel.CommonTestMethodBase;
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.compiler.Primitives;
-import org.drools.mvel.integrationtests.SerializationHelper;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 
-public class FieldAccessTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class FieldAccessTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public FieldAccessTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     // this isn't possible, we can only narrow with type safety, not widen.
@@ -50,8 +68,8 @@ public class FieldAccessTest extends CommonTestMethodBase {
         rule += "    System.out.println(\"hello person\");\n";
         rule += "end";
 
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBaseFromString(rule));
-        final KieSession session = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule);
+        KieSession session = kbase.newKieSession();
 
         final Person person = new Person();
         person.setPet(new Cat("Mittens"));
@@ -68,8 +86,8 @@ public class FieldAccessTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         ksession.insert(new Primitives());
         final int rules = ksession.fireAllRules();
@@ -86,8 +104,8 @@ public class FieldAccessTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
-        final KieSession ksession = kbase.newKieSession();
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieSession ksession = kbase.newKieSession();
 
         final Person p = new Person("x");
         p.setAddress(new Address("x", "x", "x"));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/InsertTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/InsertTest.java
@@ -17,15 +17,20 @@
 package org.drools.mvel.integrationtests.session;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import org.drools.mvel.CommonTestMethodBase;
+
 import org.drools.mvel.compiler.Move;
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.compiler.PersonFinal;
 import org.drools.mvel.compiler.Pet;
 import org.drools.mvel.compiler.Win;
-import org.drools.mvel.integrationtests.SerializationHelper;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 
@@ -33,7 +38,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-public class InsertTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class InsertTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public InsertTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testInsert() throws Exception {
@@ -56,8 +73,8 @@ public class InsertTest extends CommonTestMethodBase {
         drl += "  list.add( $person );\n";
         drl += "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(drl);
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieSession ksession = kbase.newKieSession();
         final List list = new ArrayList();
         ksession.setGlobal("list", list);
 
@@ -73,9 +90,8 @@ public class InsertTest extends CommonTestMethodBase {
 
     @Test
     public void testInsertionOrder() {
-        final KieBase kbase = loadKnowledgeBase("test_InsertionOrder.drl");
-
-        KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_InsertionOrder.drl");
+        KieSession ksession = kbase.newKieSession();
         List<String> results = new ArrayList<>();
         ksession.setGlobal("results", results);
         ksession.insert(new Move(1, 2));
@@ -90,7 +106,7 @@ public class InsertTest extends CommonTestMethodBase {
         assertTrue(results.contains(win3));
 
         ksession.dispose();
-        ksession = createKnowledgeSession(kbase);
+        ksession = kbase.newKieSession();
         results = new ArrayList<>();
         ksession.setGlobal("results", results);
         // reverse the order of the inserts
@@ -105,8 +121,8 @@ public class InsertTest extends CommonTestMethodBase {
 
     @Test
     public void testInsertFinalClassInstance() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_FinalClass.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_FinalClass.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List list = new ArrayList();
         ksession.setGlobal("results", list);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/LocaleTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/LocaleTest.java
@@ -17,18 +17,36 @@
 package org.drools.mvel.integrationtests.session;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+
 import org.drools.mvel.compiler.Cheese;
-import org.drools.mvel.CommonTestMethodBase;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 
 import static org.junit.Assert.assertEquals;
 
-public class LocaleTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class LocaleTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public LocaleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testLatinLocale() throws Exception {
@@ -38,8 +56,8 @@ public class LocaleTest extends CommonTestMethodBase {
             // setting a locale that uses COMMA as decimal separator
             Locale.setDefault(new Locale("pt", "BR"));
 
-            final KieBase kbase = loadKnowledgeBase("test_LatinLocale.drl");
-            final KieSession ksession = createKnowledgeSession(kbase);
+            KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_LatinLocale.drl");
+            KieSession ksession = kbase.newKieSession();
 
             final List<String> results = new ArrayList<String>();
             ksession.setGlobal("results", results);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/RuleRuntimeEventTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/RuleRuntimeEventTest.java
@@ -16,14 +16,15 @@
 
 package org.drools.mvel.integrationtests.session;
 
-import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import java.util.Collection;
 
 import org.drools.mvel.compiler.Cheese;
-import org.drools.mvel.CommonTestMethodBase;
-import org.drools.mvel.integrationtests.SerializationHelper;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.event.rule.ObjectDeletedEvent;
 import org.kie.api.event.rule.ObjectInsertedEvent;
@@ -32,12 +33,28 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.mockito.ArgumentCaptor;
 
-public class RuleRuntimeEventTest extends CommonTestMethodBase {
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class RuleRuntimeEventTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public RuleRuntimeEventTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 
     @Test
     public void testEventModel() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_EventModel.drl"));
-        final KieSession wm = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_EventModel.drl");
+        KieSession wm = kbase.newKieSession();
 
         final RuleRuntimeEventListener wmel = mock(RuleRuntimeEventListener.class);
         wm.addEventListener(wmel);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/TypeCoercionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/TypeCoercionTest.java
@@ -17,13 +17,18 @@
 package org.drools.mvel.integrationtests.session;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import org.drools.mvel.CommonTestMethodBase;
+
 import org.drools.mvel.compiler.Person;
 import org.drools.mvel.compiler.PolymorphicFact;
 import org.drools.mvel.compiler.Primitives;
-import org.drools.mvel.integrationtests.SerializationHelper;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.definition.type.FactType;
 import org.kie.api.runtime.KieSession;
@@ -31,12 +36,25 @@ import org.kie.api.runtime.rule.FactHandle;
 
 import static org.junit.Assert.assertEquals;
 
-public class TypeCoercionTest extends CommonTestMethodBase {
+@RunWith(Parameterized.class)
+public class TypeCoercionTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public TypeCoercionTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+     // TODO: EM failed with some tests. File JIRAs
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
 
     @Test
     public void testRuntimeTypeCoercion() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_RuntimeTypeCoercion.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_RuntimeTypeCoercion.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List list = new ArrayList();
         ksession.setGlobal("results", list);
@@ -64,8 +82,8 @@ public class TypeCoercionTest extends CommonTestMethodBase {
 
     @Test
     public void testRuntimeTypeCoercion2() throws Exception {
-        final KieBase kbase = SerializationHelper.serializeObject(loadKnowledgeBase("test_RuntimeTypeCoercion2.drl"));
-        final KieSession ksession = createKnowledgeSession(kbase);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_RuntimeTypeCoercion2.drl");
+        KieSession ksession = kbase.newKieSession();
 
         final List list = new ArrayList();
         ksession.setGlobal("results", list);
@@ -132,7 +150,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                 "   System.out.println(\"ID compared values: 3.0, 4.0 - actual ID value: \" + $id);\n" +
                 "end";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(rule);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, rule);
         final KieSession ksession = kbase.newKieSession();
 
         final InnerBean innerTest = new InnerBean();
@@ -198,7 +216,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final FactType typeA = kbase.getFactType("org.drools.mvel.compiler.test", "A");
@@ -220,7 +238,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                 "then\n" +
                 "end\n";
 
-        final KieBase kbase = loadKnowledgeBaseFromString(str);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
         final KieSession ksession = kbase.newKieSession();
 
         final Person p = new Person("42", 42);
@@ -247,7 +265,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                            "    Person(name == \"11\")\n" +
                            " then end\n";
 
-        KieBase kieBase = loadKnowledgeBaseFromString(drl);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession kieSession = kieBase.newKieSession();
 
         kieSession.insert(new Person("11"));
@@ -269,7 +287,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                            "    Person(age == 11)\n" +
                            " then end\n";
 
-        KieBase kieBase = loadKnowledgeBaseFromString(drl);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession kieSession = kieBase.newKieSession();
 
         kieSession.insert(new Person("Mario", 11));
@@ -285,7 +303,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                 "     String(this == $i)\n" +
                 " then end\n";
 
-        KieBase kieBase = loadKnowledgeBaseFromString(drl);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession kieSession = kieBase.newKieSession();
 
         kieSession.insert(2);
@@ -303,7 +321,7 @@ public class TypeCoercionTest extends CommonTestMethodBase {
                 "     Person(name == $i)\n" +
                 " then end\n";
 
-        KieBase kieBase = loadKnowledgeBaseFromString(drl);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
         KieSession kieSession = kieBase.newKieSession();
 
         kieSession.insert(2);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/ReteOOWaltzTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/ReteOOWaltzTest.java
@@ -16,6 +16,22 @@
 
 package org.drools.mvel.integrationtests.waltz;
 
+import java.util.Collection;
+
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
 public class ReteOOWaltzTest extends Waltz {
 
+    public ReteOOWaltzTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        super(kieBaseTestConfiguration);
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Waltz.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Waltz.java
@@ -22,8 +22,8 @@ import java.io.InputStreamReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.drools.mvel.CommonTestMethodBase;
-
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.junit.Test;
 import org.kie.api.KieBase;
 import org.kie.api.runtime.KieSession;
@@ -33,7 +33,13 @@ import static org.junit.Assert.fail;
 /**
  * This is a sample file to launch a rule package from a rule source file.
  */
-public abstract class Waltz extends CommonTestMethodBase {
+public abstract class Waltz {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public Waltz(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
 
     @Test(timeout = 20000 )
     public void testWaltz() {
@@ -74,8 +80,7 @@ public abstract class Waltz extends CommonTestMethodBase {
     }
 
     public KieBase readKnowledegBase() {
-        KieBase kbase = loadKnowledgeBase( "waltz.drl");
-        return ( KieBase ) kbase;
+        return KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "waltz.drl");
     }
 
     private void loadLines(final KieSession kSession,

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/WaltzMain.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/WaltzMain.java
@@ -15,9 +15,15 @@
 
 package org.drools.mvel.integrationtests.waltz;
 
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+
 public class WaltzMain extends ReteOOWaltzTest {
 
+    public WaltzMain(KieBaseTestConfiguration kieBaseTestConfiguration) {
+        super(kieBaseTestConfiguration);
+    }
+
     public static final void main(String[] args) {
-        new WaltzMain().testWaltz();
+        new WaltzMain(KieBaseTestConfiguration.CLOUD_IDENTITY).testWaltz();
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/thread_class_test.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/mvel/integrationtests/thread_class_test.drl
@@ -18,7 +18,7 @@ package nesting;
 //dialect "mvel"
 
 import org.drools.mvel.compiler.Person
-import org.drools.Address
+import org.drools.mvel.compiler.Address
 
 
 

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
@@ -286,6 +286,10 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
         return Optional.ofNullable(executableModelProjectClass);
     }
 
+    public boolean isExecutabelModel() {
+        return executableModelProjectClass != null;
+    }
+
     @Override
     public KieBaseModel getKieBaseModel(final KieModuleModel kieModuleModel) {
         final KieBaseModel kieBaseModel = kieModuleModel.newKieBaseModel(KIE_BASE_MODEL_NAME);

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseUtil.java
@@ -140,7 +140,33 @@ public final class KieBaseUtil {
                                                            final KieBaseTestConfiguration kieBaseTestConfiguration,
                                                            final String... classpathResources) {
         final List<Resource> resources = KieUtil.getClasspathResources(classLoaderFromClass, classpathResources);
-        KieModuleModel kieModuleModel = KieUtil.getKieModuleModel(kieBaseTestConfiguration, KieSessionTestConfiguration.STATEFUL_REALTIME, new HashMap<>());
+        return getKieBaseFromResourcesWithClassLoaderForKieBuilder(moduleGroupId, classLoaderForKieBuilder, kieBaseTestConfiguration, new HashMap<>(), resources);
+    }
+
+    public static KieBase getKieBaseFromClasspathResourcesWithClassLoaderForKieBuilder(final String moduleGroupId,
+                                                                                       final Class<?> classLoaderFromClass,
+                                                                                       final ClassLoader classLoaderForKieBuilder,
+                                                                                       final KieBaseTestConfiguration kieBaseTestConfiguration,
+                                                                                       final Map<String, String> kieModuleConfigurationProperties,
+                                                                                       final String... classpathResources) {
+        final List<Resource> resources = KieUtil.getClasspathResources(classLoaderFromClass, classpathResources);
+        return getKieBaseFromResourcesWithClassLoaderForKieBuilder(moduleGroupId, classLoaderForKieBuilder, kieBaseTestConfiguration, kieModuleConfigurationProperties, resources);
+    }
+
+    public static KieBase getKieBaseFromDrlWithClassLoaderForKieBuilder(final String moduleGroupId,
+                                                                        final ClassLoader classLoaderForKieBuilder,
+                                                                        final KieBaseTestConfiguration kieBaseTestConfiguration,
+                                                                        final String... drls) {
+        final List<Resource> resources = KieUtil.getResourcesFromDrls(drls);
+        return getKieBaseFromResourcesWithClassLoaderForKieBuilder(moduleGroupId, classLoaderForKieBuilder, kieBaseTestConfiguration, new HashMap<>(), resources);
+    }
+
+    private static KieBase getKieBaseFromResourcesWithClassLoaderForKieBuilder(final String moduleGroupId,
+                                                                               final ClassLoader classLoaderForKieBuilder,
+                                                                               final KieBaseTestConfiguration kieBaseTestConfiguration,
+                                                                               final Map<String, String> kieModuleConfigurationProperties,
+                                                                               final List<Resource> resources) {
+        KieModuleModel kieModuleModel = KieUtil.getKieModuleModel(kieBaseTestConfiguration, KieSessionTestConfiguration.STATEFUL_REALTIME, kieModuleConfigurationProperties);
         KieFileSystem kfs = KieUtil.getKieFileSystemWithKieModule(kieModuleModel, KieUtil.generateReleaseId(moduleGroupId), resources.toArray(new Resource[]{}));
         KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, false, classLoaderForKieBuilder);
         final KieModule kieModule = kieBuilder.getKieModule();


### PR DESCRIPTION
…ge : 3rd round

- reviewed all tests under org/drools/mvel/ and applied exec-model coverage where possible

Remaining works)
- File JIRAs for "// TODO: EM failed with some tests" cases
- Fix those JIRAs
- Check drools-mvel dependency (e.g. MvelConstraint) in tests. Fix if possible
- Check any leftovers in drools-mvel (e.g. some test-jar dependency to other modules)

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6074

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
