### PR TITLE
[DROOLS-6343] Fix ExternalisedLambdaTest side effect

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ExternalisedLambdaTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/ExternalisedLambdaTest.java
@@ -51,18 +51,21 @@ import static org.junit.Assert.fail;
  */
 public class ExternalisedLambdaTest extends BaseModelTest {
 
+    private boolean checkNonExternalisedLambdaOrig;
+
     public ExternalisedLambdaTest(RUN_TYPE testRunType) {
         super(testRunType);
     }
 
     @Before
     public void init() {
+        checkNonExternalisedLambdaOrig = RuleWriter.isCheckNonExternalisedLambda();
         RuleWriter.setCheckNonExternalisedLambda(true);
     }
 
     @After
     public void clear() {
-        RuleWriter.setCheckNonExternalisedLambda(false);
+        RuleWriter.setCheckNonExternalisedLambda(checkNonExternalisedLambdaOrig);
     }
 
     @Test


### PR DESCRIPTION
Without this fix, tests will go with `checkNonExternalisedLambda = false` after running ExternalisedLambdaTest regardless of the initial system property value.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6343

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
