### PR TITLE
[DROOLS-6366] Reproducers: compile error in exec model when comparing  BigDecimal with result of accumulate max

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/MvelDialectTest.java
@@ -604,6 +604,74 @@ public class MvelDialectTest extends BaseModelTest {
     }
 
     @Test
+    public void testBigDecimalAccumulate() {
+        // DROOLS-6366
+        String drl =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "import " + BigDecimal.class.getCanonicalName() + "\n" +
+                "global java.util.List results;\n" +
+                "dialect \"mvel\"\n" +
+                "rule R\n" +
+                "when\n" +
+                "    accumulate( Person($m : money); $maxMoney:max($m))\n" +
+                "    $john : Person(money == $maxMoney)\n" +
+                "then\n" +
+                "    results.add($john);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(drl);
+
+        List<Person> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        Person john = new Person("John", 30);
+        john.setMoney( new BigDecimal( 90 ) );
+
+        Person mark = new Person("Mark", 30);
+        mark.setMoney( new BigDecimal( 80 ) );
+
+        ksession.insert(john);
+        ksession.insert(mark);
+
+        assertEquals(1, ksession.fireAllRules());
+        assertThat(results).containsExactly(john);
+    }
+
+    @Test
+    public void testBigDecimalAccumulateWithFrom() {
+        // DROOLS-6366
+        String drl =
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "import " + BigDecimal.class.getCanonicalName() + "\n" +
+                "global java.util.List results;\n" +
+                "dialect \"mvel\"\n" +
+                "rule R\n" +
+                "when\n" +
+                "    $maxMoney : BigDecimal() from accumulate( Person($m : money); max($m))\n" +
+                "    $john : Person(money == $maxMoney)\n" +
+                "then\n" +
+                "    results.add($john);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(drl);
+
+        List<Person> results = new ArrayList<>();
+        ksession.setGlobal("results", results);
+
+        Person john = new Person("John", 30);
+        john.setMoney( new BigDecimal( 90 ) );
+
+        Person mark = new Person("Mark", 30);
+        mark.setMoney( new BigDecimal( 80 ) );
+
+        ksession.insert(john);
+        ksession.insert(mark);
+
+        assertEquals(1, ksession.fireAllRules());
+        assertThat(results).containsExactly(john);
+    }
+
+    @Test
     public void testCompoundOperatorBigDecimalConstant() throws Exception {
         // DROOLS-5894
         String drl =


### PR DESCRIPTION
As this issue has been already solved by https://github.com/kiegroup/drools/commit/b20de7e76818dcd1b717fcfacace843bed3ea146

We only add regression tests

https://issues.redhat.com/browse/DROOLS-6366


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
