### PR TITLE
[DROOLS-6091] A statement containing only a parenthesized expression …

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -577,6 +577,7 @@ public class MvelDialectTest extends BaseModelTest {
                 "    result -= 10000B;\n" + // 40000
                 "    result /= 10B;\n" + // 4000
                 "    result *= 10B;\n" + // 40000
+                "    (result *= 10B);\n" + // 400000
                 "    $p.money = result;" +
                 "end";
 
@@ -587,7 +588,7 @@ public class MvelDialectTest extends BaseModelTest {
 
         ksession.insert(john);
         assertEquals(1, ksession.fireAllRules());
-        assertEquals(new BigDecimal( 40000 ), john.getMoney());
+        assertEquals(new BigDecimal( 400000 ), john.getMoney());
     }
 
     @Test

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
@@ -13,6 +13,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
@@ -256,6 +257,12 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, Void> {
 
         Optional<TypedExpression> expression = ofNullable(n.getExpression().accept(this, arg));
         return new ExpressionStmtT(expression.orElseGet(this::rhsOrError));
+    }
+
+    @Override
+    public TypedExpression visit(EnclosedExpr n, Void arg) {
+        // We don't want our LHS to be ever wrapped
+        return n.getInner().accept(this, arg);
     }
 
     @Override

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -451,10 +451,11 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ " +
                      "    BigDecimal result = 0B;" +
-                     "    result += 50000;\n" + // 50000
-                     "    result -= 10000;\n" + // 40000
-                     "    result /= 10;\n" + // 4000
-                     "    result *= 10;\n" + // 40000
+                     "    result += 50000;\n" +
+                     "    result -= 10000;\n" +
+                     "    result /= 10;\n" +
+                     "    result *= 10;\n" +
+                     "    (result *= $p.salary);\n" +
                      "    $p.salary = result;" +
                      "}",
              "{ " +
@@ -463,6 +464,7 @@ public class MvelCompilerTest implements CompilerTest {
                      "        result = result.subtract(new java.math.BigDecimal(10000));\n" +
                      "        result = result.divide(new java.math.BigDecimal(10));\n" +
                      "        result = result.multiply(new java.math.BigDecimal(10));\n" +
+                     "        result = result.multiply($p.getSalary());\n" +
                      "        $p.setSalary(result);\n" +
                      "}");
     }


### PR DESCRIPTION
…written in MVEL dialect causes compilation error in executable model.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6091


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
