### PR TITLE
speeding up DMN showcase

### DIFF
--- a/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/pom.xml
@@ -183,6 +183,8 @@
         <artifactId>gwt-maven-plugin</artifactId>
         <version>${maven.gwt.plugin.version}</version>
         <configuration>
+          <localWorkers>8</localWorkers>
+          <optimizationLevel>0</optimizationLevel>
           <runTarget>index.html</runTarget>
           <extraJvmArgs>-Xmx1g -Xms756m -XX:CompileThreshold=1000</extraJvmArgs>
           <hostedWebapp>src/main/webapp/</hostedWebapp>
@@ -222,8 +224,8 @@
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <warName>${project.artifactId}</warName>
 
-          <!-- Exclude GWT client local classes from the deployment, lest 
-            classpath scanners such as Hibernate and Weld get confused when the webapp 
+          <!-- Exclude GWT client local classes from the deployment, lest
+            classpath scanners such as Hibernate and Weld get confused when the webapp
             is bootstrapping. -->
           <packagingExcludes>**/javax/**/*.*,**/client/local/**/*.class</packagingExcludes>
           <warSourceExcludes>WEB-INF/web.xml</warSourceExcludes>

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/src/main/java/org/kie/dmn/feel/FEELShowcaseWebapp.gwt.xml
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/src/main/java/org/kie/dmn/feel/FEELShowcaseWebapp.gwt.xml
@@ -4,5 +4,9 @@
 <module rename-to="FEELShowcaseWebapp">
   <inherits name="org.jboss.errai.enterprise.All"/>
   <inherits name="org.kie.dmn.feel.DMNFeelGWT"/>
+
   <source path="client"/>
+
+  <set-property name="user.agent" value="safari" />
+
 </module>


### PR DESCRIPTION
Speeds up the DMN showcase compile.

I got it from 53 seconds to 43.

Tests take almost 10 seconds on my computer.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
