### PR TITLE
[DROOLS-6528] Added support to contribute ExecutionFrame values to FEELProfile

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELProfile.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/FEELProfile.java
@@ -16,11 +16,17 @@
 
 package org.kie.dmn.feel.lang;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.kie.dmn.feel.runtime.FEELFunction;
 
 public interface FEELProfile {
 
     List<FEELFunction> getFEELFunctions();
+    
+    default Map<String,Object> getValues() {
+        return Collections.emptyMap();
+    };
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
@@ -87,6 +87,12 @@ public class FEELImpl
                 frame.setValue(f.getName(), f);
                 functions.put(f.getName(), f);
             }
+            for (Map.Entry<String,Object> v : p.getValues().entrySet()) {
+                if (frame == null) {
+                    frame = new ExecutionFrameImpl(null);
+                }
+                frame.setValue(v.getKey(), v.getValue());
+            }
         }
         doCompile = profiles.stream().anyMatch(DoCompileFEELProfile.class::isInstance);
         customFrame = Optional.ofNullable(frame);

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
@@ -1,0 +1,64 @@
+package org.kie.dmn.feel.lang.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.functions.BaseFEELFunction;
+import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FEELProfileTest {
+
+    @Test
+    public void testFeelProfileFunctionsAndValues() {
+
+        // Instantiate a new FEEL with the profile to try the method that uses the data cache
+        FEEL feel = FEEL.newInstance(List.of(new TestFEELProfile()));
+
+        assertThat(feel.evaluate("use cache(\"val 1\")"), equalTo("1"));
+        assertThat(feel.evaluate("use cache(\"val 3\")"), equalTo("3"));
+        assertThat(feel.evaluate("use cache(\"val 5\")"), equalTo(null));
+    }
+
+    /**
+     * This profile adds a function that use an object introduced as a value to the feel stack to reference external data 
+     */
+    public static class TestFEELProfile implements FEELProfile {
+
+        @Override
+        public List<FEELFunction> getFEELFunctions() {
+            return List.of(new UseCacheFunction());
+        }
+
+        @Override
+        public Map<String, Object> getValues() {
+            return Map.of("[internal-cache]", Map.of("val 1", "1", "val 2", "2", "val 3", "3"));
+        }
+    }
+
+    public static class UseCacheFunction extends BaseFEELFunction {
+
+        public UseCacheFunction() {
+            super("use cache");
+        }
+
+        public FEELFnResult<String> invoke(EvaluationContext ctx, String key) {
+
+            @SuppressWarnings("unchecked")
+            Map<String, String> cache = (Map<String, String>) ctx.getValue("[internal-cache]");
+            if (cache != null) {
+                return FEELFnResult.ofResult(cache.get(key));
+            }
+
+            return FEELFnResult.ofResult(null);
+
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/lang/impl/FEELProfileTest.java
@@ -1,5 +1,6 @@
 package org.kie.dmn.feel.lang.impl;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +14,8 @@ import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.kie.dmn.feel.util.DynamicTypeUtils.entry;
+import static org.kie.dmn.feel.util.DynamicTypeUtils.mapOf;
 
 public class FEELProfileTest {
 
@@ -20,7 +23,7 @@ public class FEELProfileTest {
     public void testFeelProfileFunctionsAndValues() {
 
         // Instantiate a new FEEL with the profile to try the method that uses the data cache
-        FEEL feel = FEEL.newInstance(List.of(new TestFEELProfile()));
+        FEEL feel = FEEL.newInstance(Arrays.asList(new TestFEELProfile()));
 
         assertThat(feel.evaluate("use cache(\"val 1\")"), equalTo("1"));
         assertThat(feel.evaluate("use cache(\"val 3\")"), equalTo("3"));
@@ -34,12 +37,12 @@ public class FEELProfileTest {
 
         @Override
         public List<FEELFunction> getFEELFunctions() {
-            return List.of(new UseCacheFunction());
+            return Arrays.asList(new UseCacheFunction());
         }
 
         @Override
         public Map<String, Object> getValues() {
-            return Map.of("[internal-cache]", Map.of("val 1", "1", "val 2", "2", "val 3", "3"));
+            return mapOf(entry("[internal-cache]", mapOf(entry("val 1", "1"), entry("val 2", "2"), entry("val 3", "3"))));
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/DROOLS-6528

This PR adds support for FEELProfile to add values on to the FEEL engine that can be referenced by functions. This enables extension profiles to create functions that can reference contexts that are external to FEEL in their logic.

I've provided a simple example of how a function can access a Map cache. 

@tarilabs This is a little bit late but this is the extensions that we have discussed by email a few weeks ago with a unit test added