### PR TITLE
[DROOLS-6254] fix AccumulateConsistencyTest

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -25,7 +25,6 @@ import org.drools.testcoverage.common.model.MyFact;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,11 +35,15 @@ import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.Variable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class AccumulateConsistencyTest {
+    
+    Logger logger = LoggerFactory.getLogger(AccumulateConsistencyTest.class);
 
     private final KieBaseTestConfiguration kieBaseTestConfiguration;
     private final boolean accumulateNullPropagation;
@@ -232,9 +235,10 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Ignore("Ignoring because this test is not essential to the original JIRA (DROOLS-6064) so will investigate in another JIRA: DROOLS-6254")
+    //@Ignore("Ignoring because this test is not essential to the original JIRA (DROOLS-6064) so will investigate in another JIRA: DROOLS-6254")
     @Test
     public void testMinMaxMatch() {
+        logger.warn("*** testMinMaxMatch start");
         final String drl =
                 "package org.drools.compiler.integrationtests;\n" +
                            "import " + Person.class.getCanonicalName() + ";\n" +
@@ -268,6 +272,7 @@ public class AccumulateConsistencyTest {
         } finally {
             kieSession.dispose();
         }
+        logger.warn("*** testMinMaxMatch end");
     }
 
     @Test


### PR DESCRIPTION
The issue is not reproducible on my local end. So I will use this PR to validate the fix.

Setting `id` for `Person` is required anyway in order to have different hashCodes for the inserted facts.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6254

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
