### PR TITLE
[DROOLS-6352] Investigate ParallelEvaluationTest error in CI Build Chain

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ParallelEvaluationTest.java
@@ -567,7 +567,12 @@ public class ParallelEvaluationTest {
         sb.append( "global java.util.List list;\n" );
         sb.append( "import " + MyEvent.class.getCanonicalName() + ";\n" );
         sb.append( "declare MyEvent @role( event ) @expires( 20ms ) @timestamp( timestamp ) end\n" );
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 5; i++) {
+            sb.append( getRuleWithEventForExpiration( i ) );
+        }
+        // See DROOLS-6352 : To avoid bias in CompositePartitionAwareObjectSinkAdapter.partitionedPropagators by artificial repetition of rule pattern
+        sb.append("rule R_ex1\n when MyEvent(id == 100)\n then\n end\n");
+        for (int i = 5; i < 10; i++) {
             sb.append( getRuleWithEventForExpiration( i ) );
         }
 


### PR DESCRIPTION
- Avoid bias in CompositePartitionAwareObjectSinkAdapter.partitionedPropagators

The rule in ParallelEvaluationTest.testFireUntilHaltWithExpiration causes partition bias in CompositePartitionAwareObjectSinkAdapter.partitionedPropagators. For example, if you have 8 core CPU (KieExecutors.Pool.SIZE = 8), partitionedPropagators size is 8. But during rete network construction, only odd arrays are populated (because of artificial repetition of rule pattern) so getUsedPartitionsCount() returns 4. At the moment, CI Build Chain allocates 2 cores so getUsedPartitionsCount() returns 1. It results in "The rete network cannot be partitioned: disabling multithread evaluation"

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6352

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
