### PR TITLE
[7.52.x] DROOLS-6265 : Guided Rule Editor: Formula with contains does not reopen correctly

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -4222,7 +4222,7 @@ public class RuleModelDRLPersistenceImpl
                 con.setValue(value.substring(1,
                                              value.length() - 1));
             } else if (value.startsWith("(")) {
-                if (operator != null && operator.contains("in")) {
+                if (operator != null && (Objects.equals("in", operator) || Objects.equals("not in", operator))) {
                     con.setConstraintValueType(SingleFieldConstraint.TYPE_LITERAL);
                     String[] split = ListSplitter.splitPreserveQuotes("\"", true, unwrapParenthesis(value));
                     con.setValue(String.join(", ", split));

--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceUnmarshallingTest.java
@@ -10099,11 +10099,44 @@ public class RuleModelDRLPersistenceUnmarshallingTest extends BaseRuleModelTest 
         assertTrue(constraint instanceof SingleFieldConstraint);
         assertEquals("contains", ((SingleFieldConstraint) constraint).getOperator());
         assertEquals("String.join( \"-\", \"abc\",\"xyz\")",((SingleFieldConstraint)constraint).getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_RET_VALUE, ((SingleFieldConstraint) constraint).getConstraintValueType());
 
         final FieldConstraint constraintNot = ((FactPattern) m.lhs[0]).getConstraint(1);
         assertTrue(constraintNot instanceof SingleFieldConstraint);
         assertEquals("not contains", ((SingleFieldConstraint) constraintNot).getOperator());
         assertEquals("String.join( \"hello\", \" \",\"there\")",((SingleFieldConstraint)constraintNot).getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_RET_VALUE, ((SingleFieldConstraint) constraintNot).getConstraintValueType());
+    }
+
+    @Test
+    public void testContainsWithFormula_Integer() {
+
+        final String drl = "rule \"therule\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "CustomerProfile( listValue contains ( Integer.max( 1, 2 ) )," +
+                "listValue not contains ( Integer.min( 1, 2 ) ) )\n" +
+                "then\n" +
+                "end";
+
+        final PackageDataModelOracle dmo = mock(PackageDataModelOracle.class);
+        final RuleModel m =  RuleModelDRLPersistenceImpl.getInstance().unmarshal(drl,
+                                                                                 Collections.EMPTY_LIST,
+                                                                                 dmo);
+        assertNotNull(m);
+        assertTrue(m.lhs[0] instanceof FactPattern);
+
+        final FieldConstraint constraint = ((FactPattern) m.lhs[0]).getConstraint(0);
+        assertTrue(constraint instanceof SingleFieldConstraint);
+        assertEquals("contains", ((SingleFieldConstraint) constraint).getOperator());
+        assertEquals("Integer.max( 1, 2 )",((SingleFieldConstraint)constraint).getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_RET_VALUE, ((SingleFieldConstraint) constraint).getConstraintValueType());
+
+        final FieldConstraint constraintNot = ((FactPattern) m.lhs[0]).getConstraint(1);
+        assertTrue(constraintNot instanceof SingleFieldConstraint);
+        assertEquals("not contains", ((SingleFieldConstraint) constraintNot).getOperator());
+        assertEquals("Integer.min( 1, 2 )",((SingleFieldConstraint)constraintNot).getValue());
+        assertEquals(BaseSingleFieldConstraint.TYPE_RET_VALUE, ((SingleFieldConstraint) constraintNot).getConstraintValueType());
     }
 
     /**


### PR DESCRIPTION
**JIRA**: 

[DROOLS-6265](https://issues.redhat.com/browse/DROOLS-6265)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
