### PR TITLE
[DROOLS-6196] Int to short casting fails with bracket and functionCall in executable model

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
@@ -812,11 +812,16 @@ public class ExpressionTyper {
         try {
             for (int i = 0; i < methodCallExpr.getArguments().size(); i++) {
                 Expression arg = methodCallExpr.getArgument( i );
-                TypedExpressionResult typedArg = toTypedExpressionFromMethodCallOrField( arg );
-                TypedExpression typedExpr = typedArg.getTypedExpression()
-                        .orElseThrow( () -> new NoSuchElementException( "Node argument doesn't contain typed expression!" ) );
-                argsType[i] = toRawClass( typedExpr.getType() );
-                methodCallExpr.setArgument( i, typedExpr.getExpression() );
+                TypedExpressionResult typedArgumentResult = toTypedExpressionFromMethodCallOrField( arg );
+                Optional<TypedExpression> optTypedArgumentExpression = typedArgumentResult.getTypedExpression();
+                if(optTypedArgumentExpression.isPresent()) {
+                    TypedExpression typedArgumentExpression = optTypedArgumentExpression.get();
+                    argsType[i] = toRawClass(typedArgumentExpression.getType() );
+                    methodCallExpr.setArgument(i, typedArgumentExpression.getExpression() );
+                } else {
+                    argsType[i] = Object.class;
+                    methodCallExpr.setArgument( i, arg );
+                }
             }
         } finally {
             context.setRegisterPropertyReactivity( true );

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/PrimitiveTypeConsequenceRewriteTest.java
@@ -47,6 +47,18 @@ public class PrimitiveTypeConsequenceRewriteTest {
     }
 
     @Test
+    public void doNotConvertBinaryExpr() {
+        RuleContext context = createContext();
+        context.addDeclaration("$testDouble", Double.class);
+
+        String rewritten = new PrimitiveTypeConsequenceRewrite(context)
+                .rewrite("{    $integerToShort.setTestShort((short)((16 + $testDouble))); \n }");
+
+        assertThat(rewritten,
+                   equalToIgnoringWhiteSpace("{    $integerToShort.setTestShort((short) ((16 + $testDouble))); \n }"));
+    }
+
+    @Test
     public void shouldConvertCastOfShortToShortValueEnclosed() {
         RuleContext context = createContext();
         context.addDeclaration("$interimVar", int.class);
@@ -80,6 +92,7 @@ public class PrimitiveTypeConsequenceRewriteTest {
 
         String rewritten = new PrimitiveTypeConsequenceRewrite(context)
                 .rewrite("{ $address.setShortNumber((short)($interimVar.unboxed())); }");
+
 
         assertThat(rewritten,
                    equalToIgnoringWhiteSpace("{ $address.setShortNumber(java.lang.Integer.valueOf($interimVar.unboxed()).shortValue()); }"));


### PR DESCRIPTION

- Avoid failing when type inference fails on method call arguments
- Avoid converting BinaryExpr

**Thank you for submitting this pull request**

https://issues.redhat.com/browse/DROOLS-6196


**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
