### PR TITLE
[7.52.x] DROOLS-6268 : Guided Rule Editor: Add memberOf and not memberOf operators

### DIFF
--- a/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
+++ b/drools-workbench-models/drools-workbench-models-commons/src/test/java/org/drools/workbench/models/commons/backend/rule/RuleModelDRLPersistenceTest.java
@@ -5156,4 +5156,51 @@ public class RuleModelDRLPersistenceTest extends BaseRuleModelTest {
                 "end\n";
         assertEqualsIgnoreWhitespace(expectedDrl, resultDrl);
     }
+
+    @Test
+    public void testMemberOfWithVariable() {
+
+        final RuleModel ruleModel = new RuleModel();
+        ruleModel.name = "test";
+
+        addModelField("ListContainer",
+                      "list",
+                      "java.util.List",
+                      DataType.TYPE_COLLECTION);
+
+        final FactPattern containerPattern = new FactPattern("ListContainer");
+        SingleFieldConstraint listField = new SingleFieldConstraint();
+        listField.setFieldType(DataType.TYPE_COLLECTION);
+        listField.setFieldName("list");
+        listField.setFieldBinding("$list");
+        containerPattern.addConstraint(listField);
+
+        final FactPattern otherPattern = new FactPattern("Other");
+        SingleFieldConstraint inField = new SingleFieldConstraint();
+        inField.setFieldType(DataType.TYPE_STRING);
+        inField.setFieldName("item");
+        inField.setOperator("memberOf");
+        inField.setValue("$list");
+
+        final SingleFieldConstraint notInField = new SingleFieldConstraint();
+        notInField.setFieldType(DataType.TYPE_STRING);
+        notInField.setFieldName("item");
+        notInField.setOperator("not memberOf");
+        notInField.setValue("$list");
+
+        otherPattern.addConstraint(inField);
+        otherPattern.addConstraint(notInField);
+
+        ruleModel.addLhsItem(containerPattern);
+        ruleModel.addLhsItem(otherPattern);
+
+        checkMarshalling("rule \"test\"\n" +
+                                 "dialect \"mvel\"\n" +
+                                 "when\n" +
+                                 "ListContainer( $list : list)\n" +
+                                 "Other( item memberOf $list, item not memberOf $list )\n" +
+                                 "then\n" +
+                                 "end",
+                         ruleModel);
+    }
 }


### PR DESCRIPTION


(cherry picked from commit d7f53fa20b2b2a79d6302d1b01e994d943f99ea2)
**JIRA**: 

[DROOLS-6268](https://issues.redhat.com/browse/DROOLS-6268)

Ok. So I had to recreate this one. Forgot to reopen before I push.
https://github.com/kiegroup/drools/pull/3537


**referenced Pull Requests**:

* https://github.com/kiegroup/kie-soup/pull/194
* https://github.com/kiegroup/drools/pull/3537
* https://github.com/kiegroup/kie-wb-common/pull/3620
* https://github.com/kiegroup/drools-wb/pull/1483

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
