### PR TITLE
[DROOLS-6336] Calling KieBaseUpdaterANC.generateAndSetInMemoryANC twice on the same KieBase cause rules not to fire

### DIFF
--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -43,6 +43,12 @@
       <artifactId>kie-internal</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+
 
     <!-- Logging -->
     <dependency>

--- a/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ObjectTypeNodeCompiler.java
+++ b/drools-alphanetwork-compiler/src/main/java/org/drools/ancompiler/ObjectTypeNodeCompiler.java
@@ -247,8 +247,13 @@ public class ObjectTypeNodeCompiler {
     public static List<ObjectTypeNode> objectTypeNodes(Rete rete) {
         return rete.getEntryPointNodes().values().stream()
                 .flatMap(ep -> ep.getObjectTypeNodes().values().stream())
-                .filter(f -> !InitialFact.class.isAssignableFrom(f.getObjectType().getClassType()))
+                .filter(ObjectTypeNodeCompiler::shouldCreateCompiledAlphaNetwork)
                 .collect(Collectors.toList());
+    }
+
+    private static boolean shouldCreateCompiledAlphaNetwork(ObjectTypeNode f) {
+        return !InitialFact.class.isAssignableFrom(f.getObjectType().getClassType())
+                && !(f.getObjectSinkPropagator() instanceof CompiledNetwork); // DROOLS-6336 Avoid generating an ANC from an ANC, it won't work anyway
     }
 
     public static Map<String, CompiledNetworkSource> compiledNetworkSourceMap(Rete rete) {

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkCompilerTest.java
@@ -19,7 +19,6 @@ package org.drools.ancompiler;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.common.NamedEntryPoint;

--- a/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkInitTest.java
+++ b/drools-alphanetwork-compiler/src/test/java/org/drools/ancompiler/AlphaNetworkInitTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.ancompiler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.kie.api.runtime.KieSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AlphaNetworkInitTest extends BaseModelTest {
+
+    public AlphaNetworkInitTest(RUN_TYPE testRunType) {
+        super(testRunType);
+    }
+
+    // ANC is assembled manually
+    final static Object[] STANDARD = {
+            RUN_TYPE.STANDARD_FROM_DRL,
+    };
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[] params() {
+        return STANDARD;
+    }
+
+    @Test // DROOLS-6336
+    public void testGenerateAndSetInMemoryANC() {
+        final List<Person> results = new ArrayList<>();
+        KieSession kSession = setupKieSession();
+        KieBaseUpdaterANC.generateAndSetInMemoryANC(kSession.getKieBase());
+        assertResult(results, kSession);
+    }
+
+    @Test // DROOLS-6336
+    public void testGenerateAndSetInMemoryANCCalledTwice() {
+        final List<Person> results = new ArrayList<>();
+        KieSession kSession = setupKieSession();
+        KieBaseUpdaterANC.generateAndSetInMemoryANC(kSession.getKieBase());
+        KieBaseUpdaterANC.generateAndSetInMemoryANC(kSession.getKieBase());
+        assertResult(results, kSession);
+    }
+
+    private void assertResult(List<Person> results, KieSession ksession) {
+        ksession.setGlobal("results", results);
+        final Person jamesBond = new Person("James Bond", 40);
+        ksession.insert(jamesBond);
+        ksession.fireAllRules();
+
+        assertThat(results).containsExactly(jamesBond);
+    }
+
+    private KieSession setupKieSession() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                        "global java.util.List results;\n" +
+                        "rule \"Find James Bond\"\n" +
+                        "    when\n" +
+                        "        $p : Person(name == \"James Bond\")\n" +
+                        "    then\n" +
+                        "        results.add($p);\n" +
+                        "end";
+
+        KieSession ksession = getKieSession(str);
+        return ksession;
+    }
+}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6336

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
