### PR TITLE
[7.52.x] [DROOLS-6296] updateToVersion unexpectedly overwrite ObjectTypeNode.e…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -1097,7 +1097,7 @@ public class KnowledgeBaseImpl
             // if we are running in STREAM mode, update expiration offset
             for( EntryPointNode ep : this.rete.getEntryPointNodes().values() ) {
                 for( ObjectTypeNode node : ep.getObjectTypeNodes().values() ) {
-                    if( node.isAssignableFrom( typeDeclaration.getObjectType() ) ) {
+                    if( node.getObjectType().equals( typeDeclaration.getObjectType() ) ) {
                         node.setExpirationOffset( Math.max( node.getExpirationOffset(), exp ) );
                     }
                 }

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventA.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventA.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.testcoverage.common.model;
+
+import java.util.Date;
+import java.util.Objects;
+
+public class ChildEventA extends ParentEvent {
+
+    private String name;
+
+    public ChildEventA(Date eventTimestamp, String name) {
+        super(eventTimestamp);
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ChildEventA aEvent = (ChildEventA) o;
+        return Objects.equals(name, aEvent.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "ChildEventA{" +
+               "name='" + name + '\'' +
+               '}';
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventB.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ChildEventB.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.testcoverage.common.model;
+
+import java.util.Date;
+import java.util.Objects;
+
+public class ChildEventB extends ParentEvent {
+
+    private String id;
+
+    public ChildEventB(Date eventTimestamp, String id) {
+        super(eventTimestamp);
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ChildEventB bEvent = (ChildEventB) o;
+        return Objects.equals(id, bEvent.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "ChildEventB{" +
+               "id='" + id + '\'' +
+               '}';
+    }
+}

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ParentEvent.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/common/model/ParentEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.testcoverage.common.model;
+
+import java.util.Date;
+
+public abstract class ParentEvent {
+
+    public ParentEvent(Date eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+
+    private Date eventTimestamp;
+
+    public Date getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(Date eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+}


### PR DESCRIPTION
…xpirationOffset of super type (#3557)

Backport DROOLS-6296 to 7.52.x

**JIRA**: 
https://issues.redhat.com/browse/RHDM-1708

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
