### PR TITLE
[DROOLS-6361] compile error in exec model when setting BigDecimal variable to String type property

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -564,18 +564,24 @@ public class MvelDialectTest extends BaseModelTest {
 
     @Test
     public void testBigDecimalPatternWithString() {
-        // DROOLS-6356
+        // DROOLS-6356 // DROOLS-6361
         String drl =
                 "import " + Person.class.getCanonicalName() + "\n" +
+                "import " + BigDecimal.class.getCanonicalName() + "\n" +
                 "global java.util.List results;\n" +
                 "dialect \"mvel\"\n" +
                 "rule R\n" +
                 "when\n" +
-                "    $p : Person(money == \"90\" )\n" +
+                "    $p : Person($m : money == \"90\" )\n" +
                 "then\n" +
                 "    if($p.money == \"90\") {\n" +
                 "       results.add($p);\n" +
                 "    }\n" +
+                "    $p.name = $m;\n"  +
+                "    $p.name = $p.money;"  +
+                "    $p.name = BigDecimal.ZERO;\n"  +
+                "    $p.name = BigDecimal.valueOf(133);\n"  +
+                "    $p.name = 144B;\n"  +
                 "end";
 
         KieSession ksession = getKieSession(drl);
@@ -594,6 +600,7 @@ public class MvelDialectTest extends BaseModelTest {
 
         assertEquals(1, ksession.fireAllRules());
         assertThat(results).containsOnly(john);
+        assertThat(results.iterator().next().getName()).isEqualTo("144");
     }
 
     @Test

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
@@ -249,7 +249,10 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, Void> {
     private Optional<TypedExpression> tryParseItAsSetter(FieldAccessExpr n, TypedExpression scope, Class<?> setterArgumentType) {
         return scope.getType().flatMap(scopeType -> {
             String setterName = printConstraint(n.getName());
-            Optional<Method> optAccessor = ofNullable(getSetter((Class<?>) scopeType, setterName, setterArgumentType));
+            Optional<Method> optAccessor =
+                    ofNullable(getSetter((Class<?>) scopeType, setterName, setterArgumentType))
+                    .map(Optional::of)
+                    .orElse(ofNullable(getSetter((Class<?>) scopeType, setterName, String.class)));
 
             List<TypedExpression> arguments = rhs.map(Collections::singletonList)
                     .orElse(emptyList());

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -256,6 +256,57 @@ public class MvelCompilerTest implements CompilerTest {
     }
 
     @Test
+    public void testSetterStringWithBigDecimal() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "{ $p.name = BigDecimal.valueOf(1); }",
+             "{ $p.setName((BigDecimal.valueOf(1)).toString()); }");
+    }
+
+    @Test
+    public void testSetterStringWithBigDecimalFromField() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "{ $p.name = $p.salary; }",
+             "{ $p.setName(($p.getSalary()).toString()); }");
+    }
+
+    @Test
+    public void testSetterStringWithBigDecimalFromVariable() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+                 ctx.addDeclaration("$m", BigDecimal.class);
+             },
+             "{ $p.name = $m; }",
+             "{ $p.setName(($m).toString()); }");
+    }
+
+    @Test
+    public void testSetterStringWithBigDecimalFromBigDecimalLiteral() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+             },
+             "{ $p.name = 10000B; }",
+             "{ $p.setName((new java.math.BigDecimal(\"10000\")).toString()); }");
+    }
+
+    @Test
+    public void testSetterStringWithBigDecimalFromBigDecimalConstant() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+             },
+             "{ $p.name = BigDecimal.ZERO; }",
+             "{ $p.setName((BigDecimal.ZERO).toString()); }");
+    }
+
+    @Test
+    public void testSetterStringWithNull() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+             },
+             "{ $p.name = null; }",
+             "{ $p.setName(null); }");
+    }
+
+    @Test
     public void testSetterBigDecimalConstantModify() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify ( $p )  { salary = 50000 }; }",
@@ -412,6 +463,17 @@ public class MvelCompilerTest implements CompilerTest {
              "{ " +
                      "java.lang.String key3 = \"key3\";\n" +
                      "$p.getItems().put(key3, java.lang.String.valueOf(\"value3\")); " +
+                     "}");
+    }
+
+    @Test
+    public void testMapSetWithConstant() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "{" +
+                     "$p.items[\"key3\"] = \"value3\";\n" +
+                     "}",
+             "{ " +
+                     "$p.getItems().put(\"key3\", java.lang.String.valueOf(\"value3\")); " +
                      "}");
     }
 
@@ -625,6 +687,17 @@ public class MvelCompilerTest implements CompilerTest {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ modify ( $p )  { name = \"Luca\", age = 35 }; }",
              "{\n {\n $p.setName(\"Luca\");\n $p.setAge(35);\n }\n }",
+             result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
+    }
+
+    @Test
+    public void testModifyMap() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+                 ctx.addDeclaration("$p2", Person.class);
+             },
+             "{ modify ( $p )  { items = $p2.items }; }",
+             "{\n {\n $p.setItems($p2.getItems());\n }\n }",
              result -> assertThat(allUsedBindings(result), containsInAnyOrder("$p")));
     }
 


### PR DESCRIPTION

* Convert String fields with expression with toString method called upon
* Avoid toString a null

https://issues.redhat.com/browse/DROOLS-6361


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
