### PR TITLE
DROOLS-6416 DMN FEEL GWT Showcase only on explicit GWT properties

### DIFF
--- a/kie-dmn/kie-dmn-feel-gwt-showcase/README.md
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/README.md
@@ -1,0 +1,8 @@
+To compile and run this project in the main Maven build, ensure the necessary profile property is set.
+
+Eg.
+```
+mvn clean install -Pgwt-showcase
+ or
+mvn clean install -DgwtShowcase
+```

--- a/kie-dmn/kie-dmn-feel-gwt-showcase/README.md
+++ b/kie-dmn/kie-dmn-feel-gwt-showcase/README.md
@@ -2,7 +2,7 @@ To compile and run this project in the main Maven build, ensure the necessary pr
 
 Eg.
 ```
-mvn clean install -Pgwt-showcase
+mvn clean install -PfullProfile
  or
-mvn clean install -DgwtShowcase
+mvn clean install -Dfull
 ```

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -22,7 +22,7 @@
     <module>kie-dmn-feel</module>
     <module>kie-dmn-feel-gwt-functions</module>
     <module>kie-dmn-feel-gwt</module>
-    <module>kie-dmn-feel-gwt-showcase</module>
+    <!-- <module>kie-dmn-feel-gwt-showcase</module> -->
     <module>kie-dmn-backend</module>
     <module>kie-dmn-core</module>
     <module>kie-dmn-validation-bootstrap</module>
@@ -48,5 +48,20 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  
+  <profiles>
+    <profile>
+      <id>gwt-showcase</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>gwt.compiler.skip</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kie-dmn-feel-gwt-showcase</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -50,11 +50,10 @@
   
   <profiles>
     <profile>
-      <id>gwt-showcase</id>
+      <id>fullProfile</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
         <property>
-          <name>gwtShowcase</name>
+          <name>full</name>
         </property>
       </activation>
       <modules>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -22,7 +22,6 @@
     <module>kie-dmn-feel</module>
     <module>kie-dmn-feel-gwt-functions</module>
     <module>kie-dmn-feel-gwt</module>
-    <!-- <module>kie-dmn-feel-gwt-showcase</module> -->
     <module>kie-dmn-backend</module>
     <module>kie-dmn-core</module>
     <module>kie-dmn-validation-bootstrap</module>
@@ -55,7 +54,7 @@
       <activation>
         <activeByDefault>false</activeByDefault>
         <property>
-          <name>gwt.compiler.skip</name>
+          <name>gwtShowcase</name>
         </property>
       </activation>
       <modules>


### PR DESCRIPTION
# nothing specified, eg. `mvn clean install`

![image](https://user-images.githubusercontent.com/1699252/122019104-c3aace80-cdc3-11eb-9f8a-5a01bcaf39ba.png)

# specifying profile, eg: `... -PfullProfile`

![image](https://user-images.githubusercontent.com/1699252/122019252-e341f700-cdc3-11eb-8ebc-97e567d02338.png)

# specify with property `... -Dfull`

![image](https://user-images.githubusercontent.com/1699252/122019479-197f7680-cdc4-11eb-8d62-215a4001023d.png)

---

**JIRA**: https://issues.redhat.com/browse/DROOLS-6416

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
