### PR TITLE
[DROOLS-6432] Calling fireAllRules simultaneously from multiple threa…

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceConcurrencyTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/ConsequenceConcurrencyTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.drools.compiler.integrationtests.ConstraintConcurrencyTest.Album;
+import org.drools.compiler.integrationtests.ConstraintConcurrencyTest.Bus;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+import org.kie.test.testcategory.TurtleTestCategory;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Category(TurtleTestCategory.class)
+public class ConsequenceConcurrencyTest {
+
+    private static int LOOP = 500;
+
+    private static int THREADS = 32;
+    private static int REQUESTS = 32;
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public ConsequenceConcurrencyTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(false); // TODO: This rule fails with exec-model. Filed DROOLS-6430
+    }
+
+    @Test(timeout = 300000)
+    public void testConsequenceConcurrency() {
+        final String drl =
+                "package com.example.reproducer\n" +
+                           "import " + Bus.class.getCanonicalName() + ";\n" +
+                           "dialect \"mvel\"\n" +
+                           "global java.util.List result;\n" +
+                           "rule \"rule_mt_1a\"\n" +
+                           "    when\n" +
+                           "        $bus : Bus( $title: \"POWER PLANT\" )\n" +
+                           "    then\n" +
+                           "        result.add($bus.karaoke.dvd[$title].artist);\n" +
+                           "end";
+
+        List<Exception> exceptions = new ArrayList<>();
+
+        KieBase kieBase = null;
+        if (kieBaseTestConfiguration.isExecutableModel()) { // There's no such a thing as jitting, so we can create the KieBase once
+            kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+        }
+        for (int i = 0; i < LOOP; i++) {
+            if (!kieBaseTestConfiguration.isExecutableModel()) { // to reset MVELConstraint Jitting we need to create a new KieBase each time
+                kieBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("accumulate-test", kieBaseTestConfiguration, drl);
+            }
+            ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+            CountDownLatch latch = new CountDownLatch(THREADS);
+            for (int j = 0; j < REQUESTS; j++) {
+                KieBase finalKieBase = kieBase;
+                executor.execute(new Runnable() {
+
+                    public void run() {
+                        KieSession kSession = finalKieBase.newKieSession();
+                        List<String> result = new ArrayList<>();
+                        kSession.setGlobal("result", result);
+
+                        Bus bus1 = new Bus("red", 30);
+                        bus1.getKaraoke().getDvd().put("POWER PLANT", new Album("POWER PLANT", "GAMMA RAY"));
+                        bus1.getKaraoke().getDvd().put("Somewhere Out In Space", new Album("Somewhere Out In Space", "GAMMA RAY"));
+                        kSession.insert(bus1);
+
+                        try {
+                            latch.countDown();
+                            latch.await();
+                        } catch (InterruptedException e) {
+                            // ignore
+                        }
+
+                        try {
+                            kSession.fireAllRules();
+                        } catch (Exception e) {
+                            // [Exception executing consequence for rule "rule_mt_1a" in com.example.reproducer: [Error: unable to resolve method using strict-mode: java.lang.Object.artist()]
+                            exceptions.add(e);
+                        } finally {
+                            kSession.dispose();
+                        }
+                    }
+                });
+            }
+
+            executor.shutdown();
+            try {
+                executor.awaitTermination(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+
+        assertEquals(0, exceptions.size());
+    }
+}


### PR DESCRIPTION
…ds sometimes causes an exception inside MVELConsequence#evaluate.

- Unit test (TurtleTest) only

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6432

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
