### PR TITLE
[DROOLS-6332] parallelize rules generation in executable model

### DIFF
--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/PackageParser.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/impl/PackageParser.java
@@ -53,7 +53,7 @@ public class PackageParser {
     }
 
     private Rule parseRule( RuleDescr ruleDescr ) {
-        RuleContext context = new RuleContext(kbuilder, packageModel, pkgRegistry.getTypeResolver());
+        RuleContext context = new RuleContext(kbuilder, packageModel, pkgRegistry.getTypeResolver(), ruleDescr);
         context.setDialectFromAttributes( packageDescr.getAttributes() );
         Rule rule = new Rule( packageDescr.getName(), ruleDescr.getName(), ruleDescr.getResource().getSourcePath() );
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DRLIdGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DRLIdGenerator.java
@@ -16,20 +16,20 @@
 
 package org.drools.modelcompiler.builder.generator;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static org.drools.model.impl.NamesGenerator.generateName;
 import static org.drools.core.util.StringUtils.md5Hash;
+import static org.drools.model.impl.NamesGenerator.generateName;
 import static org.drools.model.impl.VariableImpl.GENERATED_VARIABLE_PREFIX;
 
 public class DRLIdGenerator {
 
-    private Map<PatternTypeDRLConstraint, String> generatedCondIds = new HashMap<>();
-    private Map<PatternTypeDRLConstraint, String> generateOOPathId = new HashMap<>();
-    private Map<PatternTypeDRLConstraint, String> generateUnificationVariableId = new HashMap<>();
-    private Map<PatternTypeDRLConstraint, String> generateAccumulateBindingId = new HashMap<>();
+    private Map<PatternTypeDRLConstraint, String> generatedCondIds = new ConcurrentHashMap<>();
+    private Map<PatternTypeDRLConstraint, String> generateOOPathId = new ConcurrentHashMap<>();
+    private Map<PatternTypeDRLConstraint, String> generateUnificationVariableId = new ConcurrentHashMap<>();
+    private Map<PatternTypeDRLConstraint, String> generateAccumulateBindingId = new ConcurrentHashMap<>();
 
     public String getExprId(Class<?> patternType, String drlConstraint) {
         return GENERATED_VARIABLE_PREFIX + md5Hash(patternType + drlConstraint);

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DslMethodNames.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DslMethodNames.java
@@ -71,7 +71,6 @@ public class DslMethodNames {
     public static final String EXPR_END_AND_CALL = "endAnd";
 
     // indexing
-    public static final String INDEXED_BY_CALL = "indexedBy";
     public static final String ALPHA_INDEXED_BY_CALL = "D.alphaIndexedBy";
     public static final String BETA_INDEXED_BY_CALL = "D.betaIndexedBy";
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -49,6 +49,7 @@ import org.drools.compiler.lang.descr.ForallDescr;
 import org.drools.compiler.lang.descr.PatternDescr;
 import org.drools.compiler.lang.descr.RuleDescr;
 import org.drools.core.addon.TypeResolver;
+import org.drools.core.base.evaluators.EvaluatorDefinition;
 import org.drools.core.ruleunit.RuleUnitDescriptionLoader;
 import org.drools.core.util.Bag;
 import org.drools.modelcompiler.builder.PackageModel;
@@ -74,8 +75,10 @@ public class RuleContext {
     private final KnowledgeBuilderImpl kbuilder;
     private final PackageModel packageModel;
     private final TypeResolver typeResolver;
+    private final RuleDescr ruleDescr;
+    private final int ruleIndex;
+
     private DRLIdGenerator idGenerator;
-    private RuleDescr descr;
 
     private Map<String, DeclarationSpec> allDeclarations = new LinkedHashMap<>();
     private Map<String, DeclarationSpec> scopedDeclarations = new LinkedHashMap<>();
@@ -124,32 +127,39 @@ public class RuleContext {
 
     private AndDescr parentDescr;
 
-    public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, TypeResolver typeResolver) {
+    public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, TypeResolver typeResolver, RuleDescr ruleDescr) {
+        this(kbuilder, packageModel, typeResolver, ruleDescr, -1);
+    }
+
+    public RuleContext(KnowledgeBuilderImpl kbuilder, PackageModel packageModel, TypeResolver typeResolver, RuleDescr ruleDescr, int ruleIndex) {
         this.kbuilder = kbuilder;
         this.packageModel = packageModel;
         this.idGenerator = packageModel.getExprIdGenerator();
         exprPointer.push( this.expressions::add );
         this.typeResolver = typeResolver;
+        this.ruleDescr = ruleDescr;
+        processUnitData();
+        this.ruleIndex = ruleIndex;
     }
 
     private void findUnitDescr() {
-        if (descr == null) {
+        if (ruleDescr == null) {
             return;
         }
 
         boolean useNamingConvention = false;
         String unitName = null;
-        AnnotationDescr unitAnn = descr.getAnnotation( "Unit" );
+        AnnotationDescr unitAnn = ruleDescr.getAnnotation( "Unit" );
         if (unitAnn != null) {
             unitName = ( String ) unitAnn.getValue();
             unitName = unitName.substring( 0, unitName.length() - ".class".length() );
-        } else if (descr.getUnit() != null) {
-            unitName = descr.getUnit().getTarget();
+        } else if (ruleDescr.getUnit() != null) {
+            unitName = ruleDescr.getUnit().getTarget();
         } else {
-            if (descr.getResource() == null) {
+            if (ruleDescr.getResource() == null) {
                 return;
             }
-            String drlFile = descr.getResource().getSourcePath();
+            String drlFile = ruleDescr.getResource().getSourcePath();
             if (drlFile != null) {
                 String drlFileName = drlFile.substring(drlFile.lastIndexOf('/')+1);
                 unitName = packageModel.getName() + '.' + drlFileName.substring(0, drlFileName.length() - ".drl".length());
@@ -192,12 +202,22 @@ public class RuleContext {
         return kbuilder;
     }
 
+    public int getRuleIndex() {
+        return ruleIndex;
+    }
+
+    public EvaluatorDefinition getEvaluatorDefinition(String opName) {
+        return kbuilder.getBuilderConfiguration().getEvaluatorRegistry().getEvaluatorDefinition( opName );
+    }
+
     public void addCompilationError( KnowledgeBuilderResult error ) {
         hasCompilationError = true;
         if ( error instanceof BaseKnowledgeBuilderResultImpl ) {
-            (( BaseKnowledgeBuilderResultImpl ) error).setResource( descr.getResource() );
+            (( BaseKnowledgeBuilderResultImpl ) error).setResource( ruleDescr.getResource() );
         }
-        kbuilder.addBuilderResult( error );
+        synchronized (kbuilder) {
+            kbuilder.addBuilderResult(error);
+        }
     }
 
     public boolean hasCompilationError() {
@@ -419,16 +439,11 @@ public class RuleContext {
     }
 
     public RuleDescr getRuleDescr() {
-        return descr;
-    }
-
-    public void setDescr(RuleDescr descr) {
-        this.descr = descr;
-        processUnitData();
+        return ruleDescr;
     }
 
     public String getRuleName() {
-        return descr.getName();
+        return ruleDescr.getName();
     }
 
     public RuleDialect getRuleDialect() {
@@ -666,7 +681,7 @@ public class RuleContext {
 
     @Override
     public String toString() {
-        return "RuleContext for " + descr.getNamespace() + "." + descr.getName();
+        return "RuleContext for " + ruleDescr.getNamespace() + "." + ruleDescr.getName();
     }
 }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/WindowReferenceGenerator.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/WindowReferenceGenerator.java
@@ -135,7 +135,7 @@ public class WindowReferenceGenerator {
         return descrs.stream()
                 .map( descr -> {
                     String expression = descr.toString();
-                    RuleContext context = new RuleContext(kbuilder, packageModel, typeResolver);
+                    RuleContext context = new RuleContext(kbuilder, packageModel, typeResolver, null);
                     DrlxParseResult drlxParseResult = new ConstraintParser(context, packageModel).drlxParse(patternType, pattern.getIdentifier(), expression);
                     return drlxParseResult.acceptWithReturnValue(new ParseResultVisitor<Optional<Expression>>() {
                         @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/operatorspec/CustomOperatorSpec.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/operatorspec/CustomOperatorSpec.java
@@ -28,7 +28,7 @@ public class CustomOperatorSpec extends NativeOperatorSpec {
 
     @Override
     protected Operator addOperatorArgument( RuleContext context, MethodCallExpr methodCallExpr, String opName ) {
-        EvaluatorDefinition evalDef = context.getKbuilder().getBuilderConfiguration().getEvaluatorRegistry().getEvaluatorDefinition( opName );
+        EvaluatorDefinition evalDef = context.getEvaluatorDefinition( opName );
         if (evalDef == null) {
             throw new RuntimeException( "Unknown custom operator: " + opName );
         }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/NamedConsequenceVisitor.java
@@ -155,7 +155,7 @@ public class NamedConsequenceVisitor {
             return null;
         }
         BlockStmt ruleVariablesBlock = new BlockStmt();
-        createVariables(context.getKbuilder(), ruleVariablesBlock, packageModel, context);
+        createVariables(ruleVariablesBlock, packageModel, context);
         return new Consequence(context).createCall(null, namedConsequenceString, ruleVariablesBlock, namedConsequence.isBreaking() );
     }
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ExpressionTyperTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ExpressionTyperTest.java
@@ -49,8 +49,7 @@ public class ExpressionTyperTest {
         imports = new HashSet<>();
         packageModel = new PackageModel("", "", null, null, new DRLIdGenerator());
         typeResolver = new ClassTypeResolver(imports, getClass().getClassLoader());
-        ruleContext = new RuleContext(knowledgeBuilder, packageModel, typeResolver);
-        ruleContext.setDescr(ruleDescr);
+        ruleContext = new RuleContext(knowledgeBuilder, packageModel, typeResolver, ruleDescr);
         imports.add("org.drools.modelcompiler.domain.Person");
     }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6332

Before introducing this parallelization I had these results on customer's benchmark

```
Benchmark                                        Mode  Cnt    Score    Error  Units
KjarCompilerBenchmark.buildKjarFromBigProject      ss    5  101.791 ± 10.435   s/op
KjarCompilerBenchmark.buildKjarFromSmallProject    ss    5   43.387 ±  6.516   s/op
```

After parallelization I got

```
Benchmark                                        Mode  Cnt   Score    Error  Units
KjarCompilerBenchmark.buildKjarFromBigProject      ss    5  82.010 ± 10.133   s/op
KjarCompilerBenchmark.buildKjarFromSmallProject    ss    5  38.896 ±  8.514   s/op
```

I also found a further minor improvement in the lambda externalization part and with also this change in place I finally got

```
Benchmark                                        Mode  Cnt   Score    Error  Units
KjarCompilerBenchmark.buildKjarFromBigProject      ss    5  79.634 ± 10.578   s/op
KjarCompilerBenchmark.buildKjarFromSmallProject    ss    5  37.702 ±  7.072   s/op
```
