### PR TITLE
[DROOLS-6284] Rules not fired when RUN_TYPE==STANDARD_FROM_DRL and wh…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/rule/constraint/EvaluatorHelper.java
+++ b/drools-core/src/main/java/org/drools/core/rule/constraint/EvaluatorHelper.java
@@ -250,22 +250,24 @@ public class EvaluatorHelper {
     }
 
     public static boolean coercingComparison(Object obj1, Object obj2, String op) {
-        try {
-            double d1 = toDouble( obj1 );
-            double d2 = toDouble( obj2 );
+        if (canCoerceToNumber(obj1, obj2)) {
+            try {
+                double d1 = toDouble( obj1 );
+                double d2 = toDouble( obj2 );
 
-            if (Double.isNaN( d1 ) || Double.isNaN( d2 )) {
-                return false;
-            }
+                if (Double.isNaN( d1 ) || Double.isNaN( d2 )) {
+                    return false;
+                }
 
-            switch (op) {
-                case "<": return d1 < d2;
-                case "<=": return d1 <= d2;
-                case ">": return d1 > d2;
-                case ">=": return d1 >= d2;
-            }
+                switch (op) {
+                    case "<": return d1 < d2;
+                    case "<=": return d1 <= d2;
+                    case ">": return d1 > d2;
+                    case ">=": return d1 >= d2;
+                }
 
-        } catch (NumberFormatException nfe) { }
+            } catch (NumberFormatException nfe) { }
+        }
 
         String s1 = obj1.toString();
         String s2 = obj2.toString();
@@ -277,6 +279,15 @@ public class EvaluatorHelper {
         }
 
         throw new UnsupportedOperationException("Unable to compare " + obj1 + " and " + obj2);
+    }
+
+    private static boolean canCoerceToNumber(Object left, Object right) {
+        // don't coerce to number when the left type is String and the right type is not number (to meet mvel behaviour)
+        if (left instanceof String && !(right instanceof Number)) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     private static double toDouble(Object obj) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/TypeObjectCoercionTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/TypeObjectCoercionTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 
@@ -211,18 +210,6 @@ public class TypeObjectCoercionTest extends BaseModelTest {
         ksession.insert(new ObjectHolder("DEF"));
         assertEquals(1, ksession.fireAllRules()); // standard-drl : "DEF" < "ABC" (String comparison)
         ksession.dispose();
-    }
-
-    @Ignore("in case of standard-drl, MathProcessor.doOperationNonNumeric() returns false when the left operand is not Comparable. But it doesn't make sense to keep compatibility for this behaviour")
-    @Test
-    public void testJoinStringToObjectNonComparable() {
-
-        KieSession ksession = getKieSessionForJoinStringToObject();
-
-        // Object > String "10"
-        ksession.insert(new StringHolder("10"));
-        ksession.insert(new ObjectHolder(new Object())); // not Comparable
-        assertEquals(0, ksession.fireAllRules()); // in case of standard-drl, MathProcessor.doOperationNonNumeric() returns false when the left operand is not Comparable
     }
 
     private KieSession getKieSessionForJoinIntegerToObject() {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/TypeObjectCoercionTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/TypeObjectCoercionTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 
@@ -212,6 +213,7 @@ public class TypeObjectCoercionTest extends BaseModelTest {
         ksession.dispose();
     }
 
+    @Ignore("in case of standard-drl, MathProcessor.doOperationNonNumeric() returns false when the left operand is not Comparable. But it doesn't make sense to keep compatibility for this behaviour")
     @Test
     public void testJoinStringToObjectNonComparable() {
 


### PR DESCRIPTION
…en the constraint is jitted

Fixed for these 3 tests:
org.drools.modelcompiler.TypeObjectCoercionTest.testJoinStringToObject2[STANDARD_FROM_DRL]
org.drools.modelcompiler.TypeObjectCoercionTest.testJoinObjectToString2[STANDARD_FROM_DRL]
org.drools.modelcompiler.TypeObjectCoercionTest.testJoinStringToObjectNonComparable[STANDARD_FROM_DRL]

Also tested drools-model-compiler and drools-test-coverage with `mvn clean test -Ddrools.jittingThreshold=0` locally.

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6284
https://issues.redhat.com/browse/RHDM-1595

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
