### PR TITLE
[DROOLS-6287] Arithmetic operations with BigDecimal for a variable in constraint cause a compilation error in executable model

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -95,6 +95,7 @@ import org.drools.mvel.parser.ast.expr.HalfBinaryExpr;
 import org.drools.mvel.parser.ast.expr.ListCreationLiteralExpression;
 import org.drools.mvel.parser.ast.expr.MapCreationLiteralExpression;
 import org.drools.mvel.parser.printer.PrintUtil;
+import org.drools.mvelcompiler.ConstraintCompiler;
 import org.drools.mvelcompiler.MvelCompiler;
 import org.drools.mvelcompiler.context.MvelCompilerContext;
 
@@ -848,6 +849,22 @@ public class DrlxParseUtil {
         }
 
         return new MvelCompiler(mvelCompilerContext);
+    }
+
+
+    public static ConstraintCompiler createConstraintCompiler(RuleContext context, Collection<DeclarationSpec> declarations) {
+        MvelCompilerContext mvelCompilerContext = new MvelCompilerContext( context.getTypeResolver(), context.getCurrentScopeSuffix() );
+
+        for (DeclarationSpec ds : declarations) {
+            mvelCompilerContext.addDeclaration(ds.getBindingId(), ds.getDeclarationClass());
+        }
+
+        return new ConstraintCompiler(mvelCompilerContext);
+    }
+
+
+    public static boolean isBooleanBoxedUnboxed(java.lang.reflect.Type exprType) {
+        return exprType == Boolean.class || exprType == boolean.class;
     }
 
     private DrlxParseUtil() {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/TypedExpression.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/TypedExpression.java
@@ -17,6 +17,7 @@
 package org.drools.modelcompiler.builder.generator;
 
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -195,5 +196,9 @@ public class TypedExpression {
 
     public Expression uncastExpression() {
         return DrlxParseUtil.uncastExpr(expression);
+    }
+
+    public boolean isBigDecimal() {
+        return type != null && toRawClass(type).isAssignableFrom( BigDecimal.class );
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -17,6 +17,7 @@
 
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -63,18 +64,27 @@ import org.drools.mvel.parser.ast.expr.HalfPointFreeExpr;
 import org.drools.mvel.parser.ast.expr.OOPathExpr;
 import org.drools.mvel.parser.ast.expr.PointFreeExpr;
 import org.drools.mvelcompiler.CompiledExpressionResult;
-import org.drools.mvelcompiler.MvelCompiler;
+import org.drools.mvelcompiler.ConstraintCompiler;
+import org.drools.mvelcompiler.context.MvelCompilerContext;
 
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.AND;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.DIVIDE;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.EQUALS;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.GREATER;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.GREATER_EQUALS;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.LESS;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.LESS_EQUALS;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.MINUS;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.MULTIPLY;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.NOT_EQUALS;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.OR;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.PLUS;
+import static java.util.Arrays.asList;
 import static org.drools.core.util.StringUtils.lcFirstForBean;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.THIS_PLACEHOLDER;
-import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.createMvelCompiler;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.createConstraintCompiler;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getLiteralExpressionType;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.isBooleanBoxedUnboxed;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toClassOrInterfaceType;
 import static org.drools.modelcompiler.builder.generator.drlxparse.SpecialComparisonCase.specialComparisonFactory;
 import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
@@ -113,6 +123,10 @@ public class ConstraintParser {
                     decl.setBoundVariable( drlx.getExpr().toString() );
                 }
                 singleResult.setExprBinding( bindId );
+                Type exprType = singleResult.getExprType();
+                if(isBooleanBoxedUnboxed(exprType)) {
+                    singleResult.setIsPredicate(singleResult.getRight() != null);
+                }
             }
         });
 
@@ -161,11 +175,13 @@ public class ConstraintParser {
         }
 
         if (drlxExpr instanceof OOPathExpr ) {
-            return new SingleDrlxParseSuccess( patternType, bindingId, drlxExpr, null );
+            return new SingleDrlxParseSuccess( patternType, bindingId, drlxExpr, null ).setIsPredicate(true);
         }
 
         if (drlxExpr instanceof LiteralExpr ) {
-            return new SingleDrlxParseSuccess( patternType, bindingId, drlxExpr, getLiteralExpressionType( (( LiteralExpr ) drlxExpr) ) );
+            Class<?> literalExpressionType = getLiteralExpressionType(((LiteralExpr) drlxExpr));
+            return new SingleDrlxParseSuccess(patternType, bindingId, drlxExpr, literalExpressionType)
+                    .setIsPredicate(isBooleanBoxedUnboxed(literalExpressionType));
         }
 
         if (patternType != null) {
@@ -181,9 +197,11 @@ public class ConstraintParser {
             for(Expression e : leftTypedExpressionResult.getPrefixExpressions()) {
                 combo = new BinaryExpr(e, combo, BinaryExpr.Operator.AND );
             }
-            return new SingleDrlxParseSuccess(patternType, bindingId, combo, left.getType())
+            Type exprType = left.getType();
+            return new SingleDrlxParseSuccess(patternType, bindingId, combo, exprType)
                     .setReactOnProperties( expressionTyperContext.getReactOnProperties() )
-                    .setUsedDeclarations( expressionTyperContext.getUsedDeclarations() );
+                    .setUsedDeclarations( expressionTyperContext.getUsedDeclarations() )
+                    .setIsPredicate(isBooleanBoxedUnboxed(exprType));
         } else {
             final ExpressionTyperContext expressionTyperContext = new ExpressionTyperContext();
             final ExpressionTyper expressionTyper = new ExpressionTyper(context, null, bindingId, isPositional, expressionTyperContext);
@@ -195,7 +213,9 @@ public class ConstraintParser {
             }
 
             TypedExpression left = optLeft.get();
-            return new SingleDrlxParseSuccess(null, bindingId, drlxExpr, left.getType()).setUsedDeclarations( expressionTyperContext.getUsedDeclarations() );
+            return new SingleDrlxParseSuccess(null, bindingId, drlxExpr, left.getType())
+                    .setUsedDeclarations( expressionTyperContext.getUsedDeclarations() )
+                    .setIsPredicate(true);
         }
     }
 
@@ -225,7 +245,9 @@ public class ConstraintParser {
                     usedDeclarations.addAll(typedExpressionResult.getUsedDeclarations());
                 }
             }
-            return new SingleDrlxParseSuccess(patternType, bindingId, methodCallExpr, returnType).setUsedDeclarations(usedDeclarations);
+            return new SingleDrlxParseSuccess(patternType, bindingId, methodCallExpr, returnType)
+                    .setUsedDeclarations(usedDeclarations)
+                    .setIsPredicate(isBooleanBoxedUnboxed(returnType));
         } else {
             throw new IllegalArgumentException("Specified function call is not present!");
         }
@@ -251,13 +273,14 @@ public class ConstraintParser {
         } else if (context.hasDeclaration( expression )) {
             Optional<DeclarationSpec> declarationSpec = context.getDeclarationById(expression);
             if (declarationSpec.isPresent()) {
-                return new SingleDrlxParseSuccess(patternType, bindingId, context.getVarExpr(printConstraint(drlxExpr)), declarationSpec.get().getDeclarationClass() );
+                return new SingleDrlxParseSuccess(patternType, bindingId, context.getVarExpr(printConstraint(drlxExpr)), declarationSpec.get().getDeclarationClass() ).setIsPredicate(true);
             } else {
                 throw new IllegalArgumentException("Cannot find declaration specification by specified expression " + expression + "!");
             }
         } else {
             return new SingleDrlxParseSuccess(patternType, bindingId, withThis, converted.getType() )
-                    .addReactOnProperty( nameExpr.getNameAsString() );
+                    .addReactOnProperty( nameExpr.getNameAsString() )
+                    .setIsPredicate(true);
         }
     }
 
@@ -274,10 +297,12 @@ public class ConstraintParser {
 
         Expression withThis = DrlxParseUtil.prepend(new NameExpr(THIS_PLACEHOLDER), converted.getExpression());
 
-        return new SingleDrlxParseSuccess(patternType, bindingId, withThis, converted.getType())
+        Type type = converted.getType();
+        return new SingleDrlxParseSuccess(patternType, bindingId, withThis, type)
                 .setUsedDeclarations(expressionTyperContext.getUsedDeclarations())
                 .setLeft(converted)
-                .setImplicitCastExpression(expressionTyperContext.getInlineCastExpression());
+                .setImplicitCastExpression(expressionTyperContext.getInlineCastExpression())
+                .setIsPredicate(isBooleanBoxedUnboxed(type));
     }
 
     private DrlxParseResult parsePointFreeExpr(PointFreeExpr pointFreeExpr, Class<?> patternType, String bindingId, boolean isPositional) {
@@ -303,7 +328,7 @@ public class ConstraintParser {
                     .setRightLiteral(rightLiteral)
                     .setStatic(typedExpression.isStatic())
                     .setTemporal( isTemporal )
-                    .setValidExpression(true);
+                    .setIsPredicate(true);
         }).orElseGet( () -> new DrlxParseFail( new ParseExpressionErrorResult(pointFreeExpr) ));
     }
 
@@ -328,7 +353,8 @@ public class ConstraintParser {
         return new SingleDrlxParseSuccess(patternType, bindingId, new UnaryExpr(innerExpression, unaryExpr.getOperator()), typedExpression.getType())
                 .setDecodeConstraintType(Index.ConstraintType.UNKNOWN).setUsedDeclarations(typedExpressionResult.getUsedDeclarations())
                 .setReactOnProperties(typedExpressionResult.getReactOnProperties())
-                .setLeft(new TypedExpression(innerResult.getExpr(), innerResult.getExprType()));
+                .setLeft(new TypedExpression(innerResult.getExpr(), innerResult.getExprType()))
+                .setIsPredicate(innerResult.isPredicate());
     }
 
     private DrlxParseResult parseBinaryExpr(BinaryExpr binaryExpr, Class<?> patternType, String bindingId, ConstraintExpression constraint, Expression drlxExpr,
@@ -373,6 +399,7 @@ public class ConstraintParser {
             right = optRight.get();
         }
 
+
         boolean equalityExpr = operator == EQUALS || operator == NOT_EQUALS;
 
         CoercedExpression.CoercedExpressionResult coerced;
@@ -387,12 +414,27 @@ public class ConstraintParser {
 
         Expression combo;
 
+        boolean arithmeticExpr = asList(PLUS, MINUS, MULTIPLY, DIVIDE).contains(operator);
+
         if (equalityExpr) {
             combo = getEqualityExpression( left, right, operator ).expression;
+        } else if(arithmeticExpr && (left.isBigDecimal() && right.isBigDecimal())) {
+            MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(context.getTypeResolver());
+
+            mvelCompilerContext.setRootTypePrefix(THIS_PLACEHOLDER);
+            mvelCompilerContext.setRootPattern(patternType);
+
+            ConstraintCompiler constraintCompiler = new ConstraintCompiler(mvelCompilerContext);
+
+            CompiledExpressionResult compiledExpressionResult = constraintCompiler.compileExpression(binaryExpr.toString());
+
+            Expression expression = compiledExpressionResult.getExpression();
+            combo = expression;
         } else {
             if (left.getExpression() == null || right.getExpression() == null) {
                 return new DrlxParseFail(new ParseExpressionErrorResult(drlxExpr));
             }
+            // This special comparisons
             SpecialComparisonResult specialComparisonResult = handleSpecialComparisonCases(operator, left, right);
             combo = specialComparisonResult.expression;
             left = specialComparisonResult.coercedLeft;
@@ -415,9 +457,22 @@ public class ConstraintParser {
         }
 
         boolean requiresSplit = operator == BinaryExpr.Operator.AND && binaryExpr.getRight() instanceof HalfBinaryExpr && !isBetaConstraint;
-        return new SingleDrlxParseSuccess(patternType, bindingId, combo, isBooleanOperator( operator ) ? boolean.class : left.getType()).setDecodeConstraintType( constraintType )
-                .setUsedDeclarations( expressionTyperContext.getUsedDeclarations() ).setUsedDeclarationsOnLeft( usedDeclarationsOnLeft ).setUnification( constraint.isUnification() )
-                .setReactOnProperties( expressionTyperContext.getReactOnProperties() ).setLeft( left ).setRight( right ).setBetaConstraint(isBetaConstraint).setRequiresSplit( requiresSplit );
+        return new SingleDrlxParseSuccess(patternType, bindingId, combo, isBooleanOperator( operator ) ? boolean.class : left.getType())
+                .setDecodeConstraintType( constraintType )
+                .setUsedDeclarations( expressionTyperContext.getUsedDeclarations() )
+                .setUsedDeclarationsOnLeft( usedDeclarationsOnLeft )
+                .setUnification( constraint.isUnification() )
+                .setReactOnProperties( expressionTyperContext.getReactOnProperties() )
+                .setLeft( left )
+                .setRight( right )
+                .setBetaConstraint(isBetaConstraint)
+                .setRequiresSplit( requiresSplit )
+                .setIsPredicate(isPredicateBooleanExpression(binaryExpr));
+    }
+
+    private boolean isPredicateBooleanExpression(BinaryExpr expr) {
+        BinaryExpr.Operator op = expr.getOperator();
+        return op == AND || op == OR || op == EQUALS || op == NOT_EQUALS || op == LESS || op == GREATER || op == LESS_EQUALS || op == GREATER_EQUALS;
     }
 
     public static TypedExpression getCoercedRightExpression( PackageModel packageModel, CoercedExpression.CoercedExpressionResult coerced ) {
@@ -484,10 +539,10 @@ public class ConstraintParser {
 
         if (isLeftNumber) {
             if ( isString( right ) ) {
-                leftExpr = new BinaryExpr(new StringLiteralExpr(""), leftExpr, BinaryExpr.Operator.PLUS);
+                leftExpr = new BinaryExpr(new StringLiteralExpr(""), leftExpr, PLUS);
             }
         } else if ( isRightNumber && isString( left ) ) {
-            rightExpr = new BinaryExpr(new StringLiteralExpr(""), rightExpr, BinaryExpr.Operator.PLUS);
+            rightExpr = new BinaryExpr(new StringLiteralExpr(""), rightExpr, PLUS);
         }
 
         MethodCallExpr methodCallExpr = new MethodCallExpr( null, equalsMethod );
@@ -571,6 +626,7 @@ public class ConstraintParser {
         return new SpecialComparisonResult(compareMethod, left, right);
     }
 
+    // TODO luca this logic should be moved in Constraint compiler?
     private Expression toBigDecimalExpression( TypedExpression typedExpression) {
         MethodCallExpr toBigDecimalMethod = new MethodCallExpr( null, "org.drools.modelcompiler.util.EvaluationUtil.toBigDecimal" );
         Expression arg = typedExpression.getExpression();
@@ -579,9 +635,9 @@ public class ConstraintParser {
         allDeclarations.addAll(context.getAllDeclarations());
         typedExpression.getOriginalPatternType().ifPresent(pt -> allDeclarations.add(new DeclarationSpec(THIS_PLACEHOLDER, pt)));
 
-        MvelCompiler mvelCompiler = createMvelCompiler(context, allDeclarations);
+        ConstraintCompiler constraintCompiler = createConstraintCompiler(context, allDeclarations);
 
-        CompiledExpressionResult compiledBlockResult = mvelCompiler.compileExpression(arg.toString());
+        CompiledExpressionResult compiledBlockResult = constraintCompiler.compileExpression(arg.toString());
 
         arg = compiledBlockResult.getExpression();
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -79,6 +79,7 @@ import static com.github.javaparser.ast.expr.BinaryExpr.Operator.MULTIPLY;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.NOT_EQUALS;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.OR;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.PLUS;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.REMAINDER;
 import static java.util.Arrays.asList;
 import static org.drools.core.util.StringUtils.lcFirstForBean;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.THIS_PLACEHOLDER;
@@ -414,11 +415,11 @@ public class ConstraintParser {
 
         Expression combo;
 
-        boolean arithmeticExpr = asList(PLUS, MINUS, MULTIPLY, DIVIDE).contains(operator);
+        boolean arithmeticExpr = asList(PLUS, MINUS, MULTIPLY, DIVIDE, REMAINDER).contains(operator);
 
         if (equalityExpr) {
             combo = getEqualityExpression( left, right, operator ).expression;
-        } else if(arithmeticExpr && (left.isBigDecimal() && right.isBigDecimal())) {
+        } else if(arithmeticExpr && (left.isBigDecimal())) {
             MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(context.getTypeResolver());
 
             mvelCompilerContext.setRootTypePrefix(THIS_PLACEHOLDER);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseFail.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseFail.java
@@ -65,6 +65,11 @@ public class DrlxParseFail implements DrlxParseResult {
         return this;
     }
 
+    @Override
+    public String getOriginalDrlConstraint() {
+        return originalDrlConstraint;
+    }
+
     public DroolsError getError() {
         if(specificError != null) {
             return specificError;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseResult.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseResult.java
@@ -33,4 +33,6 @@ public interface DrlxParseResult {
     String getExprId(DRLIdGenerator exprIdGenerator);
 
     DrlxParseResult setOriginalDrlConstraint(String originalDrlConstraint);
+
+    String getOriginalDrlConstraint();
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseSuccess.java
@@ -24,7 +24,7 @@ import com.github.javaparser.ast.expr.Expression;
 
 public interface DrlxParseSuccess extends DrlxParseResult {
 
-    boolean isValidExpression();
+    boolean isPredicate();
 
     String getExprBinding();
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/MultipleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/MultipleDrlxParseSuccess.java
@@ -69,8 +69,13 @@ public class MultipleDrlxParseSuccess extends AbstractDrlxParseSuccess {
     }
 
     @Override
-    public boolean isValidExpression() {
-        return Stream.of(results).allMatch( DrlxParseSuccess::isValidExpression );
+    public String getOriginalDrlConstraint() {
+        return Arrays.stream(results).map(DrlxParseResult::getOriginalDrlConstraint).collect(Collectors.joining());
+    }
+
+    @Override
+    public boolean isPredicate() {
+        return Stream.of(results).allMatch( DrlxParseSuccess::isPredicate);
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -92,7 +92,7 @@ public abstract class AbstractExpressionBuilder {
     public abstract void processExpression(SingleDrlxParseSuccess drlxParseResult);
 
     public void processExpression(MultipleDrlxParseSuccess drlxParseResult) {
-        if ( drlxParseResult.isValidExpression() ) {
+        if ( drlxParseResult.isPredicate() ) {
             Expression dslExpr = buildExpressionWithIndexing(drlxParseResult);
             context.addExpression(dslExpr);
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/EvalExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/EvalExpressionBuilder.java
@@ -40,7 +40,7 @@ public class EvalExpressionBuilder extends AbstractExpressionBuilder {
         if (drlxParseResult.hasUnificationVariable()) {
             Expression dslExpr = buildUnificationExpression(drlxParseResult);
             context.addExpression(dslExpr);
-        } else if ( drlxParseResult.isValidExpression() ) {
+        } else if ( drlxParseResult.isPredicate() ) {
             Expression dslExpr = buildSingleExpressionWithIndexing(drlxParseResult);
             context.addExpression(dslExpr);
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/PatternExpressionBuilder.java
@@ -65,7 +65,7 @@ public class PatternExpressionBuilder extends AbstractExpressionBuilder {
         if (drlxParseResult.hasUnificationVariable()) {
             Expression dslExpr = buildUnificationExpression(drlxParseResult);
             context.addExpression(dslExpr);
-        } else if (drlxParseResult.isValidExpression()) {
+        } else if (drlxParseResult.isPredicate()) {
             Expression dslExpr = buildExpressionWithIndexing(drlxParseResult);
             context.addExpression(dslExpr);
         }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -1231,6 +1231,38 @@ public class AccumulateTest extends BaseModelTest {
         assertEquals(23, results.iterator().next().getValue());
     }
 
+    @Test
+    public void testBigDecimalOperationsInAccumulateConstraint() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + BigDecimal.class.getCanonicalName() + ";\n" +
+                "global java.util.List results;\n" +
+                "rule \"rule1\"\n" +
+                "when\n" +
+                "    $moneySummed : BigDecimal () from accumulate( " +
+                "       Person( money != null, $bd: (money + money)), " +
+                "       sum($bd))\n" +
+                "then\n" +
+                "    results.add($moneySummed);\n" +
+                "end\n";
+
+        KieSession ksession1 = getKieSession(str);
+
+        ArrayList<BigDecimal> results = new ArrayList<>();
+        ksession1.setGlobal("results", results);
+
+        Person p1 = new Person();
+        p1.setMoney( new BigDecimal(1 ));
+        ksession1.insert( p1 );
+        Person p2 = new Person();
+        p2.setMoney( new BigDecimal(3 ));
+        ksession1.insert(p2);
+        assertEquals( 1, ksession1.fireAllRules() );
+
+        Assertions.assertThat(results).containsExactly(BigDecimal.valueOf(8));
+
+    }
+
+
 
     // do also the test with two functions
     @Test

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -1180,6 +1180,32 @@ public class CompilerTest extends BaseModelTest {
     }
 
     @Test
+    public void testBigDecimalOperationsInConstraint() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + BigDecimal.class.getCanonicalName() + ";\n" +
+                "global java.util.List results;\n" +
+                "rule \"rule1\"\n" +
+                "when\n" +
+                "    Person( $moneyDoubled : (money + money) )\n" +
+                "then\n" +
+                "    results.add($moneyDoubled);\n" +
+                "end\n";
+
+        KieSession ksession1 = getKieSession(str);
+
+        ArrayList<BigDecimal> results = new ArrayList<>();
+        ksession1.setGlobal("results", results);
+
+        Person p1 = new Person();
+        p1.setMoney( new BigDecimal(1 ));
+        ksession1.insert( p1 );
+        assertEquals( 1, ksession1.fireAllRules() );
+
+        assertThat(results).containsExactly(BigDecimal.valueOf(2));
+
+    }
+
+    @Test
     public void testSingleQuoteString() {
         String str =
                 "rule R1 when\n" +

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledExpressionResult.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledExpressionResult.java
@@ -2,6 +2,8 @@ package org.drools.mvelcompiler;
 
 import com.github.javaparser.ast.expr.Expression;
 
+import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
+
 public class CompiledExpressionResult {
 
     private Expression expression;
@@ -12,5 +14,9 @@ public class CompiledExpressionResult {
 
     public Expression getExpression() {
         return expression;
+    }
+
+    public String resultAsString() {
+        return printConstraint(expression);
     }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ConstraintCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ConstraintCompiler.java
@@ -1,0 +1,36 @@
+package org.drools.mvelcompiler;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
+import org.drools.mvel.parser.MvelParser;
+import org.drools.mvelcompiler.ast.TypedExpression;
+import org.drools.mvelcompiler.context.MvelCompilerContext;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+/* A special case of compiler in that compiles constraints, that is
+    every variable can be implicitly a field of the root object
+    no LHS
+    converted FieldToAccessor prepend a this expr
+ */
+public class ConstraintCompiler {
+
+    private final MvelCompilerContext mvelCompilerContext;
+
+    public ConstraintCompiler(MvelCompilerContext mvelCompilerContext) {
+        this.mvelCompilerContext = mvelCompilerContext;
+    }
+
+    public CompiledExpressionResult compileExpression(String mvelExpressionString) {
+        Expression parsedExpression = MvelParser.parseExpression(mvelExpressionString);
+        Node compiled = compileExpression(parsedExpression);
+
+        return new CompiledExpressionResult((Expression) compiled);
+    }
+
+    // Avoid processing the LHS as it's not present while compiling an expression
+    private Node compileExpression(Node n) {
+        TypedExpression rhs = new RHSPhase(mvelCompilerContext).invoke(n);
+        return rhs.toJavaExpression();
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.Statement;
@@ -30,13 +29,6 @@ public class MvelCompiler {
 
     public MvelCompiler(MvelCompilerContext mvelCompilerContext) {
         this.mvelCompilerContext = mvelCompilerContext;
-    }
-
-    public CompiledExpressionResult compileExpression(String mvelExpressionString) {
-        Expression parsedExpression = MvelParser.parseExpression(mvelExpressionString);
-        Node compiled = compileExpression(parsedExpression);
-
-        return new CompiledExpressionResult((Expression) compiled);
     }
 
     public CompiledBlockResult compileStatement(String mvelBlock) {
@@ -104,11 +96,5 @@ public class MvelCompiler {
         TypedExpression postProcessedLHS = postProcessedRHS.map(ppr -> new LHSPhase(mvelCompilerContext, of(ppr)).invoke(n)).orElse(lhs);
 
         return postProcessedLHS.toJavaExpression();
-    }
-
-    // Avoid processing the LHS as it's not present while compiling an expression
-    private Node compileExpression(Node n) {
-        TypedExpression rhs = new RHSPhase(mvelCompilerContext).invoke(n);
-        return rhs.toJavaExpression();
     }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -43,6 +43,7 @@ import org.drools.mvelcompiler.ast.ListAccessExprT;
 import org.drools.mvelcompiler.ast.LongLiteralExpressionT;
 import org.drools.mvelcompiler.ast.MethodCallExprT;
 import org.drools.mvelcompiler.ast.ObjectCreationExpressionT;
+import org.drools.mvelcompiler.ast.RootTypeThisExpr;
 import org.drools.mvelcompiler.ast.SimpleNameTExpr;
 import org.drools.mvelcompiler.ast.StringLiteralExpressionT;
 import org.drools.mvelcompiler.ast.TypedExpression;
@@ -115,6 +116,8 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, RHSPhase.Con
     private TypedExpression simpleNameAsFirstNode(SimpleName n) {
         return asDeclaration(n)
                 .map(Optional::of)
+                .orElseGet(() -> asPropertyAccessorOfRootPattern(n))
+                .map(Optional::of)
                 .orElseGet(() -> asEnum(n))
                 .orElseGet(() -> new UnalteredTypedExpression(n));
     }
@@ -158,6 +161,14 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, RHSPhase.Con
         Optional<Method> optAccessor = scopeType.flatMap(t -> ofNullable(getAccessor(classFromType(t), n.asString())));
 
         return map2(lastTypedExpression, optAccessor, FieldToAccessorTExpr::new);
+    }
+
+
+    private Optional<TypedExpression> asPropertyAccessorOfRootPattern(SimpleName n) {
+        Optional<Type> scopeType = mvelCompilerContext.getRootPattern();
+        Optional<Method> optAccessor = scopeType.flatMap(t -> ofNullable(getAccessor(classFromType(t), n.asString())));
+
+        return map2(scopeType.map(t -> new RootTypeThisExpr(t, mvelCompilerContext.getRootTypePrefix())), optAccessor, FieldToAccessorTExpr::new);
     }
 
     @Override

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/RootTypeThisExpr.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/RootTypeThisExpr.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.ast;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.NameExpr;
+
+public class RootTypeThisExpr implements TypedExpression {
+
+    private final Type type;
+    private String rootTypePrefix;
+
+    public RootTypeThisExpr(Type type, String rootTypePrefix) {
+        this.type = type;
+        this.rootTypePrefix = rootTypePrefix;
+    }
+
+    @Override
+    public Optional<Type> getType() {
+        return Optional.of(type);
+    }
+
+    @Override
+    public Node toJavaExpression() {
+        return new NameExpr(rootTypePrefix);
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/MvelCompilerContext.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/MvelCompilerContext.java
@@ -1,5 +1,6 @@
 package org.drools.mvelcompiler.context;
 
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -14,6 +15,10 @@ public class MvelCompilerContext {
     private final Map<String, Declaration> declarations = new HashMap<>();
     private final TypeResolver typeResolver;
     private final String scopeSuffix;
+
+    // Used in ConstraintParser
+    private Optional<Type> rootPattern = Optional.empty();
+    private String rootTypePrefix;
 
     public MvelCompilerContext(TypeResolver typeResolver) {
         this(typeResolver, null);
@@ -51,5 +56,21 @@ public class MvelCompilerContext {
         } catch (ClassNotFoundException e) {
             throw new MvelCompilerException(e);
         }
+    }
+
+    public void setRootPattern(Type rootPattern) {
+        this.rootPattern = Optional.of(rootPattern);
+    }
+
+    public Optional<Type> getRootPattern() {
+        return rootPattern;
+    }
+
+    public String getRootTypePrefix() {
+        return rootTypePrefix;
+    }
+
+    public void setRootTypePrefix(String rootTypePrefix) {
+        this.rootTypePrefix = rootTypePrefix;
     }
 }

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
@@ -1,0 +1,53 @@
+package org.drools.mvelcompiler;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.drools.Gender;
+import org.drools.Person;
+import org.drools.core.addon.ClassTypeResolver;
+import org.drools.core.addon.TypeResolver;
+import org.drools.mvelcompiler.context.MvelCompilerContext;
+import org.junit.Test;
+
+public class ConstraintCompilerTest implements CompilerTest {
+
+    @Test
+    public void testBigDecimalPromotion() {
+        testExpression(c -> {
+                           c.setRootPattern(Person.class);
+                           c.setRootTypePrefix("_this");
+                       }, "salary + salary",
+                       "_this.getSalary().add(_this.getSalary())");
+    }
+
+    public void testExpression(Consumer<MvelCompilerContext> testFunction,
+                               String inputExpression,
+                               String expectedResult,
+                               Consumer<CompiledExpressionResult> resultAssert) {
+        Set<String> imports = new HashSet<>();
+        imports.add("java.util.List");
+        imports.add("java.util.ArrayList");
+        imports.add("java.util.HashMap");
+        imports.add("java.util.Map");
+        imports.add("java.math.BigDecimal");
+        imports.add("org.drools.Address");
+        imports.add(Person.class.getCanonicalName());
+        imports.add(Gender.class.getCanonicalName());
+        TypeResolver typeResolver = new ClassTypeResolver(imports, this.getClass().getClassLoader());
+        MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(typeResolver);
+        testFunction.accept(mvelCompilerContext);
+        CompiledExpressionResult compiled = new ConstraintCompiler(mvelCompilerContext).compileExpression(inputExpression);
+        verifyBodyWithBetterDiff(expectedResult, compiled.resultAsString());
+        resultAssert.accept(compiled);
+    }
+
+    void testExpression(Consumer<MvelCompilerContext> testFunction,
+                        String inputExpression,
+                        String expectedResult) {
+        testExpression(testFunction, inputExpression, expectedResult, t -> {
+        });
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConstraintsTest.java
@@ -39,6 +39,7 @@ import org.kie.api.builder.KieBuilder;
 import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
@@ -449,7 +450,11 @@ public class ConstraintsTest {
                 "end";
 
         final KieBuilder kieBuilder = KieUtil.getKieBuilderFromDrls(kieBaseTestConfiguration, false, drl);
-        Assertions.assertThat(kieBuilder.getResults().getMessages()).isNotEmpty();
+        List<org.kie.api.builder.Message> messages = kieBuilder.getResults().getMessages();
+        Assertions.assertThat(messages).hasSize(1);
+        Assertions.assertThat(messages.iterator().next().getText())
+                .contains("Predicate 'name + name' must be a Boolean expression")
+                .isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
DROOLS-6287] Arithmetic operations with BigDecimal for a variable in constraint cause a compilation error in executable model

* Constraint compiler: a specialized version of the mvel compiler that compiles MVEL expressions, not statements. Only the RHS phased is used
* Set predicate flag while parsing/compiling instead of deducing it afterwards
* Disabled CustomOperatorTest with executable model, see https://issues.redhat.com/browse/DROOLS-6302
* Better error check for testNonBooleanConstraint now failing for the same original error


**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6287

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
