### PR TITLE
[DROOLS-6064] Inconsistent behavior when accumulate function returns …

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -48,6 +48,9 @@ import static org.drools.core.phreak.RuleNetworkEvaluator.normalizeStagedTuples;
 * To change this template use File | Settings | File Templates.
 */
 public class PhreakAccumulateNode {
+
+    public static boolean ALLOW_NULL_PROPAGATION = true; // default will be false for backward compatibility
+
     public void doNode(AccumulateNode accNode,
                        LeftTupleSink sink,
                        AccumulateMemory am,
@@ -610,14 +613,14 @@ public class PhreakAccumulateNode {
 
         Object result = accumulate.getResult(memory.workingMemoryContext, accctx, leftTuple, workingMemory);
         propagateResult( accNode, sink, leftTuple, context, workingMemory, memory, trgLeftTuples, stagedLeftTuples,
-                         null, result, (AccumulateContextEntry) accctx, propagationContext );
+                         null, result, (AccumulateContextEntry) accctx, propagationContext, ALLOW_NULL_PROPAGATION);
     }
 
     protected final void propagateResult(AccumulateNode accNode, LeftTupleSink sink, LeftTuple leftTuple, PropagationContext context,
                                          InternalWorkingMemory workingMemory, AccumulateMemory memory, TupleSets<LeftTuple> trgLeftTuples,
                                          TupleSets<LeftTuple> stagedLeftTuples, Object key, Object result,
-                                         AccumulateContextEntry accPropCtx, PropagationContext propagationContext) {
-        if ( result == null) {
+                                         AccumulateContextEntry accPropCtx, PropagationContext propagationContext, boolean allowNullPropagation) {
+        if ( !allowNullPropagation && result == null) {
             if ( accPropCtx.isPropagated()) {
                 // retract
                 trgLeftTuples.addDelete( accPropCtx.getResultLeftTuple());

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
@@ -67,7 +67,7 @@ public class PhreakGroupByNode extends PhreakAccumulateNode {
             Object result = accumulate.getResult(memory.workingMemoryContext, contextEntry, leftTuple, workingMemory);
 
             propagateResult( accNode, sink, leftTuple, context, workingMemory, memory, trgLeftTuples, stagedLeftTuples,
-                             contextEntry.getKey(), result, contextEntry, propagationContext );
+                             contextEntry.getKey(), result, contextEntry, propagationContext, false ); // don't want to propagate null
 
             contextEntry.setToPropagate(false);
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.testcoverage.common.model.MyFact;
+import org.drools.testcoverage.common.model.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.QueryResults;
+import org.kie.api.runtime.rule.Variable;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class AccumulateConsistencyTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public AccumulateConsistencyTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+        @Parameterized.Parameters(name = "KieBase type={0}")
+        public static Collection<Object[]> getParameters() {
+            return TestParametersUtil.getKieBaseCloudConfigurations(true);
+        }
+
+    @Test
+    public void testMinNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($min);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMaxNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $max : max( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testAveNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $ave : average( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($ave);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testSumNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $sum : sum( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($sum);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testCountNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $count : count( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($count);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMaxNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ),\n" +
+                           "                $max : max( $p.getAge() ))\n" +
+                           "then\n" +
+                           "    System.out.println($min + \", \" + $max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMaxMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "global java.util.Map result;\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ),\n" +
+                           "                $max : max( $p.getAge() ))\n" +
+                           "then\n" +
+                           "    result.put(\"min\", $min);\n" +
+                           "    result.put(\"max\", $max);\n" +
+                           "    System.out.println($min + \", \" + $max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+        Map<String, Integer> result = new HashMap<>();
+        kieSession.setGlobal("result", result);
+
+        try {
+            kieSession.insert(new Person("John", 20));
+            kieSession.insert(new Person("John", 60));
+
+            assertEquals(1, kieSession.fireAllRules());
+            assertEquals(20, result.get("min").intValue());
+            assertEquals(60, result.get("max").intValue());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinNoMatchAccFrom() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    $min : Number() from accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($min);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMatchUnification() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + MyFact.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    MyFact($i : currentValue)\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $i := min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($i);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("John", 20));
+            kieSession.insert(new MyFact("A", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinNoMatchUnification() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + MyFact.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    MyFact($i : currentValue)\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $i := min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($i);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            kieSession.insert(new MyFact("A", null));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMatchUnificationQuery() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import java.util.List;\n" +
+                           "query getResults( String $name, List $persons )\n" +
+                           "  accumulate(  \n" +
+                           "    $p : Person( name == $name),\n" +
+                           "    $persons := collectList( $p )\n" +
+                           "  ) \n" +
+                           "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kieBase.newKieSession();
+
+        try {
+            kieSession.insert(new Person(0, "John", 20));
+            kieSession.insert(new Person(1, "John", 19));
+            final QueryResults results = kieSession.getQueryResults("getResults", "John", Variable.v);
+            List<Person> persons = (List<Person>)results.iterator().next().get("$persons");
+            assertEquals(2, persons.size());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -66,11 +66,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -3790,8 +3790,10 @@ public class AccumulateTest {
         list.clear();
 
         kieSession.delete( fh );
-        assertEquals(0, kieSession.fireAllRules() );
-        assertEquals(0, list.size() );
+        // changed by DROOLS-6064
+        assertEquals(1, kieSession.fireAllRules() );
+        assertEquals(1, list.size() );
+        assertNull(list.get(0));
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
@@ -2704,7 +2704,7 @@ public class PropertySpecificTest {
                 "import " + BigDecimalFact.class.getCanonicalName() + "\n" +
                 "rule R when\n" +
                 "        accumulate( BigDecimalFact( $bdVal: bdVal), $minVal : min($bdVal))\n" +
-                "        accumulate( BigDecimalFact( $bdVal2: bdVal, $bdVal2 > $minVal), $minVal2 : min($bdVal2))\n" +
+                "        accumulate( BigDecimalFact( $bdVal2: bdVal, $bdVal2 > $minVal), $minVal2 : min($bdVal2); $minVal2 != null)\n" + // guard for DROOLS-6064
                 "\n" +
                 "        \n" +
                 "        $minFact: BigDecimalFact( bdVal == new BigDecimal($minVal.intValue()))\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
@@ -265,7 +265,7 @@ public class MultithreadTest {
                 "rule \"average temperature\"\n" +
                 "when\n" +
                 "  $s : Server (hostname == \"hiwaesdk\")\n" +
-                " $avg := Number( ) from accumulate ( " +
+                " $avg := Number( this != null ) from accumulate ( " +
                 "      IntEvent ( $temp : data ) over window:length(10) from entry-point ep01; " +
                 "      average ($temp)\n" +
                 "  )\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverage.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverage.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $avg    : Number( intValue >= 10 )
+        $avg    : Number( this != null, intValue >= 10 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 average( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverageMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverageMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $avg    : Number( intValue >= 10 )
+        $avg    : Number( this != null, intValue >= 10 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 average( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMax.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMax.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $max    : Number( intValue >= 5 )
+        $max    : Number( this != null, intValue >= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 max( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMaxMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMaxMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $max    : Number( intValue >= 5 )
+        $max    : Number( this != null, intValue >= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 max( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMin.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMin.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $min    : Number( intValue <= 5 )
+        $min    : Number( this != null, intValue <= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 min( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMinMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMinMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $min    : Number( intValue <= 5 )
+        $min    : Number( this != null, intValue <= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 min( $price ) );
     then

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
@@ -56,6 +56,12 @@ public class Person implements Serializable {
         this.age = age;
     }
 
+    public Person(final int id, final String name, final int age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
     public Person(final String name, final String likes, final int age) {
         this.name = name;
         this.likes = likes;


### PR DESCRIPTION
…null

- WIP. This should be disabled by default

https://issues.redhat.com/browse/DROOLS-6064

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6064

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
