### PR TITLE
Refactor of unit tests - DROOLS-6440

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/ConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/ConstraintTestUtil.java
@@ -12,10 +12,10 @@ import org.drools.mvel.model.Cheese;
 public class ConstraintTestUtil {
 
     public static AlphaNodeFieldConstraint createCheeseTypeEqualsConstraint(ClassFieldAccessorStore store, String rightvalue, boolean useLambdaConstraint) {
+        final ClassFieldReader extractor = store.getReader(Cheese.class, "type");
         if (useLambdaConstraint) {
-            return LambdaConstraintTestUtil.createCheeseTypeEqualsConstraint(rightvalue);
+            return LambdaConstraintTestUtil.createCheeseTypeEqualsConstraint(rightvalue, extractor.getIndex());
         } else {
-            final ClassFieldReader extractor = store.getReader(Cheese.class, "type");
             final FieldValue field = FieldFactory.getInstance().getFieldValue(rightvalue);
             return new MVELConstraintTestUtil("type == \"" + rightvalue + "\"", field, extractor);
         }
@@ -23,7 +23,7 @@ public class ConstraintTestUtil {
 
     public static AlphaNodeFieldConstraint createCheeseTypeEqualsConstraint(InternalReadAccessor extractor, String rightvalue, boolean useLambdaConstraint) {
         if (useLambdaConstraint) {
-            return LambdaConstraintTestUtil.createCheeseTypeEqualsConstraint(rightvalue);
+            return LambdaConstraintTestUtil.createCheeseTypeEqualsConstraint(rightvalue, extractor.getIndex());
         } else {
             final FieldValue field = FieldFactory.getInstance().getFieldValue(rightvalue);
             return new MVELConstraintTestUtil("type == \"" + rightvalue + "\"", field, extractor);
@@ -48,7 +48,7 @@ public class ConstraintTestUtil {
 
     public static AlphaNodeFieldConstraint createCheesePriceEqualsConstraint(InternalReadAccessor extractor, int rightvalue, boolean useLambdaConstraint) {
         if (useLambdaConstraint) {
-            return LambdaConstraintTestUtil.createCheesePriceEqualsConstraint(rightvalue);
+            return LambdaConstraintTestUtil.createCheesePriceEqualsConstraint(rightvalue, extractor.getIndex());
         } else {
             final FieldValue field = FieldFactory.getInstance().getFieldValue(rightvalue);
             return new MVELConstraintTestUtil("price == " + rightvalue, field, extractor);
@@ -57,7 +57,7 @@ public class ConstraintTestUtil {
 
     public static AlphaNodeFieldConstraint createCheesePriceGreaterConstraint(InternalReadAccessor extractor, int rightvalue, boolean useLambdaConstraint) {
         if (useLambdaConstraint) {
-            return LambdaConstraintTestUtil.createCheesePriceGreaterConstraint(rightvalue);
+            return LambdaConstraintTestUtil.createCheesePriceGreaterConstraint(rightvalue, extractor.getIndex());
         } else {
             final FieldValue field = FieldFactory.getInstance().getFieldValue(rightvalue);
             return new MVELConstraintTestUtil("price > " + rightvalue, field, extractor);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LambdaConstraintTestUtil.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/LambdaConstraintTestUtil.java
@@ -61,27 +61,27 @@ public class LambdaConstraintTestUtil {
         return new LambdaConstraint(constraintEvaluator);
     }
 
-    public static LambdaConstraint createCheeseTypeEqualsConstraint(final String rightValue) {
+    public static LambdaConstraint createCheeseTypeEqualsConstraint(final String rightValue, int indexId) {
         // Typical LambdaConstraint used in drools-test-coverage. (type == "xxx")
         Pattern pattern = new Pattern( 0, new ClassObjectType( Cheese.class )  );
         Predicate1<Cheese> predicate = new Predicate1.Impl<Cheese>(_this -> EvaluationUtil.areNullSafeEquals(_this.getType(), rightValue));
-        AlphaIndexImpl<Cheese, String> index = new AlphaIndexImpl<Cheese, String>(String.class, org.drools.model.Index.ConstraintType.EQUAL, 1, _this -> _this.getType(), rightValue);
+        AlphaIndexImpl<Cheese, String> index = new AlphaIndexImpl<Cheese, String>(String.class, org.drools.model.Index.ConstraintType.EQUAL, indexId, _this -> _this.getType(), rightValue);
         return createLambdaConstraint1(Cheese.class, pattern, predicate, index);
     }
 
-    public static LambdaConstraint createCheesePriceEqualsConstraint(final int rightValue) {
+    public static LambdaConstraint createCheesePriceEqualsConstraint(final int rightValue, int indexId) {
         // Typical LambdaConstraint used in drools-test-coverage. (price == xxx)
         Pattern pattern = new Pattern(0, new ClassObjectType(Cheese.class));
         Predicate1<Cheese> predicate = new Predicate1.Impl<Cheese>(_this -> EvaluationUtil.areNullSafeEquals(_this.getPrice(), rightValue));
-        AlphaIndexImpl<Cheese, Integer> index = new AlphaIndexImpl<Cheese, Integer>(Integer.class, org.drools.model.Index.ConstraintType.EQUAL, 1, _this -> _this.getPrice(), rightValue);
+        AlphaIndexImpl<Cheese, Integer> index = new AlphaIndexImpl<Cheese, Integer>(Integer.class, org.drools.model.Index.ConstraintType.EQUAL, indexId, _this -> _this.getPrice(), rightValue);
         return createLambdaConstraint1(Cheese.class, pattern, predicate, index);
     }
 
-    public static LambdaConstraint createCheesePriceGreaterConstraint(final int rightValue) {
+    public static LambdaConstraint createCheesePriceGreaterConstraint(final int rightValue, int indexId) {
         // Typical LambdaConstraint used in drools-test-coverage. (price > xxx)
         Pattern pattern = new Pattern(0, new ClassObjectType(Cheese.class));
         Predicate1<Cheese> predicate = new Predicate1.Impl<Cheese>(_this -> EvaluationUtil.greaterThan(_this.getPrice(), rightValue));
-        AlphaIndexImpl<Cheese, Integer> index = new AlphaIndexImpl<Cheese, Integer>(Integer.class, org.drools.model.Index.ConstraintType.GREATER_THAN, 1, _this -> _this.getPrice(), rightValue);
+        AlphaIndexImpl<Cheese, Integer> index = new AlphaIndexImpl<Cheese, Integer>(Integer.class, org.drools.model.Index.ConstraintType.GREATER_THAN, indexId, _this -> _this.getPrice(), rightValue);
         return createLambdaConstraint1(Cheese.class, pattern, predicate, index);
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/MockBetaNode.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/MockBetaNode.java
@@ -1,0 +1,115 @@
+package org.drools.mvel;
+
+import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.common.EmptyBetaConstraints;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.common.Memory;
+import org.drools.core.reteoo.BetaNode;
+import org.drools.core.reteoo.LeftTuple;
+import org.drools.core.reteoo.LeftTupleImpl;
+import org.drools.core.reteoo.LeftTupleSource;
+import org.drools.core.reteoo.ModifyPreviousTuples;
+import org.drools.core.reteoo.ObjectSource;
+import org.drools.core.reteoo.ReteooBuilder;
+import org.drools.core.reteoo.RightTuple;
+import org.drools.core.reteoo.RuleRemovalContext;
+import org.drools.core.reteoo.Sink;
+import org.drools.core.reteoo.builder.BuildContext;
+import org.drools.core.spi.PropagationContext;
+
+public class MockBetaNode extends BetaNode {
+    
+    public MockBetaNode() {
+        
+    }
+
+    @Override
+    protected boolean doRemove( RuleRemovalContext context, ReteooBuilder builder) {
+        return true;
+    }
+
+    MockBetaNode(final int id,
+                 final LeftTupleSource leftInput,
+                 final ObjectSource rightInput,
+                 BuildContext buildContext) {
+        super( id,
+               leftInput,
+               rightInput,
+               EmptyBetaConstraints.getInstance(),
+               buildContext );
+    }        
+
+    MockBetaNode(final int id,
+                 final LeftTupleSource leftInput,
+                 final ObjectSource rightInput) {
+        super( id,
+               leftInput,
+               rightInput,
+               EmptyBetaConstraints.getInstance(),
+               null );
+    }
+
+    public void assertObject(final InternalFactHandle factHandle,
+                             final PropagationContext pctx,
+                             final InternalWorkingMemory workingMemory) {
+    }
+
+    @Override
+    public void modifyObject( InternalFactHandle factHandle, ModifyPreviousTuples modifyPreviousTuples, PropagationContext context, InternalWorkingMemory workingMemory) {
+    }
+
+    public void retractRightTuple(final RightTuple rightTuple,
+                                  final PropagationContext context,
+                                  final InternalWorkingMemory workingMemory) {
+    }
+
+    public short getType() {
+        return 0;
+    }
+
+    public void modifyRightTuple(RightTuple rightTuple,
+                                 PropagationContext context,
+                                 InternalWorkingMemory workingMemory) {
+    }
+
+    public LeftTuple createLeftTuple( InternalFactHandle factHandle,
+                                      boolean leftTupleMemoryEnabled) {
+        return new LeftTupleImpl(factHandle, this, leftTupleMemoryEnabled );
+    }    
+    
+    public LeftTuple createLeftTuple(LeftTuple leftTuple,
+                                     Sink sink,
+                                     PropagationContext pctx, boolean leftTupleMemoryEnabled) {
+        return new LeftTupleImpl(leftTuple,sink, pctx, leftTupleMemoryEnabled );
+    }
+
+    public LeftTuple createLeftTuple(final InternalFactHandle factHandle,
+                                     final LeftTuple leftTuple,
+                                     final Sink sink) {
+        return new LeftTupleImpl(factHandle,leftTuple, sink );
+    }
+
+    public LeftTuple createLeftTuple(LeftTuple leftTuple,
+                                     RightTuple rightTuple,
+                                     Sink sink) {
+        return new LeftTupleImpl(leftTuple, rightTuple, sink );
+    }   
+    
+    public LeftTuple createLeftTuple(LeftTuple leftTuple,
+                                     RightTuple rightTuple,
+                                     LeftTuple currentLeftChild,
+                                     LeftTuple currentRightChild,
+                                     Sink sink,
+                                     boolean leftTupleMemoryEnabled) {
+        return new LeftTupleImpl(leftTuple, rightTuple, currentLeftChild, currentRightChild, sink, leftTupleMemoryEnabled );        
+    }
+    public Memory createMemory(RuleBaseConfiguration config, InternalWorkingMemory wm) {
+        return super.createMemory( config, wm);
+    }
+
+    @Override
+    public LeftTuple createPeer(LeftTuple original) {
+        return null;
+    }                
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/builder/impl/KnowledgeBuilderTest.java
@@ -87,7 +87,7 @@ import org.drools.core.test.model.DroolsTestCase;
 import org.drools.core.util.LinkedList;
 import org.drools.core.util.LinkedListNode;
 import org.drools.ecj.EclipseJavaCompiler;
-import org.drools.mvel.CompositeObjectSinkAdapterTest;
+import org.drools.mvel.MockBetaNode;
 import org.drools.mvel.compiler.Cheese;
 import org.drools.mvel.compiler.Primitives;
 import org.drools.mvel.compiler.StockTick;
@@ -196,7 +196,7 @@ public class KnowledgeBuilderTest extends DroolsTestCase {
                                  map );
 
         final LeftTupleImpl tuple = new MockTuple( new HashMap() );
-        tuple.setLeftTupleSink( new RuleTerminalNode(1, new CompositeObjectSinkAdapterTest.MockBetaNode(), rule,rule.getLhs(), 0,new BuildContext(kBase) )  );
+        tuple.setLeftTupleSink( new RuleTerminalNode(1, new MockBetaNode(), rule,rule.getLhs(), 0,new BuildContext(kBase) )  );
         final Activation activation = new MockActivation( rule,
                                                           0,
                                                           rule.getLhs(),
@@ -279,7 +279,7 @@ public class KnowledgeBuilderTest extends DroolsTestCase {
                                  map );
 
         final LeftTupleImpl tuple = new MockTuple( new HashMap() );
-        tuple.setLeftTupleSink( new RuleTerminalNode(1, new CompositeObjectSinkAdapterTest.MockBetaNode(), newRule,newRule.getLhs(), 0, new BuildContext(kBase) )  );
+        tuple.setLeftTupleSink( new RuleTerminalNode(1, new MockBetaNode(), newRule,newRule.getLhs(), 0, new BuildContext(kBase) )  );
         final Activation activation = new MockActivation( newRule,
                                                           0,
                                                           newRule.getLhs(),


### PR DESCRIPTION
**Refactoring of unit tests**



This PR is about making unit tests more readable via a number of refactorings:

* isolate logic used to create test objects from the tests
* create custom assertions that make it clearer what is being checked, hiding unnecessary implementation details
* split tests into smaller tests, so that each test checks one specific step, and not multiple steps
* use expressive names for support methods, so that tests become easier to read and understand
* use the instance variables to make support methods simpler

Relevant jira issue is [DROOLS-6440](https://issues.redhat.com/browse/DROOLS-6440)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
