### PR TITLE
[DROOLS-6053] Reduce unnecessary classloading by parent classloader

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -193,9 +194,9 @@ public interface InternalKieModule extends KieModule, Serializable {
         }
     }
 
-    default void updateKieModule(InternalKieModule newKM) {
+    default void updateKieModule(InternalKieModule newKM) {}
 
-    }
+    default void addGeneratedClassNames(Set<String> classNames) {}
 
     class CompilationCache implements Serializable {
         private static final long serialVersionUID = 3812243055974412935L;

--- a/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
+++ b/drools-core-dynamic/src/main/java/org/drools/dynamic/DynamicProjectClassLoader.java
@@ -41,6 +41,11 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
         return true;
     }
 
+    @Override
+    protected boolean isStoreFirst(String name) {
+        return isEnableStoreFirst() && generatedClassNames.contains(name);
+    }
+
     public static class IBMDynamicClassLoader extends DynamicProjectClassLoader {
 
         private final boolean parentImplementsFindResources;
@@ -123,7 +128,7 @@ public class DynamicProjectClassLoader extends ProjectClassLoader {
         }
 
         private boolean isStoreFirst(String name) {
-            return ProjectClassLoader.isEnableStoreFirst() && projectClassLoader.getGeneratedClassNames().contains(name) && projectClassLoader.containsInStore(ClassUtils.convertClassToResourcePath(name));
+            return ProjectClassLoader.isEnableStoreFirst() && projectClassLoader.getGeneratedClassNames().contains(name);
         }
 
         public Class<?> loadType(String name, boolean resolve) throws ClassNotFoundException {

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +46,8 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
                                                             new ClassNotFoundException("This is just a cached Exception. Disable non existing classes cache to see the actual one.") :
                                                             null;
 
+    private static boolean enableStoreFirst = Boolean.valueOf(System.getProperty("drools.projectClassLoader.enableStoreFirst", "true"));
+
     static {
         registerAsParallelCapable();
     }
@@ -60,6 +63,8 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
     private InternalTypesClassLoader typesClassLoader;
 
     private final Map<String, Class<?>> loadedClasses = new ConcurrentHashMap<String, Class<?>>();
+
+    private Set<String> generatedClassNames = new HashSet<>();
 
     private ResourceProvider resourceProvider;
 
@@ -122,13 +127,35 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         if (cls != null) {
             return cls;
         }
-        try {
-            cls = internalLoadClass(name, resolve);
-        } catch (ClassNotFoundException e2) {
-            cls = loadType(name, resolve);
+
+        if (isStoreFirst(name)) {
+            Class<?> clazz = findLoadedClass(name); // skip parent classloader
+            if (clazz != null) {
+                return clazz;
+            }
+            if (typesClassLoader != null) {
+                clazz = typesClassLoader.findLoadedClassWithoutParent(name);
+                if (clazz != null) {
+                    return clazz;
+                }
+            }
+            // if generated class, go straight to defineType
+            cls = tryDefineType(name, null);
+        } else {
+            try {
+                cls = internalLoadClass(name, resolve);
+            } catch (ClassNotFoundException e2) {
+                // for stored classes which are not in generatedClassNames
+                cls = loadType(name, resolve);
+            }
         }
+
         loadedClasses.put(name, cls);
         return cls;
+    }
+
+    private boolean isStoreFirst(String name) {
+        return enableStoreFirst && isDynamic() && generatedClassNames.contains(name) && containsInStore(ClassUtils.convertClassToResourcePath(name));
     }
 
     // This method has to be public because is also used by the android ClassLoader
@@ -145,7 +172,14 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         try {
             return super.loadClass(name, resolve);
         } catch (ClassNotFoundException e) {
-            return Class.forName(name, resolve, getParent());
+            try {
+                return Class.forName(name, resolve, getParent());
+            } catch (ClassNotFoundException e1) {
+                if (CACHE_NON_EXISTING_CLASSES) {
+                    nonExistingClasses.add(name);
+                }
+                throw e1;
+            }
         }
     }
 
@@ -301,6 +335,23 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         return resources;
     }
 
+    public Set<String> getGeneratedClassNames() {
+        return generatedClassNames;
+    }
+
+    public void setGeneratedClassNames(Set<String> generatedClassNames) {
+        this.generatedClassNames = generatedClassNames;
+    }
+
+    public static boolean isEnableStoreFirst() {
+        return enableStoreFirst;
+    }
+
+    // test purpose
+    static void setEnableStoreFirst(boolean enableStoreFirst) {
+        ProjectClassLoader.enableStoreFirst = enableStoreFirst;
+    }
+
     private static class ResourcesEnum implements Enumeration<URL> {
 
         private URL providedResource;
@@ -329,6 +380,10 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
 
     public byte[] getBytecode(String resourceName) {
         return store == null ? null : store.get(resourceName);
+    }
+
+    public boolean containsInStore(String resourceName) {
+        return store == null ? false : store.containsKey(resourceName);
     }
 
     @Override
@@ -394,6 +449,9 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
     public interface InternalTypesClassLoader extends KieTypeResolver {
         Class<?> defineClass( String name, byte[] bytecode );
         Class<?> loadType( String name, boolean resolve ) throws ClassNotFoundException;
+        default Class<?> findLoadedClassWithoutParent(String name) {
+            throw new UnsupportedOperationException();
+        };
     }
 
     public synchronized List<String> reinitTypes() {

--- a/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/classloader/ProjectClassLoader.java
@@ -64,7 +64,7 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
 
     private final Map<String, Class<?>> loadedClasses = new ConcurrentHashMap<String, Class<?>>();
 
-    private Set<String> generatedClassNames = new HashSet<>();
+    protected Set<String> generatedClassNames = new HashSet<>();
 
     private ResourceProvider resourceProvider;
 
@@ -154,8 +154,8 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
         return cls;
     }
 
-    private boolean isStoreFirst(String name) {
-        return enableStoreFirst && isDynamic() && generatedClassNames.contains(name) && containsInStore(ClassUtils.convertClassToResourcePath(name));
+    protected boolean isStoreFirst(String name) {
+        return false;
     }
 
     // This method has to be public because is also used by the android ClassLoader
@@ -380,10 +380,6 @@ public abstract class ProjectClassLoader extends ClassLoader implements KieTypeR
 
     public byte[] getBytecode(String resourceName) {
         return store == null ? null : store.get(resourceName);
-    }
-
-    public boolean containsInStore(String resourceName) {
-        return store == null ? false : store.containsKey(resourceName);
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelWriter.java
@@ -20,6 +20,7 @@ package org.drools.modelcompiler.builder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
@@ -28,6 +29,7 @@ import org.kie.api.builder.ReleaseId;
 
 import static org.drools.modelcompiler.CanonicalKieModule.MODEL_VERSION;
 import static org.drools.modelcompiler.CanonicalKieModule.getModelFileWithGAV;
+import static org.drools.modelcompiler.CanonicalKieModule.getGeneratedClassNamesFile;
 
 public class ModelWriter {
 
@@ -74,6 +76,18 @@ public class ModelWriter {
             pkgNames += modelSources.stream().collect(Collectors.joining("\n"));
         }
         trgMfs.write(getModelFileWithGAV(releaseId), pkgNames.getBytes());
+    }
+
+    public void writeGeneratedClassNamesFile(Set<String> generatedClassNames, MemoryFileSystem trgMfs, ReleaseId releaseId) {
+        trgMfs.write(getGeneratedClassNamesFile(releaseId), generatedClassNamesFileContent(generatedClassNames).getBytes());
+    }
+
+    public static String generatedClassNamesFileContent(Set<String> generatedClassNames) {
+        String content = "";
+        if (!generatedClassNames.isEmpty()) {
+            content = generatedClassNames.stream().collect(Collectors.joining("\n"));
+        }
+        return content;
     }
 
     public static class Result {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GeneratedClassNamesTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GeneratedClassNamesTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.compiler.kie.builder.impl.KieContainerImpl;
+import org.drools.compiler.kie.builder.impl.MemoryKieModule;
+import org.drools.modelcompiler.domain.Person;
+import org.drools.reflective.classloader.ProjectClassLoader;
+import org.drools.reflective.classloader.ProjectClassLoaderTestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieModule;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.builder.model.KieBaseModel;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.io.Resource;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.io.ResourceFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GeneratedClassNamesTest extends BaseModelTest {
+
+    private boolean enableStoreFirstOrig;
+
+    public GeneratedClassNamesTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    @Parameters(name = "{0}")
+    public static Object[] params() {
+        return new Object[]{RUN_TYPE.PATTERN_DSL};
+    }
+
+    @Before
+    public void init() {
+        enableStoreFirstOrig = ProjectClassLoader.isEnableStoreFirst();
+        ProjectClassLoaderTestUtil.setEnableStoreFirst(true);
+    }
+
+    @After
+    public void clear() {
+        ProjectClassLoaderTestUtil.setEnableStoreFirst(enableStoreFirstOrig);
+    }
+
+    @Test
+    public void testGeneratedClassNames() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "  $p : Person(name == \"Mario\")\n" +
+                     "then\n" +
+                     "  System.out.println(\"hello\");\n" +
+                     "end";
+
+        KieServices ks = KieServices.get();
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "kjar-test-" + UUID.randomUUID(), "1.0");
+
+        createKieBuilder(ks, null, releaseId, toKieFiles(new String[]{str}));
+        KieContainer kcontainer = ks.newKieContainer(releaseId);
+
+        KieModule kieModule = ((KieContainerImpl) kcontainer).getKieModuleForKBase("defaultKieBase");
+
+        assertTrue(kieModule instanceof CanonicalKieModule);
+
+        KieSession ksession = kcontainer.newKieSession();
+
+        Set<String> generatedClassNames = ((CanonicalKieModule) kieModule).getGeneratedClassNames();
+        assertGeneratedClassNames(generatedClassNames);
+
+        Person me = new Person("Mario", 40);
+        ksession.insert(me);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
+    }
+
+    private void assertGeneratedClassNames(Set<String> generatedClassNames) {
+        assertNotNull(generatedClassNames);
+        String[] nameFragments = new String[]{"Rules", "LambdaConsequence", "LambdaPredicate", "LambdaExtractor", "DomainClassesMetadata", "ProjectModel", "$"};
+        for (String nameFragment : nameFragments) {
+            boolean contains = false;
+            for (String generatedClassName : generatedClassNames) {
+                if (generatedClassName.contains(nameFragment)) {
+                    contains = true;
+                    break;
+                }
+            }
+            if (!contains) {
+                fail("generatedClassNames doesn't contain [" + nameFragment + "] class. : " + generatedClassNames);
+            }
+        }
+    }
+
+    @Test
+    public void testModuleWithDepWithoutClassLoader() throws Exception {
+        testModuleWithDep(null);
+    }
+
+    @Test
+    public void testModuleWithDepWithClassLoader() throws Exception {
+        ProjectClassLoader projectClassLoader = ProjectClassLoader.createProjectClassLoader(Thread.currentThread().getContextClassLoader());
+        testModuleWithDep(projectClassLoader);
+    }
+
+    private void testModuleWithDep(ProjectClassLoader projectClassLoader) throws Exception {
+        KieServices ks = KieServices.get();
+        ReleaseId releaseIdDep = ks.newReleaseId("org.example", "depRule", "1.0.0");
+        ReleaseId releaseIdMain = ks.newReleaseId("org.example", "mainRule", "1.0.0");
+
+        String depStr =
+                "package org.example.dep\n" +
+                        "import " + Person.class.getCanonicalName() + ";\n" +
+                        "rule R_dep when\n" +
+                        "  $p : Person(name == \"Mario\")\n" +
+                        "then\n" +
+                        "  System.out.println(\"hello dep rule\");\n" +
+                        "end";
+
+        String mainStr =
+                "package org.example.main\n" +
+                         "import " + Person.class.getCanonicalName() + ";\n" +
+                         "rule R_main when\n" +
+                         "  $p : Person(name == \"Luca\")\n" +
+                         "then\n" +
+                         "  System.out.println(\"hello main rule\");\n" +
+                         "end";
+
+        String mainPom =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                         "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                         "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n" +
+                         "  <modelVersion>4.0.0</modelVersion>\n" +
+                         "\n" +
+                         "  <groupId>" + releaseIdMain.getGroupId() + "</groupId>\n" +
+                         "  <artifactId>" + releaseIdMain.getArtifactId() + "</artifactId>\n" +
+                         "  <version>" + releaseIdMain.getVersion() + "</version>\n" +
+                         "  <dependencies>\n" +
+                         "    <dependency>\n" +
+                         "      <groupId>" + releaseIdDep.getGroupId() + "</groupId>\n" +
+                         "      <artifactId>" + releaseIdDep.getArtifactId() + "</artifactId>\n" +
+                         "      <version>" + releaseIdDep.getVersion() + "</version>\n" +
+                         "    </dependency>\n" +
+                         "  </dependencies>" +
+                         "</project>";
+
+        // create dep
+        KieFileSystem depKfs = ks.newKieFileSystem();
+        KieModuleModel depModuleModel = ks.newKieModuleModel();
+        KieBaseModel depKieBaseModel = depModuleModel.newKieBaseModel("dep").setDefault(false);
+        depKieBaseModel.addPackage("*");
+        depKfs.writeKModuleXML(depModuleModel.toXML());
+        depKfs.generateAndWritePomXML(releaseIdDep);
+        Resource depResource = ResourceFactory.newByteArrayResource(depStr.getBytes());
+        depResource.setSourcePath("src/main/resources/org/example/dep/r1.drl");
+        depKfs.write(depResource);
+        KieBuilder depKieBuilder = ks.newKieBuilder(depKfs);
+        depKieBuilder.buildAll(ExecutableModelProject.class);
+        CanonicalKieModule depKieModule = (CanonicalKieModule) depKieBuilder.getKieModule();
+
+        MemoryKieModule depMemoryKieModule = (MemoryKieModule) depKieModule.getInternalKieModule();
+        MemoryFileSystem depMfs = depMemoryKieModule.getMemoryFileSystem();
+        byte[] depBinary = depMfs.writeAsBytes();
+        Resource depJarResource = ks.getResources().newByteArrayResource(depBinary);
+
+        // create main
+        KieFileSystem mainKfs = ks.newKieFileSystem();
+        KieModuleModel mainModuleModel = ks.newKieModuleModel();
+        KieBaseModel mainKieBaseModel = mainModuleModel.newKieBaseModel("main").setDefault(true);
+        mainKieBaseModel.addPackage("*");
+        mainKieBaseModel.addInclude("dep");
+        Resource mainResource = ResourceFactory.newByteArrayResource(mainStr.getBytes());
+        mainResource.setSourcePath("src/main/resources/org/example/main/r2.drl");
+        mainKfs.write(mainResource);
+        mainKfs.writeKModuleXML(mainModuleModel.toXML());
+        mainKfs.write("pom.xml", mainPom);
+        KieBuilder mainKieBuilder = ks.newKieBuilder(mainKfs);
+        mainKieBuilder.setDependencies(depJarResource);
+        mainKieBuilder.buildAll(ExecutableModelProject.class);
+        CanonicalKieModule mainKieModule = (CanonicalKieModule) mainKieBuilder.getKieModule();
+
+        MemoryKieModule mainMemoryKieModule = (MemoryKieModule) mainKieModule.getInternalKieModule();
+        MemoryFileSystem mainMfs = mainMemoryKieModule.getMemoryFileSystem();
+        byte[] mainBinary = mainMfs.writeAsBytes();
+        Resource mainJarResource = ks.getResources().newByteArrayResource(mainBinary);
+
+        // cleanup
+        ks.getRepository().removeKieModule(releaseIdMain);
+        ks.getRepository().removeKieModule(releaseIdDep);
+
+        ks.getRepository().addKieModule(mainJarResource, depJarResource);
+
+        KieContainerImpl kieContainer;
+        if (projectClassLoader == null) {
+            kieContainer = (KieContainerImpl) ks.newKieContainer(releaseIdMain);
+        } else {
+            kieContainer = (KieContainerImpl) ks.newKieContainer(releaseIdMain, projectClassLoader);
+        }
+
+        CanonicalKieModule mainLoadedModule = (CanonicalKieModule) kieContainer.getKieModuleForKBase("main");
+
+        KieBase kbase = kieContainer.getKieBase();
+
+        Set<String> mainGeneratedClassNames = mainLoadedModule.getGeneratedClassNames();
+        assertGeneratedClassNamesWithDep(mainGeneratedClassNames);
+
+        KieSession ksession = kbase.newKieSession();
+        ksession.insert(new Person("Mario"));
+        ksession.insert(new Person("Luca"));
+        int fired = ksession.fireAllRules();
+        assertEquals(2, fired);
+        ksession.dispose();
+    }
+
+    private void assertGeneratedClassNamesWithDep(Set<String> generatedClassNames) {
+        assertNotNull(generatedClassNames);
+        String[] nameFragments = new String[]{"Rules", "LambdaConsequence", "LambdaPredicate", "LambdaExtractor", "DomainClassesMetadata", "$"};
+        for (String nameFragment : nameFragments) {
+            boolean containsDep = false;
+            boolean containsMain = false;
+            for (String generatedClassName : generatedClassNames) {
+                if (generatedClassName.contains(nameFragment)) {
+                    if (generatedClassName.startsWith("org.example.dep")) {
+                        containsDep = true;
+                    } else if (generatedClassName.startsWith("org.example.main"))
+                        containsMain = true;
+                }
+            }
+            if (!containsDep) {
+                fail("generatedClassNames doesn't contain [" + nameFragment + "] class for dep. : " + generatedClassNames);
+            }
+            if (!containsMain) {
+                fail("generatedClassNames doesn't contain [" + nameFragment + "] class for main. : " + generatedClassNames);
+            }
+        }
+    }
+
+    @Test
+    public void testKjarWithoutGeneratedClassNames() {
+        // Build a kjar without generated-class-names file (= simulating a build by old drools version)
+
+        ProjectClassLoaderTestUtil.setEnableStoreFirst(false);
+
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R when\n" +
+                     "  $p : Person(name == \"Mario\")\n" +
+                     "then\n" +
+                     "  System.out.println(\"hello\");\n" +
+                     "end";
+
+        KieServices ks = KieServices.get();
+        ReleaseId releaseId = ks.newReleaseId("org.kie", "kjar-test-" + UUID.randomUUID(), "1.0");
+
+        KieBuilder kieBuilder = createKieBuilder(ks, null, releaseId, toKieFiles(new String[]{str}));
+
+        final InternalKieModule kieModule = (InternalKieModule) kieBuilder.getKieModule();
+        byte[] kjar = kieModule.getBytes();
+        Resource kjarResource = ks.getResources().newByteArrayResource(kjar);
+
+        // cleanup
+        ks.getRepository().removeKieModule(releaseId);
+
+        // Load the kjar with the current drools version
+        ProjectClassLoaderTestUtil.setEnableStoreFirst(true);
+
+        ks.getRepository().addKieModule(kjarResource);
+        KieContainer kcontainer = ks.newKieContainer(releaseId);
+
+        KieModule kieModule2 = ((KieContainerImpl) kcontainer).getKieModuleForKBase("defaultKieBase");
+
+        assertTrue(kieModule2 instanceof CanonicalKieModule);
+
+        KieSession ksession = kcontainer.newKieSession();
+
+        Set<String> generatedClassNames = ((CanonicalKieModule) kieModule2).getGeneratedClassNames();
+        assertTrue(generatedClassNames.isEmpty());
+
+        Person me = new Person("Mario", 40);
+        ksession.insert(me);
+        int fired = ksession.fireAllRules();
+
+        assertEquals(1, fired);
+    }
+
+}

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/reflective/classloader/ProjectClassLoaderTestUtil.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/reflective/classloader/ProjectClassLoaderTestUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.reflective.classloader;
+
+public class ProjectClassLoaderTestUtil {
+
+    public static void setEnableStoreFirst(boolean enableStoreFirst) {
+        ProjectClassLoader.setEnableStoreFirst(enableStoreFirst);
+    }
+}


### PR DESCRIPTION
- Avoid parent classloader
- only exec-model generated classes skip parent classloader
- add generated-class-names file
- ENABLE switch
- Collect generated class names of dependencies

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6053

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
