### PR TITLE
[DROOLS-5821] executable-model test failure in test-compiler-integrat…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FunctionsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FunctionsTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.drools.mvel.compiler.Cheese;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
@@ -47,8 +48,7 @@ public class FunctionsTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-     // TODO: EM failed with testFunctionException, testFunctionCallingFunctionWithEclipse, testFunctionCallingFunctionWithJanino. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @SuppressWarnings("unchecked")
@@ -84,8 +84,7 @@ public class FunctionsTest {
             ksession.fireAllRules();
             fail( "Should throw an Exception from the Function" );
         } catch ( final Exception e ) {
-            assertEquals( "this should throw an exception",
-                          e.getCause().getMessage() );
+            Assertions.assertThat(e.getCause().getMessage()).contains("this should throw an exception");
         }
     }
 


### PR DESCRIPTION
…ion FunctionsTest

- loosen assertion for Exception wrapping

**JIRA**:

https://issues.redhat.com/browse/DROOLS-5821

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
