### PR TITLE
[7.52.x] DROOLS-5892 Guided Rule Editor: Method calls do not support template keys

### DIFF
--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-beliefs</artifactId>

--- a/drools-cdi/pom.xml
+++ b/drools-cdi/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-cdi</artifactId>

--- a/drools-cdi/src/test/java/org/drools/cdi/kproject/KieModuleModelTest.java
+++ b/drools-cdi/src/test/java/org/drools/cdi/kproject/KieModuleModelTest.java
@@ -76,6 +76,7 @@ public class KieModuleModelTest {
                 .setFileLogger("drools.log", 10, true)
                 .addCalendar("monday", "org.domain.Monday")
                 .setDirectFiring(true)
+                .setAccumulateNullPropagation(true)
                 .setDefault(true);
 
         ksession1.newListenerModel("org.domain.FirstInterface", ListenerModel.Kind.AGENDA_EVENT_LISTENER);
@@ -131,6 +132,7 @@ public class KieModuleModelTest {
         assertEquals(BeliefSystemTypeOption.get("jtms"), kieSessionModelXML.getBeliefSystem());
         assertEquals("org.domain.Monday", kieSessionModelXML.getCalendars().get("monday"));
         assertTrue(kieSessionModelXML.isDirectFiring());
+        assertTrue(kieSessionModelXML.isAccumulateNullPropagation());
         assertTrue(kieSessionModelXML.isDefault());
 
         FileLoggerModel fileLogger = kieSessionModelXML.getFileLogger();

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-compiler</artifactId>

--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieSessionModelImpl.java
@@ -66,6 +66,8 @@ public class KieSessionModelImpl
 
     private boolean                          threadSafe = true;
 
+    private boolean                          accumulateNullPropagation = false;
+
     private KieSessionModelImpl() { }
 
     public KieSessionModelImpl(KieBaseModelImpl kBase, String name) {
@@ -109,6 +111,17 @@ public class KieSessionModelImpl
     @Override
     public KieSessionModel setThreadSafe( boolean threadSafe ) {
         this.threadSafe = threadSafe;
+        return this;
+    }
+
+    @Override
+    public boolean isAccumulateNullPropagation() {
+        return accumulateNullPropagation;
+    }
+
+    @Override
+    public KieSessionModel setAccumulateNullPropagation(boolean accumulateNullPropagation) {
+        this.accumulateNullPropagation = accumulateNullPropagation;
         return this;
     }
 
@@ -280,6 +293,7 @@ public class KieSessionModelImpl
             writer.addAttribute( "default", Boolean.toString(kSession.isDefault()) );
             writer.addAttribute( "directFiring", Boolean.toString(kSession.isDirectFiring()) );
             writer.addAttribute( "threadSafe", Boolean.toString(kSession.isThreadSafe()) );
+            writer.addAttribute( "accumulateNullPropagation", Boolean.toString(kSession.isAccumulateNullPropagation()) );
             if (kSession.getClockType() != null) {
                 writer.addAttribute("clockType", kSession.getClockType().getClockType());
             }
@@ -329,6 +343,7 @@ public class KieSessionModelImpl
             kSession.setDefault( "true".equals(reader.getAttribute( "default" )) );
             kSession.setDirectFiring( "true".equals(reader.getAttribute( "directFiring" )) );
             kSession.setThreadSafe( "true".equals(reader.getAttribute( "threadSafe" )) );
+            kSession.setAccumulateNullPropagation( "true".equals(reader.getAttribute( "accumulateNullPropagation" )) );
 
             String kSessionType = reader.getAttribute("type");
             kSession.setType(kSessionType != null ? KieSessionType.valueOf( kSessionType.toUpperCase() ) : KieSessionType.STATEFUL);

--- a/drools-core-dynamic/pom.xml
+++ b/drools-core-dynamic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-core-dynamic</artifactId>

--- a/drools-core-reflective/pom.xml
+++ b/drools-core-reflective/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools</artifactId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-core-reflective</artifactId>

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-core</artifactId>

--- a/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfiguration.java
@@ -28,6 +28,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.conf.BeliefSystemTypeOption;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.conf.DirectFiringOption;
@@ -61,6 +62,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
     public abstract boolean isDirectFiring();
     public abstract void setThreadSafe(boolean threadSafe);
     public abstract boolean isThreadSafe();
+    public abstract void setAccumulateNullPropagation(boolean accumulateNullPropagation);
+    public abstract boolean isAccumulateNullPropagation();
 
     public abstract void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter);
     public abstract ForceEagerActivationFilter getForceEagerActivationFilter();
@@ -118,6 +121,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             setDirectFiring(((DirectFiringOption) option).isDirectFiring());
         } else if ( option instanceof ThreadSafeOption ) {
             setThreadSafe(((ThreadSafeOption) option).isThreadSafe());
+        } else if ( option instanceof AccumulateNullPropagationOption ) {
+            setAccumulateNullPropagation(((AccumulateNullPropagationOption) option).isAccumulateNullPropagation());
         } else if ( option instanceof ForceEagerActivationOption ) {
             setForceEagerActivationFilter(((ForceEagerActivationOption) option).getFilter());
         } else if ( option instanceof TimedRuleExecutionOption ) {
@@ -142,6 +147,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             return (T) (isDirectFiring() ? DirectFiringOption.YES : DirectFiringOption.NO);
         } else if ( ThreadSafeOption.class.equals( option ) ) {
             return (T) (isThreadSafe() ? ThreadSafeOption.YES : ThreadSafeOption.NO);
+        } else if ( AccumulateNullPropagationOption.class.equals( option ) ) {
+            return (T) (isAccumulateNullPropagation() ? AccumulateNullPropagationOption.YES : AccumulateNullPropagationOption.NO);
         } else if ( TimerJobFactoryOption.class.equals( option ) ) {
             return (T) TimerJobFactoryOption.get( getTimerJobFactoryType().toExternalForm() );
         } else if ( QueryListenerOption.class.equals( option ) ) {
@@ -175,6 +182,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             setDirectFiring(!StringUtils.isEmpty(value) && Boolean.parseBoolean(value));
         }else if ( name.equals( ThreadSafeOption.PROPERTY_NAME ) ) {
             setThreadSafe( StringUtils.isEmpty( value ) || Boolean.parseBoolean( value ) );
+        } else if ( name.equals( AccumulateNullPropagationOption.PROPERTY_NAME ) ) {
+            setAccumulateNullPropagation( !StringUtils.isEmpty( value ) && Boolean.parseBoolean( value ) );
         } else if ( name.equals( ForceEagerActivationOption.PROPERTY_NAME ) ) {
             setForceEagerActivationFilter(ForceEagerActivationOption.resolve(StringUtils.isEmpty(value) ? "false" : value).getFilter());
         } else if ( name.equals( TimedRuleExecutionOption.PROPERTY_NAME ) ) {
@@ -203,6 +212,8 @@ public abstract class SessionConfiguration implements KieSessionConfiguration, E
             return Boolean.toString(isDirectFiring());
         }else if ( name.equals( ThreadSafeOption.PROPERTY_NAME ) ) {
             return Boolean.toString(isThreadSafe());
+        } else if ( name.equals( AccumulateNullPropagationOption.PROPERTY_NAME ) ) {
+            return Boolean.toString(isAccumulateNullPropagation());
         } else if ( name.equals( ClockTypeOption.PROPERTY_NAME ) ) {
             return getClockType().toExternalForm();
         } else if ( name.equals( TimerJobFactoryOption.PROPERTY_NAME ) ) {

--- a/drools-core/src/main/java/org/drools/core/SessionConfigurationImpl.java
+++ b/drools-core/src/main/java/org/drools/core/SessionConfigurationImpl.java
@@ -32,6 +32,7 @@ import org.kie.api.KieBase;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.conf.BeliefSystemTypeOption;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.conf.DirectFiringOption;
@@ -77,6 +78,8 @@ public class SessionConfigurationImpl extends SessionConfiguration {
     private boolean                        directFiring;
 
     private boolean                        threadSafe;
+
+    private boolean                        accumulateNullPropagation;
 
     private ForceEagerActivationFilter     forceEagerActivationFilter;
     private TimedRuleExecutionFilter       timedRuleExecutionFilter;
@@ -167,6 +170,8 @@ public class SessionConfigurationImpl extends SessionConfiguration {
 
         setThreadSafe(Boolean.valueOf( getPropertyValue( ThreadSafeOption.PROPERTY_NAME, "true" ) ));
 
+        setAccumulateNullPropagation(Boolean.valueOf( getPropertyValue( AccumulateNullPropagationOption.PROPERTY_NAME, "false" ) ));
+
         setForceEagerActivationFilter(ForceEagerActivationOption.resolve( getPropertyValue( ForceEagerActivationOption.PROPERTY_NAME, "false" ) ).getFilter());
 
         setTimedRuleExecutionFilter(TimedRuleExecutionOption.resolve( getPropertyValue( TimedRuleExecutionOption.PROPERTY_NAME, "false" ) ).getFilter());
@@ -239,6 +244,15 @@ public class SessionConfigurationImpl extends SessionConfiguration {
 
     public boolean isThreadSafe() {
         return this.threadSafe;
+    }
+
+    public void setAccumulateNullPropagation(boolean accumulateNullPropagation) {
+        checkCanChange(); // throws an exception if a change isn't possible;
+        this.accumulateNullPropagation = accumulateNullPropagation;
+    }
+
+    public boolean isAccumulateNullPropagation() {
+        return this.accumulateNullPropagation;
     }
 
     public void setForceEagerActivationFilter(ForceEagerActivationFilter forceEagerActivationFilter) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakAccumulateNode.java
@@ -48,6 +48,7 @@ import static org.drools.core.phreak.RuleNetworkEvaluator.normalizeStagedTuples;
 * To change this template use File | Settings | File Templates.
 */
 public class PhreakAccumulateNode {
+
     public void doNode(AccumulateNode accNode,
                        LeftTupleSink sink,
                        AccumulateMemory am,
@@ -610,14 +611,14 @@ public class PhreakAccumulateNode {
 
         Object result = accumulate.getResult(memory.workingMemoryContext, accctx, leftTuple, workingMemory);
         propagateResult( accNode, sink, leftTuple, context, workingMemory, memory, trgLeftTuples, stagedLeftTuples,
-                         null, result, (AccumulateContextEntry) accctx, propagationContext );
+                         null, result, (AccumulateContextEntry) accctx, propagationContext, workingMemory.getSessionConfiguration().isAccumulateNullPropagation());
     }
 
     protected final void propagateResult(AccumulateNode accNode, LeftTupleSink sink, LeftTuple leftTuple, PropagationContext context,
                                          InternalWorkingMemory workingMemory, AccumulateMemory memory, TupleSets<LeftTuple> trgLeftTuples,
                                          TupleSets<LeftTuple> stagedLeftTuples, Object key, Object result,
-                                         AccumulateContextEntry accPropCtx, PropagationContext propagationContext) {
-        if ( result == null) {
+                                         AccumulateContextEntry accPropCtx, PropagationContext propagationContext, boolean allowNullPropagation) {
+        if ( !allowNullPropagation && result == null) {
             if ( accPropCtx.isPropagated()) {
                 // retract
                 trgLeftTuples.addDelete( accPropCtx.getResultLeftTuple());

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
@@ -73,7 +73,7 @@ public class PhreakGroupByNode extends PhreakAccumulateNode {
             Object result = accumulate.getResult(memory.workingMemoryContext, contextEntry, leftTuple, workingMemory);
 
             propagateResult( accNode, sink, leftTuple, context, workingMemory, memory, trgLeftTuples, stagedLeftTuples,
-                             contextEntry.getKey(), result, contextEntry, propagationContext );
+                             contextEntry.getKey(), result, contextEntry, propagationContext, false ); // don't want to propagate null
 
             contextEntry.setToPropagate(false);
         }

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-decisiontables</artifactId>

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-distribution</artifactId>

--- a/drools-ecj/pom.xml
+++ b/drools-ecj/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>drools</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-engine-classic/pom.xml
+++ b/drools-engine-classic/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-engine/pom.xml
+++ b/drools-engine/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-examples-api/default-kiesession-from-file/pom.xml
+++ b/drools-examples-api/default-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession-from-file</artifactId>

--- a/drools-examples-api/default-kiesession/pom.xml
+++ b/drools-examples-api/default-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession</artifactId>

--- a/drools-examples-api/kie-module-from-multiple-files/pom.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-module-from-multiple-files</artifactId>

--- a/drools-examples-api/kiebase-inclusion/pom.xml
+++ b/drools-examples-api/kiebase-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiebase-inclusion</artifactId>

--- a/drools-examples-api/kiecontainer-from-kierepo/pom.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiecontainer-from-kierepo</artifactId>

--- a/drools-examples-api/kiefilesystem-example/pom.xml
+++ b/drools-examples-api/kiefilesystem-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiefilesystem-example</artifactId>

--- a/drools-examples-api/kiemodulemodel-example/pom.xml
+++ b/drools-examples-api/kiemodulemodel-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiemodulemodel-example</artifactId>

--- a/drools-examples-api/multiple-kbases/pom.xml
+++ b/drools-examples-api/multiple-kbases/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>multiple-kbases</artifactId>

--- a/drools-examples-api/named-kiesession-from-file/pom.xml
+++ b/drools-examples-api/named-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <name>Drools API examples - Named KieSession from File</name>

--- a/drools-examples-api/named-kiesession/pom.xml
+++ b/drools-examples-api/named-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>named-kiesession</artifactId>

--- a/drools-examples-api/pom.xml
+++ b/drools-examples-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-examples-api</artifactId>

--- a/drools-examples-api/reactive-kiesession/pom.xml
+++ b/drools-examples-api/reactive-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>reactive-kiesession</artifactId>

--- a/drools-examples-api/ruleunit/pom.xml
+++ b/drools-examples-api/ruleunit/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ruleunit</artifactId>

--- a/drools-examples-cdi/cdi-example-scopes/pom.xml
+++ b/drools-examples-cdi/cdi-example-scopes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>cdi-example-scopes</artifactId>
 

--- a/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdi-example-with-inclusion</artifactId>

--- a/drools-examples-cdi/cdi-example/pom.xml
+++ b/drools-examples-cdi/cdi-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdi-example</artifactId>

--- a/drools-examples-cdi/pom.xml
+++ b/drools-examples-cdi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-examples-cdi</artifactId>

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-examples</artifactId>

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-impact-analysis</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-model/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-impact-analysis</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-impact-analysis</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/pom.xml
+++ b/drools-impact-analysis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>drools</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -45,27 +45,27 @@
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-impact-analysis-model</artifactId>
-                <version>7.53.0-SNAPSHOT</version>
+                <version>7.52.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-impact-analysis-parser</artifactId>
-                <version>7.53.0-SNAPSHOT</version>
+                <version>7.52.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-impact-analysis-graph-common</artifactId>
-                <version>7.53.0-SNAPSHOT</version>
+                <version>7.52.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-impact-analysis-graph-graphviz</artifactId>
-                <version>7.53.0-SNAPSHOT</version>
+                <version>7.52.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-impact-analysis-itests</artifactId>
-                <version>7.53.0-SNAPSHOT</version>
+                <version>7.52.1-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/drools-metric/pom.xml
+++ b/drools-metric/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-metric</artifactId>

--- a/drools-model/drools-canonical-model/pom.xml
+++ b/drools-model/drools-canonical-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-canonical-model</artifactId>

--- a/drools-model/drools-model-compiler/pom.xml
+++ b/drools-model/drools-model-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-model-compiler</artifactId>

--- a/drools-model/drools-mvel-compiler/pom.xml
+++ b/drools-model/drools-mvel-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-mvel-compiler</artifactId>

--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-mvel-parser</artifactId>

--- a/drools-model/pom.xml
+++ b/drools-model/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>drools</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-persistence/drools-persistence-api/pom.xml
+++ b/drools-persistence/drools-persistence-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-api</artifactId>

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-jpa</artifactId>

--- a/drools-persistence/pom.xml
+++ b/drools-persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence</artifactId>

--- a/drools-ruleunit/pom.xml
+++ b/drools-ruleunit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/pom.xml
+++ b/drools-scenario-simulation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scorecards/pom.xml
+++ b/drools-scorecards/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-scorecards</artifactId>

--- a/drools-serialization-protobuf/pom.xml
+++ b/drools-serialization-protobuf/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>drools</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-templates</artifactId>

--- a/drools-test-coverage/pom.xml
+++ b/drools-test-coverage/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools.testcoverage</groupId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/pom.xml
+++ b/drools-test-coverage/standalone/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-standalone-parent</artifactId>

--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.testcoverage.common.model.MyFact;
+import org.drools.testcoverage.common.model.Person;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
+import org.kie.api.runtime.rule.QueryResults;
+import org.kie.api.runtime.rule.Variable;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class AccumulateConsistencyTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+    private final boolean accumulateNullPropagation;
+
+    public AccumulateConsistencyTest(final KieBaseTestConfiguration kieBaseTestConfiguration, boolean accumulateNullPropagation) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+        this.accumulateNullPropagation = accumulateNullPropagation;
+    }
+
+    // accumulateNullPropagation is false by default in drools 7.x
+    @Parameterized.Parameters(name = "KieBase type={0}, accumulateNullPropagation= {1}")
+    public static Collection<Object[]> getParameters() {
+        Collection<Object[]> parameters = new ArrayList<>();
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY, false});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_FLOW, false});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, false});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY, true});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_FLOW, true});
+        parameters.add(new Object[]{KieBaseTestConfiguration.CLOUD_IDENTITY_MODEL_PATTERN, true});
+        return parameters;
+    }
+
+    @Test
+    public void testMinNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($min);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMaxNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $max : max( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testAveNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $ave : average( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($ave);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testSumNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $sum : sum( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($sum);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testCountNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $count : count( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($count);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMaxNoMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ),\n" +
+                           "                $max : max( $p.getAge() ))\n" +
+                           "then\n" +
+                           "    System.out.println($min + \", \" + $max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Ignore("Ignoring because this test is not essential to the original JIRA (DROOLS-6064) so will investigate in another JIRA: DROOLS-6254")
+    @Test
+    public void testMinMaxMatch() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "global java.util.Map result;\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $min : min( $p.getAge() ),\n" +
+                           "                $max : max( $p.getAge() ))\n" +
+                           "then\n" +
+                           "    result.put(\"min\", $min);\n" +
+                           "    result.put(\"max\", $max);\n" +
+                           "    System.out.println($min + \", \" + $max);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        Map<String, Integer> result = new HashMap<>();
+        kieSession.setGlobal("result", result);
+
+        try {
+            kieSession.insert(new Person(0, "John", 20));
+            kieSession.insert(new Person(1, "John", 60));
+
+            assertEquals(1, kieSession.fireAllRules());
+            assertEquals(20, result.get("min").intValue());
+            assertEquals(60, result.get("max").intValue());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinNoMatchAccFrom() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    $min : Number() from accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($min);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMatchUnification() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + MyFact.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    MyFact($i : currentValue)\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $i := min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($i);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("John", 20));
+            kieSession.insert(new MyFact("A", 20));
+            assertEquals(1, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinNoMatchUnification() {
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import " + MyFact.class.getCanonicalName() + ";\n" +
+                           "rule R\n" +
+                           "when\n" +
+                           "    MyFact($i : currentValue)\n" +
+                           "    accumulate( $p : Person( name == \"John\" ),\n" +
+                           "                $i := min( $p.getAge() ) )\n" +
+                           "then\n" +
+                           "    System.out.println($i);\n" +
+                           "end";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person("Paul", 20));
+            kieSession.insert(new MyFact("A", null));
+            if (accumulateNullPropagation) {
+                assertEquals(1, kieSession.fireAllRules());
+            } else {
+                assertEquals(0, kieSession.fireAllRules()); // don't propagate null
+            }
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testMinMatchUnificationQuery() {
+
+        final String drl =
+                "package org.drools.compiler.integrationtests;\n" +
+                           "import " + Person.class.getCanonicalName() + ";\n" +
+                           "import java.util.List;\n" +
+                           "query getResults( String $name, List $persons )\n" +
+                           "  accumulate(  \n" +
+                           "    $p : Person( name == $name),\n" +
+                           "    $persons := collectList( $p )\n" +
+                           "  ) \n" +
+                           "end\n";
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        KieSessionConfiguration kieSessionConfiguration = KieServices.get().newKieSessionConfiguration();
+        kieSessionConfiguration.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME, Boolean.toString(accumulateNullPropagation));
+        final KieSession kieSession = kieBase.newKieSession(kieSessionConfiguration, null);
+
+        try {
+            kieSession.insert(new Person(0, "John", 20));
+            kieSession.insert(new Person(1, "John", 19));
+            final QueryResults results = kieSession.getQueryResults("getResults", "John", Variable.v);
+            List<Person> persons = (List<Person>)results.iterator().next().get("$persons");
+            assertEquals(2, persons.size());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.Assertions;
 import org.drools.compiler.integrationtests.incrementalcompilation.TestUtil;
 import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.drools.core.SessionConfiguration;
 import org.drools.core.command.runtime.rule.InsertElementsCommand;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.testcoverage.common.model.Cheese;
@@ -65,11 +66,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -3789,8 +3790,15 @@ public class AccumulateTest {
         list.clear();
 
         kieSession.delete( fh );
-        assertEquals(0, kieSession.fireAllRules() );
-        assertEquals(0, list.size() );
+        // changed by DROOLS-6064
+        if (((SessionConfiguration)kieSession.getSessionConfiguration()).isAccumulateNullPropagation()) {
+            assertEquals(1, kieSession.fireAllRules() );
+            assertEquals(1, list.size() );
+            assertNull(list.get(0));
+        } else {
+            assertEquals(0, kieSession.fireAllRules() );
+            assertEquals(0, list.size() );
+        }
     }
 
     @Test

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeSessionConfigurationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/conf/KnowledgeSessionConfigurationTest.java
@@ -19,6 +19,7 @@ import org.drools.core.BeliefSystemType;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.KieServices;
+import org.kie.api.runtime.conf.AccumulateNullPropagationOption;
 import org.kie.api.runtime.conf.BeliefSystemTypeOption;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
@@ -86,5 +87,30 @@ public class KnowledgeSessionConfigurationTest {
                       config.getProperty( BeliefSystemTypeOption.PROPERTY_NAME ) );
     }
 
+    @Test
+    public void testAccumulateNullPropagation() {
+        // false by default
+        assertEquals(AccumulateNullPropagationOption.NO, config.getOption(AccumulateNullPropagationOption.class));
+        assertEquals("false", config.getProperty(AccumulateNullPropagationOption.PROPERTY_NAME));
 
+        config.setOption(AccumulateNullPropagationOption.YES);
+
+        assertEquals(AccumulateNullPropagationOption.YES,
+                     config.getOption(AccumulateNullPropagationOption.class));
+
+        // checking the string based getProperty() method
+        assertEquals("true",
+                     config.getProperty(AccumulateNullPropagationOption.PROPERTY_NAME));
+
+        // setting the options using the string based setProperty() method
+        config.setProperty(AccumulateNullPropagationOption.PROPERTY_NAME,
+                           "false");
+
+        // checking the type safe getOption() method
+        assertEquals(AccumulateNullPropagationOption.NO,
+                     config.getOption(AccumulateNullPropagationOption.class));
+        // checking the string based getProperty() method
+        assertEquals("false",
+                     config.getProperty(AccumulateNullPropagationOption.PROPERTY_NAME));
+    }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
@@ -771,8 +771,8 @@ public class ExpirationTest {
         final KieSessionConfiguration sessionConfig = new SessionConfigurationImpl();
         sessionConfig.setOption(ClockTypeOption.get(ClockType.PSEUDO_CLOCK.getId()));
 
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, drl);
         final KieSession kieSession = kieBase.newKieSession(sessionConfig, null);
 
         //clock init to current time

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FirstOrderLogicTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/FirstOrderLogicTest.java
@@ -1107,8 +1107,8 @@ public class FirstOrderLogicTest {
         final KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration, "test_ForallSlidingWindow.drl");
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), streamConfig, "test_ForallSlidingWindow.drl");
         KieSession ksession = kbase.newKieSession(conf, null);
 
         final SessionPseudoClock clock = (SessionPseudoClock) ksession.<SessionClock>getSessionClock();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELTest.java
@@ -889,8 +889,8 @@ public class MVELTest {
                 "  list.add( \"OK\" ); \n" +
                 "end";
 
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, str);
         KieSession ksession = kbase.newKieSession();
 
         final List list = new ArrayList();
@@ -934,8 +934,8 @@ public class MVELTest {
                 "    }\n" +
                 "end";
 
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, str);
         KieSession ksession = kbase.newKieSession();
         Human h = new Human(2);
         ksession.insert(h);
@@ -960,8 +960,8 @@ public class MVELTest {
                 "    }\n" +
                 "end";
 
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, str);
         KieSession ksession = kbase.newKieSession();
         Human h = new Human(2);
         ksession.insert(h);
@@ -1020,8 +1020,8 @@ public class MVELTest {
                 "        System.out.println( $fact );\n" +
                 "end";
 
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, str);
         KieSession ksession = kbase.newKieSession();
 
         Fact f = new Fact();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/Misc2Test.java
@@ -2722,8 +2722,8 @@ public class Misc2Test {
                 "    $f.setX( 2 );\n" +
                 "end";
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, str);
         KieSession ksession = kbase.newKieSession();
 
         ksession.setGlobal( "context", new ArrayList() {{
@@ -4544,8 +4544,8 @@ public class Misc2Test {
                 "then\n" +
                 "end\n";
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, drl);
         KieSession ksession = kbase.newKieSession();
 
         final AtomicInteger i = new AtomicInteger( 0 );

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullTest.java
@@ -240,8 +240,8 @@ public class NullTest {
                 "  list.add( \"OK\" ); \n" +
                 "end";
 
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig, str);
         KieSession ksession = kbase.newKieSession();
 
         final java.util.List list = new java.util.ArrayList();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
@@ -453,9 +453,9 @@ public class ParallelEvaluationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", streamConfig, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, streamConfig, MultithreadEvaluationOption.YES );
         KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
@@ -496,9 +496,9 @@ public class ParallelEvaluationTest {
 
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", streamConfig, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, streamConfig, MultithreadEvaluationOption.YES );
         KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
@@ -574,9 +574,9 @@ public class ParallelEvaluationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, sb.toString());
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", streamConfig, sb.toString());
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, streamConfig, MultithreadEvaluationOption.YES );
         KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         assertTrue( ( (InternalWorkingMemory) ksession ).getAgenda().isParallelAgenda() );
@@ -684,9 +684,9 @@ public class ParallelEvaluationTest {
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         sessionConfig.setOption( ClockTypeOption.get( ClockType.PSEUDO_CLOCK.getId() ) );
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", kieBaseTestConfiguration, drl);
-        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, kieBaseTestConfiguration, MultithreadEvaluationOption.YES );
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        final KieModule kieModule = KieUtil.getKieModuleFromDrls("test", streamConfig, drl);
+        final KieBase kbase = KieBaseUtil.newKieBaseFromKieModuleWithAdditionalOptions(kieModule, streamConfig, MultithreadEvaluationOption.YES );
         KieSession ksession = kbase.newKieSession(sessionConfig, null);
 
         try {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/PropertySpecificTest.java
@@ -2704,7 +2704,7 @@ public class PropertySpecificTest {
                 "import " + BigDecimalFact.class.getCanonicalName() + "\n" +
                 "rule R when\n" +
                 "        accumulate( BigDecimalFact( $bdVal: bdVal), $minVal : min($bdVal))\n" +
-                "        accumulate( BigDecimalFact( $bdVal2: bdVal, $bdVal2 > $minVal), $minVal2 : min($bdVal2))\n" +
+                "        accumulate( BigDecimalFact( $bdVal2: bdVal, $bdVal2 > $minVal), $minVal2 : min($bdVal2); $minVal2 != null)\n" + // guard for DROOLS-6064
                 "\n" +
                 "        \n" +
                 "        $minFact: BigDecimalFact( bdVal == new BigDecimal($minVal.intValue()))\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryInRHSCepTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/QueryInRHSCepTest.java
@@ -210,8 +210,8 @@ public class QueryInRHSCepTest {
                 "  myGlobal.add(drools.getKieRuntime().getQueryResults(\"myQuery\"));\n"+
                 "end\n";
 
-        kieBaseTestConfiguration.setStreamMode(false); // CLOUD
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration cloudConfig = TestParametersUtil.getCloudInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", cloudConfig, drl);
         KieSession kSession = kbase.newKieSession();
 
         myGlobal = new ArrayList<>();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
@@ -265,7 +265,7 @@ public class MultithreadTest {
                 "rule \"average temperature\"\n" +
                 "when\n" +
                 "  $s : Server (hostname == \"hiwaesdk\")\n" +
-                " $avg := Number( ) from accumulate ( " +
+                " $avg := Number( this != null ) from accumulate ( " +
                 "      IntEvent ( $temp : data ) over window:length(10) from entry-point ep01; " +
                 "      average ($temp)\n" +
                 "  )\n" +

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/MultithreadTest.java
@@ -93,8 +93,8 @@ public class MultithreadTest {
 
         final List<Exception> errors = new ArrayList<>();
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, str);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, str);
 
         final KieSession ksession = kbase.newKieSession();
         final EntryPoint ep = ksession.getEntryPoint("X");
@@ -275,8 +275,8 @@ public class MultithreadTest {
                 "end\n" +
                 "\n";
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, drl);
 
 
         final KieSession session = kbase.newKieSession();
@@ -348,8 +348,8 @@ public class MultithreadTest {
                 "    list.add( $count ); \n" +
                 "end";
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, drl);
 
         final KieSessionConfiguration conf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
         conf.setOption(ClockTypeOption.REALTIME);
@@ -562,8 +562,8 @@ public class MultithreadTest {
                 "then\n" +
                 "end";
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, drl);
 
         final KieSessionConfiguration ksconf = KieServices.Factory.get().newKieSessionConfiguration();
         ksconf.setOption(TimedRuleExecutionOption.YES);
@@ -612,8 +612,8 @@ public class MultithreadTest {
                 "then\n" +
                 "end";
 
-        kieBaseTestConfiguration.setStreamMode(true);
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drl);
+        KieBaseTestConfiguration streamConfig = TestParametersUtil.getStreamInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", streamConfig, drl);
 
         final KieSessionConfiguration ksconf = KieServices.Factory.get().newKieSessionConfiguration();
         ksconf.setOption(TimedRuleExecutionOption.YES);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/StatefulSessionTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/session/StatefulSessionTest.java
@@ -133,8 +133,8 @@ public class StatefulSessionTest {
 
     @Test
     public void testGetFactHandleEqualityBehavior() throws Exception {
-        kieBaseTestConfiguration.setIdentity(false); // EQUALITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration);
+        KieBaseTestConfiguration equalityConfig = TestParametersUtil.getEqualityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", equalityConfig);
         KieSession ksession = kbase.newKieSession();
 
         final CheeseEqual cheese = new CheeseEqual("stilton", 10);
@@ -145,8 +145,8 @@ public class StatefulSessionTest {
 
     @Test
     public void testGetFactHandleIdentityBehavior() throws Exception {
-        kieBaseTestConfiguration.setIdentity(true); // IDENTITY
-        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration);
+        KieBaseTestConfiguration identityConfig = TestParametersUtil.getIdentityInstanceOf(kieBaseTestConfiguration);
+        KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", identityConfig);
         KieSession ksession = kbase.newKieSession();
 
         final CheeseEqual cheese = new CheeseEqual("stilton", 10);

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverage.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverage.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $avg    : Number( intValue >= 10 )
+        $avg    : Number( this != null, intValue >= 10 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 average( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverageMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateAverageMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $avg    : Number( intValue >= 10 )
+        $avg    : Number( this != null, intValue >= 10 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 average( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMax.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMax.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $max    : Number( intValue >= 5 )
+        $max    : Number( this != null, intValue >= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 max( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMaxMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMaxMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $max    : Number( intValue >= 5 )
+        $max    : Number( this != null, intValue >= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 max( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMin.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMin.drl
@@ -23,7 +23,7 @@ global java.util.List results;
 rule "External Function" salience 80
     when
         $person : Person( $likes : likes )
-        $min    : Number( intValue <= 5 )
+        $min    : Number( this != null, intValue <= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 min( $price ) );
     then

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMinMVEL.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/test_AccumulateMinMVEL.drl
@@ -24,7 +24,7 @@ rule "External Function" salience 80
     dialect "mvel"
     when
         $person : Person( $likes : likes )
-        $min    : Number( intValue <= 5 )
+        $min    : Number( this != null, intValue <= 5 )
                                from accumulate( $cheese : Cheese( type == $likes, $price : price ),
                                                 min( $price ) );
     then

--- a/drools-test-coverage/test-suite/pom.xml
+++ b/drools-test-coverage/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-test-suite</artifactId>

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/Person.java
@@ -56,6 +56,12 @@ public class Person implements Serializable {
         this.age = age;
     }
 
+    public Person(final int id, final String name, final int age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
     public Person(final String name, final String likes, final int age) {
         this.name = name;
         this.likes = likes;

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/KieBaseTestConfiguration.java
@@ -261,19 +261,9 @@ public enum KieBaseTestConfiguration implements KieBaseModelProvider {
         return identity;
     }
 
-    // identity is mutable for test convenience but basically we don't need to use this (One test class should focus on identity or equality)
-    public void setIdentity(boolean identity) {
-        this.identity = identity;
-    }
-
     @Override
     public boolean isStreamMode() {
         return streamMode;
-    }
-
-    // streamMode is mutable for test convenience but basically we don't need to use this (One test class should focus on cloud or stream)
-    public void setStreamMode(boolean streamMode) {
-        this.streamMode = streamMode;
     }
 
     @Override

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtil.java
@@ -259,6 +259,66 @@ public final class TestParametersUtil {
         return parameters;
     }
 
+    /**
+     * Returns KieBaseTestConfiguration instance with Equality while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getEqualityInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (!config.isIdentity()
+                    && config.isStreamMode() == orig.isStreamMode()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Equality instance of " + orig);
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Identity while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getIdentityInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (config.isIdentity()
+                    && config.isStreamMode() == orig.isStreamMode()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Identity instance of " + orig);
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Stream while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getStreamInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (config.isStreamMode()
+                    && config.isIdentity() == orig.isIdentity()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Stream instance of " + orig);
+    }
+
+    /**
+     * Returns KieBaseTestConfiguration instance with Cloud while other properties are the same as original.
+     */
+    public static KieBaseTestConfiguration getCloudInstanceOf(KieBaseTestConfiguration orig) {
+        for (final KieBaseTestConfiguration config : KieBaseTestConfiguration.values()) {
+            if (!config.isStreamMode()
+                    && config.isIdentity() == orig.isIdentity()
+                    && config.useAlphaNetworkCompiler() == orig.useAlphaNetworkCompiler()
+                    && config.getExecutableModelProjectClass().equals(orig.getExecutableModelProjectClass())) {
+                return config;
+            }
+        }
+        throw new RuntimeException("Cannot find Cloud instance of " + orig);
+    }
+
     private TestParametersUtil() {
         // Creating instances of util classes should not be possible.
     }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtilTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/util/TestParametersUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.testcoverage.common.util;
+
+import org.junit.Test;
+
+import static org.drools.testcoverage.common.util.KieBaseTestConfiguration.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestParametersUtilTest {
+
+    @Test
+    public void testGetEqualityInstanceOf() {
+        assertEquals(CLOUD_EQUALITY, TestParametersUtil.getEqualityInstanceOf(CLOUD_IDENTITY));
+        assertEquals(CLOUD_EQUALITY, TestParametersUtil.getEqualityInstanceOf(CLOUD_EQUALITY));
+        assertEquals(CLOUD_EQUALITY_ALPHA_NETWORK, TestParametersUtil.getEqualityInstanceOf(CLOUD_IDENTITY_ALPHA_NETWORK));
+        assertEquals(CLOUD_EQUALITY_MODEL_FLOW, TestParametersUtil.getEqualityInstanceOf(CLOUD_IDENTITY_MODEL_FLOW));
+        assertEquals(CLOUD_EQUALITY_MODEL_PATTERN, TestParametersUtil.getEqualityInstanceOf(CLOUD_IDENTITY_MODEL_PATTERN));
+        assertEquals(CLOUD_EQUALITY_MODEL_PATTERN_ALPHA_NETWORK, TestParametersUtil.getEqualityInstanceOf(CLOUD_IDENTITY_MODEL_PATTERN_ALPHA_NETWORK));
+    }
+
+    @Test
+    public void testGetIdentityInstanceOf() {
+        assertEquals(CLOUD_IDENTITY, TestParametersUtil.getIdentityInstanceOf(CLOUD_EQUALITY));
+        assertEquals(CLOUD_IDENTITY, TestParametersUtil.getIdentityInstanceOf(CLOUD_IDENTITY));
+        assertEquals(CLOUD_IDENTITY_ALPHA_NETWORK, TestParametersUtil.getIdentityInstanceOf(CLOUD_EQUALITY_ALPHA_NETWORK));
+        assertEquals(CLOUD_IDENTITY_MODEL_FLOW, TestParametersUtil.getIdentityInstanceOf(CLOUD_EQUALITY_MODEL_FLOW));
+        assertEquals(CLOUD_IDENTITY_MODEL_PATTERN, TestParametersUtil.getIdentityInstanceOf(CLOUD_EQUALITY_MODEL_PATTERN));
+        assertEquals(CLOUD_IDENTITY_MODEL_PATTERN_ALPHA_NETWORK, TestParametersUtil.getIdentityInstanceOf(CLOUD_EQUALITY_MODEL_PATTERN_ALPHA_NETWORK));
+    }
+
+    @Test
+    public void testGetStreamInstanceOf() {
+        assertEquals(STREAM_IDENTITY, TestParametersUtil.getStreamInstanceOf(CLOUD_IDENTITY));
+        assertEquals(STREAM_IDENTITY, TestParametersUtil.getStreamInstanceOf(STREAM_IDENTITY));
+        assertEquals(STREAM_IDENTITY_ALPHA_NETWORK, TestParametersUtil.getStreamInstanceOf(CLOUD_IDENTITY_ALPHA_NETWORK));
+        assertEquals(STREAM_IDENTITY_MODEL_FLOW, TestParametersUtil.getStreamInstanceOf(CLOUD_IDENTITY_MODEL_FLOW));
+        assertEquals(STREAM_IDENTITY_MODEL_PATTERN, TestParametersUtil.getStreamInstanceOf(CLOUD_IDENTITY_MODEL_PATTERN));
+        assertEquals(STREAM_IDENTITY_MODEL_PATTERN_ALPHA_NETWORK, TestParametersUtil.getStreamInstanceOf(CLOUD_IDENTITY_MODEL_PATTERN_ALPHA_NETWORK));
+    }
+
+    @Test
+    public void testGetCloudInstanceOf() {
+        assertEquals(CLOUD_IDENTITY, TestParametersUtil.getCloudInstanceOf(STREAM_IDENTITY));
+        assertEquals(CLOUD_IDENTITY, TestParametersUtil.getCloudInstanceOf(CLOUD_IDENTITY));
+        assertEquals(CLOUD_IDENTITY_ALPHA_NETWORK, TestParametersUtil.getCloudInstanceOf(STREAM_IDENTITY_ALPHA_NETWORK));
+        assertEquals(CLOUD_IDENTITY_MODEL_FLOW, TestParametersUtil.getCloudInstanceOf(STREAM_IDENTITY_MODEL_FLOW));
+        assertEquals(CLOUD_IDENTITY_MODEL_PATTERN, TestParametersUtil.getCloudInstanceOf(STREAM_IDENTITY_MODEL_PATTERN));
+        assertEquals(CLOUD_IDENTITY_MODEL_PATTERN_ALPHA_NETWORK, TestParametersUtil.getCloudInstanceOf(STREAM_IDENTITY_MODEL_PATTERN_ALPHA_NETWORK));
+    }
+}

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-traits</artifactId>

--- a/drools-verifier/drools-verifier-api/pom.xml
+++ b/drools-verifier/drools-verifier-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-verifier</artifactId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-core/pom.xml
+++ b/drools-verifier/drools-verifier-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools-verifier</artifactId>
         <groupId>org.drools</groupId>
-        <version>7.53.0-SNAPSHOT</version>
+        <version>7.52.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-drl/pom.xml
+++ b/drools-verifier/drools-verifier-drl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-verifier</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-verifier-drl</artifactId>

--- a/drools-verifier/pom.xml
+++ b/drools-verifier/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-verifier</artifactId>

--- a/drools-workbench-models/drools-workbench-models-commons/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models-commons</artifactId>

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -3211,14 +3211,13 @@ public class RuleModelDRLPersistenceImpl
                     }
                 } else {
 
-                    final StringBuilder sb = new StringBuilder();
+                    final StringBuilder drl = new StringBuilder();
                     for (final String setter : entry.getValue()) {
-                        sb.append(setter).append("\n");
+                        drl.append(setter).append("\n");
                     }
-                    final String drl = sb.toString();
 
                     final FreeFormLine action = new FreeFormLine();
-                    action.setText(drl);
+                    action.setText(drl.toString());
                     m.addRhsItem(action,
                                  setStatementsPosition.get(entry.getKey()));
                 }

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceImpl.java
@@ -284,6 +284,7 @@ public class RuleModelDRLPersistenceImpl
 
     /**
      * Marshal model attributes
+     *
      * @param buf
      * @param model
      */
@@ -314,6 +315,7 @@ public class RuleModelDRLPersistenceImpl
 
     /**
      * Marshal model metadata
+     *
      * @param buf
      * @param model
      */
@@ -328,6 +330,7 @@ public class RuleModelDRLPersistenceImpl
 
     /**
      * Marshal LHS patterns
+     *
      * @param buf
      * @param model
      */
@@ -1668,12 +1671,22 @@ public class RuleModelDRLPersistenceImpl
 
         public void visitActionSetField(final ActionSetField action) {
             if (action instanceof ActionCallMethod) {
-                this.generateSetMethodCallsMethod((ActionCallMethod) action,
-                                                  action.getFieldValues());
+                visitActionCallMethod((ActionCallMethod)action);
             } else {
                 this.generateSetMethodCalls(action.getVariable(),
                                             action.getFieldValues());
             }
+        }
+
+        public void visitActionCallMethod(final ActionCallMethod action) {
+            final RHSGeneratorContext gctx = generatorContextFactory.newChildGeneratorContext(rootContext,
+                                                                                              action);
+            preGenerateAction(gctx);
+
+            this.generateActionCallMethod(action,
+                                          action.getFieldValues());
+
+            postGenerateAction(gctx);
         }
 
         private void generateSetMethodCalls(final String variableName,
@@ -1833,8 +1846,8 @@ public class RuleModelDRLPersistenceImpl
                                                       fieldValue.getValue());
         }
 
-        private void generateSetMethodCallsMethod(final ActionCallMethod action,
-                                                  final FieldNature[] fieldValues) {
+        private void generateActionCallMethod(final ActionCallMethod action,
+                                              final FieldNature[] fieldValues) {
             buf.append(indentation);
             if (isDSLEnhanced) {
                 buf.append(">");
@@ -1858,6 +1871,10 @@ public class RuleModelDRLPersistenceImpl
                     buf.append(valueFunction.getValue());
                 } else if (valueFunction.getNature() == FieldNatureType.TYPE_VARIABLE) {
                     buf.append(valueFunction.getValue());
+                } else if (valueFunction.getNature() == FieldNatureType.TYPE_TEMPLATE) {
+                    buf.append("@{");
+                    buf.append(valueFunction.getValue());
+                    buf.append("}");
                 } else {
                     buildDefaultFieldValue(valueFunction,
                                            buf);
@@ -1917,7 +1934,31 @@ public class RuleModelDRLPersistenceImpl
     public RuleModel unmarshal(final String str,
                                final List<String> globals,
                                final PackageDataModelOracle dmo,
+                               final boolean splitEvals) {
+        return unmarshal(str,
+                         globals,
+                         dmo,
+                         Collections.emptyList(),
+                         splitEvals);
+    }
+
+    @Override
+    public RuleModel unmarshal(final String str,
+                               final List<String> globals,
+                               final PackageDataModelOracle dmo,
                                final Collection<RuleModelIActionPersistenceExtension> extensions) {
+        return unmarshal(str,
+                         globals,
+                         dmo,
+                         extensions,
+                         false);
+    }
+
+    public RuleModel unmarshal(final String str,
+                               final List<String> globals,
+                               final PackageDataModelOracle dmo,
+                               final Collection<RuleModelIActionPersistenceExtension> extensions,
+                               final boolean splitEvals) {
         PortablePreconditions.checkNotNull("extensions",
                                            extensions);
 
@@ -1929,7 +1970,8 @@ public class RuleModelDRLPersistenceImpl
                                               false).registerGlobals(dmo,
                                                                      globals),
                                 dmo,
-                                extensions);
+                                extensions,
+                                splitEvals);
         } catch (RuleModelDRLPersistenceException e) {
             throw new RuntimeException(e);
         } catch (Exception e) {
@@ -1964,7 +2006,8 @@ public class RuleModelDRLPersistenceImpl
                                           dsls).registerGlobals(dmo,
                                                                 globals),
                                 dmo,
-                                extensions);
+                                extensions,
+                                false);
         } catch (RuleModelDRLPersistenceException e) {
             throw new RuntimeException(e);
         } catch (Exception e) {
@@ -2032,7 +2075,8 @@ public class RuleModelDRLPersistenceImpl
 
     private RuleModel getRuleModel(final ExpandedDRLInfo expandedDRLInfo,
                                    final PackageDataModelOracle dmo,
-                                   final Collection<RuleModelIActionPersistenceExtension> extensions) throws RuleModelDRLPersistenceException {
+                                   final Collection<RuleModelIActionPersistenceExtension> extensions,
+                                   final boolean splitEvals) throws RuleModelDRLPersistenceException {
         //De-serialize model
         RuleDescr ruleDescr = parseDrl(expandedDRLInfo);
         RuleModel model = new RuleModel();
@@ -2067,7 +2111,8 @@ public class RuleModelDRLPersistenceImpl
                  boundParams,
                  expandedDRLInfo,
                  dmo,
-                 extensions);
+                 extensions,
+                 splitEvals);
         return model;
     }
 
@@ -2878,7 +2923,8 @@ public class RuleModelDRLPersistenceImpl
                           final Map<String, String> boundParams,
                           final ExpandedDRLInfo expandedDRLInfo,
                           final PackageDataModelOracle dmo,
-                          final Collection<RuleModelIActionPersistenceExtension> extensions) throws RuleModelDRLPersistenceException {
+                          final Collection<RuleModelIActionPersistenceExtension> extensions,
+                          final boolean splitEvals) throws RuleModelDRLPersistenceException {
         PortableWorkDefinition pwd = null;
         Map<String, List<String>> setStatements = new HashMap<String, List<String>>();
         Map<String, Integer> setStatementsPosition = new HashMap<String, Integer>();
@@ -3153,16 +3199,30 @@ public class RuleModelDRLPersistenceImpl
                 m.addRhsItem(action,
                              setStatementsPosition.get(entry.getKey()));
             } else {
-                StringBuilder sb = new StringBuilder();
-                for (String setter : entry.getValue()) {
-                    sb.append(setter).append("\n");
-                }
-                String drl = sb.toString();
 
-                FreeFormLine action = new FreeFormLine();
-                action.setText(drl);
-                m.addRhsItem(action,
-                             setStatementsPosition.get(entry.getKey()));
+                if (splitEvals) {
+
+                    for (final String drl : entry.getValue()) {
+
+                        final FreeFormLine action = new FreeFormLine();
+                        action.setText(drl);
+                        m.addRhsItem(action,
+                                     setStatementsPosition.get(entry.getKey()));
+                    }
+                } else {
+
+                    final StringBuilder sb = new StringBuilder();
+                    for (final String setter : entry.getValue()) {
+                        sb.append(setter).append("\n");
+                    }
+                    final String drl = sb.toString();
+
+                    final FreeFormLine action = new FreeFormLine();
+                    action.setText(drl);
+                    m.addRhsItem(action,
+                                 setStatementsPosition.get(entry.getKey()));
+                }
+
             }
         }
 
@@ -4366,6 +4426,7 @@ public class RuleModelDRLPersistenceImpl
          * It breaks the UI if user has a rule with this case, so we convert to the new format:
          * Fact(something != null && something matches "P.*")
          *                           ^^^^^^^^
+         *
          * @param comp The CompositeFieldConstraint with legacy 'matches'.
          */
         private void convertLegacyMatchesToNewFormat(final CompositeFieldConstraint comp) {

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistence.java
@@ -30,6 +30,12 @@ public interface RuleModelPersistence {
                         final List<String> globals,
                         final PackageDataModelOracle dmo);
 
+    /**
+     *
+     * @param splitEvals When true, each unresolved DRL will be split to a separate FreeFromLine element.
+     *                   When false, the DRL will be placed into FreeFormLine as a blob.
+     * @return
+     */
     RuleModel unmarshal(final String str,
                         final List<String> globals,
                         final PackageDataModelOracle dmo,

--- a/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/main/java/org/drools/workbench/models/commons/backend/rule/RuleModelPersistence.java
@@ -33,6 +33,11 @@ public interface RuleModelPersistence {
     RuleModel unmarshal(final String str,
                         final List<String> globals,
                         final PackageDataModelOracle dmo,
+                        final boolean splitEvals);
+
+    RuleModel unmarshal(final String str,
+                        final List<String> globals,
+                        final PackageDataModelOracle dmo,
                         final Collection<RuleModelIActionPersistenceExtension> extensions);
 
     RuleModel unmarshalUsingDSL(final String str,

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models-datamodel-api</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models-guided-dtable</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.models.guided.dtable.backend.util;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -322,7 +323,6 @@ public class GuidedDTBRDRLPersistence extends RuleModelDRLPersistenceImpl {
         @Override
         public void visitActionCallMethod(final ActionCallMethod action) {
 
-            // Clony clonies
             final ActionCallMethod clone = new ActionCallMethod();
             clone.setState(action.getState());
             clone.setVariable(action.getVariable());
@@ -341,7 +341,11 @@ public class GuidedDTBRDRLPersistence extends RuleModelDRLPersistenceImpl {
                     afvClone.setType(fieldValue.getType());
                     String value = fieldValue.getValue();
                     String templateKeyValue = rowDataProvider.getTemplateKeyValue(value);
-                    afvClone.setValue(templateKeyValue);
+                    if (Objects.equals("", templateKeyValue)) {
+                        afvClone.setValue(value);
+                    } else {
+                        afvClone.setValue(templateKeyValue);
+                    }
 
                     clone.getFieldValues()[i] = afvClone;
                 }

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/backend/util/GuidedDTBRDRLPersistence.java
@@ -26,6 +26,8 @@ import org.drools.workbench.models.commons.backend.rule.context.LHSGeneratorCont
 import org.drools.workbench.models.commons.backend.rule.context.LHSGeneratorContextFactory;
 import org.drools.workbench.models.commons.backend.rule.context.RHSGeneratorContext;
 import org.drools.workbench.models.commons.backend.rule.context.RHSGeneratorContextFactory;
+import org.drools.workbench.models.datamodel.rule.ActionCallMethod;
+import org.drools.workbench.models.datamodel.rule.ActionFieldFunction;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.ExpressionFormLine;
@@ -318,27 +320,66 @@ public class GuidedDTBRDRLPersistence extends RuleModelDRLPersistenceImpl {
         }
 
         @Override
+        public void visitActionCallMethod(final ActionCallMethod action) {
+
+            // Clony clonies
+            final ActionCallMethod clone = new ActionCallMethod();
+            clone.setState(action.getState());
+            clone.setVariable(action.getVariable());
+            clone.setMethodName(action.getMethodName());
+
+            final ActionFieldValue[] actionFieldValuesClones = new ActionFieldValue[action.getFieldValues().length];
+            clone.setFieldValues(actionFieldValuesClones);
+            for (int i = 0; i < action.getFieldValues().length; i++) {
+                final ActionFieldValue fieldValue = action.getFieldValue(i);
+
+                if (fieldValue instanceof ActionFieldFunction) {
+                    final ActionFieldFunction afvClone = new ActionFieldFunction();
+                    afvClone.setMethod(((ActionFieldFunction) fieldValue).getMethod());
+                    afvClone.setField(fieldValue.getField());
+                    afvClone.setNature(BaseSingleFieldConstraint.TYPE_LITERAL);
+                    afvClone.setType(fieldValue.getType());
+                    String value = fieldValue.getValue();
+                    String templateKeyValue = rowDataProvider.getTemplateKeyValue(value);
+                    afvClone.setValue(templateKeyValue);
+
+                    clone.getFieldValues()[i] = afvClone;
+                }
+            }
+
+            super.visitActionCallMethod(clone);
+        }
+
+        @Override
         public void visitFreeFormLine(final FreeFormLine ffl) {
 
+            StringBuffer interpolatedResult = replace(ffl.getText());
+            if (interpolatedResult == null) {
+                return;
+            }
+
+            //Don't update the original FreeFormLine object
+            FreeFormLine fflClone = new FreeFormLine();
+            fflClone.setText(interpolatedResult.toString());
+            super.visitFreeFormLine(fflClone);
+        }
+
+        protected StringBuffer replace(final String text) {
             StringBuffer interpolatedResult = new StringBuffer();
-            final Matcher matcherTemplateKey = patternTemplateKey.matcher(ffl.getText());
+            final Matcher matcherTemplateKey = patternTemplateKey.matcher(text);
             while (matcherTemplateKey.find()) {
                 String varName = matcherTemplateKey.group(1);
                 String value = rowDataProvider.getTemplateKeyValue(varName);
 
                 // All vars must be populated for a single FreeFormLine
                 if (StringUtils.isEmpty(value)) {
-                    return;
+                    return null;
                 }
                 matcherTemplateKey.appendReplacement(interpolatedResult,
                                                      value);
             }
             matcherTemplateKey.appendTail(interpolatedResult);
-
-            //Don't update the original FreeFormLine object
-            FreeFormLine fflClone = new FreeFormLine();
-            fflClone.setText(interpolatedResult.toString());
-            super.visitFreeFormLine(fflClone);
+            return interpolatedResult;
         }
 
         @Override

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/util/ColumnUtilitiesBase.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/main/java/org/drools/workbench/models/guided/dtable/shared/util/ColumnUtilitiesBase.java
@@ -196,19 +196,7 @@ public abstract class ColumnUtilitiesBase {
     }
 
     private String getType(final BRLActionVariableColumn col) {
-
-        //If the parameter is not bound to a Fact or FactField use the explicit type. This is (currently)
-        //used when a BRL fragment does not contain any Template Keys and a single BRLActionVariableColumn
-        //is created with type SuggestionCompletionEngine.TYPE_BOOLEAN i.e. Limited Entry
-        if (col.getFactType() == null && col.getFactField() == null) {
             return col.getFieldType();
-        }
-
-        //Otherwise lookup from SuggestionCompletionEngine
-        final String factType = col.getFactType();
-        final String fieldName = col.getFactField();
-        return getTypeFromDataOracle(factType,
-                                     fieldName);
     }
 
     protected abstract String getTypeFromDataOracle(final String factType,

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/src/test/java/org/drools/workbench/models/guided/dtable/backend/BRLRuleModelTest.java
@@ -1342,6 +1342,56 @@ public class BRLRuleModelTest {
     }
 
     @Test
+    public void testActionCallWithTemplateKeys() {
+        final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+
+        final Pattern52 p1 = new Pattern52();
+        p1.setBoundName("x");
+        p1.setFactType("Context");
+
+        final ConditionCol52 c = new ConditionCol52();
+        c.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        p1.getChildColumns().add(c);
+        dt.getConditions().add(p1);
+
+        final BRLActionColumn brlAction1 = new BRLActionColumn();
+        final ActionCallMethod actionCallMethod = new ActionCallMethod("x");
+        actionCallMethod.setState(ActionCallMethod.TYPE_DEFINED);
+        actionCallMethod.setMethodName("add");
+        ActionFieldFunction actionFieldFunction = new ActionFieldFunction();
+        actionFieldFunction.setMethod("");
+        actionFieldFunction.setField("add");
+        actionFieldFunction.setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        actionFieldFunction.setType("String");
+        actionFieldFunction.setValue("$p");
+        actionCallMethod.setFieldValues(new ActionFieldValue[]{actionFieldFunction});
+
+        brlAction1.getDefinition().add(actionCallMethod);
+        brlAction1.getChildColumns().add(new BRLActionVariableColumn("$p",
+                                                                     DataType.TYPE_STRING,
+                                                                     null,
+                                                                     null));
+        dt.getActionCols().add(brlAction1);
+
+        dt.setData(DataUtilities.makeDataLists(new Object[][]{
+                new Object[]{"1", "", "desc", "x", "test"}
+        }));
+        final String drl = GuidedDTDRLPersistence.getInstance().marshal(dt);
+        final String expected = "//from row number: 1\n" +
+                "//desc\n" +
+                "rule \"Row 1 null\"\n" +
+                "dialect \"mvel\"\n" +
+                "when\n" +
+                "  x : Context( )\n" +
+                "then\n" +
+                "  x.add( \"test\" );\n" +
+                "end\n";
+
+        assertEqualsIgnoreWhitespace(expected,
+                                     drl);
+    }
+
+    @Test
     public void testLHSNonEmptyStringValues() {
         GuidedDecisionTable52 dt = new GuidedDecisionTable52();
         dt.setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);

--- a/drools-workbench-models/drools-workbench-models-guided-dtree/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-dtree/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-workbench-models/drools-workbench-models-guided-scorecard/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-scorecard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models-guided-scorecard</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-template/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-template/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models-guided-template</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-guided-template/src/test/java/org/drools/workbench/models/guided/template/backend/RuleTemplateModelDRLPersistenceTest.java
@@ -18,6 +18,8 @@ package org.drools.workbench.models.guided.template.backend;
 
 import org.assertj.core.api.Assertions;
 import org.drools.workbench.models.commons.backend.rule.RuleModelPersistence;
+import org.drools.workbench.models.datamodel.rule.ActionCallMethod;
+import org.drools.workbench.models.datamodel.rule.ActionFieldFunction;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
 import org.drools.workbench.models.datamodel.rule.ActionSetField;
@@ -37,6 +39,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
+import static org.drools.workbench.models.datamodel.rule.ActionCallMethod.TYPE_DEFINED;
+import static org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint.TYPE_TEMPLATE;
 import static org.junit.Assert.assertNotNull;
 
 public class RuleTemplateModelDRLPersistenceTest {
@@ -68,7 +72,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("in");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         m.addLhsItem(p);
@@ -79,23 +83,67 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         final String expected =
                 "rule \"t1_0\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (1, 2) )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_1\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (3, 4) )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_2\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (5, 6) )" +
-                "then \n" +
-                "end";
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (1, 2) )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_1\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (3, 4) )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_2\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (5, 6) )" +
+                        "then \n" +
+                        "end";
+
+        checkMarshall(expected, m);
+    }
+
+    @Test
+    public void testActionCallMethod() {
+        final TemplateModel m = new TemplateModel();
+        m.name = "t1";
+
+        final FactPattern p = new FactPattern("Person");
+        p.setBoundName("p");
+        final SingleFieldConstraint con = new SingleFieldConstraint();
+        con.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
+        con.setFieldName("field1");
+        con.setOperator("in");
+        con.setValue("$f1");
+        con.setConstraintValueType(TYPE_TEMPLATE);
+        p.addConstraint(con);
+
+        m.addLhsItem(p);
+
+        final ActionCallMethod actionCallMethod = new ActionCallMethod();
+        actionCallMethod.setMethodName("add");
+        actionCallMethod.setVariable("p");
+        final ActionFieldFunction actionFieldFunction = new ActionFieldFunction();
+        actionFieldFunction.setField("add");
+        actionFieldFunction.setValue("$f2");
+        actionFieldFunction.setType("String");
+        actionFieldFunction.setNature(TYPE_TEMPLATE);
+        actionCallMethod.setFieldValues(new ActionFieldValue[]{actionFieldFunction});
+        actionCallMethod.setState(TYPE_DEFINED);
+
+        m.addRhsItem(actionCallMethod);
+
+        m.addRow(new String[]{"1", "2"});
+
+        final String expected =
+                "rule \"t1_0\"\n" +
+                        "dialect \"mvel\"\n" +
+                        "when\n" +
+                        "p : Person( field1 in  (1) )\n" +
+                        "then\n" +
+                        "p.add( 2 );\n" +
+                        "end";
 
         checkMarshall(expected, m);
     }
@@ -111,7 +159,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("in");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         m.addLhsItem(p);
@@ -124,35 +172,35 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         String expected =
                 "rule \"t1_0\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (\"ak1\",\"mk1\") )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_1\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (\"ak2\",\"mk2\") )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_2\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (\"ak3\",\"mk3\") )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_3\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (\"ak4\",\"mk4\") )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_4\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 in (\"ak5 \",\" mk5\") )" +
-                "then \n" +
-                "end";
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (\"ak1\",\"mk1\") )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_1\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (\"ak2\",\"mk2\") )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_2\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (\"ak3\",\"mk3\") )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_3\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (\"ak4\",\"mk4\") )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_4\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 in (\"ak5 \",\" mk5\") )" +
+                        "then \n" +
+                        "end";
 
         checkMarshall(expected,
                       m);
@@ -169,7 +217,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("in");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         m.addLhsItem(p);
@@ -198,7 +246,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         m.addLhsItem(p);
@@ -227,7 +275,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         m.addLhsItem(p);
@@ -238,23 +286,23 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         final String expected =
                 "rule \"t1_0\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 == \"foo1\" )" +
-                "then \n" +
-                "end\n" +
-                "rule \"t1_1\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 == \"foo3\" )" +
-                "then \n" +
-                "end" +
-                "rule \"t1_2\"" +
-                "dialect \"mvel\"\n" +
-                "when \n" +
-                "  Person( field1 == \"foo2\" )" +
-                "then \n" +
-                "end";
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 == \"foo1\" )" +
+                        "then \n" +
+                        "end\n" +
+                        "rule \"t1_1\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 == \"foo3\" )" +
+                        "then \n" +
+                        "end" +
+                        "rule \"t1_2\"" +
+                        "dialect \"mvel\"\n" +
+                        "when \n" +
+                        "  Person( field1 == \"foo2\" )" +
+                        "then \n" +
+                        "end";
 
         checkMarshall(expected, m);
     }
@@ -269,7 +317,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         m.addLhsItem(p);
@@ -309,7 +357,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         SingleFieldConstraint con2 = new SingleFieldConstraint();
@@ -346,7 +394,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         SingleFieldConstraint con2 = new SingleFieldConstraint();
@@ -354,7 +402,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con2.setFieldName("field2");
         con2.setOperator("==");
         con2.setValue("$f2");
-        con2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con2.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con2);
 
         m.addLhsItem(p);
@@ -383,7 +431,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         SingleFieldConstraint con2 = new SingleFieldConstraint();
@@ -391,7 +439,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con2.setFieldName("field2");
         con2.setOperator("==");
         con2.setValue("$f2");
-        con2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con2.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con2);
 
         m.addLhsItem(p);
@@ -420,7 +468,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         SingleFieldConstraint con2 = new SingleFieldConstraint();
@@ -428,7 +476,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con2.setFieldName("field2");
         con2.setOperator("==");
         con2.setValue("$f2");
-        con2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con2.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con2);
 
         m.addLhsItem(p);
@@ -457,7 +505,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con.setFieldName("field1");
         con.setOperator("==");
         con.setValue("$f1");
-        con.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con);
 
         SingleFieldConstraint con2 = new SingleFieldConstraint();
@@ -465,7 +513,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         con2.setFieldName("field2");
         con2.setOperator("==");
         con2.setValue("$f2");
-        con2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        con2.setConstraintValueType(TYPE_TEMPLATE);
         p.addConstraint(con2);
 
         m.addLhsItem(p);
@@ -501,7 +549,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         comp.addConstraint(X);
@@ -509,7 +557,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint Y = new SingleFieldConstraint();
         Y.setFieldName("field2");
         Y.setFieldType(DataType.TYPE_STRING);
-        Y.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        Y.setConstraintValueType(TYPE_TEMPLATE);
         Y.setValue("$f2");
         Y.setOperator("==");
         comp.addConstraint(Y);
@@ -542,7 +590,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         comp.addConstraint(X);
@@ -550,7 +598,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint Y = new SingleFieldConstraint();
         Y.setFieldName("field2");
         Y.setFieldType(DataType.TYPE_STRING);
-        Y.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        Y.setConstraintValueType(TYPE_TEMPLATE);
         Y.setValue("$f2");
         Y.setOperator("==");
         comp.addConstraint(Y);
@@ -583,7 +631,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         comp.addConstraint(X);
@@ -591,7 +639,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint Y = new SingleFieldConstraint();
         Y.setFieldName("field2");
         Y.setFieldType(DataType.TYPE_STRING);
-        Y.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        Y.setConstraintValueType(TYPE_TEMPLATE);
         Y.setValue("$f2");
         Y.setOperator("==");
         comp.addConstraint(Y);
@@ -624,7 +672,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         comp.addConstraint(X);
@@ -641,7 +689,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint Y = new SingleFieldConstraint();
         Y.setFieldName("field2");
         Y.setFieldType(DataType.TYPE_STRING);
-        Y.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        Y.setConstraintValueType(TYPE_TEMPLATE);
         Y.setValue("$f2");
         Y.setOperator("==");
         comp.addConstraint(Y);
@@ -674,7 +722,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         comp.addConstraint(X);
@@ -691,7 +739,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint Y = new SingleFieldConstraint();
         Y.setFieldName("field2");
         Y.setFieldType(DataType.TYPE_STRING);
-        Y.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        Y.setConstraintValueType(TYPE_TEMPLATE);
         Y.setValue("$f2");
         Y.setOperator("==");
         comp.addConstraint(Y);
@@ -724,7 +772,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         comp.addConstraint(X);
@@ -741,7 +789,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint Y = new SingleFieldConstraint();
         Y.setFieldName("field2");
         Y.setFieldType(DataType.TYPE_STRING);
-        Y.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        Y.setConstraintValueType(TYPE_TEMPLATE);
         Y.setValue("$f2");
         Y.setOperator("==");
         comp.addConstraint(Y);
@@ -769,7 +817,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         p1.addConstraint(sfc1);
@@ -778,7 +826,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         p2.addConstraint(sfc2);
@@ -815,7 +863,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         p1.addConstraint(sfc1);
@@ -824,7 +872,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         p2.addConstraint(sfc2);
@@ -861,7 +909,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         p1.addConstraint(sfc1);
@@ -870,7 +918,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         p2.addConstraint(sfc2);
@@ -912,7 +960,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -924,7 +972,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -933,7 +981,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc2.setFieldName("field3");
         comp2sfc2.setOperator("==");
         comp2sfc2.setValue("$f3");
-        comp2sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc2);
 
@@ -967,7 +1015,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -979,7 +1027,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -988,7 +1036,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc2.setFieldName("field3");
         comp2sfc2.setOperator("==");
         comp2sfc2.setValue("$f3");
-        comp2sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc2);
 
@@ -1022,7 +1070,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1034,7 +1082,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1043,7 +1091,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc2.setFieldName("field3");
         comp2sfc2.setOperator("==");
         comp2sfc2.setValue("$f3");
-        comp2sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc2);
 
@@ -1077,7 +1125,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1089,7 +1137,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1098,7 +1146,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc2.setFieldName("field3");
         comp2sfc2.setOperator("==");
         comp2sfc2.setValue("$f3");
-        comp2sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc2);
 
@@ -1132,7 +1180,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1144,7 +1192,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1178,7 +1226,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1190,7 +1238,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1224,7 +1272,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1236,7 +1284,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field2");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f2");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1270,7 +1318,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1278,7 +1326,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         comp.addConstraint(sfc2);
@@ -1290,7 +1338,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1324,7 +1372,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1332,7 +1380,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         comp.addConstraint(sfc2);
@@ -1344,7 +1392,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1378,7 +1426,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1386,7 +1434,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         comp.addConstraint(sfc2);
@@ -1398,7 +1446,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1432,7 +1480,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         comp.addConstraint(sfc1);
@@ -1440,7 +1488,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
         sfc2.setOperator("==");
         comp.addConstraint(sfc2);
@@ -1452,7 +1500,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
 
         comp2.addConstraint(comp2sfc1);
 
@@ -1486,7 +1534,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp1.addConstraint(comp1sfc1);
@@ -1494,7 +1542,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp1.addConstraint(comp1sfc2);
@@ -1509,13 +1557,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp2.addConstraint(comp2sfc1);
 
         final SingleFieldConstraint comp2sfc2 = new SingleFieldConstraint();
         comp2sfc2.setFieldName("field4");
         comp2sfc2.setFieldType(DataType.TYPE_STRING);
-        comp2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp2sfc2.setValue("$f4");
         comp2sfc2.setOperator("==");
         comp2.addConstraint(comp2sfc2);
@@ -1550,7 +1598,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp1.addConstraint(comp1sfc1);
@@ -1558,7 +1606,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp1.addConstraint(comp1sfc2);
@@ -1573,13 +1621,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp2.addConstraint(comp2sfc1);
 
         final SingleFieldConstraint comp2sfc2 = new SingleFieldConstraint();
         comp2sfc2.setFieldName("field4");
         comp2sfc2.setFieldType(DataType.TYPE_STRING);
-        comp2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp2sfc2.setValue("$f4");
         comp2sfc2.setOperator("==");
         comp2.addConstraint(comp2sfc2);
@@ -1614,7 +1662,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp1.addConstraint(comp1sfc1);
@@ -1622,7 +1670,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp1.addConstraint(comp1sfc2);
@@ -1637,13 +1685,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp2.addConstraint(comp2sfc1);
 
         final SingleFieldConstraint comp2sfc2 = new SingleFieldConstraint();
         comp2sfc2.setFieldName("field4");
         comp2sfc2.setFieldType(DataType.TYPE_STRING);
-        comp2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp2sfc2.setValue("$f4");
         comp2sfc2.setOperator("==");
         comp2.addConstraint(comp2sfc2);
@@ -1678,7 +1726,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp1.addConstraint(comp1sfc1);
@@ -1686,7 +1734,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp1.addConstraint(comp1sfc2);
@@ -1701,13 +1749,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp2.addConstraint(comp2sfc1);
 
         final SingleFieldConstraint comp2sfc2 = new SingleFieldConstraint();
         comp2sfc2.setFieldName("field4");
         comp2sfc2.setFieldType(DataType.TYPE_STRING);
-        comp2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp2sfc2.setValue("$f4");
         comp2sfc2.setOperator("==");
         comp2.addConstraint(comp2sfc2);
@@ -1742,7 +1790,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp1.addConstraint(comp1sfc1);
@@ -1750,7 +1798,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp1.addConstraint(comp1sfc2);
@@ -1765,13 +1813,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         comp2sfc1.setFieldName("field3");
         comp2sfc1.setOperator("==");
         comp2sfc1.setValue("$f3");
-        comp2sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp2.addConstraint(comp2sfc1);
 
         final SingleFieldConstraint comp2sfc2 = new SingleFieldConstraint();
         comp2sfc2.setFieldName("field4");
         comp2sfc2.setFieldType(DataType.TYPE_STRING);
-        comp2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp2sfc2.setValue("$f4");
         comp2sfc2.setOperator("==");
         comp2.addConstraint(comp2sfc2);
@@ -1806,7 +1854,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp.addConstraint(comp1sfc1);
@@ -1814,7 +1862,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp.addConstraint(comp1sfc2);
@@ -1822,7 +1870,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc3 = new SingleFieldConstraint();
         comp1sfc3.setFieldName("field3");
         comp1sfc3.setFieldType(DataType.TYPE_STRING);
-        comp1sfc3.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc3.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc3.setValue("$f3");
         comp1sfc3.setOperator("==");
         comp.addConstraint(comp1sfc3);
@@ -1855,7 +1903,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp.addConstraint(comp1sfc1);
@@ -1863,7 +1911,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp.addConstraint(comp1sfc2);
@@ -1871,7 +1919,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc3 = new SingleFieldConstraint();
         comp1sfc3.setFieldName("field3");
         comp1sfc3.setFieldType(DataType.TYPE_STRING);
-        comp1sfc3.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc3.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc3.setValue("$f3");
         comp1sfc3.setOperator("==");
         comp.addConstraint(comp1sfc3);
@@ -1904,7 +1952,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp.addConstraint(comp1sfc1);
@@ -1912,7 +1960,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp.addConstraint(comp1sfc2);
@@ -1920,7 +1968,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc3 = new SingleFieldConstraint();
         comp1sfc3.setFieldName("field3");
         comp1sfc3.setFieldType(DataType.TYPE_STRING);
-        comp1sfc3.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc3.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc3.setValue("$f3");
         comp1sfc3.setOperator("==");
         comp.addConstraint(comp1sfc3);
@@ -1953,7 +2001,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc1 = new SingleFieldConstraint();
         comp1sfc1.setFieldName("field1");
         comp1sfc1.setFieldType(DataType.TYPE_STRING);
-        comp1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc1.setValue("$f1");
         comp1sfc1.setOperator("==");
         comp.addConstraint(comp1sfc1);
@@ -1961,7 +2009,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc2 = new SingleFieldConstraint();
         comp1sfc2.setFieldName("field2");
         comp1sfc2.setFieldType(DataType.TYPE_STRING);
-        comp1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc2.setValue("$f2");
         comp1sfc2.setOperator("==");
         comp.addConstraint(comp1sfc2);
@@ -1969,7 +2017,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint comp1sfc3 = new SingleFieldConstraint();
         comp1sfc3.setFieldName("field3");
         comp1sfc3.setFieldType(DataType.TYPE_STRING);
-        comp1sfc3.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        comp1sfc3.setConstraintValueType(TYPE_TEMPLATE);
         comp1sfc3.setValue("$f3");
         comp1sfc3.setOperator("==");
         comp.addConstraint(comp1sfc3);
@@ -2002,14 +2050,14 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc1 = new SingleFieldConstraint();
         cfc1sfc1.setFieldName("field1");
         cfc1sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc1.setValue("$f1");
         cfc1sfc1.setOperator("==");
         cfc1.addConstraint(cfc1sfc1);
         final SingleFieldConstraint cfc1sfc2 = new SingleFieldConstraint();
         cfc1sfc2.setFieldName("field2");
         cfc1sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc2.setValue("$f2");
         cfc1sfc2.setOperator("==");
         cfc1.addConstraint(cfc1sfc2);
@@ -2020,14 +2068,14 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc1 = new SingleFieldConstraint();
         cfc2sfc1.setFieldName("field3");
         cfc2sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc1.setValue("$f3");
         cfc2sfc1.setOperator("==");
         cfc2.addConstraint(cfc2sfc1);
         final SingleFieldConstraint cfc2sfc2 = new SingleFieldConstraint();
         cfc2sfc2.setFieldName("field4");
         cfc2sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc2.setValue("$f4");
         cfc2sfc2.setOperator("==");
         cfc2.addConstraint(cfc2sfc2);
@@ -2038,14 +2086,14 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc1 = new SingleFieldConstraint();
         cfc3sfc1.setFieldName("field5");
         cfc3sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc1.setValue("$f5");
         cfc3sfc1.setOperator("==");
         cfc3.addConstraint(cfc3sfc1);
         final SingleFieldConstraint cfc3sfc2 = new SingleFieldConstraint();
         cfc3sfc2.setFieldName("field6");
         cfc3sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc2.setValue("$f6");
         cfc3sfc2.setOperator("==");
         cfc3.addConstraint(cfc3sfc2);
@@ -2078,14 +2126,14 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc1 = new SingleFieldConstraint();
         cfc1sfc1.setFieldName("field1");
         cfc1sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc1.setValue("$f1");
         cfc1sfc1.setOperator("==");
         cfc1.addConstraint(cfc1sfc1);
         final SingleFieldConstraint cfc1sfc2 = new SingleFieldConstraint();
         cfc1sfc2.setFieldName("field2");
         cfc1sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc2.setValue("$f2");
         cfc1sfc2.setOperator("==");
         cfc1.addConstraint(cfc1sfc2);
@@ -2096,14 +2144,14 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc1 = new SingleFieldConstraint();
         cfc2sfc1.setFieldName("field3");
         cfc2sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc1.setValue("$f3");
         cfc2sfc1.setOperator("==");
         cfc2.addConstraint(cfc2sfc1);
         final SingleFieldConstraint cfc2sfc2 = new SingleFieldConstraint();
         cfc2sfc2.setFieldName("field4");
         cfc2sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc2.setValue("$f4");
         cfc2sfc2.setOperator("==");
         cfc2.addConstraint(cfc2sfc2);
@@ -2114,14 +2162,14 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc1 = new SingleFieldConstraint();
         cfc3sfc1.setFieldName("field5");
         cfc3sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc1.setValue("$f5");
         cfc3sfc1.setOperator("==");
         cfc3.addConstraint(cfc3sfc1);
         final SingleFieldConstraint cfc3sfc2 = new SingleFieldConstraint();
         cfc3sfc2.setFieldName("field6");
         cfc3sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc2.setValue("$f6");
         cfc3sfc2.setOperator("==");
         cfc3.addConstraint(cfc3sfc2);
@@ -2153,7 +2201,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc1 = new SingleFieldConstraint();
         cfc1sfc1.setFieldName("field1");
         cfc1sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc1.setValue("$f1");
         cfc1sfc1.setOperator("==");
         cfc1.addConstraint(cfc1sfc1);
@@ -2171,7 +2219,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc1 = new SingleFieldConstraint();
         cfc2sfc1.setFieldName("field3");
         cfc2sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc1.setValue("$f3");
         cfc2sfc1.setOperator("==");
         cfc2.addConstraint(cfc2sfc1);
@@ -2189,7 +2237,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc1 = new SingleFieldConstraint();
         cfc3sfc1.setFieldName("field5");
         cfc3sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc1.setValue("$f5");
         cfc3sfc1.setOperator("==");
         cfc3.addConstraint(cfc3sfc1);
@@ -2229,7 +2277,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc1 = new SingleFieldConstraint();
         cfc1sfc1.setFieldName("field1");
         cfc1sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc1.setValue("$f1");
         cfc1sfc1.setOperator("==");
         cfc1.addConstraint(cfc1sfc1);
@@ -2247,7 +2295,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc1 = new SingleFieldConstraint();
         cfc2sfc1.setFieldName("field3");
         cfc2sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc1.setValue("$f3");
         cfc2sfc1.setOperator("==");
         cfc2.addConstraint(cfc2sfc1);
@@ -2265,7 +2313,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc1 = new SingleFieldConstraint();
         cfc3sfc1.setFieldName("field5");
         cfc3sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc1.setValue("$f5");
         cfc3sfc1.setOperator("==");
         cfc3.addConstraint(cfc3sfc1);
@@ -2305,7 +2353,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc1 = new SingleFieldConstraint();
         cfc1sfc1.setFieldName("field1");
         cfc1sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc1.setValue("$f1");
         cfc1sfc1.setOperator("==");
         cfc1.addConstraint(cfc1sfc1);
@@ -2323,7 +2371,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc1 = new SingleFieldConstraint();
         cfc2sfc1.setFieldName("field3");
         cfc2sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc1.setValue("$f3");
         cfc2sfc1.setOperator("==");
         cfc2.addConstraint(cfc2sfc1);
@@ -2341,7 +2389,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc1 = new SingleFieldConstraint();
         cfc3sfc1.setFieldName("field5");
         cfc3sfc1.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc1.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc1.setValue("$f5");
         cfc3sfc1.setOperator("==");
         cfc3.addConstraint(cfc3sfc1);
@@ -2388,7 +2436,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc2 = new SingleFieldConstraint();
         cfc1sfc2.setFieldName("field2");
         cfc1sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc2.setValue("$f2");
         cfc1sfc2.setOperator("==");
         cfc1.addConstraint(cfc1sfc2);
@@ -2406,7 +2454,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc2 = new SingleFieldConstraint();
         cfc2sfc2.setFieldName("field4");
         cfc2sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc2.setValue("$f4");
         cfc2sfc2.setOperator("==");
         cfc2.addConstraint(cfc2sfc2);
@@ -2424,7 +2472,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc2 = new SingleFieldConstraint();
         cfc3sfc2.setFieldName("field6");
         cfc3sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc2.setValue("$f6");
         cfc3sfc2.setOperator("==");
         cfc3.addConstraint(cfc3sfc2);
@@ -2464,7 +2512,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc1sfc2 = new SingleFieldConstraint();
         cfc1sfc2.setFieldName("field2");
         cfc1sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc1sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc1sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc1sfc2.setValue("$f2");
         cfc1sfc2.setOperator("==");
         cfc1.addConstraint(cfc1sfc2);
@@ -2482,7 +2530,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc2sfc2 = new SingleFieldConstraint();
         cfc2sfc2.setFieldName("field4");
         cfc2sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc2sfc2.setValue("$f4");
         cfc2sfc2.setOperator("==");
         cfc2.addConstraint(cfc2sfc2);
@@ -2500,7 +2548,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint cfc3sfc2 = new SingleFieldConstraint();
         cfc3sfc2.setFieldName("field6");
         cfc3sfc2.setFieldType(DataType.TYPE_STRING);
-        cfc3sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        cfc3sfc2.setConstraintValueType(TYPE_TEMPLATE);
         cfc3sfc2.setValue("$f6");
         cfc3sfc2.setOperator("==");
         cfc3.addConstraint(cfc3sfc2);
@@ -2529,13 +2577,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         p1.addConstraint(X);
 
         ConnectiveConstraint connective = new ConnectiveConstraint();
-        connective.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        connective.setConstraintValueType(TYPE_TEMPLATE);
         connective.setFieldType(DataType.TYPE_STRING);
         connective.setOperator("|| ==");
         connective.setValue("$f2");
@@ -2567,13 +2615,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         p1.addConstraint(X);
 
         ConnectiveConstraint connective = new ConnectiveConstraint();
-        connective.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        connective.setConstraintValueType(TYPE_TEMPLATE);
         connective.setFieldType(DataType.TYPE_STRING);
         connective.setOperator("|| ==");
         connective.setValue("$f2");
@@ -2605,13 +2653,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         final SingleFieldConstraint X = new SingleFieldConstraint();
         X.setFieldName("field1");
         X.setFieldType(DataType.TYPE_STRING);
-        X.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        X.setConstraintValueType(TYPE_TEMPLATE);
         X.setValue("$f1");
         X.setOperator("==");
         p1.addConstraint(X);
 
         ConnectiveConstraint connective = new ConnectiveConstraint();
-        connective.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        connective.setConstraintValueType(TYPE_TEMPLATE);
         connective.setFieldType(DataType.TYPE_STRING);
         connective.setOperator("|| ==");
         connective.setValue("$f2");
@@ -2640,7 +2688,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         FactPattern fp = new FactPattern("Person");
 
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
@@ -2672,7 +2720,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp = new FactPattern("Person");
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
@@ -2680,7 +2728,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp2 = new FactPattern("java.util.List");
         SingleFieldConstraint sfc2 = new SingleFieldConstraint("size");
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
         sfc2.setOperator(">");
         sfc2.setValue("$f2");
@@ -2711,7 +2759,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp = new FactPattern("Person");
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
@@ -2719,7 +2767,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp2 = new FactPattern("java.util.List");
         SingleFieldConstraint sfc2 = new SingleFieldConstraint("size");
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
         sfc2.setOperator(">");
         sfc2.setValue("$f2");
@@ -2750,7 +2798,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp = new FactPattern("Person");
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
@@ -2758,7 +2806,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp2 = new FactPattern("java.util.List");
         SingleFieldConstraint sfc2 = new SingleFieldConstraint("size");
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
         sfc2.setOperator(">");
         sfc2.setValue("$f2");
@@ -2871,14 +2919,14 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp = new FactPattern("Person");
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
         fp.addConstraint(sfc);
 
         SingleFieldConstraint sfc1 = new SingleFieldConstraint("field2");
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setFieldType(DataType.TYPE_STRING);
         sfc1.setOperator("==");
         sfc1.setValue("$f2");
@@ -2886,7 +2934,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp2 = new FactPattern("java.util.List");
         SingleFieldConstraint sfc2 = new SingleFieldConstraint("size");
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
         sfc2.setOperator(">");
         sfc2.setValue("$f3");
@@ -2917,14 +2965,14 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp = new FactPattern("Person");
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
         fp.addConstraint(sfc);
 
         SingleFieldConstraint sfc1 = new SingleFieldConstraint("field2");
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setFieldType(DataType.TYPE_STRING);
         sfc1.setOperator("==");
         sfc1.setValue("$f2");
@@ -2932,7 +2980,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp2 = new FactPattern("java.util.List");
         SingleFieldConstraint sfc2 = new SingleFieldConstraint("size");
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
         sfc2.setOperator(">");
         sfc2.setValue("$f3");
@@ -2963,14 +3011,14 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp = new FactPattern("Person");
         SingleFieldConstraint sfc = new SingleFieldConstraint("field1");
-        sfc.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc.setConstraintValueType(TYPE_TEMPLATE);
         sfc.setFieldType(DataType.TYPE_STRING);
         sfc.setOperator("==");
         sfc.setValue("$f1");
         fp.addConstraint(sfc);
 
         SingleFieldConstraint sfc1 = new SingleFieldConstraint("field2");
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setFieldType(DataType.TYPE_STRING);
         sfc1.setOperator("==");
         sfc1.setValue("$f2");
@@ -2978,7 +3026,7 @@ public class RuleTemplateModelDRLPersistenceTest {
 
         FactPattern fp2 = new FactPattern("java.util.List");
         SingleFieldConstraint sfc2 = new SingleFieldConstraint("size");
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
         sfc2.setOperator(">");
         sfc2.setValue("$f3");
@@ -3452,7 +3500,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         SingleFieldConstraint sfc1 = new SingleFieldConstraint();
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
         sfc1.setOperator("==");
         fp.addConstraint(sfc1);
@@ -3959,7 +4007,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc1.setFactType("Smurf");
         sfc1.setFieldName("name");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
 
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
@@ -3967,7 +4015,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc2.setFactType("Smurf");
         sfc2.setFieldName("age");
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
 
         fp.addConstraint(sfc1);
@@ -4051,7 +4099,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc1.setFactType("Smurf");
         sfc1.setFieldName("name");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
 
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
@@ -4059,7 +4107,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc2.setFactType("Smurf");
         sfc2.setFieldName("age");
         sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
 
         fp.addConstraint(sfc1);
@@ -4142,13 +4190,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         auf1.addFieldValue(new ActionFieldValue("name",
                                                 "$name",
                                                 DataType.TYPE_STRING));
-        auf1.getFieldValues()[0].setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        auf1.getFieldValues()[0].setNature(TYPE_TEMPLATE);
 
         ActionUpdateField auf2 = new ActionUpdateField("p1");
         auf2.addFieldValue(new ActionFieldValue("age",
                                                 "$age",
                                                 DataType.TYPE_NUMERIC_INTEGER));
-        auf2.getFieldValues()[0].setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        auf2.getFieldValues()[0].setNature(TYPE_TEMPLATE);
 
         //Test 1
         TemplateModel m1 = new TemplateModel();
@@ -4242,13 +4290,13 @@ public class RuleTemplateModelDRLPersistenceTest {
         auf1.addFieldValue(new ActionFieldValue("name",
                                                 "$name",
                                                 DataType.TYPE_STRING));
-        auf1.getFieldValues()[0].setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        auf1.getFieldValues()[0].setNature(TYPE_TEMPLATE);
 
         ActionUpdateField auf2 = new ActionUpdateField("p1");
         auf2.addFieldValue(new ActionFieldValue("age",
                                                 "$age",
                                                 DataType.TYPE_NUMERIC_INTEGER));
-        auf2.getFieldValues()[0].setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        auf2.getFieldValues()[0].setNature(TYPE_TEMPLATE);
 
         //Test 1
         TemplateModel m1 = new TemplateModel();
@@ -4348,7 +4396,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc1.setFactType("Smurf");
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
 
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
@@ -4356,7 +4404,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc2.setFactType("Smurf");
         sfc2.setFieldName("field1");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue("$f2");
 
         SingleFieldConstraint sfc3 = new SingleFieldConstraint();
@@ -4450,7 +4498,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc1.setFactType("Smurf");
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue("$f1");
 
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
@@ -4466,7 +4514,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc3.setFactType("Smurf");
         sfc3.setFieldName("field1");
         sfc3.setFieldType(DataType.TYPE_STRING);
-        sfc3.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc3.setConstraintValueType(TYPE_TEMPLATE);
         sfc3.setValue("$f2");
 
         fp.addConstraint(sfc1);
@@ -4574,7 +4622,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         p2sfc1.setFactType("Smurf");
         p2sfc1.setFieldName("field3");
         p2sfc1.setFieldType(DataType.TYPE_STRING);
-        p2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        p2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         p2sfc1.setValue("$key");
 
         fp2.addConstraint(p2sfc1);
@@ -4660,7 +4708,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         p2sfc1.setFactType("Smurf");
         p2sfc1.setFieldName("field1");
         p2sfc1.setFieldType(DataType.TYPE_STRING);
-        p2sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        p2sfc1.setConstraintValueType(TYPE_TEMPLATE);
         p2sfc1.setValue("$oldField1");
 
         SingleFieldConstraint p2sfc2 = new SingleFieldConstraint();
@@ -4668,19 +4716,19 @@ public class RuleTemplateModelDRLPersistenceTest {
         p2sfc2.setFactType("Smurf");
         p2sfc2.setFieldName("field2");
         p2sfc2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
-        p2sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        p2sfc2.setConstraintValueType(TYPE_TEMPLATE);
         p2sfc2.setValue("$oldField2");
 
         ActionUpdateField p2auf1 = new ActionUpdateField("p2");
         p2auf1.addFieldValue(new ActionFieldValue("field1",
                                                   "$newField1",
                                                   DataType.TYPE_STRING));
-        p2auf1.getFieldValues()[0].setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        p2auf1.getFieldValues()[0].setNature(TYPE_TEMPLATE);
         ActionUpdateField p2auf2 = new ActionUpdateField("p2");
         p2auf2.addFieldValue(new ActionFieldValue("field2",
                                                   "$newField2",
                                                   DataType.TYPE_NUMERIC_INTEGER));
-        p2auf2.getFieldValues()[0].setNature(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        p2auf2.getFieldValues()[0].setNature(TYPE_TEMPLATE);
 
         fp2.addConstraint(p2sfc1);
         fp2.addConstraint(p2sfc2);
@@ -4746,7 +4794,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc1.setFactType("Smurf");
         sfc1.setFieldName("field1");
         sfc1.setFieldType(DataType.TYPE_STRING);
-        sfc1.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setConstraintValueType(TYPE_TEMPLATE);
         sfc1.setValue(templateKeyOne);
 
         SingleFieldConstraint sfc2 = new SingleFieldConstraint();
@@ -4754,7 +4802,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc2.setFactType("Smurf");
         sfc2.setFieldName("field2");
         sfc2.setFieldType(DataType.TYPE_STRING);
-        sfc2.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setConstraintValueType(TYPE_TEMPLATE);
         sfc2.setValue(templateKeyOne);
 
         SingleFieldConstraint sfc3 = new SingleFieldConstraint();
@@ -4762,7 +4810,7 @@ public class RuleTemplateModelDRLPersistenceTest {
         sfc3.setFactType("Smurf");
         sfc3.setFieldName("field3");
         sfc3.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
-        sfc3.setConstraintValueType(SingleFieldConstraint.TYPE_TEMPLATE);
+        sfc3.setConstraintValueType(TYPE_TEMPLATE);
         sfc3.setValue(templateKeyTwo);
 
         fp.addConstraint(sfc1);

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>drools-workbench-models</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models-test-scenarios</artifactId>

--- a/drools-workbench-models/pom.xml
+++ b/drools-workbench-models/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-workbench-models</artifactId>

--- a/kie-ci-osgi/pom.xml
+++ b/kie-ci-osgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-api</artifactId>

--- a/kie-dmn/kie-dmn-backend/pom.xml
+++ b/kie-dmn/kie-dmn-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-backend</artifactId>

--- a/kie-dmn/kie-dmn-core-osgi/pom.xml
+++ b/kie-dmn/kie-dmn-core-osgi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-core-osgi</artifactId>
   <packaging>bundle</packaging><!-- bundle = jar + OSGi metadata -->

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-core</artifactId>

--- a/kie-dmn/kie-dmn-feel-gwt-functions/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-functions/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel-gwt-functions</artifactId>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel-gwt-showcase</artifactId>

--- a/kie-dmn/kie-dmn-feel-gwt/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel-gwt</artifactId>

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel</artifactId>

--- a/kie-dmn/kie-dmn-legacy-tests/pom.xml
+++ b/kie-dmn/kie-dmn-legacy-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-legacy-tests</artifactId>
   

--- a/kie-dmn/kie-dmn-model/pom.xml
+++ b/kie-dmn/kie-dmn-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-model</artifactId>

--- a/kie-dmn/kie-dmn-openapi/pom.xml
+++ b/kie-dmn/kie-dmn-openapi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-openapi</artifactId>
   

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-legacy/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-legacy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-signavio/pom.xml
+++ b/kie-dmn/kie-dmn-signavio/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-signavio</artifactId>
   

--- a/kie-dmn/kie-dmn-tck/pom.xml
+++ b/kie-dmn/kie-dmn-tck/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
+++ b/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation-bootstrap</artifactId>
 

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation</artifactId>
     <packaging>jar</packaging>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-memory-compiler/pom.xml
+++ b/kie-memory-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/iinterfaces/SerializableFunction.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/iinterfaces/SerializableFunction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.api.iinterfaces;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+public interface SerializableFunction<T, R> extends Function<T, R>,
+                                              Serializable {
+
+}

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/MiningField.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.api.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.kie.pmml.api.enums.DATA_TYPE;
@@ -24,8 +25,9 @@ import org.kie.pmml.api.enums.OP_TYPE;
 /**
  * User-friendly representation of a <b>MiningField</b>
  */
-public class MiningField {
+public class MiningField implements Serializable {
 
+    private static final long serialVersionUID = -7718478772317847187L;
     private final String name;
     private final FIELD_USAGE_TYPE usageType;
     private final OP_TYPE opType;
@@ -34,13 +36,13 @@ public class MiningField {
     private final List<String> allowedValues;
     private final List<Interval> intervals;
 
-    public MiningField(String name,
-                       FIELD_USAGE_TYPE usageType,
-                       OP_TYPE opType,
-                       DATA_TYPE dataType,
-                       String missingValueReplacement,
-                       List<String> allowedValues,
-                       List<Interval> intervals) {
+    public MiningField(final String name,
+                       final FIELD_USAGE_TYPE usageType,
+                       final OP_TYPE opType,
+                       final DATA_TYPE dataType,
+                       final String missingValueReplacement,
+                       final List<String> allowedValues,
+                       final List<Interval> intervals) {
         this.name = name;
         this.usageType = usageType;
         this.opType = opType;

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/OutputField.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/models/OutputField.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.api.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.kie.pmml.api.enums.DATA_TYPE;
@@ -24,8 +25,9 @@ import org.kie.pmml.api.enums.RESULT_FEATURE;
 /**
  * User-friendly representation of an <b>OutputField</b>
  */
-public class OutputField {
+public class OutputField implements Serializable {
 
+    private static final long serialVersionUID = 9103824387333264568L;
     private final String name;
     private final OP_TYPE opType;
     private final DATA_TYPE dataType;
@@ -38,7 +40,7 @@ public class OutputField {
                        final DATA_TYPE dataType,
                        final String targetField,
                        final RESULT_FEATURE resultFeature,
-                       List<String> allowedValues) {
+                       final List<String> allowedValues) {
         this.name = name;
         this.opType = opType;
         this.dataType = dataType;

--- a/kie-pmml-trusty/kie-pmml-benchmarks/kie-pmml-benchmarks-regression/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-benchmarks/kie-pmml-benchmarks-regression/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-benchmarks</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-benchmarks/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-benchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/KiePMMLModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/KiePMMLModelUtils.java
@@ -27,7 +27,7 @@ public class KiePMMLModelUtils {
      * @return
      */
     public static String getSanitizedPackageName(String modelName) {
-        return modelName.replace(" ", "").replace("-", "").replace("_", "").toLowerCase();
+        return modelName.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
     }
 
     /**
@@ -37,6 +37,6 @@ public class KiePMMLModelUtils {
      */
     public static String getSanitizedClassName(String input) {
         String upperCasedInput = input.substring(0, 1).toUpperCase() + input.substring(1);
-        return upperCasedInput.replace(".", "").replace("-", "").replace("_", "").replace(" ", "");
+        return upperCasedInput.replaceAll("[^A-Za-z0-9]", "");
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/KiePMMLModelUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/utils/KiePMMLModelUtilsTest.java
@@ -38,6 +38,7 @@ public class KiePMMLModelUtilsTest {
         packageNameMap.put("a spaced name", "aspacedname");
         packageNameMap.put("AnUpperCasedMame", "anuppercasedmame");
         packageNameMap.put("a_Mixed -name", "amixedname");
+        packageNameMap.put("C:\\w-ind_ow Path", "cwindowpath");
 
         classNameMap = new HashMap<>();
         classNameMap.put("a-dashed-name", "Adashedname");
@@ -46,6 +47,7 @@ public class KiePMMLModelUtilsTest {
         classNameMap.put("anUpperCasedName", "AnUpperCasedName");
         classNameMap.put("a.dotted.name", "Adottedname");
         classNameMap.put("a_.Mixed -name", "AMixedname");
+        classNameMap.put("C:\\w-ind_ow Path", "CwindowPath");
     }
 
     @Test

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerService.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerService.java
@@ -53,6 +53,10 @@ public class PMMLAssemblerService implements KieAssemblerService {
     public static final String PMML_COMPILER_CACHE_KEY = "PMML_COMPILER_CACHE_KEY";
     private static final Logger logger = LoggerFactory.getLogger(PMMLAssemblerService.class);
 
+    private static final String FOLDER_SEPARATOR = "/";
+
+    private static final String WINDOWS_FOLDER_SEPARATOR = "\\";
+
     private static boolean isBuildFromMaven() {
         final String property = System.getProperty("kie-maven-plugin-launcher", "false");
         return property.equals("true");
@@ -66,7 +70,21 @@ public class PMMLAssemblerService implements KieAssemblerService {
      */
     public static String[] getFactoryClassNamePackageName(Resource resource) {
         String sourcePath = resource.getSourcePath();
-        String fileName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
+        if (sourcePath == null || sourcePath.isEmpty()) {
+            throw new IllegalArgumentException("Missing required sourcePath in resource " + resource + " -> " + resource.getClass().getName());
+        }
+        return getFactoryClassNamePackageName(sourcePath);
+    }
+
+    /**
+     * Returns an array where the first item is the <b>factory class</b> name and the second item is the <b>package</b> name,
+     * built starting from the given <b>sourcePath</b> <code>String</code>
+     * @param sourcePath
+     * @return
+     */
+    static String[] getFactoryClassNamePackageName(String sourcePath) {
+        sourcePath = sourcePath.replace(WINDOWS_FOLDER_SEPARATOR, FOLDER_SEPARATOR);
+        String fileName = sourcePath.substring(sourcePath.lastIndexOf(FOLDER_SEPARATOR) + 1);
         fileName = fileName.replace(".pmml", "");
         String packageName = getSanitizedPackageName(fileName);
         String factoryClassName = getSanitizedClassName(fileName + "Factory");

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerServiceTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/service/PMMLAssemblerServiceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.evaluator.assembler.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
+import org.kie.api.io.ResourceType;
+
+import static org.junit.Assert.*;
+
+public class PMMLAssemblerServiceTest {
+
+    private static Map<String, String[]> resourcePathMap;
+
+    @BeforeClass
+    public static void setup() {
+        resourcePathMap = new HashMap<>();
+        resourcePathMap.put("/a/linux/path/a-dashed-name.pmml", new String[]{"AdashednameFactory", "adashedname"});
+        resourcePathMap.put("/a_/l inux/p-a_th/an_underscored_name.pmml", new String[]{"AnunderscorednameFactory", "anunderscoredname"});
+        resourcePathMap.put("/a_/l inux/p-a_th/a spaced name.pmml", new String[]{"AspacednameFactory", "aspacedname"});
+        resourcePathMap.put("/A_/L inux/pAtH/AnUpperCasedMame.pmml", new String[]{"AnUpperCasedMameFactory", "anuppercasedmame"});
+        resourcePathMap.put("C:\\from\\window\\w-ind_ow Path\\AnUpperCasedMame.pmml", new String[]{"AnUpperCasedMameFactory", "anuppercasedmame"});
+        resourcePathMap.put("C:\\from/window\\mixed Path/AnUpperCasedMame.pmml", new String[]{"AnUpperCasedMameFactory", "anuppercasedmame"});
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getFactoryClassNamePackageNameResourceNoFile() {
+        Resource resource = new MockResource();
+        PMMLAssemblerService.getFactoryClassNamePackageName(resource);
+    }
+
+    @Test
+    public void getFactoryClassNamePackageNameResourceWithFile() {
+        resourcePathMap.forEach((sourcePath, comparison) -> {
+            Resource resource = new MockResource(sourcePath);
+            String[] retrieved = PMMLAssemblerService.getFactoryClassNamePackageName(resource);
+            commonVerifyStrings(retrieved, comparison);
+        });
+    }
+
+    @Test
+    public void testGetFactoryClassNamePackageName() {
+        resourcePathMap.forEach((sourcePath, comparison) -> {
+            String[] retrieved = PMMLAssemblerService.getFactoryClassNamePackageName(sourcePath);
+            commonVerifyStrings(retrieved, comparison);
+        });
+    }
+
+    private void commonVerifyStrings(String[] toVerify, String[] comparison) {
+        assertEquals(toVerify.length, comparison.length);
+        assertEquals(2, toVerify.length);
+        for (int i = 0; i < toVerify.length; i ++) {
+            assertEquals(comparison[i], toVerify[i]);
+        }
+    }
+
+    private static class  MockResource implements Resource {
+
+        private String sourcePath;
+
+        public MockResource() {
+        }
+
+        public MockResource(String sourcePath) {
+            this.sourcePath = sourcePath;
+        }
+
+
+        @Override
+            public InputStream getInputStream() throws IOException {
+                return null;
+            }
+
+            @Override
+            public Reader getReader() throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getSourcePath() {
+                return sourcePath;
+            }
+
+            @Override
+            public String getTargetPath() {
+                return null;
+            }
+
+            @Override
+            public ResourceType getResourceType() {
+                return null;
+            }
+
+            @Override
+            public ResourceConfiguration getConfiguration() {
+                return null;
+            }
+
+            @Override
+            public Resource setSourcePath(String path) {
+                return null;
+            }
+
+            @Override
+            public Resource setTargetPath(String path) {
+                return null;
+            }
+
+            @Override
+            public Resource setResourceType(ResourceType type) {
+                return null;
+            }
+
+            @Override
+            public Resource setConfiguration(ResourceConfiguration conf) {
+                return null;
+            }
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-kie-internal/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-kie-internal/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models-archetype/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models-archetype/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-pmml-models-archetype</artifactId>

--- a/kie-pmml-trusty/kie-pmml-models-drools-archetype/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models-drools-archetype/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-pmml-models-drools-archetype</artifactId>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
@@ -160,8 +160,8 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
         List<GeneratedFile> generatedRuleFiles = generateRulesFiles(packageDescr);
         return generatedRuleFiles.stream()
                 .collect(Collectors.toMap(generatedFile -> generatedFile.getPath()
-                                                  .replaceAll(File.separator, ".")
-                                          .replaceAll(".java", ""),
+                                                  .replace(File.separator, ".")
+                                          .replace(".java", ""),
                                           generatedFile -> new String(generatedFile.getData())));
 
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValue.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOperatorValue.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.models.drools.tuples;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 import org.kie.pmml.api.enums.OPERATOR;
@@ -22,9 +23,10 @@ import org.kie.pmml.api.enums.OPERATOR;
 /**
  * Tupla representing the operator and the value to be applied to a given field
  */
-public class KiePMMLOperatorValue {
+public class KiePMMLOperatorValue implements Serializable {
 
     public static final String VALUE_CONSTRAINT_PATTERN = "value %s %s";
+    private static final long serialVersionUID = 4850428778643763607L;
     private final OPERATOR operator;
     private final Object value;
     private final String constraintsString;

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOriginalTypeGeneratedType.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLOriginalTypeGeneratedType.java
@@ -1,12 +1,14 @@
 package org.kie.pmml.models.drools.tuples;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Class to represent a <b>original type/generated type</b> tupla
  */
-public class KiePMMLOriginalTypeGeneratedType {
+public class KiePMMLOriginalTypeGeneratedType implements Serializable {
 
+    private static final long serialVersionUID = 3887366581807183963L;
     private final String originalType;
     private final String generatedType;
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLReasonCodeAndValue.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/tuples/KiePMMLReasonCodeAndValue.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.models.drools.tuples;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -23,8 +24,9 @@ import java.util.StringJoiner;
  *
  * @see <a href=http://dmg.org/pmml/v4-4/Scorecard.html#rankinReasongCodes>Ranking Reason Codes</a>
  */
-public class KiePMMLReasonCodeAndValue {
+public class KiePMMLReasonCodeAndValue implements Serializable {
 
+    private static final long serialVersionUID = 5978972455322748898L;
     private final String reasonCode;
     private final double value;
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/test/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionModelFactoryTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 import org.kie.pmml.api.enums.MINING_FUNCTION;
 import org.kie.pmml.api.enums.OP_TYPE;
 import org.kie.pmml.api.enums.PMML_MODEL;
+import org.kie.pmml.api.iinterfaces.SerializableFunction;
 import org.kie.pmml.compiler.commons.mocks.HasClassLoaderMock;
 import org.kie.pmml.models.regression.model.KiePMMLRegressionClassificationTable;
 import org.kie.pmml.models.regression.model.KiePMMLRegressionModel;
@@ -222,15 +223,15 @@ public class KiePMMLRegressionModelFactoryTest {
 
     private void evaluateRegressionTable(KiePMMLRegressionTable regressionTable, RegressionTable originalRegressionTable) {
         assertEquals(originalRegressionTable.getIntercept(), regressionTable.getIntercept());
-        final Map<String, Function<Double, Double>> numericFunctionMap = regressionTable.getNumericFunctionMap();
+        final Map<String, SerializableFunction<Double, Double>> numericFunctionMap = regressionTable.getNumericFunctionMap();
         for (NumericPredictor numericPredictor : originalRegressionTable.getNumericPredictors()) {
             assertTrue(numericFunctionMap.containsKey(numericPredictor.getName().getValue()));
         }
-        final Map<String, Function<Object, Double>> categoricalFunctionMap = regressionTable.getCategoricalFunctionMap();
+        final Map<String, SerializableFunction<Object, Double>> categoricalFunctionMap = regressionTable.getCategoricalFunctionMap();
         for (CategoricalPredictor categoricalPredictor : originalRegressionTable.getCategoricalPredictors()) {
             assertTrue(categoricalFunctionMap.containsKey(categoricalPredictor.getName().getValue()));
         }
-        final Map<String, Function<Map<String, Object>, Double>> predictorTermsFunctionMap = regressionTable.getPredictorTermsFunctionMap();
+        final Map<String, SerializableFunction<Map<String, Object>, Double>> predictorTermsFunctionMap = regressionTable.getPredictorTermsFunctionMap();
         for (PredictorTerm predictorTerm : originalRegressionTable.getPredictorTerms()) {
             assertTrue(predictorTermsFunctionMap.containsKey(predictorTerm.getName().getValue()));
         }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTable.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTable.java
@@ -15,17 +15,21 @@
  */
 package org.kie.pmml.models.regression.model;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-public abstract class KiePMMLRegressionTable {
+import org.kie.pmml.api.iinterfaces.SerializableFunction;
 
-    protected Map<String, Function<Double, Double>> numericFunctionMap = new HashMap<>();
-    protected Map<String, Function<Object, Double>> categoricalFunctionMap = new HashMap<>();
+public abstract class KiePMMLRegressionTable implements Serializable {
+
+    private static final long serialVersionUID = -7899446939844650691L;
+    protected Map<String, SerializableFunction<Double, Double>> numericFunctionMap = new HashMap<>();
+    protected Map<String, SerializableFunction<Object, Double>> categoricalFunctionMap = new HashMap<>();
     protected Map<String, Object> outputFieldsMap = new HashMap<>();
-    protected Map<String, Function<Map<String, Object>, Double>> predictorTermsFunctionMap = new HashMap<>();
+    protected Map<String, SerializableFunction<Map<String, Object>, Double>> predictorTermsFunctionMap = new HashMap<>();
     protected double intercept;
     protected String targetField;
 
@@ -34,19 +38,19 @@ public abstract class KiePMMLRegressionTable {
     public Object evaluateRegression(Map<String, Object> input) {
         final AtomicReference<Double> result = new AtomicReference<>(intercept);
         final Map<String, Double> resultMap = new HashMap<>();
-        for (Map.Entry<String, Function<Double, Double>> entry : numericFunctionMap.entrySet()) {
+        for (Map.Entry<String, SerializableFunction<Double, Double>> entry : numericFunctionMap.entrySet()) {
             String key = entry.getKey();
             if (input.containsKey(key)) {
                 resultMap.put(key, entry.getValue().apply(((Number) input.get(key)).doubleValue()));
             }
         }
-        for (Map.Entry<String, Function<Object, Double>> entry : categoricalFunctionMap.entrySet()) {
+        for (Map.Entry<String, SerializableFunction<Object, Double>> entry : categoricalFunctionMap.entrySet()) {
             String key = entry.getKey();
             if (input.containsKey(key)) {
                 resultMap.put(key, entry.getValue().apply(input.get(key)));
             }
         }
-        for (Map.Entry<String, Function<Map<String, Object>, Double>> entry : predictorTermsFunctionMap.entrySet()) {
+        for (Map.Entry<String, SerializableFunction<Map<String, Object>, Double>> entry : predictorTermsFunctionMap.entrySet()) {
             resultMap.put(entry.getKey(), entry.getValue().apply(input));
         }
         resultMap.values().forEach(value -> result.accumulateAndGet(value, Double::sum));
@@ -64,15 +68,15 @@ public abstract class KiePMMLRegressionTable {
         return targetField;
     }
 
-    public Map<String, Function<Double, Double>> getNumericFunctionMap() {
+    public Map<String, SerializableFunction<Double, Double>> getNumericFunctionMap() {
         return numericFunctionMap;
     }
 
-    public Map<String, Function<Object, Double>> getCategoricalFunctionMap() {
+    public Map<String, SerializableFunction<Object, Double>> getCategoricalFunctionMap() {
         return categoricalFunctionMap;
     }
 
-    public Map<String, Function<Map<String, Object>, Double>> getPredictorTermsFunctionMap() {
+    public Map<String, SerializableFunction<Map<String, Object>, Double>> getPredictorTermsFunctionMap() {
         return predictorTermsFunctionMap;
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/tuples/KiePMMLTableSourceCategory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/tuples/KiePMMLTableSourceCategory.java
@@ -15,13 +15,15 @@
  */
 package org.kie.pmml.models.regression.model.tuples;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Class to represent a <b>table source/table category</b> tupla
  */
-public class KiePMMLTableSourceCategory {
+public class KiePMMLTableSourceCategory implements Serializable {
 
+    private static final long serialVersionUID = -8635798961429806015L;
     private final String source;
 
     private final String category;

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTableTest.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.kie.pmml.api.iinterfaces.SerializableFunction;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -38,11 +39,11 @@ public class KiePMMLRegressionTableTest {
     private static final String SECOND_NUMERIC_INPUT = "SECOND_NUMERIC_INPUT";
     private static final String FIRST_CATEGORICAL_INPUT = "FIRST_CATEGORICAL_INPUT";
     private static final String SECOND_CATEGORICAL_INPUT = "SECOND_CATEGORICAL_INPUT";
-    private static final Function<Double, Double> FIRST_NUMERIC_FUNCTION = aDouble -> 1 / aDouble;
-    private static final Function<Double, Double> SECOND_NUMERIC_FUNCTION = aDouble -> 1 - aDouble;
+    private static final SerializableFunction<Double, Double> FIRST_NUMERIC_FUNCTION = aDouble -> 1 / aDouble;
+    private static final SerializableFunction<Double, Double> SECOND_NUMERIC_FUNCTION = aDouble -> 1 - aDouble;
     private final KiePMMLRegressionTable regressionTable;
-    private final Function<Object, Double> firstCategoricalFunction;
-    private final Function<Object, Double> secondCategoricalFunction;
+    private final SerializableFunction<Object, Double> firstCategoricalFunction;
+    private final SerializableFunction<Object, Double> secondCategoricalFunction;
     private final double firstNumericalInput;
     private final double secondNumericalInput;
     private final double expectedResult;

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
@@ -75,7 +75,7 @@ public class LinearRegressionSampleWithTransformationsTest extends AbstractPMMLT
                 {49, 78000, "carpark", 1301.37},
                 {57, 72000, "street", 1582.1},
                 {61, 123000, "carpark", 1836.5699999999997},
-                {18, 26000, "street", 845.1999999999999},
+                {18, 26000, "street", 845.1999999999999}
         });
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-pmml-models</artifactId>
     <groupId>org.kie</groupId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/pom.xml
+++ b/kie-pmml-trusty/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-pmml/pom.xml
+++ b/kie-pmml/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-pmml</artifactId>

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.53.0-SNAPSHOT</version>
+    <version>7.52.1-SNAPSHOT</version>
     <!-- relativePath causes out-of-date problems on hudson slaves -->
     <!--<relativePath>../droolsjbpm-build-bootstrap/pom.xml</relativePath>-->
   </parent>


### PR DESCRIPTION
[DROOLS-5892](https://issues.redhat.com/browse/DROOLS-5892) Guided Rule Editor: Method calls do not support template keys

**referenced Pull Requests**: 

* aaa
* bbb
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
