### PR TITLE
[DROOLS-6254] investigate and fix AccumulateConsistencyTest.testMinMa…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AccumulateConsistencyTest.java
@@ -25,7 +25,6 @@ import org.drools.testcoverage.common.model.MyFact;
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -230,7 +229,6 @@ public class AccumulateConsistencyTest {
         }
     }
 
-    @Ignore("Ignoring because this test is not essential to the original JIRA (DROOLS-6064) so will investigate in another JIRA: DROOLS-6254")
     @Test
     public void testMinMaxMatch() {
         final String drl =
@@ -257,8 +255,8 @@ public class AccumulateConsistencyTest {
         kieSession.setGlobal("result", result);
 
         try {
-            kieSession.insert(new Person("John", 20));
-            kieSession.insert(new Person("John", 60));
+            kieSession.insert(new Person(0, "John", 20));
+            kieSession.insert(new Person(1, "John", 60));
 
             assertEquals(1, kieSession.fireAllRules());
             assertEquals(20, result.get("min").intValue());


### PR DESCRIPTION
…xMatch

The root cause was https://issues.redhat.com/browse/DROOLS-6258 and it was already fixed and merged. Now the test is executed with `EqualityBehaviorOption.IDENTITY` so it no longer causes the issue. 

However, In addition, I fixed the testMinMaxMatch() method to use `Person.id` so that facts are clearly distinguished even in case of `EqualityBehaviorOption.EQUALITY`.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6254

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
