### PR TITLE
DROOLS-6193 : Subnetwork Optimization - DO NOT MERGE YET

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/BaseNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/BaseNode.java
@@ -128,7 +128,9 @@ public abstract class BaseNode
      * Attaches the node into the network. Usually to the parent <code>ObjectSource</code> or <code>TupleSource</code>
      */
     public void attach(BuildContext context) {
+        // do common shared code here, so it executes for all nodes
         doAttach(context);
+        // do common shared code here, so it executes for all nodes
     }
 
     public void doAttach(BuildContext context) {

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakFromNode.java
@@ -40,13 +40,6 @@ import org.drools.core.util.LinkedList;
 
 import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
 
-/**
-* Created with IntelliJ IDEA.
-* User: mdproctor
-* Date: 03/05/2013
-* Time: 15:43
-* To change this template use File | Settings | File Templates.
-*/
 public class PhreakFromNode {
     public void doNode(FromNode fromNode,
                        FromMemory fm,

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakGroupByNode.java
@@ -105,7 +105,7 @@ public class PhreakGroupByNode extends PhreakAccumulateNode {
                     RightTuple         rightTuple  = childMatch.getRightParent();
                     InternalFactHandle childHandle = rightTuple.getFactHandle();
                     LeftTuple          tuple       = leftTuple;
-                    if (accNode.isUnwrapRightObject()) {
+                    if (accNode.isRightInputIsRiaNode()) {
                         // if there is a subnetwork, handle must be unwrapped
                         tuple = (LeftTuple) rightTuple;
                         childHandle = rightTuple.getFactHandleForEvaluation();

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakJoinNode.java
@@ -456,6 +456,7 @@ public class PhreakJoinNode {
             switch ( childLeftTuple.getStagedType() ) {
                 // handle clash with already staged entries
                 case LeftTuple.INSERT:
+                    // Was insert before, should continue as insert
                     stagedLeftTuples.removeInsert( childLeftTuple );
                     trgLeftTuples.addInsert( childLeftTuple );
                     break;
@@ -464,6 +465,7 @@ public class PhreakJoinNode {
                     trgLeftTuples.addUpdate( childLeftTuple );
                     break;
                 default:
+                    // no clash, so just add
                     trgLeftTuples.addUpdate( childLeftTuple );
             }
         }

--- a/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/PhreakSubnetworkNotExistsNode.java
@@ -1,0 +1,183 @@
+package org.drools.core.phreak;
+
+import org.drools.core.common.TupleSets;
+import org.drools.core.reteoo.BetaMemory;
+import org.drools.core.reteoo.BetaNode;
+import org.drools.core.reteoo.LeftTuple;
+import org.drools.core.reteoo.LeftTupleSink;
+import org.drools.core.reteoo.NodeTypeEnums;
+import org.drools.core.reteoo.RightTuple;
+import org.drools.core.reteoo.SubnetworkTuple;
+import org.drools.core.reteoo.TupleMemory;
+import org.drools.core.spi.Tuple;
+import org.drools.core.util.index.TupleList;
+
+import static org.drools.core.phreak.PhreakJoinNode.updateChildLeftTuple;
+
+public class PhreakSubnetworkNotExistsNode {
+    public static void doSubNetworkNode(BetaNode node,
+                                        LeftTupleSink sink,
+                                        BetaMemory bm,
+                                        TupleSets<LeftTuple> srcLeftTuples,
+                                        TupleSets<LeftTuple> trgLeftTuples,
+                                        TupleSets<LeftTuple> stagedLeftTuples) {
+
+        TupleSets<RightTuple> srcRightTuples = bm.getStagedRightTuples().takeAll();
+
+        TupleMemory ltm                = bm.getLeftTupleMemory();
+        boolean     tupleMemoryEnabled = node.isLeftTupleMemoryEnabled();
+
+        deleteLeft(srcLeftTuples, trgLeftTuples, stagedLeftTuples, ltm);
+
+        insertRight(node, sink, trgLeftTuples, stagedLeftTuples, srcRightTuples, tupleMemoryEnabled);
+
+        insertLeft(node, sink, srcLeftTuples, trgLeftTuples, ltm, tupleMemoryEnabled);
+
+        updateRight(srcRightTuples);
+
+        deleteRight(node, sink, trgLeftTuples, stagedLeftTuples, srcRightTuples);
+
+        updateLeft(srcLeftTuples, trgLeftTuples, stagedLeftTuples, ltm);
+
+        srcRightTuples.resetAll();
+        srcLeftTuples.resetAll();
+    }
+
+    private static void updateLeft(TupleSets<LeftTuple> srcLeftTuples, TupleSets<LeftTuple> trgLeftTuples, TupleSets<LeftTuple> stagedLeftTuples, TupleMemory ltm) {
+        for (LeftTuple leftTuple = srcLeftTuples.getUpdateFirst(); leftTuple != null; ) {
+            LeftTuple next = leftTuple.getStagedNext();
+
+            LeftTuple childLeftTuple = leftTuple.getFirstChild();
+
+            if (!leftTuple.isExpired()  &&
+                childLeftTuple != null && // Not/Exists nodes only have one child
+                childLeftTuple.getStagedType() == Tuple.NONE) {  // only apply if not already staged
+                childLeftTuple.setPropagationContext(leftTuple.getPropagationContext());
+                // By adding the child now, it avoid iterating again to find all leftTuples that have no matches
+                updateChildLeftTuple(childLeftTuple, stagedLeftTuples, trgLeftTuples);
+            }
+
+            leftTuple.clearStaged();
+            leftTuple = next;
+        }
+    }
+
+    private static void deleteRight(BetaNode node, LeftTupleSink sink, TupleSets<LeftTuple> trgLeftTuples, TupleSets<LeftTuple> stagedLeftTuples, TupleSets<RightTuple> srcRightTuples) {
+        if (srcRightTuples.getDeleteFirst() != null) {
+            // must come last, to avoid staging something for propagation that is then unstaged
+            for (RightTuple rightTuple = srcRightTuples.getDeleteFirst(); rightTuple != null; ) {
+                RightTuple next = rightTuple.getStagedNext();
+
+                LeftTuple leftTuple = node.getStartTuple((SubnetworkTuple)rightTuple);
+                // don't use matches here, as it may be null, if the LT was also being removed.
+                rightTuple.getMemory().remove(rightTuple);
+
+                TupleList<RightTuple> matches = (TupleList<RightTuple>) leftTuple.getContextObject();
+                if (matches != null && matches.isEmpty()) { // matches is null, if LT was deleted too
+                    // Not/Exists nodes only have one child
+                    if (node.getType() == NodeTypeEnums.ExistsNode) {
+                        LeftTuple childLeftTuple = leftTuple.getFirstChild();
+                        childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
+                        RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+                    } else if (!leftTuple.isExpired()) { // else !exists
+                        trgLeftTuples.addInsert(sink.createLeftTuple(leftTuple, sink, leftTuple.getPropagationContext(), true));
+                    }
+                }
+                rightTuple.clearStaged();
+                rightTuple = next;
+            }
+        }
+    }
+
+    private static void updateRight(TupleSets<RightTuple> srcRightTuples) {
+        if (srcRightTuples.getUpdateFirst() != null) {
+            // Does nothing. It was here before, here now, so over all state does not change.
+            for (RightTuple rightTuple = srcRightTuples.getUpdateFirst(); rightTuple != null; ) {
+                RightTuple next = rightTuple.getStagedNext();
+                rightTuple.clearStaged();
+                rightTuple = next;
+            }
+        }
+    }
+
+    private static void insertLeft(BetaNode node, LeftTupleSink sink, TupleSets<LeftTuple> srcLeftTuples, TupleSets<LeftTuple> trgLeftTuples, TupleMemory ltm, boolean tupleMemoryEnabled) {
+        for (LeftTuple leftTuple = srcLeftTuples.getInsertFirst(); leftTuple != null; ) {
+            LeftTuple next = leftTuple.getStagedNext();
+
+            boolean useTupleMemory = tupleMemoryEnabled || RuleNetworkEvaluator.useLeftMemory(node, leftTuple);
+            // Do not need to init tupleList for matches, as this is done on right inserts.
+            if (useTupleMemory) {
+                ltm.add(leftTuple);
+            }
+
+            if (node.getType() == NodeTypeEnums.NotNode) {
+                // It's a not node, to check if there was no matches, and if so create and propagate the child lt
+                TupleList<RightTuple> matches = (TupleList<RightTuple>) leftTuple.getContextObject();
+                if (matches == null && !leftTuple.isExpired()) {
+                    // By adding the child now, it avoid iterating again to find all leftTuples that have no matches
+                    trgLeftTuples.addInsert(sink.createLeftTuple(leftTuple, sink, leftTuple.getPropagationContext(), useTupleMemory));
+                }
+            }
+
+            leftTuple.clearStaged();
+            leftTuple = next;
+        }
+    }
+
+    private static void insertRight(BetaNode node, LeftTupleSink sink, TupleSets<LeftTuple> trgLeftTuples, TupleSets<LeftTuple> stagedLeftTuples, TupleSets<RightTuple> srcRightTuples, boolean tupleMemoryEnabled) {
+        if (srcRightTuples.getInsertFirst() != null) {
+            // this must come before left insert, so 'not' knows if there are matches or not before creating the child lt
+            for (RightTuple rightTuple = srcRightTuples.getInsertFirst(); rightTuple != null; ) {
+                RightTuple next = rightTuple.getStagedNext();
+
+                LeftTuple leftTuple = node.getStartTuple((SubnetworkTuple)rightTuple);
+                TupleList<RightTuple> matches = (TupleList<RightTuple>) leftTuple.getContextObject();
+                if (matches == null) { // even if there is no tuple memory, we still need to know if there are matches or not, in later code
+                    matches = new TupleList<>();
+                    leftTuple.setContextObject(matches);
+                }
+                matches.add(rightTuple);
+
+                if (matches.size() == 1) {
+                    // first match was added, so create or delete child
+                    // Not/Exists nodes only have one child
+                    if (node.getType() == NodeTypeEnums.ExistsNode) {
+                        if (!leftTuple.isExpired()) {
+                            boolean useTupleMemory = tupleMemoryEnabled || RuleNetworkEvaluator.useLeftMemory(node, rightTuple);
+                            trgLeftTuples.addInsert(sink.createLeftTuple(leftTuple, sink, leftTuple.getPropagationContext(), useTupleMemory));
+                        }
+                    } else { // else !exists
+                        LeftTuple childLeftTuple = leftTuple.getFirstChild();
+                        if (childLeftTuple != null) { // this can be null if the LT is not yet added
+                            childLeftTuple.setPropagationContext(rightTuple.getPropagationContext());
+                            RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+                        }
+                    }
+                }
+
+                rightTuple.clearStaged();
+                rightTuple = next;
+            }
+        }
+    }
+
+    private static void deleteLeft(TupleSets<LeftTuple> srcLeftTuples, TupleSets<LeftTuple> trgLeftTuples, TupleSets<LeftTuple> stagedLeftTuples, TupleMemory ltm) {
+        if (srcLeftTuples.getDeleteFirst() != null) {
+            for (LeftTuple leftTuple = srcLeftTuples.getDeleteFirst(); leftTuple != null; ) {
+                LeftTuple next = leftTuple.getStagedNext();
+                if (leftTuple.getMemory() != null) {
+                    ltm.remove(leftTuple);
+                }
+                LeftTuple childLeftTuple = leftTuple.getFirstChild();
+                if (childLeftTuple != null) {
+                    childLeftTuple.setPropagationContext(leftTuple.getPropagationContext());
+                    RuleNetworkEvaluator.unlinkAndDeleteChildLeftTuple(childLeftTuple, trgLeftTuples, stagedLeftTuples);
+                }
+
+                leftTuple.setContextObject(null); // this is now right delete knows the LT is also being removed
+                leftTuple.clearStaged();
+                leftTuple = next;
+            }
+        }
+    }
+}

--- a/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/RuleNetworkEvaluator.java
@@ -942,11 +942,11 @@ public class RuleNetworkEvaluator {
         }
     }
 
-    public static boolean useLeftMemory(LeftTupleSource tupleSource, Tuple leftTuple) {
+    public static boolean useLeftMemory(LeftTupleSource tupleSource, Tuple tuple) {
         boolean useLeftMemory = true;
         if (!tupleSource.isLeftTupleMemoryEnabled()) {
             // This is a hack, to not add closed DroolsQuery objects
-            Object object = leftTuple.getRootTuple().getFactHandle().getObject();
+            Object object = tuple.getRootTuple().getFactHandle().getObject();
             if (!(object instanceof DroolsQuery) || !((DroolsQuery) object).isOpen()) {
                 useLeftMemory = false;
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AccumulateNode.java
@@ -45,6 +45,7 @@ import org.drools.core.spi.ObjectType;
 import org.drools.core.spi.PropagationContext;
 import org.drools.core.spi.Tuple;
 import org.drools.core.util.AbstractBaseLinkedListNode;
+import org.drools.core.util.FastIterator;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.index.TupleList;
 
@@ -60,7 +61,6 @@ public class AccumulateNode extends BetaNode {
 
     private static final long          serialVersionUID = 510l;
 
-    protected boolean                    unwrapRightObject;
     protected Accumulate                 accumulate;
     protected AlphaNodeFieldConstraint[] resultConstraints;
     protected BetaConstraints            resultBinder;
@@ -75,7 +75,6 @@ public class AccumulateNode extends BetaNode {
                           final BetaConstraints sourceBinder,
                           final BetaConstraints resultBinder,
                           final Accumulate accumulate,
-                          final boolean unwrapRightObject,
                           final BuildContext context) {
         super( id,
                leftInput,
@@ -87,7 +86,6 @@ public class AccumulateNode extends BetaNode {
         this.resultBinder.init( context, getType() );
         this.resultConstraints = resultConstraints;
         this.accumulate = accumulate;
-        this.unwrapRightObject = unwrapRightObject;
         this.tupleMemoryEnabled = context.isTupleMemoryEnabled();
 
         addAccFunctionDeclarationsToLeftMask( context.getKnowledgeBase(), leftInput, accumulate );
@@ -127,7 +125,6 @@ public class AccumulateNode extends BetaNode {
     public void readExternal( ObjectInput in ) throws IOException,
                                               ClassNotFoundException {
         super.readExternal( in );
-        unwrapRightObject = in.readBoolean();
         accumulate = (Accumulate) in.readObject();
         resultConstraints = (AlphaNodeFieldConstraint[]) in.readObject();
         resultBinder = (BetaConstraints) in.readObject();
@@ -135,7 +132,6 @@ public class AccumulateNode extends BetaNode {
 
     public void writeExternal( ObjectOutput out ) throws IOException {
         super.writeExternal( out );
-        out.writeBoolean( unwrapRightObject );
         out.writeObject( accumulate );
         out.writeObject( resultConstraints );
         out.writeObject( resultBinder );
@@ -155,10 +151,6 @@ public class AccumulateNode extends BetaNode {
 
     public BetaConstraints getResultBinder() {
         return resultBinder;
-    }
-
-    public boolean isUnwrapRightObject() {
-        return unwrapRightObject;
     }
 
     public InternalFactHandle createResultFactHandle(final PropagationContext context,

--- a/drools-core/src/main/java/org/drools/core/reteoo/BaseLeftTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BaseLeftTuple.java
@@ -67,13 +67,14 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             factHandle.addTupleInPosition( this );
         }
     }
-    
+
     public BaseLeftTuple(InternalFactHandle factHandle,
                          LeftTuple leftTuple,
                          Sink sink) {
         setFactHandle( factHandle );
         this.index = leftTuple.getIndex() + 1;
         this.parent = leftTuple.getNextParentWithHandle();
+        this.leftParent = leftTuple;
         this.sink = sink;
     }
 
@@ -83,10 +84,10 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
                          boolean leftTupleMemoryEnabled) {
         this.index = leftTuple.getIndex() + 1;
         this.parent = leftTuple.getNextParentWithHandle();
+        this.leftParent = leftTuple;
         setPropagationContext( pctx );
 
         if ( leftTupleMemoryEnabled ) {
-            this.leftParent = leftTuple;
             if ( leftTuple.getLastChild() != null ) {
                 this.handlePrevious = leftTuple.getLastChild();
                 this.handlePrevious.setHandleNext( this );
@@ -95,19 +96,21 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             }
             leftTuple.setLastChild( this );
         }
-        
+
         this.sink = sink;
     }
-    
+
     public BaseLeftTuple(LeftTuple leftTuple,
                          RightTuple rightTuple,
                          Sink sink) {
         this.index = leftTuple.getIndex() + 1;
         this.parent = leftTuple.getNextParentWithHandle();
+        this.leftParent = leftTuple;
+        this.rightParent = rightTuple;
+
         setFactHandle( rightTuple.getFactHandle() );
         setPropagationContext( rightTuple.getPropagationContext() );
 
-        this.leftParent = leftTuple;
         // insert at the end f the list
         if ( leftTuple.getLastChild() != null ) {
             this.handlePrevious = leftTuple.getLastChild();
@@ -116,9 +119,8 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             leftTuple.setFirstChild( this );
         }
         leftTuple.setLastChild( this );
-        
+
         // insert at the end of the list
-        this.rightParent = rightTuple;
         if ( rightTuple.getLastChild() != null ) {
             this.rightParentPrevious = rightTuple.getLastChild();
             this.rightParentPrevious.setRightParentNext( this );
@@ -127,7 +129,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
         }
         rightTuple.setLastChild( this );
         this.sink = sink;
-    }    
+    }
 
     public BaseLeftTuple(LeftTuple leftTuple,
                          RightTuple rightTuple,
@@ -140,7 +142,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
               sink,
               leftTupleMemoryEnabled );
     }
-    
+
     public BaseLeftTuple(LeftTuple leftTuple,
                          RightTuple rightTuple,
                          LeftTuple currentLeftChild,
@@ -150,13 +152,13 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
         setFactHandle( rightTuple.getFactHandle() );
         this.index = leftTuple.getIndex() + 1;
         this.parent = leftTuple.getNextParentWithHandle();
+        this.leftParent = leftTuple;
+        this.rightParent = rightTuple;
         setPropagationContext( rightTuple.getPropagationContext() );
 
         if ( leftTupleMemoryEnabled ) {
-            this.leftParent = leftTuple;
-            this.rightParent = rightTuple;
             if( currentLeftChild == null ) {
-                // insert at the end of the list 
+                // insert at the end of the list
                 if ( leftTuple.getLastChild() != null ) {
                     this.handlePrevious = leftTuple.getLastChild();
                     this.handlePrevious.setHandleNext( this );
@@ -175,7 +177,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
                     this.handlePrevious.setHandleNext( this );
                 }
             }
-            
+
             if( currentRightChild == null ) {
                 // insert at the end of the list
                 if ( rightTuple.getLastChild() != null ) {
@@ -197,7 +199,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
                 }
             }
         }
-        
+
         this.sink = sink;
     }
 
@@ -206,7 +208,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
         // if parent is null, then we are LIAN
         return (handle!=null) ? this : parent != null ? parent.getNextParentWithHandle() : this;
     }
-    
+
     @Override
     public void reAdd() {
         getFactHandle().addLastLeftTuple( this );
@@ -238,7 +240,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
 
     @Override
     public void reAddRight() {
-        // make sure we aren't already at the end        
+        // make sure we aren't already at the end
         if ( this.rightParentNext != null ) {
             if ( this.rightParentPrevious != null ) {
                 // remove the current LeftTuple from the middle of the chain
@@ -251,7 +253,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
                 }
                 this.rightParentNext.setRightParentPrevious( null );
             }
-            // re-add to end            
+            // re-add to end
             this.rightParentPrevious = this.rightParent.getLastChild();
             this.rightParentPrevious.setRightParentNext( this );
             this.rightParent.setLastChild( this );
@@ -297,7 +299,6 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             }
         }
 
-        this.leftParent = null;
         this.handlePrevious = null;
         this.handleNext = null;
     }
@@ -308,7 +309,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             // no right parent;
             return;
         }
-        
+
         LeftTuple previousParent = this.rightParentPrevious;
         LeftTuple nextParent = this.rightParentNext;
 
@@ -321,7 +322,7 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             this.rightParent.setFirstChild( nextParent );
             nextParent.setRightParentPrevious( null );
         } else if ( previousParent != null ) {
-            // remove from end     
+            // remove from end
             this.rightParent.setLastChild( previousParent );
             previousParent.setRightParentNext( null );
         } else {
@@ -330,7 +331,6 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
             this.rightParent.setLastChild( null );
         }
 
-        this.rightParent = null;
         this.rightParentPrevious = null;
         this.rightParentNext = null;
     }
@@ -344,8 +344,8 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
     public LeftTupleSink getTupleSink() {
         return (LeftTupleSink)sink;
     }
-    
-    /* Had to add the set method because sink adapters must override 
+
+    /* Had to add the set method because sink adapters must override
      * the tuple sink set when the tuple was created.
      */
     @Override
@@ -625,12 +625,13 @@ public class BaseLeftTuple extends BaseTuple implements LeftTuple {
     public void clear() {
         super.clear();
         this.memory = null;
-    }   
-    
+    }
+
     public void initPeer(BaseLeftTuple original, LeftTupleSink sink) {
         this.index = original.index;
         this.parent = original.parent;
-        
+        this.leftParent = original.leftParent;
+
         setFactHandle( original.getFactHandle() );
         setPropagationContext( original.getPropagationContext() );
         this.sink = sink;

--- a/drools-core/src/main/java/org/drools/core/reteoo/BaseTuple.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/BaseTuple.java
@@ -152,13 +152,17 @@ public abstract class BaseTuple implements Tuple {
     }
 
     @Override
-    public Tuple getRootTuple() {
-        Tuple tuple = this;
-
-        while (tuple.getParent() != null ) {
-            tuple = tuple.getParent();
+    public Tuple getTuple(int index) {
+        Tuple entry = this;
+        while ( entry.getIndex() != index) {
+            entry = entry.getParent();
         }
-        return tuple;
+        return entry;
+    }
+
+    @Override
+    public Tuple getRootTuple() {
+        return getTuple(0);
     }
 
     @Override

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -205,15 +205,28 @@ public class LeftInputAdapterNode extends LeftTupleSource
         LeftTupleSink sink = liaNode.getSinkPropagator().getFirstLeftTupleSink();
         LeftTuple leftTuple = sink.createLeftTuple( factHandle, useLeftMemory );
         leftTuple.setPropagationContext( context );
-        doInsertSegmentMemory( wm, notifySegment, lm, sm, leftTuple, liaNode.isStreamMode() );
 
-        if ( sm.getRootNode() != liaNode ) {
+        if ( sm.getRootNode() == liaNode ) {
+            doInsertSegmentMemory( wm, notifySegment, lm, sm, leftTuple, liaNode.isStreamMode() );
+        } else {
             // sm points to lia child sm, so iterate for all remaining children
-
+            // all peer tuples must be created before propagation, or eager evaluation subnetworks have problem
+            LeftTuple peer = leftTuple;
+            SegmentMemory originaSm = sm;
             for ( sm = sm.getNext(); sm != null; sm = sm.getNext() ) {
                 sink =  sm.getSinkFactory();
-                leftTuple = sink.createPeer( leftTuple ); // pctx is set during peer cloning
-                doInsertSegmentMemory( wm, notifySegment, lm, sm, leftTuple, liaNode.isStreamMode() );
+                peer = sink.createPeer( peer ); // pctx is set during peer cloning
+            }
+
+            sm = originaSm;
+            doInsertSegmentMemory( wm, notifySegment, lm, sm, leftTuple, liaNode.isStreamMode() );
+            if ( sm.getRootNode() != liaNode ) {
+                // sm points to lia child sm, so iterate for all remaining children
+                peer = leftTuple;
+                for ( sm = sm.getNext(); sm != null; sm = sm.getNext() ) {
+                    peer = peer.getPeer();
+                    doInsertSegmentMemory( wm, notifySegment, lm, sm, peer, liaNode.isStreamMode() );
+                }
             }
         }
     }
@@ -313,25 +326,24 @@ public class LeftInputAdapterNode extends LeftTupleSource
             sm = sm.getFirst(); // repoint to the child sm
         }
 
-        TupleSets<LeftTuple> leftTuples = sm.getStagedLeftTuples();
-
-        doUpdateSegmentMemory(leftTuple, context, wm, linkOrNotify, lm, leftTuples, sm, liaNode.isStreamMode() );
+        doUpdateSegmentMemory(leftTuple, context, wm, linkOrNotify, lm, sm, liaNode.isStreamMode() );
 
         if (  sm.getNext() != null ) {
             // sm points to lia child sm, so iterate for all remaining children
             for ( sm = sm.getNext(); sm != null; sm = sm.getNext() ) {
                 // iterate for peers segment memory
                 leftTuple = leftTuple.getPeer();
-                leftTuples = sm.getStagedLeftTuples();
 
-                doUpdateSegmentMemory(leftTuple, context, wm, linkOrNotify, lm, leftTuples, sm, liaNode.isStreamMode() );
+                doUpdateSegmentMemory(leftTuple, context, wm, linkOrNotify, lm, sm, liaNode.isStreamMode() );
             }
         }
     }
 
     private static void doUpdateSegmentMemory( LeftTuple leftTuple, PropagationContext pctx, InternalWorkingMemory wm, boolean linkOrNotify,
-                                               final LiaNodeMemory lm, TupleSets<LeftTuple> leftTuples, SegmentMemory sm, boolean streamMode ) {
+                                               final LiaNodeMemory lm, SegmentMemory sm, boolean streamMode ) {
         leftTuple.setPropagationContext( pctx );
+        TupleSets<LeftTuple> leftTuples = sm.getStagedLeftTuples();
+
         if ( leftTuple.getStagedType() == LeftTuple.NONE ) {
             if ( flushLeftTupleIfNecessary( wm, sm, leftTuple, streamMode, Tuple.UPDATE ) ) {
                 if ( linkOrNotify ) {

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/AccumulateBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/AccumulateBuilder.java
@@ -17,7 +17,6 @@
 package org.drools.core.reteoo.builder;
 
 import org.drools.core.common.BetaConstraints;
-import org.drools.core.common.TupleStartEqualsConstraint;
 import org.drools.core.reteoo.AccumulateNode;
 import org.drools.core.reteoo.LeftTupleSource;
 import org.drools.core.reteoo.RightInputAdapterNode;
@@ -41,7 +40,6 @@ public class AccumulateBuilder
                       final BuildUtils utils,
                       final RuleConditionElement rce) {
         final Accumulate accumulate = (Accumulate) rce;
-        boolean existSubNetwort = false;
         context.pushRuleComponent( accumulate );
 
         final List<BetaNodeFieldConstraint> resultBetaConstraints = context.getBetaconstraints();
@@ -81,11 +79,8 @@ public class AccumulateBuilder
             context.setTupleSource( tupleSource );
 
             // create a tuple start equals constraint and set it in the context
-            final TupleStartEqualsConstraint constraint = TupleStartEqualsConstraint.getInstance();
-            final List<BetaNodeFieldConstraint> betaConstraints = new ArrayList<BetaNodeFieldConstraint>();
-            betaConstraints.add( constraint );
-            context.setBetaconstraints( betaConstraints );
-            existSubNetwort = true;
+            final List<BetaNodeFieldConstraint> betaConstraints = new ArrayList<>();
+            context.setBetaconstraints( betaConstraints ); // Empty list ensures EmptyBetaConstraints is assigned
         }
 
         NodeFactory nfactory = context.getComponentFactory().getNodeFactoryService();
@@ -104,7 +99,6 @@ public class AccumulateBuilder
                                                               sourceBinder,
                                                               resultsBinder,
                                                               accumulate,
-                                                              existSubNetwort,
                                                               context);
 
         context.setTupleSource( utils.attachNode( context, accNode ) );

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/CollectBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/CollectBuilder.java
@@ -107,7 +107,6 @@ public class CollectBuilder
                                                                                                             binder, // source binder
                                                                                                             resultBinder,
                                                                                                             accumulate,
-                                                                                                            existSubNetwort,
                                                                                                             context );
         context.setTupleSource( utils.attachNode( context, accNode ) );
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/GroupElementBuilder.java
@@ -228,7 +228,6 @@ public class GroupElementBuilder
         public void build(final BuildContext context,
                           final BuildUtils utils,
                           final RuleConditionElement rce) {
-            boolean existSubNetwort = false;
             final GroupElement not = (GroupElement) rce;
 
             final LeftTupleSource tupleSource = context.getTupleSource();
@@ -262,8 +261,6 @@ public class GroupElementBuilder
                 final List<BetaNodeFieldConstraint> predicates = new ArrayList<BetaNodeFieldConstraint>();
                 predicates.add( constraint );
                 context.setBetaconstraints( predicates );
-                existSubNetwort = true;
-
             }
 
             NodeFactory nfactory = context.getComponentFactory().getNodeFactoryService();
@@ -276,11 +273,11 @@ public class GroupElementBuilder
             // in each case
 
 
-            NotNode node = context.getComponentFactory().getNodeFactoryService().buildNotNode( context.getNextId(),
-                                                                                               context.getTupleSource(),
-                                                                                               context.getObjectSource(),
-                                                                                               betaConstraints,
-                                                                                               context );
+            NotNode node = nfactory.buildNotNode( context.getNextId(),
+                                                  context.getTupleSource(),
+                                                  context.getObjectSource(),
+                                                  betaConstraints,
+                                                  context );
 
             node.setEmptyBetaConstraints( context.getBetaconstraints().isEmpty() );
 
@@ -310,7 +307,6 @@ public class GroupElementBuilder
         public void build(final BuildContext context,
                           final BuildUtils utils,
                           final RuleConditionElement rce) {
-            boolean existSubNetwort = false;
             final GroupElement exists = (GroupElement) rce;
 
             final LeftTupleSource tupleSource = context.getTupleSource();
@@ -339,13 +335,9 @@ public class GroupElementBuilder
                 // restore tuple source from before the start of the sub network
                 context.setTupleSource( tupleSource );
 
-                // create a tuple start equals constraint and set it in the context
-                final TupleStartEqualsConstraint constraint = TupleStartEqualsConstraint.getInstance();
-                final List<BetaNodeFieldConstraint> predicates = new ArrayList<BetaNodeFieldConstraint>();
-                predicates.add( constraint );
-                context.setBetaconstraints( predicates );
-                existSubNetwort = true;
 
+                final List<BetaNodeFieldConstraint> betaConstraints = new ArrayList<>();
+                context.setBetaconstraints( betaConstraints ); // Empty list ensures EmptyBetaConstraints is assigned
             }
 
             NodeFactory nfactory = context.getComponentFactory().getNodeFactoryService();
@@ -354,11 +346,11 @@ public class GroupElementBuilder
                                                                                     context.getBetaconstraints(),
                                                                                     false );
 
-            ExistsNode node = context.getComponentFactory().getNodeFactoryService().buildExistsNode(context.getNextId(),
-                                                                                                    context.getTupleSource(),
-                                                                                                    context.getObjectSource(),
-                                                                                                    betaConstraints,
-                                                                                                    context);
+            ExistsNode node = nfactory.buildExistsNode(context.getNextId(),
+                                                       context.getTupleSource(),
+                                                       context.getObjectSource(),
+                                                       betaConstraints,
+                                                       context);
 
             // then attach the EXISTS node. It will work both as a simple exists node
             // or as subnetwork join node as the context was set appropriatelly

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/NodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/NodeFactory.java
@@ -119,15 +119,14 @@ public interface NodeFactory {
                                 BetaConstraints binder,
                                 BuildContext context );
 
-    AccumulateNode buildAccumulateNode( int id,
-                                        LeftTupleSource leftInput,
-                                        ObjectSource rightInput,
-                                        AlphaNodeFieldConstraint[] resultConstraints,
-                                        BetaConstraints sourceBinder,
-                                        BetaConstraints resultBinder,
-                                        Accumulate accumulate,
-                                        boolean unwrapRightObject,
-                                        BuildContext context );
+    AccumulateNode buildAccumulateNode(int id,
+                                       LeftTupleSource leftInput,
+                                       ObjectSource rightInput,
+                                       AlphaNodeFieldConstraint[] resultConstraints,
+                                       BetaConstraints sourceBinder,
+                                       BetaConstraints resultBinder,
+                                       Accumulate accumulate,
+                                       BuildContext context);
 
     LeftInputAdapterNode buildLeftInputAdapterNode( int nextId,
                                                     ObjectSource objectSource,

--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/PhreakNodeFactory.java
@@ -20,12 +20,9 @@ package org.drools.core.reteoo.builder;
 import java.io.Serializable;
 import java.util.List;
 
-import org.drools.core.base.ClassObjectType;
-import org.drools.core.base.ValueType;
 import org.drools.core.common.BetaConstraints;
 import org.drools.core.common.RuleBasePartitionId;
 import org.drools.core.definitions.rule.impl.RuleImpl;
-import org.drools.core.factmodel.traits.TraitProxy;
 import org.drools.core.reteoo.AccumulateNode;
 import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.AlphaTerminalNode;
@@ -50,7 +47,6 @@ import org.drools.core.reteoo.RightInputAdapterNode;
 import org.drools.core.reteoo.RuleTerminalNode;
 import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.TimerNode;
-import org.drools.core.reteoo.TraitProxyObjectTypeNode;
 import org.drools.core.reteoo.WindowNode;
 import org.drools.core.rule.Accumulate;
 import org.drools.core.rule.AsyncReceive;
@@ -121,8 +117,8 @@ public class PhreakNodeFactory implements NodeFactory, Serializable {
 
     public AccumulateNode buildAccumulateNode(int id, LeftTupleSource leftInput, ObjectSource rightInput,
                                               AlphaNodeFieldConstraint[] resultConstraints, BetaConstraints sourceBinder,
-                                              BetaConstraints resultBinder, Accumulate accumulate, boolean unwrapRightObject, BuildContext context ) {
-        return new AccumulateNode( id, leftInput, rightInput, resultConstraints, sourceBinder,resultBinder, accumulate, unwrapRightObject, context );
+                                              BetaConstraints resultBinder, Accumulate accumulate, BuildContext context) {
+        return new AccumulateNode(id, leftInput, rightInput, resultConstraints, sourceBinder, resultBinder, accumulate, context );
     }
 
     public LeftInputAdapterNode buildLeftInputAdapterNode( int id, ObjectSource objectSource, BuildContext context, boolean terminal ) {

--- a/drools-core/src/main/java/org/drools/core/spi/Tuple.java
+++ b/drools-core/src/main/java/org/drools/core/spi/Tuple.java
@@ -62,6 +62,13 @@ public interface Tuple extends Serializable, Entry<Tuple> {
     InternalFactHandle get(int pattern);
 
     /**
+     * Returns the tuple at the given index
+     * @param index
+     * @return
+     */
+    Tuple getTuple(int index);
+
+    /**
      * Returns the <code>FactHandle</code> for the given <code>Declaration</code>, which in turn
      * specifcy the <code>Pattern</code> that they depend on.
      *

--- a/drools-core/src/main/java/org/drools/core/util/FastIterator.java
+++ b/drools-core/src/main/java/org/drools/core/util/FastIterator.java
@@ -16,6 +16,18 @@
 package org.drools.core.util;
 
 public interface FastIterator {
+    public class NullFastIterator implements FastIterator {
+        public static final NullFastIterator INSTANCE = new NullFastIterator();
+
+        @Override public Entry next(Entry object) {
+            return null;
+        }
+
+        @Override public boolean isFullIterator() {
+            return true;
+        }
+    }
+
     Entry next(Entry object);
     
     boolean isFullIterator();

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -2006,13 +2006,17 @@ public class AccumulateTest extends BaseModelTest {
 
         ksession.insert(parent1);
         ksession.insert(parent2);
-        FactHandle toRemove = ksession.insert(child1);
+       FactHandle toRemove = ksession.insert(child1);
         ksession.insert(child2);
+        ksession.fireAllRules();
+        Assertions.assertThat(results)
+                  .containsOnly(Arrays.asList(child1, 2L), Arrays.asList(child2, 2L));
 
         // Remove child1, therefore it does not exist, therefore there should be no groupBy matches for the child.
+        results.clear();
         ksession.delete(toRemove);
 
-        // Yet, we still get (Child1, 0).
+        // Yet, we still get (Child2, 0).
         ksession.fireAllRules();
         Assertions.assertThat(results)
                 .containsOnly(Arrays.asList(child2, 1L));

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/BackwardChainingTest.java
@@ -2299,7 +2299,7 @@ public class BackwardChainingTest extends AbstractBackwardChainingTest {
             assertContains(new String[]{"crackers", "apple"}, food);
 
             assertEquals(2, accMemory.getBetaMemory().getRightTupleMemory().size());
-            assertEquals(2, existsMemory.getRightTupleMemory().size());
+            assertEquals(0, existsMemory.getRightTupleMemory().size()); // This is zero, as it's held directly on the LeftTuple context
             assertEquals(2, fromMemory.getBetaMemory().getLeftTupleMemory().size());
             assertEquals(0, notMemory.getRightTupleMemory().size());
 
@@ -2315,7 +2315,7 @@ public class BackwardChainingTest extends AbstractBackwardChainingTest {
             assertContains(new String[]{"crackers", "apple"}, food);
 
             assertEquals(2, accMemory.getBetaMemory().getRightTupleMemory().size());
-            assertEquals(2, existsMemory.getRightTupleMemory().size());
+            assertEquals(0, existsMemory.getRightTupleMemory().size());  // This is zero, as it's held directly on the LeftTuple context
             assertEquals(2, fromMemory.getBetaMemory().getLeftTupleMemory().size());
             assertEquals(0, notMemory.getRightTupleMemory().size());
             food.clear();
@@ -2326,9 +2326,10 @@ public class BackwardChainingTest extends AbstractBackwardChainingTest {
             ksession.fireAllRules();
 
             assertEquals(2, accMemory.getBetaMemory().getRightTupleMemory().size());
-            assertEquals(2, existsMemory.getRightTupleMemory().size());
+            assertEquals(1, existsMemory.getLeftTupleMemory().size());
+            assertEquals(0, existsMemory.getRightTupleMemory().size());  // This is zero, as it's held directly on the LeftTuple context
             assertEquals(2, fromMemory.getBetaMemory().getLeftTupleMemory().size());
-            assertEquals(1, notMemory.getRightTupleMemory().size());
+            assertEquals(0, notMemory.getRightTupleMemory().size());  // This is zero, as it's held directly on the LeftTuple context
 
             assertEquals(0, foodUpdated.size());
 
@@ -2338,7 +2339,8 @@ public class BackwardChainingTest extends AbstractBackwardChainingTest {
             ksession.fireAllRules();
 
             assertEquals(2, accMemory.getBetaMemory().getRightTupleMemory().size());
-            assertEquals(2, existsMemory.getRightTupleMemory().size());
+            assertEquals(1, existsMemory.getLeftTupleMemory().size());
+            assertEquals(0, existsMemory.getRightTupleMemory().size());  // This is zero, as it's held directly on the LeftTuple context
             assertEquals(2, fromMemory.getBetaMemory().getLeftTupleMemory().size());
             assertEquals(0, notMemory.getRightTupleMemory().size());
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SubnetworkTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.compiler.integrationtests;
 
+import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -31,6 +32,8 @@ import org.kie.api.KieBase;
 import org.kie.api.definition.type.Role;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.Agenda;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.api.runtime.rule.QueryResults;
 
 import static org.junit.Assert.assertEquals;
 
@@ -149,6 +152,125 @@ public class SubnetworkTest {
     }
 
     @Test(timeout = 10000)
+    public void testSubNeworkNotRemoveRightRemove() {
+        final String drl =
+              "import " + Dimension.class.getCanonicalName() + ";\n" +
+              "global java.util.List list;\n" +
+              "rule xR1y when\n" +
+              "    String(this == \"go\") \n" +
+              "    not(x : Dimension(x_height : height) and\n" +
+              "        y : Dimension(this!=x, height!=x_height))" +
+              "    eval(true)\n" +
+              "then\n" +
+              "    list.add(\"matched\"); \n" +
+              "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("subnetwork-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            final List<Number> list = new ArrayList<>();
+            kieSession.setGlobal("list", list);
+
+            kieSession.insert("go");
+            FactHandle fh1 = kieSession.insert(new Dimension(100, 100));
+            FactHandle fh2 = kieSession.insert(new Dimension(100, 200));
+            kieSession.fireAllRules();
+
+            kieSession.update(fh2, new Dimension(100, 100));
+            kieSession.fireAllRules();
+
+            assertEquals(1, list.size());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void testSubNeworkNotRemoveLeftRemove() {
+        final String drl =
+              "import " + Dimension.class.getCanonicalName() + ";\n" +
+              "global java.util.List list;\n" +
+              "rule xR1y when\n" +
+              "    String(this == \"go\") \n" +
+              "    not(x : Dimension(x_height : height) and\n" +
+              "        y : Dimension(this!=x, height!=x_height))" +
+              "    eval(true)\n" +
+              "then\n" +
+              "    list.add(\"matched\"); \n" +
+              "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("subnetwork-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            final List<Number> list = new ArrayList<>();
+            kieSession.setGlobal("list", list);
+
+            FactHandle fhg = kieSession.insert("go");
+            FactHandle fh1 = kieSession.insert(new Dimension(100, 100));
+            FactHandle fh2 = kieSession.insert(new Dimension(100, 200));
+            kieSession.fireAllRules();
+            assertEquals(0, list.size());
+            list.clear();;
+
+            kieSession.update(fh2, new Dimension(100, 100));
+            kieSession.delete(fhg);
+            kieSession.fireAllRules();
+            assertEquals(0, list.size());
+
+
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void testSubNeworkQueryTest() {
+        final String drl =
+              "import " + Dimension.class.getCanonicalName() + ";\n" +
+              "global java.util.List list;\n" +
+              "query q1(String s)\n" +
+              "    not(x : Dimension(x_height : height) and\n" +
+              "        y : Dimension(this!=x, height!=x_height))" +
+              "    eval(true)\n" +
+              "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("subnetwork-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            final List<Number> list = new ArrayList<>();
+            kieSession.setGlobal("list", list);
+
+            FactHandle fh1 = kieSession.insert(new Dimension(100, 100));
+            FactHandle fh2 = kieSession.insert(new Dimension(100, 200));
+            kieSession.fireAllRules();
+
+            QueryResults results = kieSession.getQueryResults("q1", "go");
+            assertEquals(0, results.size() );
+
+            kieSession.update(fh2, new Dimension(100, 100));
+            kieSession.fireAllRules();
+
+            results = kieSession.getQueryResults("q1", "go");
+            assertEquals(1, results.size() );
+
+            kieSession.update(fh1, new Dimension(100, 200));
+            kieSession.fireAllRules();
+
+            results = kieSession.getQueryResults("q1", "go");
+            assertEquals(0, results.size() );
+
+            kieSession.update(fh1, new Dimension(100, 100));
+            kieSession.fireAllRules();
+
+            results = kieSession.getQueryResults("q1", "go");
+            assertEquals(1, results.size() );
+
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test(timeout = 10000)
     public void testSubNetworks() {
         final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources("subnetwork-test", kieBaseTestConfiguration,
                                                                              "org/drools/compiler/integrationtests/test_SubNetworks.drl");
@@ -157,7 +279,7 @@ public class SubnetworkTest {
     }
 
     @Test(timeout = 10000)
-    public void testSubnetworkSharingWith2Sinks() {
+    public void testSubnetworkSharingWith2SinksFromLia() {
         // DROOLS-1656
         final String drl =
                 "import " + X.class.getCanonicalName() + "\n" +
@@ -215,6 +337,79 @@ public class SubnetworkTest {
         }
     }
 
+    @Test(timeout = 10000)
+    public void testSubnetworkSharingWith2SinksAfterLia() {
+        // DROOLS-1656
+        final String drl =
+              "import " + X.class.getCanonicalName() + "\n" +
+              "import " + Y.class.getCanonicalName() + "\n" +
+              "import " + Z.class.getCanonicalName() + "\n" +
+              "global java.util.List list" +
+              "\n" +
+              "rule R1 agenda-group \"G2\" when\n" +
+              "     Z( id == 1)" +
+              "     Z( id == 2)" +
+              "Number( intValue == 0 ) from accumulate (\n" +
+              "        X( $id : id )\n" +
+              "        and $y : Y( parentId == $id )\n" +
+              "    ;count($y))\n" +
+              "then\n" +
+              "    list.add(\"R1\");\n" +
+              "end\n" +
+              "\n" +
+              "rule R2 agenda-group \"G1\" when\n" +
+              "    Z( id == 1)" +
+              "    Z( id == 2)" +
+              "    Number( intValue < 1 ) from accumulate (\n" +
+              "        X( $id : id )\n" +
+              "        and $y : Y( parentId == $id )\n" +
+              "    ;count($y))\n" +
+              "then\n" +
+              "    list.add(\"R2\");\n" +
+              "end\n" +
+              "\n" +
+              "rule R3 agenda-group \"G1\" no-loop when\n" +
+              "    Z( id == 1)" +
+              "    Z( id == 2)" +
+              "    $x : X( $id : id )\n" +
+              "then\n" +
+              "    modify($x) { setId($id + 1) };\n" +
+              "end\n" +
+              "rule R4 agenda-group \"G1\" no-loop when\n" +
+              "    Z( id == 1)" +
+              "    Z( id == 2)" +
+              "    eval(true)\n" +
+              "then\n" +
+              "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("subnetwork-cep-test", kieBaseTestConfiguration, drl);
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            final List<String> list = new ArrayList<>();
+            kieSession.setGlobal("list", list);
+
+            kieSession.insert(new X(1));
+            kieSession.insert(new Y(1));
+            kieSession.insert(new Z(1));
+            kieSession.insert(new Z(2));
+
+            kieSession.insert(new X(3));
+            kieSession.insert(new Y(3));
+
+            final Agenda agenda = kieSession.getAgenda();
+            agenda.getAgendaGroup("G2").setFocus();
+            agenda.getAgendaGroup("G1").setFocus();
+
+            kieSession.fireAllRules();
+
+            assertEquals(2, list.size());
+            assertEquals("R2", list.get(0));
+            assertEquals("R1", list.get(1));
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
     public static class X {
 
         private int id;
@@ -242,6 +437,23 @@ public class SubnetworkTest {
 
         public int getParentId() {
             return parentId;
+        }
+    }
+
+    public static class Z {
+
+        private int id;
+
+        public Z(final int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(final int id) {
+            this.id = id;
         }
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/phreak/SegmentPropagationTest.java
@@ -128,27 +128,27 @@ public class SegmentPropagationTest {
         // @formatter:off
         test().left().insert( a0, a1 )
               .right().insert( b0, b1, b2 )
-              .preStaged(smem0).insert( )      
+              .preStaged(smem0).insert( )
                                .delete( )
                                .update( )
               .postStaged(smem0).insert( t(a1, b2),
-                                         t(a1, b0),                                         
+                                         t(a1, b0),
                                          t(a0, b2),
                                          t(a0, b1) )
                                 .delete( )
-                                .update( ) 
+                                .update( )
               .postStaged( smem1 ).insert( t(a0, b1),
                                            t(a0, b2),
                                            t(a1, b0),
                                            t(a1, b2) )
                                   .delete( )
-                                  .update( )                                        
+                                  .update( )
               .postStaged( smem2 ).insert( t(a0, b1),
                                            t(a0, b2),
                                            t(a1, b0),
-                                           t(a1, b2) )  
+                                           t(a1, b2) )
                                  .delete( )
-                                 .update( )                                        
+                                 .update( )
               .run();
         
         
@@ -156,7 +156,7 @@ public class SegmentPropagationTest {
               .preStaged(smem0).insert( t(a1, b2),
                                         t(a1, b0) )
                           .delete( )
-                          .update( ) 
+                          .update( )
               .postStaged(smem0).insert( t(a0, b2),
                                          t(a0, b1),
                                          t(a1, b2),
@@ -169,12 +169,12 @@ public class SegmentPropagationTest {
                                            t(a0, b2) )
                                   .delete( )
                                   .update( )
-                .postStaged( smem2 ).insert( t(a1, b0),
-                                             t(a1, b2),
-                                             t(a0, b1),
-                                             t(a0, b2) )
-                .delete( )
-                .update( )
+              .postStaged( smem2 ).insert( t(a1, b0),
+                                           t(a1, b2),
+                                           t(a0, b1),
+                                           t(a0, b2) )
+              .delete( )
+              .update( )
               .run();
         test().right().delete( b2 )
               .preStaged(smem0).insert( t(a0, b1),


### PR DESCRIPTION
All tests pass. Although it should add no changes in behaviour, I added some additional coverage in areas I was concerned about. I need to review changes, for cleanups, remove commented code etc. We also need to benchmark this, to make sure there are no actual regressions. It is still searching for the LT, we could optimise this further to record it in the constructor at the start - it won't matter much for small subnetworks, but would do if there was a bigger subnetwork.

When benchmark not only put lots of data inside of the subnetwork, make a lot of LTs prior to it, which we want to trigger updates on - which is also common in OP, with nesting of groupby's. These updates are the ones that typically cost the most, due to double update either side. Updates inside should be less problematic, if there is no chaining of groupbys. Need to benchmark not/exists/foreach and accumulate.