### PR TITLE
[DROOLS-6364] Hang in IncrementalCompilationTest on Windows

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -2963,11 +2963,6 @@ public class IncrementalCompilationTest {
 
     @Test(timeout = 20000L)
     public void testMultipleIncrementalCompilationsWithFireUntilHalt() throws Exception {
-        if (ClassUtils.isWindows()) {
-            // To be fixed : See DROOLS-6364
-            return;
-        }
-
         // DROOLS-1406
         final KieServices ks = KieServices.Factory.get();
 


### PR DESCRIPTION
- Enable Windows test as the issue was fixed by DROOLS-6392

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6364

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
