### PR TITLE
[DROOLS-6289] NamedConsequencesTest issues

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Cheese.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Cheese.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.modelcompiler.domain;
+
+import java.io.Serializable;
+import java.util.Date;
+
+
+public class Cheese
+    implements
+    Serializable {
+
+    public static final String STILTON = "stilton";
+
+    public static final int BASE_PRICE = 10;
+
+    private static final long serialVersionUID = 510l;
+    private String            type;
+    private int               price;
+    private int               oldPrice;
+    private Date              usedBy;
+    private double            doublePrice;
+
+    public Cheese() {
+
+    }
+
+    public Cheese(final String type) {
+        super();
+        this.type = type;
+        this.price = 0;
+    }
+
+    public Cheese(final String type,
+                  final int price) {
+        super();
+        this.type = type;
+        this.price = price;
+    }
+
+    public Cheese(final String type,
+                  final int price,
+                  final int oldPrice ) {
+        super();
+        this.type = type;
+        this.price = price;
+        this.oldPrice = oldPrice;
+    }
+
+    public int getPrice() {
+        return this.price;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public void setPrice(final int price) {
+        this.price = price;
+    }
+
+    public String toString() {
+        return "Cheese( type='" + this.type + "', price=" + this.price + " )";
+    }
+
+    public int hashCode() {
+        final int PRIME = 31;
+        int result = 1;
+        result = PRIME * result + price;
+        result = PRIME * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        final Cheese other = (Cheese) obj;
+        if ( price != other.price ) return false;
+        if ( type == null ) {
+            if ( other.type != null ) return false;
+        } else if ( !type.equals( other.type ) ) return false;
+        return true;
+    }
+
+    public int getOldPrice() {
+        return oldPrice;
+    }
+
+    public void setOldPrice(int oldPrice) {
+        this.oldPrice = oldPrice;
+    }
+
+    public Date getUsedBy() {
+        return usedBy;
+    }
+
+    public void setUsedBy(Date usedBy) {
+        this.usedBy = usedBy;
+    }
+
+    public synchronized double getDoublePrice() {
+        return doublePrice;
+    }
+
+    public synchronized void setDoublePrice(double doublePrice) {
+        this.doublePrice = doublePrice;
+    }
+
+
+
+}


### PR DESCRIPTION
- InvalidExpressionErrorResult instead of CCE/NPE
- InvalidExpressionErrorResult for Unknown consequence name
- Accept ruleDescr == null when NamedConsequence
- Use usedDeclarations in D.when lambda for non _this case
- Move breaking() to the end because onCall could be null

DROOLS-5823 (test-compiler-integration NamedConsequencesTest) has several different issues. So I split some of them to make a clearer commit.

**JIRA**:

https://issues.redhat.com/browse/DROOLS-6289

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
