### PR TITLE
[DROOLS-6331] avoid multiple executable model generation for the same…

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -188,7 +188,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
      */
     private final String defaultDialect;
 
-    private ClassLoader rootClassLoader;
+    private final ClassLoader rootClassLoader;
 
     private int parallelRulesBuildThreshold;
 
@@ -331,7 +331,14 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
     }
 
     public BuildContext getBuildContext() {
+        if (buildContext == null) {
+            buildContext = createBuildContext();
+        }
         return buildContext;
+    }
+
+    protected BuildContext createBuildContext() {
+        return new BuildContext();
     }
 
     public void setBuildContext(BuildContext buildContext) {
@@ -394,7 +401,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
     }
 
     PackageDescr decisionTableToPackageDescr(Resource resource,
-                                             ResourceConfiguration configuration) throws DroolsParserException, IOException {
+                                             ResourceConfiguration configuration) throws DroolsParserException {
         DecisionTableConfiguration dtableConfiguration = configuration instanceof DecisionTableConfiguration ?
                 (DecisionTableConfiguration) configuration :
                 new DecisionTableConfigurationImpl();
@@ -621,28 +628,6 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
                                             e.getCause());
         }
         return xmlReader.getPackageDescr();
-    }
-
-    /**
-     * Load a rule package from DRL source using the supplied DSL configuration.
-     *
-     * @param source The source of the rules.
-     * @param dsl    The source of the domain specific language configuration.
-     * @throws DroolsParserException
-     * @throws IOException
-     */
-    public void addPackageFromDrl(final Reader source,
-                                  final Reader dsl) throws DroolsParserException,
-            IOException {
-        this.resource = new ReaderResource(source, ResourceType.DSLR);
-
-        final DrlParser parser = new DrlParser(configuration.getLanguageLevel());
-        final PackageDescr pkg = parser.parse(source, dsl);
-        this.results.addAll(parser.getErrors());
-        if (!parser.hasErrors()) {
-            addPackage(pkg);
-        }
-        this.resource = null;
     }
 
     public void addPackageFromDslr(final Resource resource) throws DroolsParserException,
@@ -1842,8 +1827,7 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
             String functionClassName = functionDescr.getClassName();
             JavaDialectRuntimeData runtime = ((JavaDialectRuntimeData) pkgRegistry.getDialectRuntimeRegistry().getDialectData("java"));
             try {
-                registerFunctionClassAndInnerClasses(functionClassName, runtime,
-                                                     (name, bytes) -> ((ProjectClassLoader) rootClassLoader).storeClass(name, bytes));
+                registerFunctionClassAndInnerClasses(functionClassName, runtime, ((ProjectClassLoader) rootClassLoader)::storeClass);
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
@@ -2033,28 +2017,6 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
         this.results.clear();
         if (this.processBuilder != null) {
             this.processBuilder.getErrors().clear();
-        }
-    }
-
-    public String getDefaultDialect() {
-        return this.defaultDialect;
-    }
-
-    public static class MissingPackageNameException extends IllegalArgumentException {
-
-        private static final long serialVersionUID = 510L;
-
-        public MissingPackageNameException(final String message) {
-            super(message);
-        }
-    }
-
-    public static class PackageMergeException extends IllegalArgumentException {
-
-        private static final long serialVersionUID = 400L;
-
-        public PackageMergeException(final String message) {
-            super(message);
         }
     }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/builder/impl/KnowledgeBuilderImpl.java
@@ -80,6 +80,7 @@ import org.drools.compiler.compiler.RuleBuildError;
 import org.drools.compiler.compiler.ScoreCardFactory;
 import org.drools.compiler.compiler.TypeDeclarationError;
 import org.drools.compiler.compiler.xml.XmlPackageReader;
+import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.lang.ExpanderException;
 import org.drools.compiler.lang.descr.AbstractClassTypeDeclarationDescr;
 import org.drools.compiler.lang.descr.AccumulateImportDescr;
@@ -219,6 +220,8 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
 
     private ReleaseId releaseId;
 
+    private BuildContext buildContext;
+
     /**
      * Use this when package is starting from scratch.
      */
@@ -325,6 +328,14 @@ public class KnowledgeBuilderImpl implements InternalKnowledgeBuilder {
 
     public void setReleaseId(ReleaseId releaseId ) {
         this.releaseId = releaseId;
+    }
+
+    public BuildContext getBuildContext() {
+        return buildContext;
+    }
+
+    public void setBuildContext(BuildContext buildContext) {
+        this.buildContext = buildContext;
     }
 
     Resource getCurrentResource() {

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieModule.java
@@ -186,11 +186,11 @@ public abstract class AbstractKieModule
         return classes;
     }
 
-    public KnowledgePackagesBuildResult buildKnowledgePackages(KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages) {
+    public KnowledgePackagesBuildResult buildKnowledgePackages(KieBaseModelImpl kBaseModel, KieProject kieProject, BuildContext buildContext) {
         Collection<KiePackage> pkgs = getKnowledgePackagesForKieBase(kBaseModel.getName());
 
         if ( pkgs == null ) {
-            KnowledgeBuilder kbuilder = kieProject.buildKnowledgePackages(kBaseModel, messages);
+            KnowledgeBuilder kbuilder = kieProject.buildKnowledgePackages(kBaseModel, buildContext);
             if ( kbuilder.hasErrors() ) {
                 // Messages already populated by the buildKnowlegePackages
                 return new KnowledgePackagesBuildResult(true, pkgs);
@@ -201,8 +201,8 @@ public abstract class AbstractKieModule
         return new KnowledgePackagesBuildResult(false, pkgs);
     }
 
-    public InternalKnowledgeBase createKieBase( KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf ) {
-        KnowledgePackagesBuildResult knowledgePackagesBuildResult = buildKnowledgePackages(kBaseModel, kieProject, messages);
+    public InternalKnowledgeBase createKieBase( KieBaseModelImpl kBaseModel, KieProject kieProject, BuildContext buildContext, KieBaseConfiguration conf ) {
+        KnowledgePackagesBuildResult knowledgePackagesBuildResult = buildKnowledgePackages(kBaseModel, kieProject, buildContext);
         if(knowledgePackagesBuildResult.hasErrors()) {
             return null;
         }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/BuildContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/BuildContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.kie.builder.impl;
+
+public class BuildContext {
+    private final ResultsImpl messages;
+
+    public BuildContext() {
+        this(new ResultsImpl());
+    }
+
+    public BuildContext(ResultsImpl messages) {
+        this.messages = messages;
+    }
+
+    public ResultsImpl getMessages() {
+        return messages;
+    }
+
+    public boolean registerResourceToBuild(String kBaseName, String resource) {
+        return true;
+    }
+}

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/InternalKieModule.java
@@ -118,16 +118,16 @@ public interface InternalKieModule extends KieModule, Serializable {
 
     KnowledgeBuilderConfiguration createBuilderConfiguration( KieBaseModel kBaseModel, ClassLoader classLoader );
 
-    InternalKnowledgeBase createKieBase( KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf );
+    InternalKnowledgeBase createKieBase( KieBaseModelImpl kBaseModel, KieProject kieProject, BuildContext buildContext, KieBaseConfiguration conf );
 
     default void afterKieBaseCreationUpdate(String name, InternalKnowledgeBase kBase) { }
 
     ClassLoader getModuleClassLoader();
 
     default ResultsImpl build() {
-        ResultsImpl messages = new ResultsImpl();
-        buildKieModule(this, messages);
-        return messages;
+        BuildContext buildContext = new BuildContext();
+        buildKieModule(this, buildContext);
+        return buildContext.getMessages();
     }
 
     default KieJarChangeSet getChanges(InternalKieModule newKieModule) {

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -242,7 +242,7 @@ public class KieBuilderImpl
             
             compileJavaClasses( kProject.getClassLoader(), classFilter );
 
-            buildKieProject( results, kProject, trgMfs );
+            buildKieProject( kProject.createBuildContext(results), kProject, trgMfs );
             kModule = kProject.getInternalKieModule();
         }
         return this;
@@ -266,23 +266,23 @@ public class KieBuilderImpl
     }
 
     public static void buildKieModule( InternalKieModule kModule,
-                                       ResultsImpl messages ) {
-        buildKieProject( messages, new KieModuleKieProject( kModule ), null );
+                                       BuildContext buildContext ) {
+        buildKieProject( buildContext, new KieModuleKieProject( kModule ), null );
     }
 
-    private static void buildKieProject( ResultsImpl messages,
+    private static void buildKieProject( BuildContext buildContext,
                                          KieModuleKieProject kProject,
                                          MemoryFileSystem trgMfs ) {
         kProject.init();
-        kProject.verify( messages );
+        kProject.verify( buildContext );
 
-        if ( messages.filterMessages( Level.ERROR ).isEmpty() ) {
+        if ( buildContext.getMessages().filterMessages( Level.ERROR ).isEmpty() ) {
             InternalKieModule kModule = kProject.getInternalKieModule();
             if ( trgMfs != null ) {
                 if (hasXSTream()) {
                     CompilationCacheProvider.get().writeKieModuleMetaInfo( kModule, trgMfs );
                 }
-                kProject.writeProjectOutput(trgMfs, messages);
+                kProject.writeProjectOutput(trgMfs, buildContext);
             }
             KieRepository kieRepository = KieServices.Factory.get().getRepository();
             kieRepository.addKieModule( kModule );

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieContainerImpl.java
@@ -435,11 +435,11 @@ public class KieContainerImpl
             synchronized (kBaseModel) {
                 kBase = kBases.get( kBaseName );
                 if ( kBase == null ) {
-                    ResultsImpl msgs = new ResultsImpl();
-                    kBase = createKieBase(kBaseModel, kProject, msgs, null);
+                    BuildContext buildContext = new BuildContext();
+                    kBase = createKieBase(kBaseModel, kProject, buildContext, null);
                     if (kBase == null) {
                         // build error, throw runtime exception
-                        throw new RuntimeException("Error while creating KieBase" + msgs.filterMessages(Level.ERROR));
+                        throw new RuntimeException("Error while creating KieBase" + buildContext.getMessages().filterMessages(Level.ERROR));
                     }
                     kBases.put(kBaseName, kBase);
                 }
@@ -457,22 +457,22 @@ public class KieContainerImpl
     }
 
     public KieBase newKieBase(String kBaseName, KieBaseConfiguration conf) {
-        ResultsImpl msgs = new ResultsImpl();
-        KieBase kBase = createKieBase(getKieBaseModelImpl(kBaseName), kProject, msgs, conf);
+        BuildContext buildContext = new BuildContext();
+        KieBase kBase = createKieBase(getKieBaseModelImpl(kBaseName), kProject, buildContext, conf);
         if ( kBase == null ) {
             // build error, throw runtime exception
-            throw new RuntimeException( "Error while creating KieBase" + msgs.filterMessages( Level.ERROR  ) );
+            throw new RuntimeException( "Error while creating KieBase" + buildContext.getMessages().filterMessages( Level.ERROR  ) );
         }
         return kBase;
     }
 
-    private KieBase createKieBase(KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf) {
+    private KieBase createKieBase(KieBaseModelImpl kBaseModel, KieProject kieProject, BuildContext buildContext, KieBaseConfiguration conf) {
         if (log.isInfoEnabled()) {
             log.info( "Start creation of KieBase: " + kBaseModel.getName() );
         }
 
         InternalKieModule kModule = kieProject.getKieModuleForKBase( kBaseModel.getName() );
-        InternalKnowledgeBase kBase = kModule.createKieBase(kBaseModel, kieProject, messages, conf);
+        InternalKnowledgeBase kBase = kModule.createKieBase(kBaseModel, kieProject, buildContext, conf);
         kModule.afterKieBaseCreationUpdate(kBaseModel.getName(), kBase);
 
         if ( kBase == null ) {

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieModuleKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieModuleKieProject.java
@@ -130,6 +130,10 @@ public class KieModuleKieProject extends AbstractKieProject {
         return oldKieBaseModels;
     }
 
+    public BuildContext createBuildContext(ResultsImpl results) {
+        return new BuildContext(results);
+    }
+
     @Override
     public synchronized KieBaseModel getDefaultKieBaseModel() {
         return super.getDefaultKieBaseModel();

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieProject.java
@@ -51,7 +51,7 @@ public interface KieProject {
 
     ResultsImpl verify();
     ResultsImpl verify( String... kModelNames );
-    void verify(ResultsImpl messages);
+    void verify(BuildContext buildContext);
 
     long getCreationTimestamp();
 
@@ -60,8 +60,8 @@ public interface KieProject {
 
     InputStream getPomAsStream();
 
-    KnowledgeBuilder buildKnowledgePackages( KieBaseModelImpl kBaseModel, ResultsImpl messages );
-    KnowledgeBuilder buildKnowledgePackages( KieBaseModelImpl kBaseModel, ResultsImpl messages, Predicate<String> buildFilter );
+    KnowledgeBuilder buildKnowledgePackages( KieBaseModelImpl kBaseModel, BuildContext buildContext );
+    KnowledgeBuilder buildKnowledgePackages( KieBaseModelImpl kBaseModel, BuildContext buildContext, Predicate<String> buildFilter );
 
-    default void writeProjectOutput(MemoryFileSystem trgMfs, ResultsImpl messages) {}
+    default void writeProjectOutput(MemoryFileSystem trgMfs, BuildContext buildContext) {}
 }

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieModule.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieModule.java
@@ -24,6 +24,7 @@ import java.util.zip.ZipFile;
 import org.appformer.maven.support.DependencyFilter;
 import org.appformer.maven.support.PomModel;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieBaseUpdater;
 import org.drools.compiler.kie.builder.impl.KieBaseUpdaterImplContext;
@@ -208,8 +209,8 @@ public class ImpactAnalysisKieModule implements InternalKieModule {
     }
 
     @Override
-    public InternalKnowledgeBase createKieBase( KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf ) {
-        return internalKieModule.createKieBase( kBaseModel, kieProject, messages, conf );
+    public InternalKnowledgeBase createKieBase(KieBaseModelImpl kBaseModel, KieProject kieProject, BuildContext buildContext, KieBaseConfiguration conf ) {
+        return internalKieModule.createKieBase( kBaseModel, kieProject, buildContext, conf );
     }
 
     @Override

--- a/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieProject.java
+++ b/drools-impact-analysis/drools-impact-analysis-parser/src/main/java/org/drools/impact/analysis/parser/internal/ImpactAnalysisKieProject.java
@@ -18,6 +18,7 @@ import java.util.function.BiFunction;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
 import org.drools.compiler.kie.builder.impl.ResultsImpl;
@@ -48,7 +49,7 @@ public class ImpactAnalysisKieProject extends KieModuleKieProject {
     }
 
     @Override
-    public void writeProjectOutput(MemoryFileSystem trgMfs, ResultsImpl messages) {
+    public void writeProjectOutput(MemoryFileSystem trgMfs, BuildContext buildContext) {
         ImpactAnalysisKieModule kmodule = (ImpactAnalysisKieModule) getInternalKieModule();
         kmodule.setAnalysisModel( modelBuilder.getAnalysisModel() );
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelBuildContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelBuildContext.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.compiler.kie.builder.impl.BuildContext;
+import org.drools.compiler.kie.builder.impl.ResultsImpl;
+
+public class CanonicalModelBuildContext extends BuildContext {
+
+    private final Map<String, String> resourceOwners = new HashMap<>();
+    private final Map<String, Set<String>> notOwnedPackages = new HashMap<>();
+
+    private final Collection<GeneratedClassWithPackage> allGeneratedPojos = new HashSet<>();
+    private final Map<String, Class<?>> allCompiledClasses = new HashMap<>();
+
+    public CanonicalModelBuildContext(ResultsImpl messages) {
+        super(messages);
+    }
+
+    @Override
+    public boolean registerResourceToBuild(String kBaseName, String resource) {
+        boolean newResource = resourceOwners.putIfAbsent(resource, kBaseName) == null;
+        if (!newResource) {
+            notOwnedPackages.computeIfAbsent(kBaseName, n -> new HashSet<>()).add(resource);
+        }
+        return newResource;
+    }
+
+    public void registerGeneratedPojos(Collection<GeneratedClassWithPackage> generatedPojos, Map<String, Class<?>> compiledClasses) {
+        allGeneratedPojos.addAll(generatedPojos);
+        allCompiledClasses.putAll(compiledClasses);
+    }
+
+    public Collection<GeneratedClassWithPackage> getAllGeneratedPojos() {
+        return allGeneratedPojos;
+    }
+
+    public Map<String, Class<?>> getAllCompiledClasses() {
+        return allCompiledClasses;
+    }
+
+    public Collection<String> getNotOwnedModelFiles(Map<String, ModelBuilderImpl> modelBuilders, String kBaseName) {
+        Collection<String> notOwned = notOwnedPackages.get(kBaseName);
+        if (notOwned == null) {
+            return Collections.emptyList();
+        }
+
+        Collection<String> notOwnedModelFiles = new HashSet<>();
+        for (String resource : notOwned) {
+            PackageSources packageSources = modelBuilders.get(resourceOwners.get(resource)).getPackageSource(resource2Package(resource));
+            if (packageSources != null) {
+                notOwnedModelFiles.addAll(packageSources.getModelNames());
+            }
+        }
+        return notOwnedModelFiles;
+    }
+
+    private String resource2Package(String resource) {
+        int pathEndPos = resource.lastIndexOf('/');
+        return pathEndPos <= 0 ? "" :resource.substring(0, pathEndPos).replace('/', '.');
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelBuildContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelBuildContext.java
@@ -33,6 +33,8 @@ public class CanonicalModelBuildContext extends BuildContext {
     private final Collection<GeneratedClassWithPackage> allGeneratedPojos = new HashSet<>();
     private final Map<String, Class<?>> allCompiledClasses = new HashMap<>();
 
+    public CanonicalModelBuildContext() { }
+
     public CanonicalModelBuildContext(ResultsImpl messages) {
         super(messages);
     }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/GeneratedClassWithPackage.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/GeneratedClassWithPackage.java
@@ -18,6 +18,7 @@
 package org.drools.modelcompiler.builder;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import com.github.javaparser.ast.body.TypeDeclaration;
 
@@ -63,4 +64,16 @@ public class GeneratedClassWithPackage {
         return "package " + packageName + "\n" + generatedClass;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GeneratedClassWithPackage that = (GeneratedClassWithPackage) o;
+        return getPackageName().equals(that.getPackageName()) && getClassName().equals(that.getClassName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPackageName(), getClassName());
+    }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -28,6 +28,7 @@ import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationFactory;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.lang.descr.AbstractClassTypeDeclarationDescr;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
 import org.drools.compiler.lang.descr.EnumDeclarationDescr;
@@ -291,5 +292,10 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
 
     public T getPackageSource(String packageName) {
         return packageSources.get(packageName);
+    }
+
+    @Override
+    protected BuildContext createBuildContext() {
+        return new CanonicalModelBuildContext();
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -16,7 +16,6 @@
 
 package org.drools.modelcompiler.builder;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -47,9 +46,8 @@ import org.drools.modelcompiler.builder.generator.declaredtype.POJOGenerator;
 import org.kie.api.builder.ReleaseId;
 import org.kie.internal.builder.ResultSeverity;
 
-import static java.util.Collections.emptyList;
-
 import static com.github.javaparser.StaticJavaParser.parseImport;
+import static java.util.Collections.emptyList;
 import static org.drools.compiler.builder.impl.ClassDefinitionFactory.createClassDefinition;
 import static org.drools.core.util.Drools.hasMvel;
 import static org.drools.modelcompiler.builder.generator.ModelGenerator.generateModel;
@@ -63,7 +61,7 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
     private final Map<String, PackageModel> packageModels = new HashMap<>();
     private final ReleaseId releaseId;
     private final boolean oneClassPerRule;
-    private final Collection<T> packageSources = new ArrayList<>();
+    private final Map<String, T> packageSources = new HashMap<>();
 
     private Map<String, CompositePackageDescr> compositePackagesMap;
 
@@ -112,6 +110,7 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
         initPackageRegistries(packages);
         registerTypeDeclarations( packages );
         buildDeclaredTypes( packages );
+        storeGeneratedPojosInPackages( packages );
         buildOtherDeclarations(packages);
         deregisterTypeDeclarations( packages );
         buildRules(packages);
@@ -128,15 +127,13 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
     }
 
     private Collection<CompositePackageDescr> findPackages( Collection<CompositePackageDescr> compositePackages ) {
-        Collection<CompositePackageDescr> packages;
         if (compositePackages != null && !compositePackages.isEmpty()) {
-            packages = compositePackages;
-        } else if (compositePackagesMap != null) {
-            packages = compositePackagesMap.values();
-        } else {
-            packages = emptyList();
+            return compositePackages;
         }
-        return packages;
+        if (compositePackagesMap != null) {
+            return compositePackagesMap.values();
+        }
+        return emptyList();
     }
 
     @Override
@@ -211,7 +208,7 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
             PackageModel pkgModel = packageModels.remove( pkgRegistry.getPackage().getName() );
             pkgModel.setOneClassPerRule( oneClassPerRule );
             if (getResults( ResultSeverity.ERROR ).isEmpty()) {
-                packageSources.add( sourcesGenerator.apply( pkgModel ) );
+                packageSources.put( pkgModel.getName(), sourcesGenerator.apply( pkgModel ) );
             }
         }
     }
@@ -234,6 +231,13 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
             InternalKnowledgePackage pkg = getPackageRegistry(packageDescr.getNamespace()).getPackage();
             allCompiledClasses.putAll(compileType(this, pkg.getPackageClassLoader(), allGeneratedPojos));
         }
+
+        ((CanonicalModelBuildContext) getBuildContext()).registerGeneratedPojos(allGeneratedPojos, allCompiledClasses);
+    }
+
+    private void storeGeneratedPojosInPackages(Collection<CompositePackageDescr> packages) {
+        Collection<GeneratedClassWithPackage> allGeneratedPojos = ((CanonicalModelBuildContext) getBuildContext()).getAllGeneratedPojos();
+        Map<String, Class<?>> allCompiledClasses = ((CanonicalModelBuildContext) getBuildContext()).getAllCompiledClasses();
 
         for (CompositePackageDescr packageDescr : packages) {
             InternalKnowledgePackage pkg = getPackageRegistry(packageDescr.getNamespace()).getPackage();
@@ -282,6 +286,10 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
     }
 
     public Collection<T> getPackageSources() {
-        return packageSources;
+        return packageSources.values();
+    }
+
+    public T getPackageSource(String packageName) {
+        return packageSources.get(packageName);
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieModuleRepoTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/kie/builder/impl/KieModuleRepoTest.java
@@ -15,18 +15,18 @@ import java.util.concurrent.Executors;
 
 import org.appformer.maven.support.DependencyFilter;
 import org.appformer.maven.support.PomModel;
+import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
 import org.drools.compiler.kie.builder.impl.KieProject;
 import org.drools.compiler.kie.builder.impl.KieRepositoryImpl;
 import org.drools.compiler.kie.builder.impl.KieRepositoryImpl.KieModuleRepo;
-import org.drools.compiler.kie.builder.impl.ResultsImpl;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.drools.compiler.kproject.models.KieBaseModelImpl;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.io.internal.InternalResource;
-import org.drools.compiler.kproject.ReleaseIdImpl;
-import org.drools.compiler.kproject.models.KieBaseModelImpl;
 import org.drools.reflective.ResourceProvider;
 import org.junit.After;
 import org.junit.Before;
@@ -403,7 +403,7 @@ public class KieModuleRepoTest {
         }
 
         @Override
-        public InternalKnowledgeBase createKieBase( KieBaseModelImpl kBaseModel, KieProject kieProject, ResultsImpl messages, KieBaseConfiguration conf ) {
+        public InternalKnowledgeBase createKieBase(KieBaseModelImpl kBaseModel, KieProject kieProject, BuildContext buildContext, KieBaseConfiguration conf ) {
             throw new UnsupportedOperationException();
         }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MergePackageTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MergePackageTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.mvel.compiler.Cheese;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
@@ -78,8 +77,6 @@ public class MergePackageTest {
             assertEquals(results.toString(), 2, results.size());
             assertTrue(results.contains("p1.r1"));
             assertTrue(results.contains("p2.r1"));
-        } catch (final KnowledgeBuilderImpl.PackageMergeException e) {
-            fail("Should not raise exception when merging different packages into the same rulebase: " + e.getMessage());
         } catch (final Exception e) {
             e.printStackTrace();
             fail("unexpected exception: " + e.getMessage());
@@ -114,8 +111,6 @@ public class MergePackageTest {
                     assertEquals("rule 1", kpkg.getRules().iterator().next().getName());
                 }
             }
-        } catch (final KnowledgeBuilderImpl.PackageMergeException e) {
-            fail("unexpected exception: " + e.getMessage());
         } catch (final RuntimeException e) {
             e.printStackTrace();
             fail("unexpected exception: " + e.getMessage());

--- a/kie-dmn/kie-dmn-validation-bootstrap/src/main/java/org/kie/dmn/validation/bootstrap/GenerateModel.java
+++ b/kie-dmn/kie-dmn-validation-bootstrap/src/main/java/org/kie/dmn/validation/bootstrap/GenerateModel.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.drools.compiler.compiler.io.Folder;
 import org.drools.compiler.compiler.io.memory.MemoryFile;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.compiler.kie.builder.impl.BuildContext;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kie.builder.impl.MemoryKieModule;
@@ -139,7 +140,7 @@ public class GenerateModel {
         }
 
         @Override
-        public void writeProjectOutput(MemoryFileSystem trgMfs, ResultsImpl messages) {
+        public void writeProjectOutput(MemoryFileSystem trgMfs, BuildContext buildContext) {
             MemoryFileSystem srcMfs = new MemoryFileSystem();
             List<String> modelFiles = new ArrayList<>();
             ModelWriter modelWriter = new ModelWriter();


### PR DESCRIPTION
… type declarations during the build of a multi-kbase project

**JIRA**: https://issues.redhat.com/browse/DROOLS-6331

In reality this not avoid to regenerate the same declared types if they are used by more than one KieBase, but the same applies for all the rules belonging to packages included in more than one KieBase.

Before this improvement I had these results on customer's benchmark

```
Benchmark                                        Mode  Cnt   Score    Error  Units
KjarCompilerBenchmark.buildKjarFromBigProject      ss    5  79.634 ± 10.578   s/op
KjarCompilerBenchmark.buildKjarFromSmallProject    ss    5  37.702 ±  7.072   s/op
```

After this I got

```
Benchmark                                        Mode  Cnt   Score    Error  Units
KjarCompilerBenchmark.buildKjarFromBigProject      ss    5  76.069 ± 11.476   s/op
KjarCompilerBenchmark.buildKjarFromSmallProject    ss    5  18.912 ±  5.071   s/op
```
