### PR TITLE
[DROOLS-6362] compile error in exec model when BigDecimal is passed as int type argument to function

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
@@ -57,6 +57,7 @@ import static java.lang.reflect.Modifier.PUBLIC;
 import static java.lang.reflect.Modifier.STATIC;
 
 import static org.drools.core.util.MethodUtils.findMethod;
+import static org.drools.core.util.MethodUtils.getMethod;
 import static org.drools.core.util.StringUtils.ucFirst;
 
 public final class ClassUtils {
@@ -485,10 +486,6 @@ public final class ClassUtils {
                 .findFirst()
                 .flatMap( Function.identity() )
                 .orElse( parameterType.isPrimitive() ? getSetter(clazz, field, convertFromPrimitiveType(parameterType)) : null );
-    }
-
-    private static Optional<Method> getMethod(Class<?> clazz, String name, Class<?>... parameterTypes) {
-        return Optional.ofNullable( findMethod(clazz, name, parameterTypes) );
     }
 
     public static Member getFieldOrAccessor( Class clazz, String property ) {

--- a/drools-core/src/main/java/org/drools/core/util/MethodUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/MethodUtils.java
@@ -58,13 +58,13 @@ public class MethodUtils {
                                                  final Class[] argsType,
                                                  final Method[] methods,
                                                  final Method oldBestCandidate) {
-        Class<?>[] parmTypes;
+        Class<?>[] parameterTypes;
         int bestScore = -1;
         Method bestCandidate = oldBestCandidate;
         for (final Method method : methods) {
             if (methodName.equals(method.getName())) {
-                parmTypes = method.getParameterTypes();
-                if (parmTypes.length == 0 && argsType.length == 0) {
+                parameterTypes = method.getParameterTypes();
+                if (parameterTypes.length == 0 && argsType.length == 0) {
                     if (bestCandidate == null || isMoreSpecialized(method, bestCandidate) ) {
                         bestCandidate = method;
                     }
@@ -72,11 +72,11 @@ public class MethodUtils {
                 }
 
                 final boolean isVarArgs = method.isVarArgs();
-                if ( isArgsNumberNotCompatible( argsType, parmTypes, isVarArgs ) ) {
+                if ( isArgsNumberNotCompatible( argsType, parameterTypes, isVarArgs ) ) {
                     continue;
                 }
 
-                final int score = getMethodScore(argsType, parmTypes, isVarArgs);
+                final int score = getMethodScore(argsType, parameterTypes, isVarArgs);
                 if (score != 0) {
                     if (score > bestScore) {
                         bestCandidate = method;
@@ -90,8 +90,8 @@ public class MethodUtils {
         return bestCandidate;
     }
 
-    private static boolean isArgsNumberNotCompatible(Class[] arguments, Class<?>[] parmTypes, boolean isVarArgs ) {
-        return ( isVarArgs && parmTypes.length-1 > arguments.length ) || ( !isVarArgs && parmTypes.length != arguments.length );
+    private static boolean isArgsNumberNotCompatible(Class[] arguments, Class<?>[] parameterTypes, boolean isVarArgs ) {
+        return ( isVarArgs && parameterTypes.length-1 > arguments.length ) || ( !isVarArgs && parameterTypes.length != arguments.length );
     }
 
     private static boolean isMoreSpecialized(Method newCandidate, Method oldCandidate ) {

--- a/drools-core/src/test/java/org/drools/core/util/MethodUtilsTest.java
+++ b/drools-core/src/test/java/org/drools/core/util/MethodUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.util;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.drools.core.test.model.Person;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MethodUtilsTest {
+
+    public static class MyClass {
+
+        public static int methodInt(int a) {
+            return a;
+        }
+    }
+
+    @Test
+    public void testFindMethod() {
+        Method m = MethodUtils.findMethod(Object.class, "toString", new Class[0]);
+        assertThat(m).isNotNull();
+        assertThat(m.getName()).isEqualTo("toString");
+        assertThat(m.getParameters()).isEmpty();
+    }
+
+    @Test
+    public void testFindIntMethodWithBigDecimal() {
+        Method m = MethodUtils.findMethod(MyClass.class, "methodInt", new Class[]{BigDecimal.class});
+        assertThat(m).isNotNull();
+        assertThat(m.getName()).isEqualTo("methodInt");
+        assertThat(parametersTypeName(m.getParameters())).containsExactly("int");
+    }
+
+    @Test
+    public void testFindObjectMethodWithString() {
+        Method m = MethodUtils.findMethod(Map.class, "get", new Class[]{String.class});
+        assertThat(m).isNotNull();
+        assertThat(m.getName()).isEqualTo("get");
+        assertThat(parametersTypeName(m.getParameters())).containsExactly("java.lang.Object");
+    }
+
+    private Stream<String> parametersTypeName(Parameter[] parameters) {
+        return Arrays.stream(parameters).map(Parameter::getType).map(Class::getCanonicalName);
+    }
+}

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -256,7 +256,7 @@ public class PackageModel {
         dateFields.put( fieldName, expression );
     }
 
-    private Map<String, Method> getStaticMethods() {
+    public Map<String, Method> getStaticMethods() {
         if (staticMethods == null) {
             Map<String, Method> methodsMap = new HashMap<>();
             for (String i : staticImports) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/Consequence.java
@@ -62,9 +62,7 @@ import org.drools.modelcompiler.builder.errors.MvelCompilationError;
 import org.drools.modelcompiler.consequence.DroolsImpl;
 import org.drools.mvelcompiler.CompiledBlockResult;
 import org.drools.mvelcompiler.ModifyCompiler;
-import org.drools.mvelcompiler.MvelCompiler;
 import org.drools.mvelcompiler.MvelCompilerException;
-import org.drools.mvelcompiler.context.MvelCompilerContext;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.ast.NodeList.nodeList;
@@ -194,16 +192,9 @@ public class Consequence {
 
     private MethodCallExpr createExecuteCallMvel(String consequenceString, BlockStmt ruleVariablesBlock, Set<String> usedDeclarationInRHS, MethodCallExpr onCall) {
         String mvelBlock = addCurlyBracesToBlock(consequenceString);
-        MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(context.getTypeResolver());
-
-        for(DeclarationSpec d : context.getAllDeclarations()) {
-            Class<?> clazz = getClassFromType(context.getTypeResolver(), d.getRawType());
-            mvelCompilerContext.addDeclaration(d.getBindingId(), clazz);
-        }
-
         CompiledBlockResult compile;
         try {
-            compile = new MvelCompiler(mvelCompilerContext).compileStatement(mvelBlock);
+            compile = DrlxParseUtil.createMvelCompiler(context).compileStatement(mvelBlock);
         } catch (MvelCompilerException e) {
             context.addCompilationError(new CompilationProblemErrorResult(new MvelCompilationError(e)) );
             return null;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -20,6 +20,7 @@ package org.drools.modelcompiler.builder.generator;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -67,6 +69,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
+import static java.util.stream.Collectors.toList;
 import static org.drools.modelcompiler.builder.generator.QueryGenerator.toQueryArg;
 import static org.kie.internal.ruleunit.RuleUnitUtil.isLegacyRuleUnit;
 
@@ -504,16 +507,44 @@ public class RuleContext {
                                                       patternClass.getAnnotation( ClassReactive.class ) != null );
     }
 
-    public Optional<Class<?>> getFunctionType(String name) {
+    public Optional<FunctionType> getFunctionType(String name) {
         Method m = packageModel.getStaticMethod(name);
         if (m != null) {
-            return of(m.getReturnType());
+            return of(new FunctionType(m.getReturnType(), Arrays.asList(m.getParameterTypes())));
         }
 
         return packageModel.getFunctions().stream()
                 .filter( method -> method.getNameAsString().equals( name ) )
                 .findFirst()
-                .flatMap( method -> resolveType( method.getType().asString() ) );
+                .flatMap( method -> {
+                    Optional<Class<?>> returnType = resolveType(method.getType().asString());
+
+                    List<String> parametersType = method.getParameters().stream().map(Parameter::getType).map(Type::asString).collect(toList());
+                    List<Class<?>> resolvedParameterTypes = parametersType.stream()
+                            .map(this::resolveType)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(toList());
+                    return returnType.map(t -> new FunctionType(t, resolvedParameterTypes));
+                });
+    }
+
+    public static class FunctionType {
+        private final Class<?> returnType;
+        private final List<Class<?>> argumentsType;
+
+        public FunctionType(Class<?> returnType, List<Class<?>> argumentsType) {
+            this.returnType = returnType;
+            this.argumentsType = argumentsType;
+        }
+
+        public Class<?> getReturnType() {
+            return returnType;
+        }
+
+        public List<Class<?>> getArgumentsType() {
+            return argumentsType;
+        }
     }
 
     public Optional<Class<?>> resolveType(String name) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -489,12 +489,11 @@ public class ConstraintParser {
         } else if(arithmeticExpr && (left.isBigDecimal())) {
             MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(context.getTypeResolver());
 
-            mvelCompilerContext.setRootTypePrefix(THIS_PLACEHOLDER);
-            mvelCompilerContext.setRootPattern(patternType);
+            mvelCompilerContext.setRootPatternPrefix(patternType, THIS_PLACEHOLDER);
 
             ConstraintCompiler constraintCompiler = new ConstraintCompiler(mvelCompilerContext);
 
-            CompiledExpressionResult compiledExpressionResult = constraintCompiler.compileExpression(binaryExpr.toString());
+            CompiledExpressionResult compiledExpressionResult = constraintCompiler.compileExpression(binaryExpr);
 
             Expression expression = compiledExpressionResult.getExpression();
             combo = expression;
@@ -696,11 +695,9 @@ public class ConstraintParser {
         MethodCallExpr toBigDecimalMethod = new MethodCallExpr( null, "org.drools.modelcompiler.util.EvaluationUtil.toBigDecimal" );
         Expression arg = typedExpression.getExpression();
 
-        List<DeclarationSpec> allDeclarations = new ArrayList<>();
-        allDeclarations.addAll(context.getAllDeclarations());
-        typedExpression.getOriginalPatternType().ifPresent(pt -> allDeclarations.add(new DeclarationSpec(THIS_PLACEHOLDER, pt)));
+        Optional<Class<?>> originalPatternType = typedExpression.getOriginalPatternType();
 
-        ConstraintCompiler constraintCompiler = createConstraintCompiler(context, allDeclarations);
+        ConstraintCompiler constraintCompiler = createConstraintCompiler(context, originalPatternType);
 
         CompiledExpressionResult compiledBlockResult = constraintCompiler.compileExpression(arg.toString());
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateInline.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateInline.java
@@ -103,7 +103,7 @@ public class AccumulateInline {
         this.packageModel = packageModel;
         this.accumulateDescr = descr;
         this.basePattern = basePattern;
-        this.mvelCompiler = createMvelCompiler(context, context.getAllDeclarations());
+        this.mvelCompiler = createMvelCompiler(context);
         singleAccumulateType = null;
     }
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -29,6 +29,7 @@ import org.assertj.core.api.Assertions;
 import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.InternationalAddress;
 import org.drools.modelcompiler.domain.Person;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.builder.Message;
 import org.kie.api.builder.Results;
@@ -1096,5 +1097,119 @@ public class MvelDialectTest extends BaseModelTest {
         assertEquals( 1, ksession.fireAllRules() );
 
         assertThat(results).containsOnly("Address");
+    }
+
+    @Test
+    public void testBigDecimalPromotionUsedAsArgument() {
+        // DROOLS-6362
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "import " + Address.class.getCanonicalName() + ";" +
+                "import static " + Person.class.getCanonicalName() + ".isEven;" +
+                "import static " + Person.class.getCanonicalName() + ".isEvenShort;" +
+                "import static " + Person.class.getCanonicalName() + ".isEvenDouble;" +
+                "import static " + Person.class.getCanonicalName() + ".isEvenFloat;" +
+                "global java.util.List results;" +
+                "dialect \"mvel\"\n" +
+                "rule \"isEven\"\n" +
+                "    when\n" +
+                "        $p : Person(" +
+                                    "isEven($p.money), " +
+                                    "isEvenShort($p.money), " +
+                                    "isEvenDouble($p.money), " +
+                                    "isEvenFloat($p.money), " +
+                                    "$m : money)\n" +
+                "    then\n" +
+                "       if (" +
+                        "   $p.isEven($p.money) " +
+                        "   && $p.isEven($m) " +
+                        "   && isEven($p.money) " +
+                        "   && isEven($m)" +
+                        "   && $p.isEvenShort($p.money) " +
+                        "   && $p.isEvenShort($m) " +
+                        "   && isEvenShort($p.money) " +
+                        "   && isEvenShort($m)" +
+                        "   && $p.isEvenDouble($p.money) " +
+                        "   && $p.isEvenDouble($m) " +
+                        "   && isEvenDouble($p.money) " +
+                        "   && isEvenDouble($m)" +
+                        "   && $p.isEvenFloat($p.money) " +
+                        "   && $p.isEvenFloat($m) " +
+                        "   && isEvenFloat($p.money) " +
+                        "   && isEvenFloat($m)" +
+                        ") {\n" +
+                        "" +
+                        "  results.add($p);\n" +
+                        "}\n" +
+                "end\n";
+
+        KieSession ksession = getKieSession( str );
+
+        ArrayList<Person> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        Person john = new Person("John", 30);
+        john.setMoney( new BigDecimal( 3 ) );
+
+        Person leonardo = new Person("Leonardo", 4);
+        leonardo.setMoney( new BigDecimal( 4 ) );
+
+        ksession.insert(john);
+        ksession.insert(leonardo);
+
+        assertEquals( 1, ksession.fireAllRules() );
+
+        assertThat(results).containsOnly(leonardo);
+    }
+
+    @Test
+    public void testBigDecimalPromotionUsingDefinedFunctionAndDeclaredType() {
+        // DROOLS-6362
+        String str = "package com.sample\n" +
+                "import " + Person.class.getName() + ";\n" +
+                "import " + BigDecimal.class.getName() + ";\n" +
+                "global java.util.List results;" +
+                "declare POJOPerson\n" +
+                "    name : String\n" +
+                "    age : int\n" +
+                "    salary : BigDecimal\n" +
+                "end\n" +
+                "function int myFunction(int value) {\n" +
+                "  if (value == 10) {\n" +
+                "    return 1;\n" +
+                "  }\n" +
+                "  return 0;\n" +
+                "}\n" +
+                "dialect \"mvel\"\n" +
+                "rule create\n" +
+                "    when\n" +
+                "        $p: Person()\n" +
+                "    then\n" +
+                "       insert(new POJOPerson($p.name, $p.age, $p.money))\n" +
+                "end\n" +
+                "rule R1\n" +
+                "    when\n" +
+                "        $p: POJOPerson(myFunction(salary) == 1)\n" +
+                "    then\n" +
+                "       if (myFunction($p.salary) == 1) {" +
+                "           results.add($p.name);\n" +
+                        "}\n" +
+                "end\n";
+
+
+        KieSession ksession = getKieSession( str );
+
+        ArrayList<String> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        Person john = new Person("John", 10).setMoney(BigDecimal.valueOf(10));
+        ksession.insert(john);
+
+        Person leonardo = new Person("Leonardo", 4).setMoney(BigDecimal.valueOf(4));
+        ksession.insert(leonardo);
+
+        int rulesFired = ksession.fireAllRules();
+        assertEquals( 3, rulesFired);
+        assertThat(results).containsExactly("John");
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Person.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/Person.java
@@ -277,4 +277,20 @@ public class Person extends AbstractReactiveObject {
     public static Person identityFunction(Person p) {
         return p;
     }
+
+    public static boolean isEven( int i ){
+        return (i % 2) == 0;
+    }
+
+    public static boolean isEvenShort( short i ){
+        return (i % 2) == 0;
+    }
+
+    public static boolean isEvenDouble( double i ){
+        return (i % 2) == 0;
+    }
+
+    public static boolean isEvenFloat( float i ){
+        return (i % 2) == 0;
+    }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledExpressionResult.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/CompiledExpressionResult.java
@@ -16,7 +16,9 @@
 
 package org.drools.mvelcompiler;
 
+import java.lang.reflect.Type;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.ast.NodeList;
@@ -29,15 +31,20 @@ import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
 public class CompiledExpressionResult implements CompiledResult {
 
     private Expression expression;
+    private Optional<Type> type;
     private Set<String> usedBindings = new HashSet<>();
 
-
-    public CompiledExpressionResult(Expression expression) {
+    public CompiledExpressionResult(Expression expression, Optional<Type> type) {
         this.expression = expression;
+        this.type = type;
     }
 
     public Expression getExpression() {
         return expression;
+    }
+
+    public Optional<Type> getType() {
+        return type;
     }
 
     public String resultAsString() {

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ConstraintCompiler.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ConstraintCompiler.java
@@ -16,13 +16,10 @@
 
 package org.drools.mvelcompiler;
 
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import org.drools.mvel.parser.MvelParser;
 import org.drools.mvelcompiler.ast.TypedExpression;
 import org.drools.mvelcompiler.context.MvelCompilerContext;
-
-import static com.github.javaparser.ast.NodeList.nodeList;
 
 /* A special case of compiler in that compiles constraints, that is
     every variable can be implicitly a field of the root object
@@ -39,15 +36,16 @@ public class ConstraintCompiler {
 
     public CompiledExpressionResult compileExpression(String mvelExpressionString) {
         Expression parsedExpression = MvelParser.parseExpression(mvelExpressionString);
-        Node compiled = compileExpression(parsedExpression);
-
-        return new CompiledExpressionResult((Expression) compiled)
-                .setUsedBindings(mvelCompilerContext.getUsedBindings());
+        return compileExpression(parsedExpression);
     }
 
-    // Avoid processing the LHS as it's not present while compiling an expression
-    private Node compileExpression(Node n) {
-        TypedExpression rhs = new RHSPhase(mvelCompilerContext).invoke(n);
-        return rhs.toJavaExpression();
+    public CompiledExpressionResult compileExpression(Expression parsedExpression) {
+        // Avoid processing the LHS as it's not present while compiling an expression
+        TypedExpression compiled = new RHSPhase(mvelCompilerContext).invoke(parsedExpression);
+
+        Expression expression = (Expression) compiled.toJavaExpression();
+
+        return new CompiledExpressionResult(expression, compiled.getType())
+                .setUsedBindings(mvelCompilerContext.getUsedBindings());
     }
 }

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MethodCallExprVisitor.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MethodCallExprVisitor.java
@@ -62,10 +62,10 @@ public class MethodCallExprVisitor implements DrlGenericVisitor<TypedExpression,
             arguments.add(a);
         }
 
-        Class<?>[] argumentsType = parametersType(arguments);
+        Class<?>[] argumentsTypes = parametersType(arguments);
 
         return parseMethodFromDeclaredFunction(n, arguments)
-                .orElseGet(() -> parseMethod(n, scope, name, arguments, argumentsType));
+                .orElseGet(() -> parseMethod(n, scope, name, arguments, argumentsTypes));
     }
 
     private Optional<TypedExpression> parseMethodFromDeclaredFunction(MethodCallExpr n, List<TypedExpression> arguments) {
@@ -77,10 +77,10 @@ public class MethodCallExprVisitor implements DrlGenericVisitor<TypedExpression,
         DeclaredFunction declaredFunction = optDeclaredFunction.get();
 
         Optional<Class<?>> methodReturnType = declaredFunction.findReturnType();
-        List<Class<?>> actualArgumentType = declaredFunction.findArgumentsType();
+        List<Class<?>> actualArgumentTypes = declaredFunction.findArgumentsType();
 
         return methodReturnType.map(t -> new MethodCallExprT(n.getName().asString(), Optional.empty(), arguments,
-                                                             actualArgumentType, Optional.of(t)));
+                                                             actualArgumentTypes, Optional.of(t)));
     }
 
     private MethodCallExprT parseMethod(MethodCallExpr n,

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MethodCallExprVisitor.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MethodCallExprVisitor.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import org.drools.core.util.MethodUtils;
+import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
+import org.drools.mvelcompiler.ast.MethodCallExprT;
+import org.drools.mvelcompiler.ast.TypedExpression;
+import org.drools.mvelcompiler.context.DeclaredFunction;
+import org.drools.mvelcompiler.context.MvelCompilerContext;
+import org.drools.mvelcompiler.util.TypeUtils;
+
+import static org.drools.core.util.StreamUtils.optionalToStream;
+
+public class MethodCallExprVisitor implements DrlGenericVisitor<TypedExpression, RHSPhase.Context> {
+
+    final RHSPhase parentVisitor;
+    final MvelCompilerContext mvelCompilerContext;
+
+    public MethodCallExprVisitor(RHSPhase parentVisitor, MvelCompilerContext mvelCompilerContext) {
+        this.parentVisitor = parentVisitor;
+        this.mvelCompilerContext = mvelCompilerContext;
+    }
+
+    @Override
+    public TypedExpression defaultMethod(Node n, RHSPhase.Context context) {
+        return n.accept(parentVisitor, context);
+    }
+
+    @Override
+    public TypedExpression visit(MethodCallExpr n, RHSPhase.Context arg) {
+        Optional<TypedExpression> scope = n.getScope().map(s -> s.accept(this, arg));
+        TypedExpression name = n.getName().accept(this, new RHSPhase.Context(scope.orElse(null)));
+        final List<TypedExpression> arguments = new ArrayList<>(n.getArguments().size());
+        for(Expression child : n.getArguments()) {
+            TypedExpression a = child.accept(this, arg);
+            arguments.add(a);
+        }
+
+        Class<?>[] argumentsType = parametersType(arguments);
+
+        return parseMethodFromDeclaredFunction(n, arguments)
+                .orElseGet(() -> parseMethod(n, scope, name, arguments, argumentsType));
+    }
+
+    private Optional<TypedExpression> parseMethodFromDeclaredFunction(MethodCallExpr n, List<TypedExpression> arguments) {
+
+        Optional<DeclaredFunction> optDeclaredFunction = mvelCompilerContext.findDeclaredFunction(n.getNameAsString());
+
+        if(!optDeclaredFunction.isPresent()) return Optional.empty();
+
+        DeclaredFunction declaredFunction = optDeclaredFunction.get();
+
+        Optional<Class<?>> methodReturnType = declaredFunction.findReturnType();
+        List<Class<?>> actualArgumentType = declaredFunction.findArgumentsType();
+
+        return methodReturnType.map(t -> new MethodCallExprT(n.getName().asString(), Optional.empty(), arguments,
+                                                             actualArgumentType, Optional.of(t)));
+    }
+
+    private MethodCallExprT parseMethod(MethodCallExpr n,
+                                        Optional<TypedExpression> scope,
+                                        TypedExpression name,
+                                        List<TypedExpression> arguments,
+                                        Class<?>[] argumentsType) {
+        Optional<Method> method = scope.flatMap(TypedExpression::getType)
+                .<Class<?>>map(TypeUtils::classFromType)
+                .map(scopeClazz -> MethodUtils.findMethod(scopeClazz, n.getNameAsString(), argumentsType));
+
+        if(!method.isPresent()) {
+            method = mvelCompilerContext.getRootPattern()
+                    .map(scopeClazz -> MethodUtils.findMethod(scopeClazz, n.getNameAsString(), argumentsType));
+            if(method.isPresent()) {
+                scope = mvelCompilerContext.createRootTypePrefix();
+            }
+        }
+
+        if(!method.isPresent()) {
+            method = mvelCompilerContext.findStaticMethod(n.getNameAsString());
+        }
+
+        Optional<Method> finalMethod = method;
+        Optional<Type> methodReturnType =
+                name.getType()
+                        .map(Optional::of)
+                        .orElseGet(() -> finalMethod.map(Method::getReturnType));
+
+        List<Class<?>> actualArgumentType = optionalToStream(method)
+                .flatMap((Method m) -> Arrays.stream(m.getParameterTypes()))
+                .collect(Collectors.toList());
+
+        return new MethodCallExprT(n.getName().asString(), scope, arguments,
+                                   actualArgumentType, methodReturnType);
+    }
+
+    private Class<?>[] parametersType(List<TypedExpression> arguments) {
+        return arguments.stream()
+                .map(TypedExpression::getType)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(TypeUtils::classFromType)
+                .toArray(Class[]::new);
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ObjectCreationExpressionT.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ObjectCreationExpressionT.java
@@ -17,19 +17,23 @@
 package org.drools.mvelcompiler.ast;
 
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 
 public class ObjectCreationExpressionT implements TypedExpression {
 
     private final Class<?> type;
+    private List<TypedExpression> constructorArguments;
 
-    ObjectCreationExpr originalExpression;
-
-    public ObjectCreationExpressionT(ObjectCreationExpr originalExpression, Class<?> type) {
-        this.originalExpression = originalExpression;
+    public ObjectCreationExpressionT(List<TypedExpression> constructorArguments, Class<?> type) {
+        this.constructorArguments = constructorArguments;
         this.type = type;
     }
 
@@ -40,13 +44,19 @@ public class ObjectCreationExpressionT implements TypedExpression {
 
     @Override
     public Node toJavaExpression() {
-        return originalExpression;
+        ObjectCreationExpr objectCreationExpr = new ObjectCreationExpr();
+        objectCreationExpr.setType(type);
+        List<Expression> arguments = this.constructorArguments.stream()
+                .map(typedExpression -> (Expression)typedExpression.toJavaExpression())
+                .collect(Collectors.toList());
+        objectCreationExpr.setArguments(NodeList.nodeList(arguments));
+        return objectCreationExpr;
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("ObjectCreationExpressionT{");
-        sb.append("originalExpression=").append(originalExpression);
+        sb.append("arguments=").append(constructorArguments);
         sb.append("type=").append(type);
         sb.append('}');
         return sb.toString();

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/DeclaredFunction.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/DeclaredFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.context;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.drools.core.addon.TypeResolver;
+import org.drools.core.util.StreamUtils;
+
+public class DeclaredFunction {
+
+    private final TypeResolver typeResolver;
+    private final String name;
+    private final String returnType;
+    private final List<String> arguments;
+
+    public DeclaredFunction(TypeResolver typeResolver, String name, String returnType, List<String> arguments) {
+        this.typeResolver = typeResolver;
+        this.name = name;
+        this.returnType = returnType;
+        this.arguments = arguments;
+    }
+
+    public Optional<Class<?>> findReturnType() {
+        return resolveType(returnType);
+    }
+
+    public List<Class<?>> findArgumentsType() {
+        return arguments.stream().map(this::resolveType)
+                .flatMap(StreamUtils::optionalToStream)
+                .collect(Collectors.toList());
+    }
+
+    public Optional<Class<?>> resolveType(String name) {
+        try {
+            return Optional.ofNullable(typeResolver.resolveType(name));
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/StaticMethod.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/context/StaticMethod.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.context;
+
+import java.lang.reflect.Method;
+
+/* Represents static methods and external-defined functions */
+public class StaticMethod {
+
+    final String methodName;
+    final Method method;
+
+    public StaticMethod(String methodName, Method method) {
+        this.methodName = methodName;
+        this.method = method;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/BigDecimalArgumentCoercion.java
+++ b/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/util/BigDecimalArgumentCoercion.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.mvelcompiler.util;
+
+import java.math.BigDecimal;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class BigDecimalArgumentCoercion {
+
+    public Expression coercedArgument(Class<?> argumentType, Class<?> actualType, Expression argument) {
+        boolean argumentTypeIsBigDecimal = BigDecimal.class.isAssignableFrom(argumentType);
+
+        if (isInteger(actualType) && argumentTypeIsBigDecimal) {
+            return bigDecimalToPrimitive(argument, "intValue");
+        } else if (isShort(actualType) && argumentTypeIsBigDecimal) {
+            return bigDecimalToPrimitive(argument, "shortValue");
+        } else if (isDouble(actualType) && argumentTypeIsBigDecimal) {
+            return bigDecimalToPrimitive(argument, "doubleValue");
+        } else if (isFloat(actualType) && argumentTypeIsBigDecimal) {
+            return bigDecimalToPrimitive(argument, "floatValue");
+        }
+
+        return argument;
+    }
+
+    private MethodCallExpr bigDecimalToPrimitive(Expression argumentExpression, String intValue) {
+        return new MethodCallExpr(argumentExpression, intValue, nodeList());
+    }
+
+    private boolean isInteger(Class<?> actualType) {
+        return actualType == int.class || actualType == Integer.class;
+    }
+
+    private boolean isFloat(Class<?> actualType) {
+        return actualType == float.class || actualType == Float.class;
+    }
+
+    private boolean isDouble(Class<?> actualType) {
+        return actualType == double.class || actualType == Double.class;
+    }
+
+    private boolean isShort(Class<?> actualType) {
+        return actualType == short.class || actualType == Short.class;
+    }
+}

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/Person.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/Person.java
@@ -116,4 +116,8 @@ public class Person {
     public void setAddresses(List<Address> addresses) {
         this.addresses = addresses;
     }
+
+    public boolean isEven(int value) {
+        return true;
+    }
 }

--- a/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
+++ b/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/ConstraintCompilerTest.java
@@ -31,29 +31,32 @@ public class ConstraintCompilerTest implements CompilerTest {
 
     @Test
     public void testBigDecimalPromotion() {
-        testExpression(c -> {
-                           c.setRootPattern(Person.class);
-                           c.setRootTypePrefix("_this");
-                       }, "salary + salary",
+        testExpression(c -> c.setRootPatternPrefix(Person.class, "_this"), "salary + salary",
                        "_this.getSalary().add(_this.getSalary())");
     }
 
     @Test
     public void testBigDecimalStringEquality() {
-        testExpression(c -> {
-                           c.setRootPattern(Person.class);
-                           c.setRootTypePrefix("_this");
-                       }, "salary == \"90\"",
+        testExpression(c -> c.setRootPatternPrefix(Person.class, "_this"), "salary == \"90\"",
                        "_this.getSalary().equals(new java.math.BigDecimal(\"90\"))");
     }
 
     @Test
     public void testBigDecimalStringNonEquality() {
-        testExpression(c -> {
-                           c.setRootPattern(Person.class);
-                           c.setRootTypePrefix("_this");
-                       }, "salary != \"90\"",
+        testExpression(c -> c.setRootPatternPrefix(Person.class, "_this"), "salary != \"90\"",
                        "!(_this.getSalary().equals(new java.math.BigDecimal(\"90\")))");
+    }
+
+    @Test
+    public void testBigDecimalPromotionToIntMethod() {
+        testExpression(c -> c.setRootPatternPrefix(Person.class, "_this"), "isEven(salary)",
+                       "_this.isEven(_this.getSalary().intValue())");
+    }
+
+    @Test
+    public void testConversionConstructorArgument() {
+        testExpression(c -> c.addDeclaration("$p", Person.class), "new Person($p.name, $p)",
+                       "new Person($p.getName(), $p)");
     }
 
     public void testExpression(Consumer<MvelCompilerContext> testFunction,


### PR DESCRIPTION
* Added tests for MethodUtils
* Support promotion in consequence with instance method
* Support BigDecimal coercion in constraint
* [drools-mvel-compiler] Moved custom logic for MethodCallExpr to MethodCallExprVisitor.java
* Support defined functions in drools-mvel-compiler
* Compile constructor arguments
* Use only method for root pattern and rootPrefix

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6362

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
