### PR TITLE
DROOLS-6525: Returning more detailed error message for DMN failure

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/runner/DMNScenarioRunnerHelperTest.java
@@ -56,9 +56,11 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.RequestContext;
 import org.kie.dmn.api.core.DMNDecisionResult;
 import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.ast.DecisionNode;
+import org.kie.dmn.core.impl.DMNMessageImpl;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -78,6 +80,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus;
+import static org.kie.dmn.api.core.DMNMessage.Severity.ERROR;
+import static org.kie.dmn.api.core.DMNMessage.Severity.WARN;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
@@ -337,12 +341,31 @@ public class DMNScenarioRunnerHelperTest {
         ValueWrapper<?> failedResult = runnerHelper.getSingleFactValueResult(null,
                                                                               null,
                                                                               failedDecision,
+                                                                              null,
                                                                               expressionEvaluator);
         assertFalse(failedResult.isValid());
-        assertEquals("The decision " +
+        assertEquals("The decision \"" +
                              failedDecision.getDecisionName() +
-                             " has not been successfully evaluated: " +
+                             "\" has not been successfully evaluated: " +
                              failedDecision.getEvaluationStatus(),
+                     failedResult.getErrorMessage().get());
+    }
+
+    @Test
+    public void getSingleFactValueResultFailDecisionWithMessages() {
+        DMNMessage errorMessage = new DMNMessageImpl(ERROR, "DMN Internal Error", DMNMessageType.FEEL_EVALUATION_ERROR, null);
+        DMNMessage warnMessage = new DMNMessageImpl(WARN, "DMN Internal Warn", DMNMessageType.FEEL_EVALUATION_ERROR, null);
+
+        DMNDecisionResult failedDecision = createDecisionResultMock("Test", false, new ArrayList<>());
+        ValueWrapper<?> failedResult = runnerHelper.getSingleFactValueResult(null,
+                                                                             null,
+                                                                             failedDecision,
+                                                                             Arrays.asList(warnMessage, errorMessage),
+                                                                             expressionEvaluator);
+        assertFalse(failedResult.isValid());
+        assertEquals("The decision \"" +
+                             failedDecision.getDecisionName() +
+                             "\" has not been successfully evaluated: DMN Internal Error",
                      failedResult.getErrorMessage().get());
     }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6525

In case of a Failure on DMN side, now a more detailed message is shown to the user.
For example, in case of a failure due  to a UNIQUE hit policy error:

BEFORE
![Screenshot from 2021-07-28 10-13-23](https://user-images.githubusercontent.com/16005046/127323477-b1bad374-9cd3-4023-976f-50f246540ae1.png)

AFTER
![Screenshot from 2021-07-28 14-25-27](https://user-images.githubusercontent.com/16005046/127323504-efb72732-07c4-47fe-8ad3-e0473d2090da.png)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
