### PR TITLE
[RHDM-1796] Reset FactHandleId on KieSession.dispose

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/AbstractFactHandleFactory.java
+++ b/drools-core/src/main/java/org/drools/core/common/AbstractFactHandleFactory.java
@@ -50,7 +50,7 @@ public abstract class AbstractFactHandleFactory
     }
 
     /* (non-Javadoc)
-    * @see org.kie.reteoo.FactHandleFactory#newFactHandle()
+    * @see org.drools.core.spi.FactHandleFactory#newFactHandle()
     */
     public final InternalFactHandle newFactHandle(Object object,
                                                   ObjectTypeConf conf,
@@ -64,7 +64,7 @@ public abstract class AbstractFactHandleFactory
     }
 
     /* (non-Javadoc)
-     * @see org.kie.reteoo.FactHandleFactory#newFactHandle(long)
+     * @see org.drools.core.spi.FactHandleFactory#newFactHandle(long)
      */
     public final InternalFactHandle newFactHandle(long id,
                                                   Object object,
@@ -80,7 +80,7 @@ public abstract class AbstractFactHandleFactory
     }
 
     /* (non-Javadoc)
-     * @see org.kie.reteoo.FactHandleFactory#newFactHandle(long)
+     * @see org.drools.core.spi.FactHandleFactory#newFactHandle(long)
      */
     public abstract InternalFactHandle newFactHandle(long id,
                                                      Object object,
@@ -98,7 +98,7 @@ public abstract class AbstractFactHandleFactory
     }
 
     /* (non-Javadoc)
-     * @see org.kie.reteoo.FactHandleFactory#newInstance()
+     * @see org.drools.core.spi.FactHandleFactory#newInstance()
      */
     public abstract FactHandleFactory newInstance();
 

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -223,7 +223,6 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     protected InternalFactHandle initialFactHandle;
 
     private PropagationContextFactory pctxFactory;
-    private FactHandleFactory factHandleFactory;
 
     protected SessionConfiguration config;
 
@@ -390,7 +389,6 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         registerReceiveNodes(kBase.getReceiveNodes());
 
         this.pctxFactory = kBase.getConfiguration().getComponentFactory().getPropagationContextFactory();
-        this.factHandleFactory = this.kBase.getConfiguration().getComponentFactory().getFactHandleFactoryService();
 
         if (agenda == null) {
             this.agenda = kBase.getConfiguration().getComponentFactory().getAgendaFactory().createAgenda(kBase);
@@ -1205,7 +1203,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
     }
 
     public FactHandleFactory getFactHandleFactory() {
-        return factHandleFactory;
+        return handleFactory;
     }
 
     public void setGlobal(final String identifier,

--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/FactHandleTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/FactHandleTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.testcoverage.functional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.drools.core.common.InternalFactHandle;
+import org.drools.core.event.DefaultRuleRuntimeEventListener;
+import org.drools.testcoverage.common.model.Cheese;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.event.rule.ObjectInsertedEvent;
+import org.kie.api.runtime.KieSession;
+
+@RunWith(Parameterized.class)
+public class FactHandleTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public FactHandleTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+
+
+    @Test
+    public void testFactHandleSequence() throws Exception {
+        String drlString = "package org.jboss.brms\n" +
+                "import " +  Cheese.class.getCanonicalName() + ";\n" +
+                "rule \"FactHandleId\"\n" +
+                "    when\n" +
+                "        $c : Cheese()\n" +
+                "    then\n" +
+                "        // do something;\n" +
+                "end";
+
+        KieBase kBase = KieBaseUtil.getKieBaseFromKieModuleFromDrl("test", kieBaseTestConfiguration, drlString);
+
+        List<Long> factHandleIDs = new ArrayList<>();
+
+        KieSession kieSession = kBase.newKieSession();
+        kieSession.addEventListener(createCollectEventListener(factHandleIDs));
+
+        kieSession.insert(new Cheese("mozzarella"));
+        kieSession.insert(new Cheese("pecorino"));
+
+        kieSession.fireAllRules();
+        kieSession.dispose();
+
+        // This should reset Fact Handle IDs
+        kieSession = kBase.newKieSession();
+        kieSession.addEventListener(createCollectEventListener(factHandleIDs));
+
+        kieSession.insert(new Cheese("parmigiano"));
+
+        kieSession.fireAllRules();
+
+        Assertions.assertThat(factHandleIDs).containsExactly(1L, 2L, 1L);
+    }
+
+    private DefaultRuleRuntimeEventListener createCollectEventListener(List<Long> factHandleIDs) {
+        return new DefaultRuleRuntimeEventListener() {
+            public void objectInserted(ObjectInsertedEvent event) {
+                InternalFactHandle ifh = (InternalFactHandle) event.getFactHandle();
+                factHandleIDs.add(ifh.getId());
+            }
+        };
+    }
+}

--- a/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitFactHandleFactory.java
+++ b/drools-traits/src/main/java/org/drools/traits/core/reteoo/TraitFactHandleFactory.java
@@ -24,6 +24,7 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.reteoo.ObjectTypeConf;
 import org.drools.core.reteoo.ReteooFactHandleFactory;
 import org.drools.core.rule.TypeDeclaration;
+import org.drools.core.spi.FactHandleFactory;
 import org.drools.traits.core.common.TraitDefaultFactHandle;
 
 public class TraitFactHandleFactory extends ReteooFactHandleFactory {
@@ -31,6 +32,11 @@ public class TraitFactHandleFactory extends ReteooFactHandleFactory {
     @Override
     public DefaultFactHandle createDefaultFactHandle(long id, Object initialFact, long recency, WorkingMemoryEntryPoint wmEntryPoint) {
         return new TraitDefaultFactHandle(id, initialFact, recency, wmEntryPoint);
+    }
+
+    @Override
+    public FactHandleFactory newInstance() {
+        return new TraitFactHandleFactory();
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
In https://github.com/kiegroup/drools/commit/7fa22791ab2827617a9e64828a156bfe24ae8f5d to avoid getting the FactHandleFactory each time, probably due to performance constraint the value was cached in a field called `factHandleFactory` when there was already a `handleFactory` field that served the same purpose.

The `handleFactory` shouldn't be initialised in the Session itself because it has to be provided from the `KieBase`. 
There's a method that creates a new instance https://github.com/kiegroup/drools/blob/2ef7af4eb707b543f8a26b0cb77bcc709816cf22/drools-core/src/main/java/org/drools/core/reteoo/ReteooFactHandleFactory.java#L92 but the `TraitFactHandleFactory` didn't implement that.


**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/RHDM-1796

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
