### PR TITLE
[DROOLS-5824] executable-model test failure in test-compiler-integrat…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/MethodUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/MethodUtils.java
@@ -35,9 +35,6 @@ public class MethodUtils {
     }
 
     private static Method getBestCandidate(Class clazz, Class[] argsType, String methodName, Method[] methods) {
-        if (methods.length == 0) {
-            return null;
-        }
         final Method bestCandidate = getBestCandidateMethod(methodName, argsType, methods, null);
         if (bestCandidate != null) {
             return bestCandidate;

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/ExpirationTest.java
@@ -57,8 +57,7 @@ public class ExpirationTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-        // TODO: EM failed with testBeta, testEvalExpired, testEvalNotExpired. File JIRAs
-        return TestParametersUtil.getKieBaseStreamConfigurations(false);
+        return TestParametersUtil.getKieBaseStreamConfigurations(true);
     }
 
     @Test


### PR DESCRIPTION
…ion ExpirationTest

- Interface reference should be able to use Object.class methods even if the Interface defines no method

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-5824


In order to pass all tests in ExpirationTest, https://github.com/kiegroup/drools/pull/3624 has to be merged first. (ExpirationTest.testBeta)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
