### PR TITLE
DROOLS-6399: [Test Scenario] Runner extracts only one Map item

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -118,8 +118,7 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
 
             if (isSimpleTypeNode(jsonNode)) {
                 Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
-                Object value = internalLiteralEvaluation(getSimpleTypeNodeTextValue(jsonNode), fieldDescriptor.getKey());
-                setField(toReturn, key, value);
+                setField(toReturn, key, internalLiteralEvaluation(getSimpleTypeNodeTextValue(jsonNode), fieldDescriptor.getKey()));
             } else if (jsonNode.isArray()) {
                 List<Object> nestedList = new ArrayList<>();
                 Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluator.java
@@ -115,15 +115,12 @@ public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator
             Map.Entry<String, JsonNode> element = fields.next();
             String key = element.getKey();
             JsonNode jsonNode = element.getValue();
-            // if is a simple value just return the parsed result
+
             if (isSimpleTypeNode(jsonNode)) {
                 Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
                 Object value = internalLiteralEvaluation(getSimpleTypeNodeTextValue(jsonNode), fieldDescriptor.getKey());
                 setField(toReturn, key, value);
-                return toReturn;
-            }
-
-            if (jsonNode.isArray()) {
+            } else if (jsonNode.isArray()) {
                 List<Object> nestedList = new ArrayList<>();
                 Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
                 List<Object> returnedList = createAndFillList((ArrayNode) jsonNode, nestedList, fieldDescriptor.getKey(), fieldDescriptor.getValue());

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
@@ -117,6 +117,7 @@ public class AbstractExpressionEvaluatorTest {
         // single level
         ObjectNode objectNode = new ObjectNode(factory);
         objectNode.put("age", "1");
+        objectNode.put("name", "Polissena");
 
         Object result = expressionEvaluatorLocal.createAndFillObject(objectNode,
                                                                      new HashMap<>(),
@@ -127,6 +128,8 @@ public class AbstractExpressionEvaluatorTest {
         Map<String, Object> resultMap = (Map<String, Object>) result;
 
         assertEquals("1", resultMap.get("age"));
+        assertEquals("Polissena", resultMap.get("name"));
+        assertEquals(2, resultMap.size());
 
         // nested object
         objectNode.removeAll();

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/AbstractExpressionEvaluatorTest.java
@@ -114,21 +114,39 @@ public class AbstractExpressionEvaluatorTest {
     @SuppressWarnings("unchecked")
     @Test
     public void convertObject() {
-        // single level
+        // Test simple list
         ObjectNode objectNode = new ObjectNode(factory);
-        objectNode.put("age", "1");
-        objectNode.put("name", "Polissena");
+        ObjectNode simpleValue =  new ObjectNode(factory);
+        ObjectNode simpleValue2 =  new ObjectNode(factory);
+        simpleValue.put(VALUE, "Polissena");
+        simpleValue2.put(VALUE, "Antonia");
+        objectNode.put("key1", simpleValue);
+        objectNode.put("key2", simpleValue2);
 
-        Object result = expressionEvaluatorLocal.createAndFillObject(objectNode,
-                                                                     new HashMap<>(),
-                                                                     Map.class.getCanonicalName(),
-                                                                     Collections.singletonList(String.class.getCanonicalName()));
-
+        Object result  = expressionEvaluatorLocal.createAndFillObject(objectNode,
+                                                                      new HashMap<>(),
+                                                                      Map.class.getCanonicalName(),
+                                                                      Collections.singletonList(String.class.getCanonicalName()));
         assertTrue(result instanceof Map);
         Map<String, Object> resultMap = (Map<String, Object>) result;
+        assertEquals(2, resultMap.size());
+        assertEquals("Polissena", resultMap.get("key1"));
+        assertEquals("Antonia", resultMap.get("key2"));
+
+        // single level
+        objectNode.removeAll();
+        objectNode.put("age", "1");
+        objectNode.put("name", "FS");
+        result = expressionEvaluatorLocal.createAndFillObject(objectNode,
+                                                              new HashMap<>(),
+                                                              Map.class.getCanonicalName(),
+                                                              Collections.singletonList(String.class.getCanonicalName()));
+
+        assertTrue(result instanceof Map);
+        resultMap = (Map<String, Object>) result;
 
         assertEquals("1", resultMap.get("age"));
-        assertEquals("Polissena", resultMap.get("name"));
+        assertEquals("FS", resultMap.get("name"));
         assertEquals(2, resultMap.size());
 
         // nested object


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6399

In the case of a populated Map property, Scesim Runner extracts one item only. 
The reason for the issue is: https://github.com/kiegroup/drools/pull/3662/files#diff-b6eceb0d596a77ca6c6437b08bba85947a0768480c9ce0222ae32b5d044e19b9L123
When processing the first item of the map, the method returns, without processing the remaining ones.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
