### PR TITLE
[DROOLS-6177] Parametrize query command in kie-server to choose the return values

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/DisconnectedFactHandle.java
+++ b/drools-core/src/main/java/org/drools/core/common/DisconnectedFactHandle.java
@@ -50,6 +50,8 @@ public class DisconnectedFactHandle
         InternalFactHandle,
         Externalizable {
 
+    private static final String UNSUPPORTED_OPERATION_ERROR_MESSAGE = "DisconnectedFactHandle does not support this method";;
+
     @XmlElement
     @XmlSchemaType(name="long")
     private long    id;
@@ -160,7 +162,7 @@ public class DisconnectedFactHandle
 
     @Override
     public <K> K as( Class<K> klass ) throws ClassCastException {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     @Override
@@ -205,7 +207,7 @@ public class DisconnectedFactHandle
     }
 
     public LeftTuple getLastLeftTuple() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public String getObjectClassName() {
@@ -216,27 +218,27 @@ public class DisconnectedFactHandle
         if ( this.object != null ) {
             return this.object;
         }
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public WorkingMemoryEntryPoint getEntryPoint() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public EqualityKey getEqualityKey() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public RightTuple getRightTuple() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void invalidate() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public boolean isEvent() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public boolean isTraitOrTraitable() {
@@ -251,54 +253,54 @@ public class DisconnectedFactHandle
         return traitType == TraitTypeEnum.TRAIT.TRAIT;
     }
     public boolean isValid() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setEntryPoint(WorkingMemoryEntryPoint ep ) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setEqualityKey(EqualityKey key) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setFirstLeftTuple(LeftTuple leftTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     @Override
     public LinkedTuples getLinkedTuples() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     @Override
     public LinkedTuples detachLinkedTuples() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     @Override
     public LinkedTuples detachLinkedTuplesForPartition(int i) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setLastLeftTuple(LeftTuple leftTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setObject(Object object) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setRecency(long recency) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void setRightTuple(RightTuple rightTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public InternalFactHandle clone() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public String toExternalForm() {
@@ -323,15 +325,15 @@ public class DisconnectedFactHandle
     }
 
     public LeftTuple getFirstLeftTuple() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public RightTuple getFirstRightTuple() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public RightTuple getLastRightTuple() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public String toTupleTree(int indent) {
@@ -347,39 +349,39 @@ public class DisconnectedFactHandle
     }
 
     public void addFirstLeftTuple(LeftTuple leftTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void addLastLeftTuple(LeftTuple leftTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void removeLeftTuple(LeftTuple leftTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void clearLeftTuples() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void clearRightTuples() {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void addFirstRightTuple(RightTuple rightTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void addLastRightTuple(RightTuple rightTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void addTupleInPosition(Tuple rightTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public void removeRightTuple(RightTuple rightTuple) {
-        throw new UnsupportedOperationException( "DisonnectedFactHandle does not support this method" );
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_ERROR_MESSAGE);
     }
 
     public EntryPointId getEntryPointId() {

--- a/drools-core/src/main/java/org/drools/core/runtime/rule/impl/FlatQueryResults.java
+++ b/drools-core/src/main/java/org/drools/core/runtime/rule/impl/FlatQueryResults.java
@@ -34,6 +34,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.drools.core.QueryResultsImpl;
 import org.drools.core.QueryResultsRowImpl;
 import org.drools.core.common.DisconnectedFactHandle;
+import org.drools.core.common.InternalFactHandle;
 import org.drools.core.rule.Declaration;
 import org.drools.core.xml.jaxb.util.JaxbListAdapter;
 import org.drools.core.xml.jaxb.util.JaxbListWrapper;
@@ -115,7 +116,7 @@ public class FlatQueryResults implements QueryResults {
                         // no result value "" because "abducibl/retrieved facts are hidden
                         obj = resultImpl.get( id );
                     }
-                    factHandle = DisconnectedFactHandle.newFrom( factHandle );
+                    factHandle = newFrom( factHandle );
 
                     idFactHandleMap.put( id, factHandle );
                     idResultMap.put( id, obj );
@@ -123,6 +124,23 @@ public class FlatQueryResults implements QueryResults {
             }
             idFactHandleMaps.add(idFactHandleMap);
             idResultMaps.add(idResultMap);
+        }
+    }
+
+    // This does not put the object into the fact handle to avoid having it serialized when using JSON or JaxB, therefore
+    // Reducing the payload by roughly a half (in case of many objects returned by the query)
+    public static DisconnectedFactHandle newFrom( FactHandle handle ) {
+        if( handle instanceof DisconnectedFactHandle ) {
+            return (DisconnectedFactHandle) handle;
+        } else {
+            InternalFactHandle ifh = (InternalFactHandle) handle;
+            return new DisconnectedFactHandle(ifh.getId(),
+                                              ifh.getIdentityHashCode(),
+                                              ifh.getObjectHashCode(),
+                                              ifh.getRecency(),
+                                              ifh.getEntryPointName(),
+                                              null,
+                                              ifh.isTraitOrTraitable() );
         }
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryTest.java
@@ -183,8 +183,7 @@ public class QueryTest {
         QueryResults results = getQueryResults(session, "assertedobjquery" );
         assertEquals( 1,
                       results.size() );
-        assertEquals( new InsertedObject( "value1" ),
-                      ((InternalFactHandle) results.iterator().next().getFactHandle( "assertedobj" )).getObject() );
+        assertEquals(new InsertedObject("value1" ), results.iterator().next().get("assertedobj") );
     }
 
     @Test
@@ -204,8 +203,6 @@ public class QueryTest {
                       results.size() );
         InsertedObject value = new InsertedObject( "value1" );
         assertEquals( value,
-                      ((InternalFactHandle) results.iterator().next().getFactHandle( "assertedobj" )).getObject()  );
-        assertEquals( value,
                       results.iterator().next().get("assertedobj") );
 
         results = getQueryResults( session, "assertedobjquery", new String[]{"value3"}  );
@@ -217,14 +214,14 @@ public class QueryTest {
         assertEquals( 1,
                       results.size() );
         assertEquals( new InsertedObject( "value2" ),
-                      ((InternalFactHandle) results.iterator().next().getFactHandle( "assertedobj" )).getObject() );
+                      results.iterator().next().get( "assertedobj" ));
 
         results = getQueryResults(session, "assertedobjquery2", new String[]{"value3", "value2"}  );
 
         assertEquals( 1,
                       results.size() );
         assertEquals( new InsertedObject( "value2" ),
-                      ((InternalFactHandle) results.iterator().next().getFactHandle( "assertedobj" )).getObject()  );
+                      results.iterator().next().get( "assertedobj" ));
     }
 
     @Test


### PR DESCRIPTION
Second version of 

https://issues.redhat.com/browse/DROOLS-6177

This is far simpler but should satisfy the needs of a smaller payload

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/drools/pull/3473
https://github.com/kiegroup/droolsjbpm-integration/pull/2438

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
