### PR TITLE
[DROOLS-6387] ClassCastException for the same declared type when upda…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/definitions/InternalKnowledgePackage.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/InternalKnowledgePackage.java
@@ -155,4 +155,6 @@ public interface InternalKnowledgePackage extends KiePackage,
     TraitRegistry getTraitRegistry();
 
     void addCloningResource(String key, Object resource);
+
+    void wireTypeDeclarations();
 }

--- a/drools-core/src/main/java/org/drools/core/definitions/impl/KnowledgePackageImpl.java
+++ b/drools-core/src/main/java/org/drools/core/definitions/impl/KnowledgePackageImpl.java
@@ -618,6 +618,21 @@ public class KnowledgePackageImpl
         }
     }
 
+    public void wireTypeDeclarations() {
+        for (TypeDeclaration typeDeclaration : typeDeclarations.values()) {
+            Class<?> typeClass = null;
+            try {
+                typeClass = typeDeclaration.getTypeClass();
+                if (typeClass != null || !typeClass.isPrimitive()) {
+                    Class<?> cls = getPackageClassLoader().loadClass(typeClass.getName());
+                    typeDeclaration.setTypeClass(cls);
+                }
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Unable to load typeClass '" + typeClass.getName() + "'");
+            }
+        }
+    }
+
     public ClassFieldAccessorStore getClassFieldAccessorStore() {
         return classFieldAccessorStore;
     }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationNonExecModelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationNonExecModelTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.compiler.integrationtests.incrementalcompilation;
+
+import java.util.Collection;
+
+import org.drools.testcoverage.common.model.Message;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.definition.type.FactType;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.builder.IncrementalResults;
+import org.kie.internal.builder.InternalKieBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Incremental compilation tests which don't work with exec-model. Each test should be fixed by JIRA one-by-one
+ */
+@RunWith(Parameterized.class)
+public class IncrementalCompilationNonExecModelTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public IncrementalCompilationNonExecModelTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+    }
+
+    private static final String DRL2_COMMON_SRC = "package myPkg\n" +
+                                                  "import " + Message.class.getCanonicalName() + ";\n" +
+                                                  "declare DummyDecl\n" + // If declare exists in the updated drl file, projectClassLoader.reinitTypes() is triggered
+                                                  "  i : Integer\n" +
+                                                  "end\n" +
+                                                  "rule R1\n" + // always fired
+                                                  "when\n" +
+                                                  "then\n" +
+                                                  "  insert(new DummyDecl());\n" +
+                                                  "end\n" +
+                                                  "rule R2_A\n" +
+                                                  "when\n" +
+                                                  "  $s : StringWrapper( s == \"ABC\" )\n" +
+                                                  "then\n" +
+                                                  "end\n" +
+                                                  "rule R2_B\n" +
+                                                  "when\n" +
+                                                  "  $s : StringWrapper( s == \"DEF\" )\n" +
+                                                  "then\n" +
+                                                  "end\n";
+
+    @Test
+    public void testCreateFileSetWithDeclaredModel() throws InstantiationException, IllegalAccessException {
+
+        final String drl1 = "package myPkg\n" +
+                            "declare StringWrapper\n" +
+                            " s : String\n" +
+                            "end\n";
+
+        // Requires 3 AlphaNodes to enable hash index
+        final String drl2_1 = DRL2_COMMON_SRC +
+                              "rule R2_C\n" +
+                              "when\n" +
+                              "  $s : StringWrapper( s == \"Hi Universe\" )\n" +
+                              "then\n" +
+                              "end\n";
+
+        final String drl2_2 = DRL2_COMMON_SRC +
+                              "rule R2_C when\n" +
+                              "  $s : StringWrapper( s == \"Hello World\" )\n" +
+                              "then\n" +
+                              "  System.out.println(\"HIT\");\n" +
+                              "end\n";
+
+        final KieServices ks = KieServices.Factory.get();
+
+        final KieFileSystem kfs = ks.newKieFileSystem()
+                                    .write("src/main/resources/myPkg/r1.drl", drl1)
+                                    .write("src/main/resources/myPkg/r2.drl", drl2_1);
+
+        ReleaseId releaseId1 = ks.newReleaseId("org.default", "artifact", "1.1.0");
+        kfs.generateAndWritePomXML(releaseId1);
+
+        KieBuilder kieBuilder = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs, true);
+        final KieContainer kieContainer = ks.newKieContainer(releaseId1);
+
+        runRules(kieContainer, 1);
+
+        //---------------------
+
+        kfs.delete("src/main/resources/myPkg/r2.drl");
+        kfs.write("src/main/resources/myPkg/r2.drl", drl2_2);
+        ReleaseId releaseId2 = ks.newReleaseId("org.default", "artifact", "1.2.0");
+        kfs.generateAndWritePomXML(releaseId2);
+
+        // buildAll instead of createFileSet doesn't have the issue
+        //        if (kieBaseTestConfiguration.isExecutableModel()) {
+        //            kieBuilder = ks.newKieBuilder(kfs).buildAll(ExecutableModelProject.class);
+        //        } else {
+        //            kieBuilder = ks.newKieBuilder(kfs).buildAll(DrlProject.class);
+        //        }
+
+        final IncrementalResults results = ((InternalKieBuilder) kieBuilder).createFileSet("src/main/resources/myPkg/r2.drl").build();
+        assertEquals(0, results.getAddedMessages().size());
+        assertEquals(0, results.getRemovedMessages().size());
+
+        kieContainer.updateToVersion(releaseId2);
+
+        runRules(kieContainer, 2);
+    }
+
+    private void runRules(final KieContainer kieContainer, int expectedfireCount) throws InstantiationException, IllegalAccessException {
+        KieSession ksession = kieContainer.newKieSession();
+        FactType factType = ksession.getKieBase().getFactType("myPkg", "StringWrapper");
+        Object fact = factType.newInstance();
+        factType.set(fact, "s", "Hello World");
+        ksession.insert(fact);
+        assertEquals(expectedfireCount, ksession.fireAllRules());
+        ksession.dispose();
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/incrementalcompilation/IncrementalCompilationTest.java
@@ -43,7 +43,6 @@ import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.Rete;
 import org.drools.core.reteoo.RuleTerminalNode;
-import org.drools.core.util.ClassUtils;
 import org.drools.testcoverage.common.model.Address;
 import org.drools.testcoverage.common.model.Message;
 import org.drools.testcoverage.common.model.Person;
@@ -91,7 +90,6 @@ import org.kie.internal.builder.InternalKieBuilder;
 import org.kie.internal.command.CommandFactory;
 
 import static java.util.Arrays.asList;
-
 import static org.drools.core.util.DroolsTestUtil.rulestoMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
…teToVersion with createFileSet

- WIP : fails with exec-model

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6387


Conditions to reproduce:
 - Have a declaration type [X] in a DRL (A)
 - Have another declaration type in a DRL (B).
 - DRL (B) also contains more than 3 rules for the fact [X] so that AlphaNode hash index is enabled
 - DRL (B) is updated
 - Incremental compile using InternalKieBuilder.createFileSet().build()
     - [Note] ks.newKieBuilder(kfs).buildAll() doesn't have the issue
- call kieContainer.updateToVersion
- Execute the rule with the created FactType

What's happening internally:
 - KieBuilderSetImpl.build() -> buildChanges() detects that types are changed (because DRL (B) has a type declaration)
      - Then it triggers projectClassLoader.reinitTypes(). It clears projectClassLoader.loadedClasses so all classes will be associated with the latter (= after updateToVersion()) DynamicProjectClassLoader$DefaultInternalTypesClassLoader.
 https://github.com/kiegroup/drools/blob/master/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderSetImpl.java#L169


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
