### PR TITLE
DROOLS-6265 : Guided Rule Editor: Formula with contains does not reopen correctly

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -4281,7 +4281,7 @@ public class RuleModelDRLPersistenceImpl
                 con.setValue(value.substring(1,
                                              value.length() - 1));
             } else if (value.startsWith("(")) {
-                if (operator != null && operator.contains("in")) {
+                if (operator != null && (Objects.equals("in", operator) || Objects.equals("not in", operator))) {
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
                     String[] split = ListSplitter.splitPreserveQuotes("\"", true, unwrapParenthesis(value));
                     con.setValue(String.join(", ", split));


### PR DESCRIPTION

**JIRA**: 

[DROOLS-6265](https://issues.redhat.com/browse/DROOLS-6265)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
