### PR TITLE
[DROOLS-6418] Avoid alpha node sharing with static method

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
@@ -260,6 +260,10 @@ public class LambdaConstraint extends AbstractConstraint {
         return evaluator.hashCode();
     }
 
+    public PredicateInformation getPredicateInformation() {
+        return predicateInformation;
+    }
+
     public static class LambdaContextEntry implements ContextEntry {
 
         private Tuple tuple;

--- a/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
+++ b/drools-mvel/src/main/java/org/drools/mvel/MVELConstraintBuilder.java
@@ -95,6 +95,7 @@ import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.normalize
 import static org.drools.compiler.rule.builder.util.PatternBuilderUtil.normalizeStringOperator;
 import static org.drools.core.rule.constraint.EvaluatorHelper.WM_ARGUMENT;
 import static org.drools.core.util.ClassUtils.convertFromPrimitiveType;
+import static org.drools.core.util.StringUtils.extractFirstIdentifier;
 import static org.drools.mvel.asm.AsmUtil.copyErrorLocation;
 import static org.drools.mvel.builder.MVELExprAnalyzer.analyze;
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNodeRangeIndexingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/AlphaNodeRangeIndexingTest.java
@@ -54,8 +54,6 @@ import org.kie.internal.conf.AlphaRangeIndexThresholdOption;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public class AlphaNodeRangeIndexingTest {
@@ -1091,10 +1089,9 @@ public class AlphaNodeRangeIndexingTest {
 
         final KieBase kbase;
 
-        if (kieBaseTestConfiguration.isExecutableModel()) {
             kbase = createKieBaseWithRangeIndexThresholdValue(drl, 3);
             final KieSession ksession = kbase.newKieSession();
-            assertSinks(kbase, Person.class, 4, 4, 0, 3); // "age < StaticUtil.getThirty()" is not range indexable in exec-model
+            assertSinks(kbase, Person.class, 4, 4, 0, 3); // "age < StaticUtil.getThirty()" is not range indexable
 
             ksession.insert(new Person("John", 18));
             int fired = ksession.fireAllRules();
@@ -1103,16 +1100,6 @@ public class AlphaNodeRangeIndexingTest {
             ksession.insert(new Person("Paul", 60));
             fired = ksession.fireAllRules();
             assertEquals(2, fired);
-
-        } else {
-            // Once DROOLS-6418 is fixed, this test will not throw IllegalStateException
-            try {
-                kbase = createKieBaseWithRangeIndexThresholdValue(drl, 3);
-                fail("Should throw IllegalStateException");
-            } catch (IllegalStateException ise) {
-                assertTrue(ise.getMessage().contains("Index conflict"));
-            }
-        }
     }
 
     @Test
@@ -1135,28 +1122,17 @@ public class AlphaNodeRangeIndexingTest {
 
         final KieBase kbase;
 
-        if (kieBaseTestConfiguration.isExecutableModel()) {
-            kbase = createKieBaseWithRangeIndexThresholdValue(drl, 3);
-            final KieSession ksession = kbase.newKieSession();
-            assertSinks(kbase, Person.class, 4, 4, 0, 3); // "age < StaticUtil.getThirty()" is not range indexable in exec-model
+        kbase = createKieBaseWithRangeIndexThresholdValue(drl, 3);
+        final KieSession ksession = kbase.newKieSession();
+        assertSinks(kbase, Person.class, 4, 4, 0, 3); // "age < StaticUtil.getThirty()" is not range indexable
 
-            ksession.insert(new Person("John", 18));
-            int fired = ksession.fireAllRules();
-            assertEquals(4, fired);
+        ksession.insert(new Person("John", 18));
+        int fired = ksession.fireAllRules();
+        assertEquals(4, fired);
 
-            ksession.insert(new Person("Paul", 60));
-            fired = ksession.fireAllRules();
-            assertEquals(2, fired);
-
-        } else {
-            // Once DROOLS-6418 is fixed, this test will not throw IllegalStateException
-            try {
-                kbase = createKieBaseWithRangeIndexThresholdValue(drl, 3);
-                fail("Should throw IllegalStateException");
-            } catch (IllegalStateException ise) {
-                assertTrue(ise.getMessage().contains("Index conflict"));
-            }
-        }
+        ksession.insert(new Person("Paul", 60));
+        fired = ksession.fireAllRules();
+        assertEquals(2, fired);
     }
 
     public static class StaticUtil {

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/SharingTest.java
@@ -16,15 +16,22 @@
 
 package org.drools.compiler.integrationtests;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.drools.core.base.ClassObjectType;
 import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.reteoo.AlphaNode;
+import org.drools.core.reteoo.CompositeObjectSinkAdapter;
 import org.drools.core.reteoo.EntryPointNode;
 import org.drools.core.reteoo.ObjectTypeNode;
+import org.drools.core.spi.AlphaNodeFieldConstraint;
+import org.drools.modelcompiler.constraints.LambdaConstraint;
+import org.drools.mvel.MVELConstraint;
 import org.drools.testcoverage.common.model.FactWithList;
+import org.drools.testcoverage.common.model.Person;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieBaseUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
@@ -36,6 +43,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.Agenda;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
@@ -54,44 +62,118 @@ public class SharingTest {
 
     public static class TestStaticUtils {
 
+        public static final NestedObj nestedObj = new NestedObj();
+        public static final int FINAL_1 = 1;
+        public static int nonFinal1 = 1;
+
         public static int return1() {
             return 1;
         }
     }
 
+    public static class NestedObj {
+        public static final int FINAL_1 = 1;
+    }
+
+    public static enum TestEnum {
+        AAA,
+        BBB,
+        CCC;
+    }
+
     @Test
-    public void testShouldAlphaShareBecauseSameConstantDespiteDifferentSyntax() {
-        // DROOLS-1404
+    public void testDontShareAlphaWithStaticMethod() {
+        // DROOLS-6418
         final String drl1 = "package c;\n" +
-                "import " + TestObject.class.getCanonicalName() + "\n" +
-                "rule fileArule1 when\n" +
-                "  TestObject(value == 1)\n" +
-                "then\n" +
-                "end\n" +
-                "";
-        final String drl2 = "package iTzXzx;\n" + // <<- keep the different package
-                "import " + TestObject.class.getCanonicalName() + "\n" +
-                "import " + TestStaticUtils.class.getCanonicalName() + "\n" +
-                "rule fileBrule1 when\n" +
-                "  TestObject(value == TestStaticUtils.return1() )\n" +
-                "then\n" +
-                "end\n" +
-                "rule fileBrule2 when\n" + // <<- keep this rule
-                "  TestObject(value == 0 )\n" +
-                "then\n" +
-                "end\n" +
-                "";
+                            "import " + TestObject.class.getCanonicalName() + "\n" +
+                            "import " + TestStaticUtils.class.getCanonicalName() + "\n" +
+                            "rule R1 when\n" +
+                            "  TestObject(value == 1)\n" +
+                            "then\n" +
+                            "end\n" +
+                            "rule R2 when\n" +
+                            "  TestObject(value == TestStaticUtils.return1())\n" + // return1() doesn't guarantee that it always returns 1
+                            "then\n" +
+                            "end\n" +
+                            "rule R3 when\n" +
+                            "  TestObject(value == 0 )\n" +
+                            "then\n" +
+                            "end\n";
 
-        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl1, drl2);
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl1);
 
-        EntryPointNode epn = ((InternalKnowledgeBase) kbase).getRete().getEntryPointNodes().values().iterator().next();
-        ObjectTypeNode otn = epn.getObjectTypeNodes().get(new ClassObjectType(TestObject.class));
+        ObjectTypeNode otn = getObjectTypeNode(kbase, TestObject.class);
 
-        if (kieBaseTestConfiguration.isExecutableModel()) {
-            assertEquals(3, otn.getSinks().length); // See DROOLS-6328
-        } else {
-            assertEquals(2, otn.getSinks().length);
+        assertSinksSize(otn, 3); // Not shared
+        assertHashableSinksSize(otn, 2);
+        assertNonHashableConstraint(otn, "value == TestStaticUtils.return1()");
+
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            kieSession.insert(new TestObject(1));
+            assertEquals(2, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
         }
+    }
+
+    private ObjectTypeNode getObjectTypeNode(KieBase kbase, Class<?> factClass) {
+        EntryPointNode epn = ((InternalKnowledgeBase) kbase).getRete().getEntryPointNodes().values().iterator().next();
+        return epn.getObjectTypeNodes().get(new ClassObjectType(factClass));
+    }
+
+    private void assertSinksSize(ObjectTypeNode otn, int expected) {
+        assertEquals(expected, otn.getSinks().length);
+    }
+
+    private void assertHashableSinksSize(ObjectTypeNode otn, int expected) {
+        CompositeObjectSinkAdapter sinkAdapter = (CompositeObjectSinkAdapter) otn.getObjectSinkPropagator();
+
+        if (expected == 0) {
+            assertNull(sinkAdapter.getHashableSinks());
+        } else {
+            assertEquals(expected, sinkAdapter.getHashableSinks().size());
+        }
+    }
+
+    private void assertNonHashableConstraint(ObjectTypeNode otn, String expected) {
+        CompositeObjectSinkAdapter sinkAdapter = (CompositeObjectSinkAdapter) otn.getObjectSinkPropagator();
+
+        AlphaNode alpha = (AlphaNode) sinkAdapter.getOtherSinks().get(0);
+        AlphaNodeFieldConstraint constraint = alpha.getConstraint();
+        if (constraint instanceof MVELConstraint) {
+            assertEquals(expected, ((MVELConstraint) constraint).getExpression());
+        } else if (constraint instanceof LambdaConstraint) {
+            assertEquals(expected, ((LambdaConstraint) constraint).getPredicateInformation().getStringConstraint());
+        }
+    }
+
+    @Test
+    public void testDontShareAlphaWithNonFinalField() {
+        // DROOLS-6418
+        final String drl = "package com.example;\n" +
+                           "import " + TestObject.class.getCanonicalName() + "\n" +
+                           "import " + TestStaticUtils.class.getCanonicalName() + "\n" +
+                           "rule R1 when\n" +
+                           "  TestObject(value == 1)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when\n" +
+                           "  TestObject(value == TestStaticUtils.nonFinal1)\n" + //  nonFinal1 doesn't guarantee that it always returns 1
+                           "then\n" +
+                           "end\n" +
+                           "rule R3 when\n" +
+                           "  TestObject(value == 0 )\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl);
+
+        ObjectTypeNode otn = getObjectTypeNode(kbase, TestObject.class);
+
+        assertSinksSize(otn, 3); // Not shared
+        assertHashableSinksSize(otn, 2);
+        assertNonHashableConstraint(otn, "value == TestStaticUtils.nonFinal1");
 
         final KieSession kieSession = kbase.newKieSession();
         try {
@@ -103,32 +185,181 @@ public class SharingTest {
     }
 
     @Test
+    public void testShareAlphaWithFinalField() {
+        // DROOLS-6418
+        final String drl = "package com.example;\n" +
+                           "import " + TestObject.class.getCanonicalName() + "\n" +
+                           "import " + TestStaticUtils.class.getCanonicalName() + "\n" +
+                           "rule R1 when\n" +
+                           "  TestObject(value == 1)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when\n" +
+                           "  TestObject(value == TestStaticUtils.FINAL_1)\n" + // FINAL_1 always returns 1
+                           "then\n" +
+                           "end\n" +
+                           "rule R3 when\n" +
+                           "  TestObject(value == 0 )\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl);
+
+        ObjectTypeNode otn = getObjectTypeNode(kbase, TestObject.class);
+
+        if (kieBaseTestConfiguration.isExecutableModel()) {
+            assertSinksSize(otn, 3); // exec-model doesn't share the final filed nodes. For improvement, see DROOLS-6485
+            assertNonHashableConstraint(otn, "value == TestStaticUtils.FINAL_1");
+        } else {
+            assertSinksSize(otn, 2); // "value == 1" and "value == TestStaticUtils.FINAL_1" are shared
+        }
+
+        assertHashableSinksSize(otn, 2);
+
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            kieSession.insert(new TestObject(1));
+            assertEquals(2, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testShareAlphaWithNestedFinalField() {
+        // DROOLS-6418
+        final String drl = "package com.example;\n" +
+                           "import " + TestObject.class.getCanonicalName() + "\n" +
+                           "import " + TestStaticUtils.class.getCanonicalName() + "\n" +
+                           "rule R1 when\n" +
+                           "  TestObject(value == 1)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when\n" +
+                           "  TestObject(value == TestStaticUtils.nestedObj.FINAL_1)\n" + // FINAL_1 always returns 1
+                           "then\n" +
+                           "end\n" +
+                           "rule R3 when\n" +
+                           "  TestObject(value == 0 )\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl);
+
+        ObjectTypeNode otn = getObjectTypeNode(kbase, TestObject.class);
+
+        // standard-drl cannot analyze nested final field. So not shared
+        // exec-model doesn't share the final filed nodes. For improvement, see DROOLS-6485
+        assertSinksSize(otn, 3);
+        assertHashableSinksSize(otn, 2);
+        assertNonHashableConstraint(otn, "value == TestStaticUtils.nestedObj.FINAL_1");
+
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            kieSession.insert(new TestObject(1));
+            assertEquals(2, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testShareAlphaWithEnum() {
+        // DROOLS-6418
+        final String drl = "package com.example;\n" +
+                           "import " + TestObject.class.getCanonicalName() + "\n" +
+                           "import " + TestEnum.class.getCanonicalName() + "\n" +
+                           "rule R1 when\n" +
+                           "  TestObject(testEnum == TestEnum.AAA)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when\n" +
+                           "  TestObject(testEnum == TestEnum.AAA)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R3 when\n" +
+                           "  TestObject(testEnum == TestEnum.BBB)\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl);
+
+        ObjectTypeNode otn = getObjectTypeNode(kbase, TestObject.class);
+
+        assertSinksSize(otn, 2); // shared
+        assertHashableSinksSize(otn, 0); // not hash indexable
+
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            kieSession.insert(new TestObject(TestEnum.AAA));
+            assertEquals(2, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
+    public void testDontShareAlphaWithBigDecimalConstructor() {
+        // DROOLS-6418
+        final String drl = "package com.example;\n" +
+                           "import " + Person.class.getCanonicalName() + "\n" +
+                           "import " + BigDecimal.class.getCanonicalName() + "\n" +
+                           "rule R1 when\n" +
+                           "  Person(salary == 1)\n" +
+                           "then\n" +
+                           "end\n" +
+                           "rule R2 when\n" +
+                           "  Person(salary == new BigDecimal(\"1\"))\n" + // known constructor... always returns 1.
+                           "then\n" +
+                           "end\n" +
+                           "rule R3 when\n" +
+                           "  Person(salary == 0)\n" +
+                           "then\n" +
+                           "end\n";
+
+        final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl);
+
+        ObjectTypeNode otn = getObjectTypeNode(kbase, Person.class);
+
+        assertSinksSize(otn, 3); // Not shared. For improvement, see DROOLS-6485
+        assertHashableSinksSize(otn, 2);
+        assertNonHashableConstraint(otn, "salary == new BigDecimal(\"1\")");
+
+        final KieSession kieSession = kbase.newKieSession();
+        try {
+            kieSession.insert(new Person("John", 20, new BigDecimal("1")));
+            assertEquals(2, kieSession.fireAllRules());
+        } finally {
+            kieSession.dispose();
+        }
+    }
+
+    @Test
     public void testShouldAlphaShareNotEqualsInDifferentPackages() {
         // DROOLS-1404
         final String drl1 = "package c;\n" +
-                "import " + TestObject.class.getCanonicalName() + "\n" +
-                "rule fileArule1 when\n" +
-                "  TestObject(value >= 1 )\n" +
-                "then\n" +
-                "end\n" +
-                "";
+                            "import " + TestObject.class.getCanonicalName() + "\n" +
+                            "rule fileArule1 when\n" +
+                            "  TestObject(value >= 1 )\n" +
+                            "then\n" +
+                            "end\n" +
+                            "";
         final String drl2 = "package iTzXzx;\n" + // <<- keep the different package
-                "import " + TestObject.class.getCanonicalName() + "\n" +
-                "rule fileBrule1 when\n" +
-                "  TestObject(value >= 1 )\n" +
-                "then\n" +
-                "end\n" +
-                "rule fileBrule2 when\n" + // <<- keep this rule
-                "  TestObject(value >= 2 )\n" +
-                "then\n" +
-                "end\n" +
-                "";
+                            "import " + TestObject.class.getCanonicalName() + "\n" +
+                            "rule fileBrule1 when\n" +
+                            "  TestObject(value >= 1 )\n" +
+                            "then\n" +
+                            "end\n" +
+                            "rule fileBrule2 when\n" + // <<- keep this rule
+                            "  TestObject(value >= 2 )\n" +
+                            "then\n" +
+                            "end\n" +
+                            "";
 
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl1, drl2);
 
-        EntryPointNode epn = ((InternalKnowledgeBase) kbase).getRete().getEntryPointNodes().values().iterator().next();
-        ObjectTypeNode otn = epn.getObjectTypeNodes().get(new ClassObjectType(TestObject.class));
-        assertEquals(2, otn.getSinks().length);
+        ObjectTypeNode otn = getObjectTypeNode(kbase, TestObject.class);
+        assertSinksSize(otn, 2); // shared
 
         final KieSession kieSession = kbase.newKieSession();
         try {
@@ -143,30 +374,29 @@ public class SharingTest {
     public void testShouldAlphaShareNotEqualsInDifferentPackages2() {
         // DROOLS-1404
         final String drl1 = "package c;\n" +
-                "import " + FactWithList.class.getCanonicalName() + "\n" +
-                "\n" +
-                "rule fileArule1 when\n" +
-                "  FactWithList(items contains \"test\")\n" +
-                "then\n" +
-                "end\n" +
-                "";
+                            "import " + FactWithList.class.getCanonicalName() + "\n" +
+                            "\n" +
+                            "rule fileArule1 when\n" +
+                            "  FactWithList(items contains \"test\")\n" +
+                            "then\n" +
+                            "end\n" +
+                            "";
         final String drl2 = "package iTzXzx;\n" + // <<- keep the different package
-                "import " + FactWithList.class.getCanonicalName() + "\n" +
-                "rule fileBrule1 when\n" +
-                "  FactWithList(items contains \"test\")\n" +
-                "then\n" +
-                "end\n" +
-                "rule fileBrule2 when\n" + // <<- keep this rule
-                "  FactWithList(items contains \"testtest\")\n" +
-                "then\n" +
-                "end\n" +
-                "";
+                            "import " + FactWithList.class.getCanonicalName() + "\n" +
+                            "rule fileBrule1 when\n" +
+                            "  FactWithList(items contains \"test\")\n" +
+                            "then\n" +
+                            "end\n" +
+                            "rule fileBrule2 when\n" + // <<- keep this rule
+                            "  FactWithList(items contains \"testtest\")\n" +
+                            "then\n" +
+                            "end\n" +
+                            "";
 
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl1, drl2);
 
-        EntryPointNode epn = ((InternalKnowledgeBase) kbase).getRete().getEntryPointNodes().values().iterator().next();
-        ObjectTypeNode otn = epn.getObjectTypeNodes().get(new ClassObjectType(FactWithList.class));
-        assertEquals(2, otn.getSinks().length);
+        ObjectTypeNode otn = getObjectTypeNode(kbase, FactWithList.class);
+        assertSinksSize(otn, 2); // shared
 
         final KieSession kieSession = kbase.newKieSession();
         try {
@@ -183,41 +413,41 @@ public class SharingTest {
     public void testSubnetworkSharing() {
         final String drl =
                 "import " + A.class.getCanonicalName() + "\n" +
-                        "import " + B.class.getCanonicalName() + "\n" +
-                        "global java.util.List list" +
-                        "\n" +
-                        "rule R1 agenda-group \"G2\" when\n" +
-                        "    Number( intValue < 1 ) from accumulate (\n" +
-                        "        A( $id : id )\n" +
-                        "        and $b : B( parentId == $id )\n" +
-                        "    ;count($b))\n" +
-                        "then\n" +
-                        "    list.add(\"R1\");\n" +
-                        "end\n" +
-                        "\n" +
-                        "rule R2 agenda-group \"G1\" when\n" +
-                        "    Number( intValue < 1 ) from accumulate (\n" +
-                        "        A( $id : id )\n" +
-                        "        and $b : B( parentId == $id )\n" +
-                        "\n" +
-                        "    ;count($b))\n" +
-                        "then\n" +
-                        "    list.add(\"R2\");\n" +
-                        "end\n" +
-                        "\n" +
-                        "rule R3 agenda-group \"G1\" no-loop when\n" +
-                        "    $a : A( $id : id )\n" +
-                        "then\n" +
-                        "    modify($a) { setId($id + 1) };\n" +
-                        "end\n";
+                           "import " + B.class.getCanonicalName() + "\n" +
+                           "global java.util.List list" +
+                           "\n" +
+                           "rule R1 agenda-group \"G2\" when\n" +
+                           "    Number( intValue < 1 ) from accumulate (\n" +
+                           "        A( $id : id )\n" +
+                           "        and $b : B( parentId == $id )\n" +
+                           "    ;count($b))\n" +
+                           "then\n" +
+                           "    list.add(\"R1\");\n" +
+                           "end\n" +
+                           "\n" +
+                           "rule R2 agenda-group \"G1\" when\n" +
+                           "    Number( intValue < 1 ) from accumulate (\n" +
+                           "        A( $id : id )\n" +
+                           "        and $b : B( parentId == $id )\n" +
+                           "\n" +
+                           "    ;count($b))\n" +
+                           "then\n" +
+                           "    list.add(\"R2\");\n" +
+                           "end\n" +
+                           "\n" +
+                           "rule R3 agenda-group \"G1\" no-loop when\n" +
+                           "    $a : A( $id : id )\n" +
+                           "then\n" +
+                           "    modify($a) { setId($id + 1) };\n" +
+                           "end\n";
 
         final KieBase kbase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("sharing-test", kieBaseTestConfiguration, drl);
 
-        EntryPointNode epn = ((InternalKnowledgeBase) kbase).getRete().getEntryPointNodes().values().iterator().next();
-        ObjectTypeNode otnA = epn.getObjectTypeNodes().get(new ClassObjectType(A.class));
-        assertEquals(2, otnA.getSinks().length);
-        ObjectTypeNode otnB = epn.getObjectTypeNodes().get(new ClassObjectType(B.class));
-        assertEquals(1, otnB.getSinks().length);
+        ObjectTypeNode otnA = getObjectTypeNode(kbase, A.class);
+        assertSinksSize(otnA, 2);
+
+        ObjectTypeNode otnB = getObjectTypeNode(kbase, B.class);
+        assertSinksSize(otnB, 1);
 
         final KieSession kieSession = kbase.newKieSession();
         try {
@@ -273,15 +503,23 @@ public class SharingTest {
 
     public static class TestObject {
 
-        private final Integer value;
+        private Integer value = -1;
+        private TestEnum testEnum = TestEnum.AAA;
 
-        public TestObject(final Integer value) {
+        public TestObject(Integer value) {
             this.value = value;
+        }
+
+        public TestObject(TestEnum testEnum) {
+            this.testEnum = testEnum;
         }
 
         public Integer getValue() {
             return value;
         }
 
+        public TestEnum getTestEnum() {
+            return testEnum;
+        }
     }
 }

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/java/JavaDialectTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -90,10 +91,10 @@ public class JavaDialectTest {
         alphanode = (AlphaNode) alphanode.getObjectSinkPropagator().getSinks()[0];
         AlphaNodeFieldConstraint constraint = alphanode.getConstraint();
 
-        if (constraint instanceof MVELConstraint ) {
-            FieldValue fieldVal = (( MVELConstraint ) constraint).getField();
-            assertEquals( "xxx", fieldVal.getValue() );
-        }
+        KieSession ksession = kbase.newKieSession();
+        ksession.insert(new Person("xxx"));
+        int fired = ksession.fireAllRules();
+        assertEquals(1, fired);
     }
     
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/MVELTest.java
@@ -33,7 +33,6 @@ import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.spi.AlphaNodeFieldConstraint;
-import org.drools.core.spi.FieldValue;
 import org.drools.core.util.DateUtils;
 import org.drools.mvel.MVELConstraint;
 import org.drools.mvel.compiler.Address;
@@ -371,8 +370,6 @@ public class MVELTest {
 
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) constraint).getFieldExtractor() instanceof ClassFieldReader);
-            final FieldValue r = (( MVELConstraint ) constraint).getField();
-            assertEquals(p.getAddress(), r.getValue());
         }
     }         
     
@@ -417,7 +414,6 @@ public class MVELTest {
 
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) constraint).getFieldExtractor() instanceof MVELObjectClassFieldReader );
-            assertEquals(new Address("s1"), ((MVELConstraint) constraint).getField().getValue());
         }
 
         alphanode = (AlphaNode) alphanode.getObjectSinkPropagator().getSinks()[0];
@@ -425,7 +421,6 @@ public class MVELTest {
 
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) constraint).getFieldExtractor() instanceof MVELObjectClassFieldReader);
-            assertEquals(new Address("s1").getStreet(), ((MVELConstraint) constraint).getField().getValue());
         }
     }    
     
@@ -471,14 +466,12 @@ public class MVELTest {
 
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) alphanode.getConstraint()).getFieldExtractor() instanceof MVELObjectClassFieldReader);
-            assertEquals(new Address("s1"), ((MVELConstraint) alphanode.getConstraint()).getField().getValue());
         }
 
         alphanode = (AlphaNode) alphanode.getObjectSinkPropagator().getSinks()[0];
         constraint = alphanode.getConstraint();
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) alphanode.getConstraint()).getFieldExtractor() instanceof MVELObjectClassFieldReader);
-            assertEquals(new Address("s1").getStreet(), ((MVELConstraint) alphanode.getConstraint()).getField().getValue());
         }
     }       
     
@@ -526,7 +519,6 @@ public class MVELTest {
 
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) alphanode.getConstraint()).getFieldExtractor() instanceof MVELObjectClassFieldReader);
-            assertEquals(new Address("s1"), ((MVELConstraint) alphanode.getConstraint()).getField().getValue());
         }
 
         alphanode = (AlphaNode) alphanode.getObjectSinkPropagator().getSinks()[0];
@@ -534,7 +526,6 @@ public class MVELTest {
 
         if (constraint instanceof MVELConstraint) {
             assertTrue(((MVELConstraint) alphanode.getConstraint()).getFieldExtractor() instanceof MVELObjectClassFieldReader);
-            assertEquals(new Address("s1").getStreet(), ((MVELConstraint) alphanode.getConstraint()).getField().getValue());
         }
     }     
     

--- a/drools-traits/src/main/java/org/drools/traits/core/base/evaluators/IsAEvaluatorDefinition.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/base/evaluators/IsAEvaluatorDefinition.java
@@ -352,6 +352,9 @@ public class IsAEvaluatorDefinition implements EvaluatorDefinition {
                 }
             } else if ( target instanceof TraitableBean ) {
                 targetTraits = ((TraitableBean) target).getCurrentTypeCode();
+            } else if ( target instanceof Collection ) {
+                CodedHierarchy x = workingMemory.getKnowledgeBase().getConfiguration().getComponentFactory().getTraitRegistry().getHierarchy();
+                targetTraits = getCode( target, x );
             } else {
                 TraitableBean tbean = lookForWrapper( target, workingMemory );
                 if ( tbean != null ) {


### PR DESCRIPTION
- WIP

At the moment, fails with:
SharingTest.testDontShareAlphaWithNonFinalField[KieBase type=CLOUD_IDENTITY]
SharingTest.testShareAlphaWithBigDecimalConstructor[KieBase type=CLOUD_IDENTITY]
SharingTest.testShareAlphaWithFinalField[KieBase type=CLOUD_IDENTITY_MODEL_PATTERN]
SharingTest.testShareAlphaWithBigDecimalConstructor[KieBase type=CLOUD_IDENTITY_MODEL_PATTERN]

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6418

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
