### PR TITLE
[DROOLS-6363] Fix unstable tests in drools-test-coverage

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -43,6 +43,7 @@ import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.Rete;
 import org.drools.core.reteoo.RuleTerminalNode;
+import org.drools.core.util.ClassUtils;
 import org.drools.testcoverage.common.model.Address;
 import org.drools.testcoverage.common.model.Message;
 import org.drools.testcoverage.common.model.Person;
@@ -2962,6 +2963,11 @@ public class IncrementalCompilationTest {
 
     @Test(timeout = 20000L)
     public void testMultipleIncrementalCompilationsWithFireUntilHalt() throws Exception {
+        if (ClassUtils.isWindows()) {
+            // To be fixed : See DROOLS-6364
+            return;
+        }
+
         // DROOLS-1406
         final KieServices ks = KieServices.Factory.get();
 
@@ -2994,6 +3000,7 @@ public class IncrementalCompilationTest {
 
                 final ReleaseId releaseIdI = ks.newReleaseId("org.kie", "test-fireUntilHalt", "1." + i);
                 KieUtil.getKieModuleFromDrls(releaseIdI, kieBaseTestConfiguration, getTestRuleForFireUntilHalt(i));
+
                 kc.updateToVersion(releaseIdI);
 
                 done.await();

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Waltz.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/waltz/Waltz.java
@@ -41,7 +41,7 @@ public abstract class Waltz {
         this.kieBaseTestConfiguration = kieBaseTestConfiguration;
     }
 
-    @Test(timeout = 20000 )
+    @Test(timeout = 60000 )
     public void testWaltz() {
         try {
             //load up the rulebase


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6363

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
