### PR TITLE
[7.52.x] DROOLS-6263: Test Scenario - expected vs actual alert is misleading

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/runner/AbstractRunnerHelper.java
@@ -292,8 +292,8 @@ public abstract class AbstractRunnerHelper {
     private String determineExceptionMessage(FactMappingValue factMappingValue, String factName) {
         if (factMappingValue.getCollectionPathToValue() == null) {
             return ScenarioSimulationServerMessages.getFactWithWrongValueExceptionMessage(factName,
-                                                                                          factMappingValue.getErrorValue(),
-                                                                                          factMappingValue.getRawValue());
+                                                                                          factMappingValue.getRawValue(),
+                                                                                          factMappingValue.getErrorValue());
         }
         return ScenarioSimulationServerMessages.getCollectionFactExceptionMessage(factName,
                                                                                   factMappingValue.getCollectionPathToValue(),

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/RuleScenarioRunnerHelperTest.java
@@ -358,8 +358,8 @@ public class RuleScenarioRunnerHelperTest extends AbstractRuleCoverageTest {
         } catch (ScenarioException exception) {
             assertTrue(exception.isFailedAssertion());
             assertEquals(ScenarioSimulationServerMessages.getFactWithWrongValueExceptionMessage("Fact 2.amount",
-                                                                                                amountNameExpectedFactMappingValue.getErrorValue(),
-                                                                                                amountNameExpectedFactMappingValue.getRawValue()),
+                                                                                                amountNameExpectedFactMappingValue.getRawValue(),
+                                                                                                amountNameExpectedFactMappingValue.getErrorValue()),
                          exception.getMessage());
         }
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
