### PR TITLE
[BXMSPROD-1350] change cache key for flows using different java versions

### DIFF
--- a/.github/workflows/kogito_full_downstream.yml
+++ b/.github/workflows/kogito_full_downstream.yml
@@ -19,8 +19,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-${{ matrix.java-version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-${{ matrix.java-version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.2


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1350

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1656
* https://github.com/kiegroup/kie-soup/pull/207
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/524
* https://github.com/kiegroup/drools/pull/3642
* https://github.com/kiegroup/optaplanner/pull/1345
* https://github.com/kiegroup/lienzo-core/pull/146
* https://github.com/kiegroup/lienzo-tests/pull/119
* https://github.com/kiegroup/appformer/pull/1146
* https://github.com/kiegroup/kie-uberfire-extensions/pull/116
* https://github.com/kiegroup/jbpm/pull/1941
* https://github.com/kiegroup/kie-jpmml-integration/pull/56
* https://github.com/kiegroup/droolsjbpm-integration/pull/2500
* https://github.com/kiegroup/kie-wb-playground/pull/108
* https://github.com/kiegroup/kie-wb-common/pull/3644
* https://github.com/kiegroup/drools-wb/pull/1495
* https://github.com/kiegroup/jbpm-designer/pull/906
* https://github.com/kiegroup/jbpm-work-items/pull/199
* https://github.com/kiegroup/jbpm-wb/pull/1497
* https://github.com/kiegroup/optaplanner-wb/pull/394
* https://github.com/kiegroup/kie-wb-distributions/pull/1110
* https://github.com/kiegroup/openshift-drools-hacep/pull/110
* https://github.com/kiegroup/optaweb-employee-rostering/pull/632
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/502
* https://github.com/kiegroup/kie-docs/pull/3607