### PR TITLE
Fixed date tests on windows

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/DeclaredTypesTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/DeclaredTypesTest.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.reteoo.AlphaNode;
@@ -538,7 +539,7 @@ public class DeclaredTypesTest extends BaseModelTest {
         Object f1 = factType.newInstance();
         Object n1 = nestedType.newInstance();
 
-        SimpleDateFormat df = new SimpleDateFormat("dd-MMM-yyyy");
+        SimpleDateFormat df = new SimpleDateFormat("dd-MMM-yyyy", Locale.UK);
 
         nestedType.set(n1, "d", df.parse("01-Jan-2020"));
         factType.set(f1, "n", n1);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ForAllTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/operators/ForAllTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
@@ -171,7 +172,7 @@ public class ForAllTest {
         KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("forall-test", kieBaseTestConfiguration, drl);
         KieSession ksession = kbase.newKieSession();
 
-        SimpleDateFormat df = new SimpleDateFormat("dd-MMM-yyyy");
+        SimpleDateFormat df = new SimpleDateFormat("dd-MMM-yyyy", Locale.UK);
 
         FactType factType = kbase.getFactType(pkg, "Fact");
 


### PR DESCRIPTION
This is a simple fix for tests that fail on windows due to wrong locale.

**JIRA**: [DROOLS-6479](https://issues.redhat.com/browse/DROOLS-6479)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
