### PR TITLE
[DROOLS-6255] Ignore AccumulateConsistencyTest.testMinMaxMatch

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -25,6 +25,7 @@ import org.drools.testcoverage.common.model.MyFact;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -231,6 +232,7 @@ public class AccumulateConsistencyTest {
         }
     }
 
+    @Ignore("Ignoring because this test is not essential to the original JIRA (DROOLS-6064) so will investigate in another JIRA: DROOLS-6254")
     @Test
     public void testMinMaxMatch() {
         final String drl =


### PR DESCRIPTION
In order not to bother daily build, @Ignore AccumulateConsistencyTest.testMinMaxMatch() which causes random failures in Jenkins (not reproducible in local).

This should be okay because the test is not essential to the original JIRA (DROOLS-6064).

Investigation/Fix will be done in DROOLS-6254

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6255


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
