### PR TITLE
[DROOLS-6474] Revisit RuleContext.definedVars and coercion test

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -265,6 +265,7 @@ public class RuleContext {
         String declId = getDeclarationKey( id );
         scopedDeclarations.remove( declId );
         this.allDeclarations.remove( declId );
+        definedVars.remove(id);
     }
 
     public boolean hasDeclaration(String id) {

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpressionTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpressionTest.java
@@ -221,4 +221,12 @@ public class CoercedExpressionTest {
         Assertions.assertThatThrownBy(() -> new CoercedExpression(left, right, false).coerce())
                 .isInstanceOf(CoercedExpression.CoercedExpressionException.class);
     }
+
+    @Test
+    public void testNameExprToString() {
+        final TypedExpression left = expr(THIS_PLACEHOLDER + ".getName", String.class);
+        final TypedExpression right = expr("$maxName", Comparable.class);
+        final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right, true).coerce();
+        assertEquals(expr("(java.lang.String) $maxName", String.class), coerce.getCoercedRight());
+    }
 }


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6474

Comments from Paolo on https://github.com/kiegroup/drools/pull/3708

- should we remove the bindingId from the definedVars when we call the removeDeclarationById?
    - Thanks. It makes sense and fixed.
- should we add the bindingId to the definedVars when we call addDeclaration?
    - addDeclaration() is always called after calling defineVar() so we don't need to add.
- Since the CoercedExpressionTest already exists, we could add this new case as a test case, unless it is too complicated.
    - Thanks, Added a test case

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
