### PR TITLE
[DROOLS-5820] executable-model test failure in test-compiler-integrat…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NodesPartitioningTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NodesPartitioningTest.java
@@ -59,8 +59,7 @@ public class NodesPartitioningTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-        // TODO: EM failed with test2Partitions, testPartitioningWithSharedNodes, testChangePartitionOfAlphaSourceOfAlpha. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @Test
@@ -190,10 +189,10 @@ public class NodesPartitioningTest {
 
     public static class Account {
         private final int number;
-        private final int uuid;
+        private final String uuid;
         private final Customer owner;
 
-        public Account( int number, int uuid, Customer owner ) {
+        public Account( int number, String uuid, Customer owner ) {
             this.number = number;
             this.uuid = uuid;
             this.owner = owner;
@@ -203,7 +202,7 @@ public class NodesPartitioningTest {
             return number;
         }
 
-        public int getUuid() {
+        public String getUuid() {
             return uuid;
         }
 
@@ -213,13 +212,13 @@ public class NodesPartitioningTest {
     }
 
     public static class Customer {
-        private final int uuid;
+        private final String uuid;
 
-        public Customer( int uuid ) {
+        public Customer( String uuid ) {
             this.uuid = uuid;
         }
 
-        public int getUuid() {
+        public String getUuid() {
             return uuid;
         }
     }


### PR DESCRIPTION
…ion NodesPartitioningTest

- exec-model fails earlier if there is an incompatible comparation constraint.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-5820

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
