### PR TITLE
[RHDM-1738] Avoid quadratic behaviour when adding rule descr to CompositePackageDescr (#3625)

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/lang/descr/CompositePackageDescr.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/lang/descr/CompositePackageDescr.java
@@ -15,13 +15,14 @@
 
 package org.drools.compiler.lang.descr;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.kie.api.io.Resource;
 import org.kie.internal.builder.ResourceChange;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 public class CompositePackageDescr extends PackageDescr {
     
@@ -44,93 +45,66 @@ public class CompositePackageDescr extends PackageDescr {
     }
 
     private void internalAdd(Resource resource, PackageDescr packageDescr) {
-        List<ImportDescr> currentImports = getImports();
         for (ImportDescr descr : packageDescr.getImports()) {
-            if (!currentImports.contains(descr)) {
-                addImport(descr);
-                descr.setResource(resource);
-            }
+            addImport(descr);
+            descr.setResource(resource);
         }
 
-        List<FunctionImportDescr> currentFunctionImports = getFunctionImports();
         for (FunctionImportDescr descr : packageDescr.getFunctionImports()) {
-            if (!currentFunctionImports.contains(descr)) {
-                addFunctionImport(descr);
-                descr.setResource(resource);
-            }
+            addFunctionImport(descr);
+            descr.setResource(resource);
         }
-        
-        List<AccumulateImportDescr> accumulateImports = getAccumulateImports();
+
         for (AccumulateImportDescr descr : packageDescr.getAccumulateImports()) {
-            if (!accumulateImports.contains(descr)) {
-                addAccumulateImport(descr);
-                descr.setResource(resource);
-            }
+            addAccumulateImport(descr);
+            descr.setResource(resource);
         }
 
-        List<AttributeDescr> currentAttributeDescrs = getAttributes();
         for (AttributeDescr descr : packageDescr.getAttributes()) {
-            if (!currentAttributeDescrs.contains(descr)) {
-                addAttribute(descr);
-                descr.setResource(resource);
-            }
+            addAttribute(descr);
+            descr.setResource(resource);
         }
 
-        List<GlobalDescr> currentGlobalDescrs = getGlobals();
         for (GlobalDescr descr : packageDescr.getGlobals()) {
-            if (!currentGlobalDescrs.contains(descr)) {
-                addGlobal(descr);
-                descr.setResource(resource);
-            }
+            addGlobal(descr);
+            descr.setResource(resource);
         }
 
-        List<FunctionDescr> currentFunctionDescrs = getFunctions();
         for (FunctionDescr descr : packageDescr.getFunctions()) {
-            if (!currentFunctionDescrs.contains(descr)) {
-                addFunction(descr);
-                descr.setResource(resource);
-            }
+            addFunction(descr);
+            descr.setResource(resource);
         }
 
-        List<RuleDescr> ruleDescrs = getRules();
         for (RuleDescr descr : packageDescr.getRules()) {
-            if (!ruleDescrs.contains(descr)) {
-                addRule(descr);
-                descr.setResource(resource);
-            }
+            addRule(descr);
+            descr.setResource(resource);
         }
 
-        List<TypeDeclarationDescr> typeDeclarationDescrs = getTypeDeclarations();
+        // Avoid adding the same type declaration twice, see
+        // TypeDeclarationTest.testDuplicatedTypeDeclarationInDifferentResources
+        // IncrementalCompilationTest.testIncrementalCompilationWithAmbiguousRedeclares
+        // RHDM-1738
+        Set<TypeDeclarationDescr> typeDeclarationDescrs = new HashSet<>(getTypeDeclarations());
         for (TypeDeclarationDescr descr : packageDescr.getTypeDeclarations()) {
             if (!typeDeclarationDescrs.contains(descr)) {
                 addTypeDeclaration(descr);
                 descr.setResource(resource);
             }
-
         }
 
-        List<EnumDeclarationDescr> enumDeclarationDescrs = getEnumDeclarations();
         for (EnumDeclarationDescr enumDescr : packageDescr.getEnumDeclarations()) {
-            if (!enumDeclarationDescrs.contains(enumDescr)) {
-                addEnumDeclaration(enumDescr);
-                enumDescr.setResource(resource);
-            }
+            addEnumDeclaration(enumDescr);
+            enumDescr.setResource(resource);
         }
 
-        Set<EntryPointDeclarationDescr> entryPointDeclarationDescrs = getEntryPointDeclarations();
         for (EntryPointDeclarationDescr descr : packageDescr.getEntryPointDeclarations()) {
-            if (!entryPointDeclarationDescrs.contains(descr)) {
-                addEntryPointDeclaration(descr);
-                descr.setResource(resource);
-            }
+            addEntryPointDeclaration(descr);
+            descr.setResource(resource);
         }
 
-        Set<WindowDeclarationDescr> windowDeclarationDescrs = getWindowDeclarations();
         for (WindowDeclarationDescr descr : packageDescr.getWindowDeclarations()) {
-            if (!windowDeclarationDescrs.contains(descr)) {
-                addWindowDeclaration(descr);
-                descr.setResource(resource);
-            }
+            addWindowDeclaration(descr);
+            descr.setResource(resource);
         }
         packageDescr.getPreferredPkgUUID().ifPresent(pkgUUID -> {
             if (getPreferredPkgUUID().isPresent() && !pkgUUID.equals(getPreferredPkgUUID().get())) {


### PR DESCRIPTION
7.11. Backport for https://github.com/kiegroup/drools/pull/3625

* Avoid quadratic behaviour when adding rule descr to CompositePackageDescr

* Try remove quadratic behaviour from all descrs, incremental tests failing

* Avoid adding the same type declaration twice

(cherry picked from commit 21867916ee6d4660e4adda986b7ef183d552a39d)

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/RHDM-1738

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
