### PR TITLE
[DROOLS-6402] make ChainedProperties in RuleBaseConfiguration transient

### DIFF
--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -127,7 +127,7 @@ public class RuleBaseConfiguration
 
     protected static final transient Logger logger = LoggerFactory.getLogger(RuleBaseConfiguration.class);
 
-    private transient ChainedProperties chainedProperties;
+    private ChainedProperties chainedProperties;
 
     private boolean immutable;
 
@@ -189,6 +189,9 @@ public class RuleBaseConfiguration
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
+        // avoid serializing user defined system properties
+        chainedProperties.filterDroolsPropertiesForSerialization();
+        out.writeObject(chainedProperties);
         out.writeBoolean(immutable);
         out.writeBoolean(sequential);
         out.writeObject(sequentialAgenda);
@@ -222,6 +225,7 @@ public class RuleBaseConfiguration
 
     public void readExternal(ObjectInput in) throws IOException,
             ClassNotFoundException {
+        chainedProperties = (ChainedProperties) in.readObject();
         immutable = in.readBoolean();
         sequential = in.readBoolean();
         sequentialAgenda = (SequentialAgenda) in.readObject();

--- a/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
+++ b/drools-core/src/main/java/org/drools/core/RuleBaseConfiguration.java
@@ -127,7 +127,7 @@ public class RuleBaseConfiguration
 
     protected static final transient Logger logger = LoggerFactory.getLogger(RuleBaseConfiguration.class);
 
-    private ChainedProperties chainedProperties;
+    private transient ChainedProperties chainedProperties;
 
     private boolean immutable;
 
@@ -189,7 +189,6 @@ public class RuleBaseConfiguration
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        out.writeObject(chainedProperties);
         out.writeBoolean(immutable);
         out.writeBoolean(sequential);
         out.writeObject(sequentialAgenda);
@@ -223,7 +222,6 @@ public class RuleBaseConfiguration
 
     public void readExternal(ObjectInput in) throws IOException,
             ClassNotFoundException {
-        chainedProperties = (ChainedProperties) in.readObject();
         immutable = in.readBoolean();
         sequential = in.readBoolean();
         sequentialAgenda = (SequentialAgenda) in.readObject();

--- a/drools-core/src/main/resources/META-INF/kie.default.properties.conf
+++ b/drools-core/src/main/resources/META-INF/kie.default.properties.conf
@@ -16,7 +16,6 @@ drools.logicalOverride = DISCARD
 drools.conflictResolver = org.drools.core.conflict.DepthConflictResolver
 drools.consequenceExceptionHandler = org.drools.core.runtime.rule.impl.DefaultConsequenceExceptionHandler
 drools.workDefinitions = WorkDefinitions.conf
-droools.lrUnlinkingEnabled = false
 drools.declarativeAgendaEnabled = false
 drools.permgenThreshold = 90
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6402

Under a security point of view I agree with the issue reporter that the `System.properties` shouldn't be part of the serialized `KieBase`. I found that this can be easily achieved by completely avoiding the serialization of the `ChainedProperties` inside the `RuleBaseConfiguration`. In fact by doing so the `ChainedProperties` is automatically recreated from scratch in the context, and then using the `System.properties`, of the JVM where the `KieBase` gets deserialized. This could be more correct in some situation and less in other, I don't have a strong opinion on this, but anyway I will document this change in case we will decide to merge this PR. The other issue that I see is that this change will break all existing serialized `KieBase`s, making them incompatible with the next release. We never guaranteed seriialized `KieBase` compatibility between different versions (which is also the reason why we want to discourage the use of seriialized `KieBase` regardless of this issue), so I believe that this also won't be a issue.

@tkobayas what do you think?