### PR TITLE
[DROOLS-6351] PredicateInformation contains only one rule name even when shared

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildUtils.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/builder/BuildUtils.java
@@ -160,11 +160,13 @@ public class BuildUtils {
         if (node instanceof AlphaNode) {
             AlphaNodeFieldConstraint alphaConstraint = ((AlphaNode) node).getConstraint();
             alphaConstraint.addPackageNames(((AlphaNode) duplicate).getConstraint().getPackageNames());
+            alphaConstraint.mergeEvaluationContext(((AlphaNode) duplicate).getConstraint());
         } else if (node instanceof BetaNode) {
             BetaNodeFieldConstraint[] betaConstraints = ((BetaNode) node).getConstraints();
             int i = 0;
             for (BetaNodeFieldConstraint betaConstraint : betaConstraints) {
                 betaConstraint.addPackageNames(((BetaNode) duplicate).getConstraints()[i].getPackageNames());
+                betaConstraint.mergeEvaluationContext(((BetaNode) duplicate).getConstraints()[i]);
                 i++;
             }
         }

--- a/drools-core/src/main/java/org/drools/core/spi/Constraint.java
+++ b/drools-core/src/main/java/org/drools/core/spi/Constraint.java
@@ -86,6 +86,8 @@ public interface Constraint
 
     default void registerEvaluationContext(BuildContext buildContext) { }
 
+    default void mergeEvaluationContext(Constraint other) { }
+
     default Collection<String> getPackageNames() {
         return Collections.emptyList();
     }

--- a/drools-core/src/main/java/org/drools/core/util/MessageUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/MessageUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MessageUtils {
+
+    private MessageUtils() {}
+
+    public static String defaultToEmptyString(String str) {
+        return Optional.ofNullable(str).orElse("");
+    }
+
+    public static String formatConstraintErrorMessage(String expression, Map<String, Set<String>> ruleNameMap) {
+        return String.format("Error evaluating constraint '%s' in %s", expression, formatRuleNameMap(ruleNameMap));
+    }
+
+    public static String formatRuleNameMap(Map<String, Set<String>> ruleNameMap) {
+        if (ruleNameMap == null || ruleNameMap.isEmpty()) {
+            return "";
+        }
+        final StringBuilder sb = new StringBuilder();
+        List<String> ruleFileNameList = ruleNameMap.keySet().stream().sorted().collect(Collectors.toList());
+        ruleFileNameList.forEach(ruleFileName -> {
+            sb.append("[Rule ");
+            ruleNameMap.get(ruleFileName).stream().sorted().forEach(ruleName -> {
+                sb.append("\"" + ruleName + "\", ");
+            });
+            if (!ruleFileNameList.isEmpty()) {
+                sb.delete(sb.length() - 2, sb.length());
+            }
+            sb.append(" in " + ruleFileName + "] ");
+        });
+        sb.deleteCharAt(sb.length() - 1);
+        return sb.toString();
+    }
+}

--- a/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
+++ b/drools-model/drools-canonical-model/src/main/java/org/drools/model/functions/PredicateInformation.java
@@ -16,8 +16,12 @@
 
 package org.drools.model.functions;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Used to generate a better error message when constraints fail
@@ -27,45 +31,37 @@ public class PredicateInformation {
     public static final PredicateInformation EMPTY_PREDICATE_INFORMATION =
             new PredicateInformation("", "", "");
 
-
     // Used to generate a significant error message
     private final String stringConstraint;
-    private final String ruleName;
-    private final String ruleFileName;
+    private final Map<String, Set<String>> ruleNameMap = new HashMap<>();
+
+    public PredicateInformation(String stringConstraint) {
+        this.stringConstraint = defaultToEmptyString(stringConstraint);
+    }
 
     public PredicateInformation(String stringConstraint, String ruleName, String ruleFileName) {
         this.stringConstraint = defaultToEmptyString(stringConstraint);
-        this.ruleName = defaultToEmptyString(ruleName);
-        this.ruleFileName = defaultToEmptyString(ruleFileName);
-    }
-
-    private String defaultToEmptyString(String stringConstraint) {
-        return Optional.ofNullable(stringConstraint).orElse("");
-    }
-
-    public RuntimeException betterErrorMessage(RuntimeException originalException) {
-        if("".equals(stringConstraint)) {
-            return originalException;
-        }
-
-        String errorMessage = String.format(
-                "Error evaluating constraint '%s' in [Rule \"%s\" in %s]",
-                stringConstraint,
-                ruleName,
-                ruleFileName);
-        return new RuntimeException(errorMessage, originalException);
+        ruleName = defaultToEmptyString(ruleName);
+        ruleFileName = defaultToEmptyString(ruleFileName);
+        ruleNameMap.computeIfAbsent(ruleFileName, k -> new HashSet<>()).add(ruleName);
     }
 
     public String getStringConstraint() {
         return stringConstraint;
     }
 
-    public String getRuleName() {
-        return ruleName;
+    public Map<String, Set<String>> getRuleNameMap() {
+        return ruleNameMap;
     }
 
-    public String getRuleFileName() {
-        return ruleFileName;
+    public void addRuleName(String ruleName, String ruleFileName) {
+        ruleName = defaultToEmptyString(ruleName);
+        ruleFileName = defaultToEmptyString(ruleFileName);
+        ruleNameMap.computeIfAbsent(ruleFileName, k -> new HashSet<>()).add(ruleName);
+    }
+
+    public static String defaultToEmptyString(String str) {
+        return Optional.ofNullable(str).orElse("");
     }
 
     public boolean isEmpty() {
@@ -82,21 +78,19 @@ public class PredicateInformation {
         }
         PredicateInformation that = (PredicateInformation) o;
         return Objects.equals(stringConstraint, that.stringConstraint) &&
-                Objects.equals(ruleName, that.ruleName) &&
-                Objects.equals(ruleFileName, that.ruleFileName);
+                Objects.equals(ruleNameMap, that.ruleNameMap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stringConstraint, ruleName, ruleFileName);
+        return Objects.hash(stringConstraint, ruleNameMap);
     }
 
     @Override
     public String toString() {
         return "PredicateInformation{" +
                 "stringConstraint='" + stringConstraint + '\'' +
-                ", ruleName='" + ruleName + '\'' +
-                ", ruleFileName='" + ruleFileName + '\'' +
+                ", ruleNameMap='" + ruleNameMap + '\'' +
                 '}';
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/PackageModel.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -889,12 +888,15 @@ public class PackageModel {
         lambdaReturnTypes.put(lambdaExpr, type);
     }
 
-    public void indexConstraint(String exprId, PredicateInformation predicateInformation) {
-        allConstraintsMap.put(exprId, predicateInformation);
-    }
-
-    public Optional<PredicateInformation> findConstraintWithExprId(String exprId) {
-        return ofNullable(allConstraintsMap.get(exprId));
+    public void indexConstraint(String exprId, String constraint, String ruleName, String ruleFileName) {
+        allConstraintsMap.compute(exprId, (key, info) -> {
+            if (info == null) {
+                return new PredicateInformation(constraint, ruleName, ruleFileName);
+            } else {
+                info.addRuleName(ruleName, ruleFileName);
+                return info;
+            }
+        });
     }
 
     public Map<String, PredicateInformation> getAllConstraintsMap() {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -389,14 +389,15 @@ public abstract class AbstractExpressionBuilder {
     protected String createExprId(SingleDrlxParseSuccess drlxParseResult) {
         String exprId = drlxParseResult.getExprId(context.getPackageModel().getExprIdGenerator());
 
-        context.getPackageModel().indexConstraint(exprId, new PredicateInformation(
-                drlxParseResult.getOriginalDrlConstraint(),
-                context.getRuleName(),
-                Optional.ofNullable(context.getRuleDescr())
-                    .map(RuleDescr::getResource)
-                    .map(Resource::getSourcePath)
-                    .orElse("")
-        ));
+        String stringConstraint = drlxParseResult.getOriginalDrlConstraint();
+        String ruleName = context.getRuleName();
+        String ruleFileName = Optional.ofNullable(context.getRuleDescr())
+                                      .map(RuleDescr::getResource)
+                                      .map(Resource::getSourcePath)
+                                      .orElse("");
+
+        context.getPackageModel().indexConstraint(exprId, stringConstraint, ruleName, ruleFileName);
+
         return exprId;
     }
 

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/ConstraintEvaluationException.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/ConstraintEvaluationException.java
@@ -1,28 +1,31 @@
 /*
- * Copyright (c) 2020. Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
+ *
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
-package org.drools.mvel;
+package org.drools.modelcompiler.constraints;
 
-import org.drools.mvel.MVELConstraint.EvaluationContext;
+import org.drools.model.functions.PredicateInformation;
 
 import static org.drools.core.util.MessageUtils.formatConstraintErrorMessage;
 
 public class ConstraintEvaluationException extends RuntimeException {
 
-    private static final long serialVersionUID = -3413225194510143529L;
+    private static final long serialVersionUID = 7880877148568087603L;
 
-    public ConstraintEvaluationException(String expression, EvaluationContext evaluationContext, Throwable cause) {
-        super(formatConstraintErrorMessage(expression, evaluationContext.getRuleNameMap()), cause);
+    public ConstraintEvaluationException(PredicateInformation predicateInformation, Throwable cause) {
+        super(formatConstraintErrorMessage(predicateInformation.getStringConstraint(), predicateInformation.getRuleNameMap()), cause);
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/constraints/LambdaConstraint.java
@@ -175,20 +175,28 @@ public class LambdaConstraint extends AbstractConstraint {
         try {
             return evaluator.evaluate(handle, workingMemory);
         } catch (RuntimeException e) {
-            throw predicateInformation.betterErrorMessage(e);
+            throw new ConstraintEvaluationException(predicateInformation, e);
         }
     }
 
     @Override
     public boolean isAllowedCachedLeft(ContextEntry context, InternalFactHandle handle) {
         LambdaContextEntry lambdaContext = ((LambdaContextEntry) context);
-        return evaluator.evaluate(handle, lambdaContext.getTuple(), lambdaContext.getWorkingMemory());
+        try {
+            return evaluator.evaluate(handle, lambdaContext.getTuple(), lambdaContext.getWorkingMemory());
+        } catch (RuntimeException e) {
+            throw new ConstraintEvaluationException(predicateInformation, e);
+        }
     }
 
     @Override
     public boolean isAllowedCachedRight(Tuple tuple, ContextEntry context) {
         LambdaContextEntry lambdaContext = ((LambdaContextEntry) context);
-        return evaluator.evaluate(lambdaContext.getHandle(), tuple, lambdaContext.getWorkingMemory());
+        try {
+            return evaluator.evaluate(lambdaContext.getHandle(), tuple, lambdaContext.getWorkingMemory());
+        } catch (RuntimeException e) {
+            throw new ConstraintEvaluationException(predicateInformation, e);
+        }
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicate.java
@@ -17,12 +17,22 @@
 
 package org.drools.modelcompiler.util.lambdareplace;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
@@ -52,7 +62,7 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
     @Override
     void createMethodsDeclaration(EnumDeclaration classDeclaration) {
         createTestMethod(classDeclaration);
-        if(!predicateInformation.isEmpty()) {
+        if (!predicateInformation.isEmpty()) {
             createPredicateInformationMethod(classDeclaration);
         }
     }
@@ -60,7 +70,7 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
     private void createTestMethod(EnumDeclaration classDeclaration) {
         MethodDeclaration methodDeclaration = classDeclaration.addMethod("test", Modifier.Keyword.PUBLIC);
         methodDeclaration.setThrownExceptions(NodeList.nodeList(toClassOrInterfaceType(java.lang.Exception.class)));
-        methodDeclaration.addAnnotation( createSimpleAnnotation("Override") );
+        methodDeclaration.addAnnotation(createSimpleAnnotation("Override"));
         methodDeclaration.setType(new PrimitiveType(PrimitiveType.Primitive.BOOLEAN));
 
         setMethodParameter(methodDeclaration);
@@ -75,12 +85,28 @@ public class MaterializedLambdaPredicate extends MaterializedLambda {
         ClassOrInterfaceType predicateInformationType = (ClassOrInterfaceType) toJPType(PredicateInformation.class);
         methodDeclaration.setType(predicateInformationType);
 
-        ObjectCreationExpr newPredicateInformation = new ObjectCreationExpr(null, predicateInformationType, NodeList.nodeList(
-            new StringLiteralExpr().setString(predicateInformation.getStringConstraint()),
-            new StringLiteralExpr().setString(predicateInformation.getRuleName()),
-            new StringLiteralExpr().setString(predicateInformation.getRuleFileName())
-        ));
-        methodDeclaration.setBody(new BlockStmt(NodeList.nodeList(new ReturnStmt(newPredicateInformation))));
+        BlockStmt block = new BlockStmt();
+
+        NameExpr infoExpr = new NameExpr("info");
+        VariableDeclarationExpr infoVar = new VariableDeclarationExpr(toClassOrInterfaceType(PredicateInformation.class), "info");
+        ObjectCreationExpr newPredicateInformation = new ObjectCreationExpr(null, predicateInformationType, NodeList.nodeList(new StringLiteralExpr().setString(predicateInformation.getStringConstraint())));
+        AssignExpr infoAssign = new AssignExpr(infoVar, newPredicateInformation, AssignExpr.Operator.ASSIGN);
+        block.addStatement(infoAssign);
+
+        List<MethodCallExpr> addRuleNameMethods = new ArrayList<>();
+        Map<String, Set<String>> ruleNameMap = predicateInformation.getRuleNameMap();
+        ruleNameMap.forEach((ruleFileName, ruleNameList) -> {
+            ruleNameList.forEach(ruleName -> {
+                MethodCallExpr addRuleName = new MethodCallExpr(infoExpr, "addRuleName", NodeList.nodeList(new StringLiteralExpr(ruleName), new StringLiteralExpr(ruleFileName)));
+                addRuleNameMethods.add(addRuleName);
+            });
+        });
+        addRuleNameMethods.sort((mce1, mce2) -> mce1.toString().compareTo(mce2.toString()));
+        addRuleNameMethods.forEach(block::addStatement);
+
+        block.addStatement(new ReturnStmt(infoExpr));
+
+        methodDeclaration.setBody(block);
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -2834,6 +2834,135 @@ public class CompilerTest extends BaseModelTest {
     }
 
     @Test
+    public void testSharedPredicateInformation() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl]"));
+
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R1 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person me = new Person("Luca");
+        me.setSalary(null);
+        me.setMoney(null);
+        ksession.insert(me);
+        ksession.fireAllRules();
+    }
+
+    @Test
+    public void testSharedPredicateInformationWithNonSharedRule() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R3\" in r0.drl]"));
+
+        String str =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R1 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $p : Person()\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R3 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str);
+
+        Person me = new Person("Luca");
+        me.setSalary(null);
+        me.setMoney(null);
+        ksession.insert(me);
+        ksession.fireAllRules();
+    }
+
+    @Test
+    public void testSharedPredicateInformationWithMultipleFiles() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage(equalTo("Error evaluating constraint 'money < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl] [Rule \"R3\", \"R4\" in r1.drl]"));
+
+        String str1 =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R1 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end";
+        String str2 =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R3 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R4 when\n" +
+                     "  $p : Person(money < salary * 20 )\n" +
+                     "then\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str1, str2);
+
+        Person me = new Person("Luca");
+        me.setSalary(null);
+        me.setMoney(null);
+        ksession.insert(me);
+        ksession.fireAllRules();
+    }
+
+    @Test
+    public void testSharedBetaPredicateInformationWithMultipleFiles() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage(equalTo("Error evaluating constraint '$i < salary * 20' in [Rule \"R1\", \"R2\" in r0.drl] [Rule \"R3\", \"R4\" in r1.drl]"));
+
+        String str1 =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R1 when\n" +
+                     "  $i : Integer()\n" +
+                     "  $p : Person($i < salary * 20 )\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R2 when\n" +
+                     "  $i : Integer()\n" +
+                     "  $p : Person($i < salary * 20 )\n" +
+                     "then\n" +
+                     "end";
+        String str2 =
+                "import " + Person.class.getCanonicalName() + ";" +
+                     "rule R3 when\n" +
+                     "  $i : Integer()\n" +
+                     "  $p : Person($i < salary * 20 )\n" +
+                     "then\n" +
+                     "end\n" +
+                     "rule R4 when\n" +
+                     "  $i : Integer()\n" +
+                     "  $p : Person($i < salary * 20 )\n" +
+                     "then\n" +
+                     "end";
+
+        KieSession ksession = getKieSession(str1, str2);
+
+        Person me = new Person("Luca");
+        me.setSalary(null);
+        me.setMoney(null);
+        ksession.insert(Integer.valueOf(10));
+        ksession.insert(me);
+        ksession.fireAllRules();
+    }
+
+    @Test
     public void testWithQuotedStringConcatenationOnConstraint() {
         String str =
                 "import " + Person.class.getCanonicalName() + ";" +

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/util/lambdareplace/MaterializedLambdaPredicateTest.java
@@ -28,19 +28,24 @@ public class MaterializedLambdaPredicateTest {
 
     @Test
     public void createClassWithOneParameter() {
+        PredicateInformation predicateInformation = new PredicateInformation("p.age > 35", "rule1", "rulefilename1.drl");
+        predicateInformation.addRuleName("rule2", "rulefilename2.drl");
+        predicateInformation.addRuleName("rule3", "rulefilename3.drl");
         CreatedClass aClass = new MaterializedLambdaPredicate("org.drools.modelcompiler.util.lambdareplace",
                                                               "rulename",
-                                                              new PredicateInformation("p.age > 35", "rule1", "rulefilename.drl"))
+                                                              predicateInformation)
                 .create("(org.drools.modelcompiler.domain.Person p) -> p.getAge() > 35", new ArrayList<>(), new ArrayList());
-
+        String classNameWithPackage = aClass.getClassNameWithPackage();
+        String expectedPackageName = classNameWithPackage.substring(0, classNameWithPackage.lastIndexOf('.'));
+        String expectedClassName = classNameWithPackage.substring(classNameWithPackage.lastIndexOf('.')+1);
         //language=JAVA
         String expectedResult = "" +
-                "package org.drools.modelcompiler.util.lambdareplace.PEE;\n" +
+                "package PACKAGE_TOREPLACE;\n" +
                 "import static rulename.*; " +
                 "import org.drools.modelcompiler.dsl.pattern.D; " +
                 "" +
                 "@org.drools.compiler.kie.builder.MaterializedLambda() " +
-                "public enum LambdaPredicateEE863708F0E52E1DD7FBE6537EB76024 implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
+                "public enum CLASS_TOREPLACE implements org.drools.model.functions.Predicate1<org.drools.modelcompiler.domain.Person>, org.drools.model.functions.HashedExpression {\n" +
                 " INSTANCE; \n" +
                 "public static final String EXPRESSION_HASH = \"4DEB93975D9859892B1A5FD4B38E2155\";" +
                 "    public java.lang.String getExpressionHash() {\n" +
@@ -52,10 +57,17 @@ public class MaterializedLambdaPredicateTest {
                 "        }\n" +
                 "        @Override()\n" +
                 "        public org.drools.model.functions.PredicateInformation predicateInformation() {\n" +
-                "            return new org.drools.model.functions.PredicateInformation(\"p.age > 35\", \"rule1\", \"rulefilename.drl\");" +
+                "            org.drools.model.functions.PredicateInformation info = new org.drools.model.functions.PredicateInformation(\"p.age > 35\");\n" +
+                "            info.addRuleName(\"rule1\", \"rulefilename1.drl\");\n" +
+                "            info.addRuleName(\"rule2\", \"rulefilename2.drl\");\n" +
+                "            info.addRuleName(\"rule3\", \"rulefilename3.drl\");\n" +
+                "            return info;\n" +
                 "        }\n" +
+                "" +
                 "    }\n";
-
+        expectedResult = expectedResult
+                .replace("PACKAGE_TOREPLACE", expectedPackageName)
+                .replace("CLASS_TOREPLACE", expectedClassName);
         verifyCreatedClass(aClass, expectedResult);
     }
 


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6351

**referenced Pull Requests**: 

This is another version of https://github.com/kiegroup/drools/pull/3784
This time, I implement the *better error message* (print all associated rule names and rule file names) for non-exec-model as well.



<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
