### PR TITLE
[KOGITO-4852] Not possbile to insert comments to sets or conditions

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintExpression.java
@@ -51,10 +51,7 @@ public class ConstraintExpression {
             return constraintExpression;
         }
 
-        // I really hope we won't be comparing Strings with newline here.
-        String expressionWithoutNewLines = expression.replace("\n", "");
-
-        return new ConstraintExpression( expressionWithoutNewLines );
+        return new ConstraintExpression( expression );
     }
 
     private static String parseConstraintExpression( RuleContext context, Class<?> patternType, BaseDescr constraint, boolean isPositional ) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/InTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/InTest.java
@@ -16,11 +16,16 @@
 
 package org.drools.modelcompiler;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.Child;
+import org.drools.modelcompiler.domain.Person;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class InTest extends BaseModelTest {
@@ -53,6 +58,32 @@ public class InTest extends BaseModelTest {
         KieSession ksession = getKieSession(str);
         ksession.insert(new Child("Ben", 10));
         assertEquals( 0, ksession.fireAllRules() );
+    }
+
+    @Test
+    public void testInWithNullComments() {
+        String str = "import org.drools.modelcompiler.domain.Child; \n" +                        "global java.util.List results; \n" +
+                "global java.util.List results; \n" +
+                "rule R when                        \n" +
+                "  $c : Child(parent in (" +
+                "   \"Gustav\", // comment\n" +
+                "   \"Alice\"\n" +
+                "))\n" +
+                "then                               \n" +
+                " results.add($c);\n" +
+                "end                                ";
+
+        KieSession ksession = getKieSession(str);
+        List<Child> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        String parentName = "Gustav";
+        Person gustav = new Person(parentName);
+        Child ben = new Child("Ben", 10, parentName);
+        ksession.insert(ben);
+        ksession.insert(gustav);
+        assertEquals( 1, ksession.fireAllRules());
+        assertThat(results).containsExactly(ben);
     }
 
     @Test

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -362,6 +362,14 @@ public class DroolsMvelParserTest {
     }
 
     @Test
+    public void testInExpressionNewLine() {
+        String expr = "parent in (   \"Gustav\", // comment   \"Alice\")";
+        Expression expression = parseExpression( parser, expr ).getExpr();
+        assertTrue(expression instanceof PointFreeExpr);
+        assertEquals(expr, printConstraint(expression));
+    }
+
+    @Test
     /* This shouldn't be supported, an HalfBinaryExpr should be valid only after a && or a || */
     public void testUnsupportedImplicitParameter() {
         String expr = "== \"Mark\"";

--- a/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
+++ b/drools-model/drools-mvel-parser/src/test/java/org/drools/mvel/parser/DroolsMvelParserTest.java
@@ -362,14 +362,6 @@ public class DroolsMvelParserTest {
     }
 
     @Test
-    public void testInExpressionNewLine() {
-        String expr = "parent in (   \"Gustav\", // comment   \"Alice\")";
-        Expression expression = parseExpression( parser, expr ).getExpr();
-        assertTrue(expression instanceof PointFreeExpr);
-        assertEquals(expr, printConstraint(expression));
-    }
-
-    @Test
     /* This shouldn't be supported, an HalfBinaryExpr should be valid only after a && or a || */
     public void testUnsupportedImplicitParameter() {
         String expr = "== \"Mark\"";


### PR DESCRIPTION
We were removing newlines because of https://github.com/kiegroup/drools/pull/2561/files

but it's not needed anymore after

https://github.com/kiegroup/drools/commit/e37605f2b77b0714ea3018684eef85934ba2e5de


**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/KOGITO-4852


**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
