### PR TITLE
[DROOLS-6537] SharedSessionParallelTest timeout occasionally

### DIFF
--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SharedSessionParallelTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/concurrency/SharedSessionParallelTest.java
@@ -29,11 +29,14 @@ import org.drools.mvel.integrationtests.facts.BeanA;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.runtime.KieSession;
+import org.kie.test.testcategory.TurtleTestCategory;
 
 @RunWith(Parameterized.class)
+@Category(TurtleTestCategory.class)
 public class SharedSessionParallelTest extends AbstractConcurrentTest {
 
     @Parameterized.Parameters(name = "Enforced jitting={0}, KieBase type={1}")
@@ -62,7 +65,7 @@ public class SharedSessionParallelTest extends AbstractConcurrentTest {
         super(enforcedJitting, false, false, false, kieBaseTestConfiguration);
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     public void testNoExceptions() throws InterruptedException {
         final String drl = "rule R1 when String() then end";
 


### PR DESCRIPTION
According to the stack traces, it seemed to be just slow especially under limited CPU resources. So:
- Increase timeout
- Make it Turtle test

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6537

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
