### PR TITLE
[DROOLS-6344] Update drools-impact-analysis pom.xml

### DIFF
--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
@@ -10,6 +10,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>drools-impact-analysis-graph-common</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Drools :: Impact Analysis Graph :: Common</name>
 
   <properties>
     <java.module.name>org.drools.impact.analysis.graph</java.module.name>

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
@@ -10,6 +10,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>drools-impact-analysis-graph-graphviz</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Drools :: Impact Analysis Graph :: Graphviz</name>
 
   <properties>
     <java.module.name>org.drools.impact.analysis.graph.graphviz</java.module.name>

--- a/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
@@ -12,6 +12,8 @@
   <artifactId>drools-impact-analysis-graph</artifactId>
   <packaging>pom</packaging>
 
+  <name>Drools :: Impact Analysis Graph</name>
+
   <modules>
     <module>drools-impact-analysis-graph-common</module>
     <module>drools-impact-analysis-graph-graphviz</module>

--- a/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
@@ -10,6 +10,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>drools-impact-analysis-itests</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Drools :: Impact Analysis :: Integration Tests</name>
 
   <dependencies>
 

--- a/drools-impact-analysis/drools-impact-analysis-model/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-model/pom.xml
@@ -10,6 +10,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>drools-impact-analysis-model</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Drools :: Impact Analysis :: Model</name>
 
   <properties>
     <java.module.name>org.drools.impact.analysis.model</java.module.name>

--- a/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
@@ -10,6 +10,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>drools-impact-analysis-parser</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Drools :: Impact Analysis :: Parser</name>
 
   <properties>
     <java.module.name>org.drools.impact.analysis.parser</java.module.name>

--- a/drools-impact-analysis/pom.xml
+++ b/drools-impact-analysis/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>drools-impact-analysis</artifactId>
   <packaging>pom</packaging>
 
-  <name>drools-impact-analysis</name>
+  <name>Drools :: Impact Analysis</name>
   <description>A tool to analyze relationships between rules and also impacts of changing a rule. Visualizes the graph using Dot language format</description>
   <url>http://drools.org</url>
 


### PR DESCRIPTION
I'm not fully sure if this change affects repository deployment

Currently, jars are not deployed.
https://repository.jboss.org/nexus/content/groups/public/org/drools/drools-impact-analysis-parser/

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6344



<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
