### PR TITLE
[DROOLS-6467] NullSafeDereferencing with OR with Half binary throws N…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ConstraintUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/ConstraintUtil.java
@@ -17,6 +17,7 @@ import org.drools.modelcompiler.builder.generator.drlxparse.SingleDrlxParseSucce
 import org.drools.modelcompiler.util.EvaluationUtil;
 
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.THIS_PLACEHOLDER;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.stripEnclosedExpr;
 
 public class ConstraintUtil {
 
@@ -72,15 +73,6 @@ public class ConstraintUtil {
             return drlx;
         }
         return drlxParseResult;
-    }
-
-    private static Expression stripEnclosedExpr(EnclosedExpr eExpr) {
-        Expression inner = eExpr.getInner();
-        if (inner instanceof EnclosedExpr) {
-            return stripEnclosedExpr((EnclosedExpr) inner);
-        } else {
-            return inner;
-        }
     }
 
     private static void processTopLevelExpression(SingleDrlxParseSuccess drlx, MethodCallExpr mcExpr) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -931,6 +931,15 @@ public class DrlxParseUtil {
         return ruleBlock.findFirst(expr.getClass(), expr::equals).isPresent();
     }
 
+    public static Expression stripEnclosedExpr(EnclosedExpr eExpr) {
+        Expression inner = eExpr.getInner();
+        if (inner instanceof EnclosedExpr) {
+            return stripEnclosedExpr((EnclosedExpr) inner);
+        } else {
+            return inner;
+        }
+    }
+
     private DrlxParseUtil() {
         // It is not allowed to create instances of util classes.
     }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/NullSafeDereferencingTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/NullSafeDereferencingTest.java
@@ -16,9 +16,11 @@
 
 package org.drools.modelcompiler;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.drools.modelcompiler.domain.Address;
 import org.drools.modelcompiler.domain.Person;
 import org.drools.modelcompiler.domain.Result;
@@ -244,5 +246,29 @@ public class NullSafeDereferencingTest extends BaseModelTest {
         List<Result> results = getObjectsIntoList(ksession, Result.class);
         assertEquals(1, results.size());
         assertEquals("John2", results.get(0).getValue());
+    }
+
+    @Test
+    public void testNullSafeDereferncingWithOrHalfBinary() {
+        String str =
+                "import " + Person.class.getCanonicalName() + ";\n" +
+                     "global java.util.List result;\n" +
+                     "rule R\n" +
+                     "when\n" +
+                     "  $p : Person( name == \"John\" || == address!.city )\n" +
+                     "then\n" +
+                     "  result.add($p.getName());\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+        List<String> result = new ArrayList<>();
+        ksession.setGlobal("result", result);
+
+        ksession.insert(new Person("John", 24, new Address("ABC")));
+        ksession.insert(new Person("Paul", 22, (Address) null));
+        ksession.insert(new Person("George", 21, new Address("George")));
+        ksession.fireAllRules();
+
+        Assertions.assertThat(result).containsExactlyInAnyOrder("John", "George");
     }
 }


### PR DESCRIPTION
…PE in exec-model

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6467

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
