### PR TITLE
[7.52.x] [DROOLS-6064] Inconsistent behavior when accumulate function returns …

### DIFF
--- a/drools-cdi/src/test/java/org/drools/cdi/kproject/KieModuleModelTest.java
+++ b/drools-cdi/src/test/java/org/drools/cdi/kproject/KieModuleModelTest.java
@@ -76,6 +76,7 @@ public class KieModuleModelTest {
                 .setFileLogger("drools.log", 10, true)
                 .addCalendar("monday", "org.domain.Monday")
                 .setDirectFiring(true)
+                .setAccumulateNullPropagation(true)
                 .setDefault(true);
 
         ksession1.newListenerModel("org.domain.FirstInterface", ListenerModel.Kind.AGENDA_EVENT_LISTENER);
@@ -131,6 +132,7 @@ public class KieModuleModelTest {
         assertEquals(BeliefSystemTypeOption.get("jtms"), kieSessionModelXML.getBeliefSystem());
         assertEquals("org.domain.Monday", kieSessionModelXML.getCalendars().get("monday"));
         assertTrue(kieSessionModelXML.isDirectFiring());
+        assertTrue(kieSessionModelXML.isAccumulateNullPropagation());
         assertTrue(kieSessionModelXML.isDefault());
 
         FileLoggerModel fileLogger = kieSessionModelXML.getFileLogger();

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
@@ -66,6 +66,8 @@ public class KieSessionModelImpl
 
     private boolean                          threadSafe = true;
 
+    private boolean                          accumulateNullPropagation = false;
+
     private KieSessionModelImpl() { }
 
     public KieSessionModelImpl(KieBaseModelImpl kBase, String name) {
@@ -109,6 +111,17 @@ public class KieSessionModelImpl
     @Override
     public KieSessionModel setThreadSafe( boolean threadSafe ) {
         this.threadSafe = threadSafe;
+        return this;
+    }
+
+    @Override
+    public boolean isAccumulateNullPropagation() {
+        return accumulateNullPropagation;
+    }
+
+    @Override
+    public KieSessionModel setAccumulateNullPropagation(boolean accumulateNullPropagation) {
+        this.accumulateNullPropagation = accumulateNullPropagation;
         return this;
     }
 
@@ -280,6 +293,7 @@ public class KieSessionModelImpl
             writer.addAttribute( "default", Boolean.toString(kSession.isDefault()) );
             writer.addAttribute( "directFiring", Boolean.toString(kSession.isDirectFiring()) );
             writer.addAttribute( "threadSafe", Boolean.toString(kSession.isThreadSafe()) );
+            writer.addAttribute( "accumulateNullPropagation", Boolean.toString(kSession.isAccumulateNullPropagation()) );
             if (kSession.getClockType() != null) {
                 writer.addAttribute("clockType", kSession.getClockType().getClockType());
             }
@@ -329,6 +343,7 @@ public class KieSessionModelImpl
             kSession.setDefault( "true".equals(reader.getAttribute( "default" )) );
             kSession.setDirectFiring( "true".equals(reader.getAttribute( "directFiring" )) );
             kSession.setThreadSafe( "true".equals(reader.getAttribute( "threadSafe" )) );
+            kSession.setAccumulateNullPropagation( "true".equals(reader.getAttribute( "accumulateNullPropagation" )) );
 
             String kSessionType = reader.getAttribute("type");
             kSession.setType(kSessionType != null ? KieSessionType.valueOf( kSessionType.toUpperCase() ) : KieSessionType.STATEFUL);

--- a/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
@@ -28,6 +28,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.conf.BeliefSystemTypeOption;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.conf.DirectFiringOption;
@@ -61,6 +62,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
     public abstract boolean isDirectFiring();
     public abstract void setThreadSafe(boolean threadSafe);
     public abstract boolean isThreadSafe();
+    public abstract void setAccumulateNullPropagation(boolean accumulateNullPropagation);
+    public abstract boolean isAccumulateNullPropagation();
 
     public abstract void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter);
     public abstract ForceEagerActivationFilter getForceEagerActivationFilter();
@@ -118,6 +121,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             setDirectFiring(((DirectFiringOption) option).isDirectFiring());
         } else if ( option instanceof ThreadSafeOption ) {
             setThreadSafe(((ThreadSafeOption) option).isThreadSafe());
+        } else if ( option instanceof AccumulateNullPropagationOption ) {
+            setAccumulateNullPropagation(((AccumulateNullPropagationOption) option).isAccumulateNullPropagation());
         } else if ( option instanceof ForceEagerActivationOption ) {
             setForceEagerActivationFilter(((ForceEagerActivationOption) option).getFilter());
         } else if ( option instanceof TimedRuleExecutionOption ) {
@@ -142,6 +147,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             return (T) (isDirectFiring() ? DirectFiringOption.YES : DirectFiringOption.NO);
         } else if ( ThreadSafeOption.class.equals( option ) ) {
             return (T) (isThreadSafe() ? ThreadSafeOption.YES : ThreadSafeOption.NO);
+        } else if ( AccumulateNullPropagationOption.class.equals( option ) ) {
+            return (T) (isAccumulateNullPropagation() ? AccumulateNullPropagationOption.YES : AccumulateNullPropagationOption.NO);
         } else if ( TimerJobFactoryOption.class.equals( option ) ) {
             return (T) TimerJobFactoryOption.get( getTimerJobFactoryType().toExternalForm() );
         } else if ( QueryListenerOption.class.equals( option ) ) {
@@ -175,6 +182,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             setDirectFiring(!StringUtils.isEmpty(value) && Boolean.parseBoolean(value));
         }else if ( name.equals( ThreadSafeOption.PROPERTY_NAME ) ) {
             setThreadSafe( StringUtils.isEmpty( value ) || Boolean.parseBoolean( value ) );
+        } else if ( name.equals( AccumulateNullPropagationOption.PROPERTY_NAME ) ) {
+            setAccumulateNullPropagation( !StringUtils.isEmpty( value ) && Boolean.parseBoolean( value ) );
         } else if ( name.equals( ForceEagerActivationOption.PROPERTY_NAME ) ) {
             setForceEagerActivationFilter(ForceEagerActivationOption.resolve(StringUtils.isEmpty(value) ? "false" : value).getFilter());
         } else if ( name.equals( TimedRuleExecutionOption.PROPERTY_NAME ) ) {
@@ -203,6 +212,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             return Boolean.toString(isDirectFiring());
         }else if ( name.equals( ThreadSafeOption.PROPERTY_NAME ) ) {
             return Boolean.toString(isThreadSafe());
+        } else if ( name.equals( AccumulateNullPropagationOption.PROPERTY_NAME ) ) {
+            return Boolean.toString(isAccumulateNullPropagation());
         } else if ( name.equals( ClockTypeOption.PROPERTY_NAME ) ) {
             return getClockType().toExternalForm();
         } else if ( name.equals( TimerJobFactoryOption.PROPERTY_NAME ) ) {

--- a/drools-core/src/main/java/org/drools/core/SessionConfigurationImpl.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfigurationImpl.java
@@ -32,6 +32,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.conf.BeliefSystemTypeOption;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.conf.DirectFiringOption;
@@ -77,6 +78,8 @@ public class SessionConfigurationImpl extends SessionConfiguration {
     private boolean                        directFiring;
 
     private boolean                        threadSafe;
+
+    private boolean                        accumulateNullPropagation;
 
     private ForceEagerActivationFilter     forceEagerActivationFilter;
     private TimedRuleExecutionFilter       timedRuleExecutionFilter;
@@ -167,6 +170,8 @@ public class SessionConfigurationImpl extends SessionConfiguration {
 
         setThreadSafe(Boolean.valueOf( getPropertyValue( ThreadSafeOption.PROPERTY_NAME, "true" ) ));
 
+        setAccumulateNullPropagation(Boolean.valueOf( getPropertyValue( AccumulateNullPropagationOption.PROPERTY_NAME, "false" ) ));
+
         setForceEagerActivationFilter(ForceEagerActivationOption.resolve( getPropertyValue( ForceEagerActivationOption.PROPERTY_NAME, "false" ) ).getFilter());
 
         setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve( getPropertyValue( TimedRuleExecutionOption.PROPERTY_NAME, "false" ) ).getFilter());
@@ -239,6 +244,15 @@ public class SessionConfigurationImpl extends SessionConfiguration {
 
     public boolean isThreadSafe() {
         return this.threadSafe;
+    }
+
+    public void setAccumulateNullPropagation(boolean accumulateNullPropagation) {
+        checkCanChange(); // throws an exception if a change isn't possible;
+        this.accumulateNullPropagation = accumulateNullPropagation;
+    }
+
+    public boolean isAccumulateNullPropagation() {
+        return this.accumulateNullPropagation;
     }
 
     public void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -48,6 +48,7 @@ import static org.drools.core.phreak.RuleNetworkEvaluator.normalizeStagedTuples;
 * To change this template use File | Settings | File Templates.
 */
 public class PhreakAccumulateNode {
+
     public void doNode(AccumulateNode accNode,
                        LeftTupleSink sink,
                        AccumulateMemory am,
@@ -610,14 +611,14 @@ public class PhreakAccumulateNode {
 
         Object result = accumulate.getResult(memory.workingMemoryContext, accctx, leftTuple, workingMemory);
         propagateResult( accNode, sink, leftTuple, context, workingMemory, memory, trgLeftTuples, stagedLeftTuples,
-                         null, result, (AccumulateContextEntry) accctx, propagationContext );
+                         null, result, (AccumulateContextEntry) accctx, propagationContext, workingMemory.getSessionConfiguration().isAccumulateNullPropagation());
     }
 
     protected final void propagateResult(AccumulateNode accNode, LeftTupleSink sink, LeftTuple leftTuple, PropagationContext context,
                                          InternalWorkingMemory workingMemory, AccumulateMemory memory, TupleSets<LeftTuple> trgLeftTuples,
                                          TupleSets<LeftTuple> stagedLeftTuples, Object key, Object result,
-                                         AccumulateContextEntry accPropCtx, PropagationContext propagationContext) {
-        if ( result == null) {
+                                         AccumulateContextEntry accPropCtx, PropagationContext propagationContext, boolean allowNullPropagation) {
+        if ( !allowNullPropagation && result == null) {
             if ( accPropCtx.isPropagated()) {
                 // retract
                 trgLeftTuples.addDelete( accPropCtx.getResultLeftTuple());

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
@@ -73,7 +73,7 @@ public class PhreakGroupByNode extends PhreakAccumulateNode {
             Object result = accumulate.getResult(memory.workingMemoryContext, contextEntry, leftTuple, workingMemory);
 
             propagateResult( accNode, sink, leftTuple, context, workingMemory, memory, trgLeftTuples, stagedLeftTuples,
-                             contextEntry.getKey(), result, contextEntry, propagationContext );
+                             contextEntry.getKey(), result, contextEntry, propagationContext, false ); // don't want to propagate null
 
             contextEntry.setToPropagate(false);
         }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.testcoverage.common.model.MyFact;
+import org.drools.testcoverage.common.model.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
+import org.kie.api.runtime.rule.QueryResults;
+import org.kie.api.runtime.rule.Variable;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class AccumulateConsistencyTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+    private final boolean accumulateNullPropagation;
+
+    public AccumulateConsistencyTest(final KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+        this.accumulateNullPropagation = accumulateNullPropagation;
+    }
+
+    // accumulateNullPropagation is false by default in drools 7.x
+    @Parameterized.Parameters(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+    public static Collection<Object[]> getParameters() {
+        Collection<Object[]> parameters = new ArrayList<>();
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY, false});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_FLOW, false});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, false});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY, true});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_FLOW, true});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, true});
+        return parameters;
+    }
+
+    @Test
+    public void testMinNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($min);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMaxNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $max : max( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testAveNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $ave : average( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($ave);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testSumNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $sum : sum( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($sum);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testCountNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $count : count( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($count);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMaxNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ),\n" +
+                           "                $max : max( $p.getAge() ))\n" +
+                           "then\n" +
+                           "    System.out.println($min + \", \" + $max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMaxMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "global java.util.Map result;\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ),\n" +
+                           "                $max : max( $p.getAge() ))\n" +
+                           "then\n" +
+                           "    result.put(\"min\", $min);\n" +
+                           "    result.put(\"max\", $max);\n" +
+                           "    System.out.println($min + \", \" + $max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        Map<String, Integer> result = new HashMap<>();
+        kieSession.setGlobal("result", result);
+
+        try {
+            kieSession.insert(new Person("John", 20));
+            kieSession.insert(new Person("John", 60));
+
+            assertEquals(1, kieSession.fireAllRules());
+            assertEquals(20, result.get("min").intValue());
+            assertEquals(60, result.get("max").intValue());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinNoMatchAccFrom() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    $min : Number() from accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($min);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMatchUnification() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + MyFact.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    MyFact($i : currentValue)\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $i := min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($i);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("John", 20));
+            kieSession.insert(new MyFact("A", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinNoMatchUnification() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + MyFact.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    MyFact($i : currentValue)\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $i := min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($i);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            kieSession.insert(new MyFact("A", null));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMatchUnificationQuery() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import java.util.List;\n" +
+                           "query getResults( String $name, List $persons )\n" +
+                           "  accumulate(  \n" +
+                           "    $p : Person( name == $name),\n" +
+                           "    $persons := collectList( $p )\n" +
+                           "  ) \n" +
+                           "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person(0, "John", 20));
+            kieSession.insert(new Person(1, "John", 19));
+            final QueryResults results = kieSession.getQueryResults("getResults", "John", Variable.v);
+            List<Person> persons = (List<Person>)results.iterator().next().get("$persons");
+            assertEquals(2, persons.size());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -25,6 +25,7 @@ import org.drools.testcoverage.common.model.MyFact;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -231,6 +232,7 @@ public class AccumulateConsistencyTest {
         }
     }
 
+    @Ignore("Ignoring because this test is not essential to the original JIRA (DROOLS-6064) so will investigate in another JIRA: DROOLS-6254")
     @Test
     public void testMinMaxMatch() {
         final String drl =
@@ -257,8 +259,8 @@ public class AccumulateConsistencyTest {
         kieSession.setGlobal("result", result);
 
         try {
-            kieSession.insert(new Person("John", 20));
-            kieSession.insert(new Person("John", 60));
+            kieSession.insert(new Person(0, "John", 20));
+            kieSession.insert(new Person(1, "John", 60));
 
             assertEquals(1, kieSession.fireAllRules());
             assertEquals(20, result.get("min").intValue());

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.Assertions;
 import org.drools.compiler.integrationtests.incrementalcompilation.TestUtil;
 import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.drools.core.SessionConfiguration;
 import org.drools.core.command.runtime.rule.InsertElementsCommand;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.testcoverage.common.model.Cheese;
@@ -65,11 +66,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -3789,8 +3790,15 @@ public class AccumulateTest {
         list.clear();
 
         kieSession.delete( fh );
-        assertEquals(0, kieSession.fireAllRules() );
-        assertEquals(0, list.size() );
+        // changed by DROOLS-6064
+        if (((SessionConfiguration)kieSession.getSessionConfiguration()).isAccumulateNullPropagation()) {
+            assertEquals(1, kieSession.fireAllRules() );
+            assertEquals(1, list.size() );
+            assertNull(list.get(0));
+        } else {
+            assertEquals(0, kieSession.fireAllRules() );
+            assertEquals(0, list.size() );
+        }
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeSessionConfigurationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeSessionConfigurationTest.java
@@ -19,6 +19,7 @@ import org.drools.core.BeliefSystemType;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.KieServices;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.conf.BeliefSystemTypeOption;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
@@ -86,5 +87,30 @@ public class KnowledgeSessionConfigurationTest {
                       config.getProperty( BeliefSystemTypeOption.PROPERTY_NAME ) );
     }
 
+    @Test
+    public void testAccumulateNullPropagation() {
+        // false by default
+        assertEquals(AccumulateNullPropagationOption.NO, config.getOption(AccumulateNullPropagationOption.class));
+        assertEquals("false", config.getProperty(AccumulateNullPropagationOption.PROPERTY_NAME));
 
+        config.setOption(AccumulateNullPropagationOption.YES);
+
+        assertEquals(AccumulateNullPropagationOption.YES,
+                     config.getOption(AccumulateNullPropagationOption.class));
+
+        // checking the string based getProperty() method
+        assertEquals("true",
+                     config.getProperty(AccumulateNullPropagationOption.PROPERTY_NAME));
+
+        // setting the options using the string based setProperty() method
+        config.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME,
+                           "false");
+
+        // checking the type safe getOption() method
+        assertEquals(AccumulateNullPropagationOption.NO,
+                     config.getOption(AccumulateNullPropagationOption.class));
+        // checking the string based getProperty() method
+        assertEquals("false",
+                     config.getProperty(AccumulateNullPropagationOption.PROPERTY_NAME));
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
@@ -2704,7 +2704,7 @@ public class PropertySpecificTest {
                 "import " + BigDecimalFact.class.getCanonicalName() + "\n" +
                 "rule R when\n" +
                 "        accumulate( BigDecimalFact( $bdVal: bdVal), $minVal : min($bdVal))\n" +
-                "        accumulate( BigDecimalFact( $bdVal2: bdVal, $bdVal2 > $minVal), $minVal2 : min($bdVal2))\n" +
+                "        accumulate( BigDecimalFact( $bdVal2: bdVal, $bdVal2 > $minVal), $minVal2 : min($bdVal2); $minVal2 != null)\n" + // guard for DROOLS-6064
                 "\n" +
                 "        \n" +
                 "        $minFact: BigDecimalFact( bdVal == new BigDecimal($minVal.intValue()))\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
@@ -265,7 +265,7 @@ public class MultithreadTest {
                 "rule \"average temperature\"\n" +
                 "when\n" +
                 "  $s : Server (hostname == \"hiwaesdk\")\n" +
-                " $avg := Number( ) from accumulate ( " +
+                " $avg := Number( this != null ) from accumulate ( " +
                 "      IntEvent ( $temp : data ) over window:length(10) from entry-point ep01; " +
                 "      average ($temp)\n" +
                 "  )\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverage.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverage.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $avg    : Number( intValue >= 10 )
+        $avg    : Number( this != null, intValue >= 10 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 average( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverageMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverageMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $avg    : Number( intValue >= 10 )
+        $avg    : Number( this != null, intValue >= 10 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 average( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMax.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMax.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $max    : Number( intValue >= 5 )
+        $max    : Number( this != null, intValue >= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 max( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMaxMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMaxMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $max    : Number( intValue >= 5 )
+        $max    : Number( this != null, intValue >= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 max( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMin.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMin.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $min    : Number( intValue <= 5 )
+        $min    : Number( this != null, intValue <= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 min( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMinMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMinMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $min    : Number( intValue <= 5 )
+        $min    : Number( this != null, intValue <= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 min( $price ) );
     then

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
@@ -56,6 +56,12 @@ public class Person implements Serializable {
         this.age = age;
     }
 
+    public Person(final int id, final String name, final int age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
     public Person(final String name, final String likes, final int age) {
         this.name = name;
         this.likes = likes;


### PR DESCRIPTION
…null (#3481)

**JIRA**: 

https://issues.redhat.com/browse/RHDM-1643
(backporting DROOLS-6064)

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-knowledge/pull/514

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
