### PR TITLE
[DROOLS-6482] NullSafeDereferencing without predicate misses null che…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -236,6 +236,7 @@ public class ConstraintParser {
                     .setReactOnProperties( expressionTyperContext.getReactOnProperties() )
                     .setUsedDeclarations( expressionTyperContext.getUsedDeclarations() )
                     .setImplicitCastExpression( expressionTyperContext.getInlineCastExpression() )
+                    .setNullSafeExpressions(expressionTyperContext.getNullSafeExpressions())
                     .setIsPredicate(isPredicate);
         } else {
             final ExpressionTyperContext expressionTyperContext = new ExpressionTyperContext();
@@ -255,7 +256,10 @@ public class ConstraintParser {
     }
 
     private Expression combineExpressions( TypedExpressionResult leftTypedExpressionResult, Expression combo ) {
-        for (Expression e : leftTypedExpressionResult.getPrefixExpressions()) {
+        List<Expression> allPrefixExpressions = new ArrayList<>();
+        allPrefixExpressions.addAll(leftTypedExpressionResult.getNullSafeExpressions());
+        allPrefixExpressions.addAll(leftTypedExpressionResult.getPrefixExpressions());
+        for (Expression e : allPrefixExpressions) {
             combo = new BinaryExpr( e, combo, BinaryExpr.Operator.AND );
         }
         return combo;
@@ -481,6 +485,8 @@ public class ConstraintParser {
 
         List<Expression> leftPrefixExpresssions = new ArrayList<>();
         if (isLogicalOperator(operator)) {
+            leftPrefixExpresssions.addAll(expressionTyperContext.getNullSafeExpressions());
+            expressionTyperContext.getNullSafeExpressions().clear();
             leftPrefixExpresssions.addAll(expressionTyperContext.getPrefixExpresssions());
             expressionTyperContext.getPrefixExpresssions().clear();
         }
@@ -499,6 +505,8 @@ public class ConstraintParser {
             }
             right = optRight.get();
             if (isLogicalOperator(operator)) {
+                rightPrefixExpresssions.addAll(expressionTyperContext.getNullSafeExpressions());
+                expressionTyperContext.getNullSafeExpressions().clear();
                 rightPrefixExpresssions.addAll(expressionTyperContext.getPrefixExpresssions());
                 expressionTyperContext.getPrefixExpresssions().clear();
             }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/DrlxParseSuccess.java
@@ -18,6 +18,7 @@
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import com.github.javaparser.ast.expr.Expression;
@@ -38,6 +39,8 @@ public interface DrlxParseSuccess extends DrlxParseResult {
     DrlxParseSuccess addAllWatchedProperties(Collection<String> watchedProperties);
 
     Optional<Expression> getImplicitCastExpression();
+
+    List<Expression> getNullSafeExpressions();
 
     default boolean isOOPath() {
         return getExpr() instanceof OOPathExpr;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/MultipleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/MultipleDrlxParseSuccess.java
@@ -17,6 +17,8 @@
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,6 +53,11 @@ public class MultipleDrlxParseSuccess extends AbstractDrlxParseSuccess {
     @Override
     public Optional<Expression> getImplicitCastExpression() {
         return Optional.empty();
+    }
+
+    @Override
+    public List<Expression> getNullSafeExpressions() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
@@ -17,10 +17,12 @@
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -72,6 +74,7 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
     private boolean combined;
 
     private Optional<Expression> implicitCastExpression = Optional.empty();
+    private List<Expression> nullSafeExpressions = new ArrayList<>();
 
     public SingleDrlxParseSuccess(Class<?> patternType, String patternBinding, Expression expr, Type exprType) {
         this.patternType = patternType;
@@ -104,6 +107,7 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
         this.temporal = drlx.isTemporal();
         this.combined = drlx.isCombined();
         this.implicitCastExpression = drlx.getImplicitCastExpression();
+        this.nullSafeExpressions = drlx.getNullSafeExpressions();
 
         this.watchedProperties = drlx.getWatchedProperties();
     }
@@ -428,6 +432,16 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
     @Override
     public Optional<Expression> getImplicitCastExpression() {
         return implicitCastExpression;
+    }
+
+    @Override
+    public List<Expression> getNullSafeExpressions() {
+        return nullSafeExpressions;
+    }
+
+    public SingleDrlxParseSuccess setNullSafeExpressions(List<Expression> nullSafeExpressions) {
+        this.nullSafeExpressions = nullSafeExpressions;
+        return this;
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
@@ -751,8 +751,8 @@ public class ExpressionTyper {
         }
     }
 
-    private void addNullSafeExpression( Expression scope ) {
-        toTypedExpressionRec(scope).ifPresent(te -> context.addPrefixExpression(0, new BinaryExpr(te.getExpression(), new NullLiteralExpr(), BinaryExpr.Operator.NOT_EQUALS)));
+    private void addNullSafeExpression(Expression scope) {
+        toTypedExpressionRec(scope).ifPresent(te -> context.addNullSafeExpression(0, new BinaryExpr(te.getExpression(), new NullLiteralExpr(), BinaryExpr.Operator.NOT_EQUALS)));
     }
 
     private TypedExpressionCursor binaryExpr( BinaryExpr binaryExpr ) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyperContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyperContext.java
@@ -37,6 +37,7 @@ public class ExpressionTyperContext {
     private boolean registerPropertyReactivity = true;
 
     private Optional<Expression> inlineCastExpression = Optional.empty();
+    private List<Expression> nullSafeExpressions = new ArrayList<>();
 
     public void addUsedDeclarations(String name) {
         usedDeclarations.add(name);
@@ -82,6 +83,14 @@ public class ExpressionTyperContext {
 
     public void setInlineCastExpression(Optional<Expression> inlineCastExpression) {
         this.inlineCastExpression = inlineCastExpression;
+    }
+
+    public List<Expression> getNullSafeExpressions() {
+        return nullSafeExpressions;
+    }
+
+    public void addNullSafeExpression(int index, Expression nullSafeExpression) {
+        nullSafeExpressions.add(index, nullSafeExpression);
     }
 
     public Expression getOriginalExpression() {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/TypedExpressionResult.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/TypedExpressionResult.java
@@ -59,6 +59,10 @@ public class TypedExpressionResult {
         return expressionTyperContext.getPrefixExpresssions();
     }
 
+    public List<Expression> getNullSafeExpressions() {
+        return expressionTyperContext.getNullSafeExpressions();
+    }
+
     @Override
     public String toString() {
         return "{" +


### PR DESCRIPTION
…ck in exec-model

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6482

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
