### PR TITLE
[DROOLS-6372] Fixed MaterializedLambdaConsequenceTests

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
@@ -31,6 +31,10 @@ public class MaterializedLambdaConsequenceTest {
         CreatedClass aClass = new MaterializedLambdaConsequence("org.drools.modelcompiler.util.lambdareplace", "rulename", new ArrayList<>())
                 .create("(org.drools.modelcompiler.domain.Person p1, org.drools.modelcompiler.domain.Person p2) -> result.setValue( p1.getName() + \" is older than \" + p2.getName())", new ArrayList<>(), new ArrayList<>());
 
+        String classNameWithPackage = aClass.getClassNameWithPackage();
+        // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
+        // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
                 "package org.drools.modelcompiler.util.lambdareplace.PDB;\n" +
@@ -38,7 +42,7 @@ public class MaterializedLambdaConsequenceTest {
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "\n"+
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaConsequenceDBAE2B827A3FDBA91B7A83284F221949 implements org.drools.model.functions.Block2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
+                "public enum TOREPLACE implements org.drools.model.functions.Block2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
                 "INSTANCE;\n" +
                 "public static final String EXPRESSION_HASH = \"8305FF24AC76CB49E7AAE2C10356A105\";" +
                 "    public java.lang.String getExpressionHash() {\n" +
@@ -49,6 +53,8 @@ public class MaterializedLambdaConsequenceTest {
                 "            result.setValue(p1.getName() + \" is older than \" + p2.getName());\n" +
                 "        }\n" +
                 "    }\n";
+        // Workaround to keep the "//language=JAVA" working
+        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }
@@ -62,6 +68,10 @@ public class MaterializedLambdaConsequenceTest {
         CreatedClass aClass = new MaterializedLambdaConsequence("defaultpkg", "defaultpkg.RulesA3B8DE4BEBF13D94572A10FD20BBE729", Collections.singletonList(bitMaskVariable))
                 .create("(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Person $p) -> {{($p).setAge($p.getAge() + 1); drools.update($p, mask_$p);}}", new ArrayList<>(), new ArrayList<>());
 
+        String classNameWithPackage = aClass.getClassNameWithPackage();
+        // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
+        // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
                 "package defaultpkg.PF5;\n" +
@@ -69,7 +79,7 @@ public class MaterializedLambdaConsequenceTest {
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "\n"+
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaConsequenceF5221449583BE216D72583C108D17451 implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
+                "public enum TOREPLACE implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
                 "        INSTANCE;\n" +
                 "        public static final String EXPRESSION_HASH = \"1FE08C27A04F37AADD1A62E562519E8D\";\n" +
                 "    public java.lang.String getExpressionHash() {\n" +
@@ -84,6 +94,8 @@ public class MaterializedLambdaConsequenceTest {
                 "            }" +
                 "        }\n" +
                 "    }\n";
+        // Workaround to keep the "//language=JAVA" working
+        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }
@@ -103,6 +115,10 @@ public class MaterializedLambdaConsequenceTest {
                                                                 Arrays.asList(bitMaskPerson, bitMaskPet))
                 .create(consequenceBlock, new ArrayList<>(), new ArrayList<>());
 
+        String classNameWithPackage = aClass.getClassNameWithPackage();
+        // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
+        // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
                 "package defaultpkg.PAE;\n" +
@@ -110,7 +126,7 @@ public class MaterializedLambdaConsequenceTest {
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "\n"+
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaConsequenceAE1C6782AAF9C3BD8D8E87E6F3650620 implements org.drools.model.functions.Block3<org.drools.model.Drools, org.drools.modelcompiler.domain.Pet, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
+                "public enum TOREPLACE implements org.drools.model.functions.Block3<org.drools.model.Drools, org.drools.modelcompiler.domain.Pet, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
                 "\n" +
                 "    INSTANCE;\n" +
                 "    public static final String EXPRESSION_HASH = \"2ABFB3D359AC0D0C1F6C1BAF91E05544\";\n" +
@@ -131,6 +147,8 @@ public class MaterializedLambdaConsequenceTest {
                 "        }\n" +
                 "    }\n" +
                 "}";
+        // Workaround to keep the "//language=JAVA" working
+        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }
@@ -148,6 +166,10 @@ public class MaterializedLambdaConsequenceTest {
                                                                 Arrays.asList(bitMaskVariable))
                 .create(consequenceBlock, new ArrayList<>(), new ArrayList<>());
 
+        String classNameWithPackage = aClass.getClassNameWithPackage();
+        // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
+        // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
                 "package defaultpkg.PB9;\n" +
@@ -156,7 +178,7 @@ public class MaterializedLambdaConsequenceTest {
                 "import org.drools.modelcompiler.dsl.pattern.D;\n" +
                 "\n" +
                 "@org.drools.compiler.kie.builder.MaterializedLambda()\n" +
-                "public enum LambdaConsequenceB90161D3D33552C502EC4AF0435E3FAB implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
+                "public enum TOREPLACE implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
                 "\n" +
                 "    INSTANCE;\n" +
                 "    public static final String EXPRESSION_HASH = \"15102979E2E45F1A4617C12D3517D6B5\";\n" +
@@ -174,6 +196,8 @@ public class MaterializedLambdaConsequenceTest {
                 "        }\n" +
                 "    }\n" +
                 "}";
+        // Workaround to keep the "//language=JAVA" working
+        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaConsequenceTest.java
@@ -34,15 +34,16 @@ public class MaterializedLambdaConsequenceTest {
         String classNameWithPackage = aClass.getClassNameWithPackage();
         // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
         // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedPackageName = classNameWithPackage.substring(0, classNameWithPackage.lastIndexOf('.'));
         String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
-                "package org.drools.modelcompiler.util.lambdareplace.PDB;\n" +
+                "package PACKAGE_TOREPLACE;\n" +
                 "import static rulename.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "\n"+
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum TOREPLACE implements org.drools.model.functions.Block2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
+                "public enum CLASS_TOREPLACE implements org.drools.model.functions.Block2<org.drools.modelcompiler.domain.Person, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
                 "INSTANCE;\n" +
                 "public static final String EXPRESSION_HASH = \"8305FF24AC76CB49E7AAE2C10356A105\";" +
                 "    public java.lang.String getExpressionHash() {\n" +
@@ -54,7 +55,9 @@ public class MaterializedLambdaConsequenceTest {
                 "        }\n" +
                 "    }\n";
         // Workaround to keep the "//language=JAVA" working
-        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
+        expectedResult = expectedResult
+                .replace("PACKAGE_TOREPLACE", expectedPackageName)
+                .replace("CLASS_TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }
@@ -67,19 +70,19 @@ public class MaterializedLambdaConsequenceTest {
 
         CreatedClass aClass = new MaterializedLambdaConsequence("defaultpkg", "defaultpkg.RulesA3B8DE4BEBF13D94572A10FD20BBE729", Collections.singletonList(bitMaskVariable))
                 .create("(org.drools.model.Drools drools, org.drools.modelcompiler.domain.Person $p) -> {{($p).setAge($p.getAge() + 1); drools.update($p, mask_$p);}}", new ArrayList<>(), new ArrayList<>());
-
         String classNameWithPackage = aClass.getClassNameWithPackage();
+        String expectedPackageName = classNameWithPackage.substring(0, classNameWithPackage.lastIndexOf('.'));
         // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
         // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
         String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
-                "package defaultpkg.PF5;\n" +
+                "package PACKAGE_TOREPLACE;\n" +
                 "import static defaultpkg.RulesA3B8DE4BEBF13D94572A10FD20BBE729.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "\n"+
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum TOREPLACE implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
+                "public enum CLASS_TOREPLACE implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression  {\n" +
                 "        INSTANCE;\n" +
                 "        public static final String EXPRESSION_HASH = \"1FE08C27A04F37AADD1A62E562519E8D\";\n" +
                 "    public java.lang.String getExpressionHash() {\n" +
@@ -95,7 +98,9 @@ public class MaterializedLambdaConsequenceTest {
                 "        }\n" +
                 "    }\n";
         // Workaround to keep the "//language=JAVA" working
-        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
+        expectedResult = expectedResult
+                .replace("PACKAGE_TOREPLACE", expectedPackageName)
+                .replace("CLASS_TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }
@@ -118,15 +123,16 @@ public class MaterializedLambdaConsequenceTest {
         String classNameWithPackage = aClass.getClassNameWithPackage();
         // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
         // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedPackageName = classNameWithPackage.substring(0, classNameWithPackage.lastIndexOf('.'));
         String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
-                "package defaultpkg.PAE;\n" +
+                "package PACKAGE_TOREPLACE;\n" +
                 "import static defaultpkg.RulesB45236F6195B110E0FA3A5447BC53274.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "\n"+
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum TOREPLACE implements org.drools.model.functions.Block3<org.drools.model.Drools, org.drools.modelcompiler.domain.Pet, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
+                "public enum CLASS_TOREPLACE implements org.drools.model.functions.Block3<org.drools.model.Drools, org.drools.modelcompiler.domain.Pet, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
                 "\n" +
                 "    INSTANCE;\n" +
                 "    public static final String EXPRESSION_HASH = \"2ABFB3D359AC0D0C1F6C1BAF91E05544\";\n" +
@@ -148,7 +154,9 @@ public class MaterializedLambdaConsequenceTest {
                 "    }\n" +
                 "}";
         // Workaround to keep the "//language=JAVA" working
-        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
+        expectedResult = expectedResult
+                .replace("PACKAGE_TOREPLACE", expectedPackageName)
+                .replace("CLASS_TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }
@@ -169,16 +177,17 @@ public class MaterializedLambdaConsequenceTest {
         String classNameWithPackage = aClass.getClassNameWithPackage();
         // There is no easy way to retrieve the originally created "hashcode" because it is calculated over a CompilationUnit that soon after is modified;
         // so current "CreatedClass" contains a CompilationUnit that is different from the one used to calculate the hashcode
+        String expectedPackageName = classNameWithPackage.substring(0, classNameWithPackage.lastIndexOf('.'));
         String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
-                "package defaultpkg.PB9;\n" +
+                "package PACKAGE_TOREPLACE;\n" +
                 "\n" +
                 "import static defaultpkg.Rules53448E6B9A07CB05B976425EF329E308.*;\n" +
                 "import org.drools.modelcompiler.dsl.pattern.D;\n" +
                 "\n" +
                 "@org.drools.compiler.kie.builder.MaterializedLambda()\n" +
-                "public enum TOREPLACE implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
+                "public enum CLASS_TOREPLACE implements org.drools.model.functions.Block2<org.drools.model.Drools, org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
                 "\n" +
                 "    INSTANCE;\n" +
                 "    public static final String EXPRESSION_HASH = \"15102979E2E45F1A4617C12D3517D6B5\";\n" +
@@ -197,7 +206,9 @@ public class MaterializedLambdaConsequenceTest {
                 "    }\n" +
                 "}";
         // Workaround to keep the "//language=JAVA" working
-        expectedResult = expectedResult.replace("TOREPLACE", expectedClassName);
+        expectedResult = expectedResult
+                .replace("PACKAGE_TOREPLACE", expectedPackageName)
+                .replace("CLASS_TOREPLACE", expectedClassName);
 
         verifyCreatedClass(aClass, expectedResult);
     }


### PR DESCRIPTION
@danielezonca @mariofusco @lucamolteni @hellowdan 

See https://issues.redhat.com/browse/DROOLS-6372

I kept modification at bare minimum to have tests working on windows - I'm waiting windows build to verify that.
I had to use a couple of "workarounds"
1) I can not (easily) recreate the same hashcode as in `MaterializedLambda`, so I just use the "generated" classname in the expected String
2) I can not use the standard String.format, because it would break the //language=JAVA annotation - so I put a "TOREPLACE" string in the originally expected one, and soon after I replace it with the generated class name

I've verified that on my machine (linux)

