### PR TITLE
[DROOLS-6547] NullSafeDereferencing misses null check in LambdaExtrac…

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
@@ -34,6 +34,7 @@ import org.drools.model.Index;
 import org.drools.modelcompiler.builder.generator.DRLIdGenerator;
 import org.drools.modelcompiler.builder.generator.TypedExpression;
 import org.drools.modelcompiler.builder.generator.UnificationTypedExpression;
+import org.drools.modelcompiler.util.StreamUtils;
 
 import static java.util.Optional.ofNullable;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toClassOrInterfaceType;
@@ -399,6 +400,20 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
         newReactOnProperties.addAll( this.reactOnProperties );
         newReactOnProperties.addAll( otherDrlx.reactOnProperties );
 
+        List<Expression> newNullSafeExpressions = new ArrayList<>();
+        if (operator == BinaryExpr.Operator.OR) {
+            // NullSafeExpressions are combined here because the order is complex
+            this.expr = combineExpressions(this.expr, this.nullSafeExpressions);
+            otherDrlx.expr = combineExpressions(otherDrlx.expr, otherDrlx.nullSafeExpressions);
+            // Also combine implicitCast earlier than null-check
+            this.expr = combineExpressions(this.expr, StreamUtils.optionalToList(this.implicitCastExpression));
+            otherDrlx.expr = combineExpressions(otherDrlx.expr, StreamUtils.optionalToList(otherDrlx.implicitCastExpression));
+        } else {
+            // NullSafeExpressions will be added by PatternDSL.addNullSafeExpr
+            newNullSafeExpressions.addAll(this.nullSafeExpressions);
+            newNullSafeExpressions.addAll(otherDrlx.nullSafeExpressions);
+        }
+
         return new SingleDrlxParseSuccess(patternType, patternBinding, new EnclosedExpr( new BinaryExpr(expr, otherDrlx.expr, operator) ), exprType)
                 .setDecodeConstraintType(Index.ConstraintType.UNKNOWN)
                 .setUsedDeclarations(newUsedDeclarations)
@@ -410,7 +425,16 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
                 .setRight(new TypedExpression(otherDrlx.expr, right != null ? right.getType() : boolean.class))
                 .setBoundExpr(left)
                 .setIsPredicate(this.isPredicate && otherDrlx.isPredicate)
+                .setNullSafeExpressions(newNullSafeExpressions)
                 .setExprBinding(this.exprBinding); // only left exprBinding
+    }
+
+    private Expression combineExpressions(Expression mainExpr, List<Expression> prefixExpressions) {
+        Expression combo = mainExpr;
+        for (Expression e : prefixExpressions) {
+            combo = new BinaryExpr( e, combo, BinaryExpr.Operator.AND );
+        }
+        return combo;
     }
 
     @Override

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SingleDrlxParseSuccess.java
@@ -403,11 +403,11 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
         List<Expression> newNullSafeExpressions = new ArrayList<>();
         if (operator == BinaryExpr.Operator.OR) {
             // NullSafeExpressions are combined here because the order is complex
-            this.expr = combineExpressions(this.expr, this.nullSafeExpressions);
-            otherDrlx.expr = combineExpressions(otherDrlx.expr, otherDrlx.nullSafeExpressions);
+            this.expr = combinePredicatesWithAnd(this.expr, this.nullSafeExpressions);
+            otherDrlx.expr = combinePredicatesWithAnd(otherDrlx.expr, otherDrlx.nullSafeExpressions);
             // Also combine implicitCast earlier than null-check
-            this.expr = combineExpressions(this.expr, StreamUtils.optionalToList(this.implicitCastExpression));
-            otherDrlx.expr = combineExpressions(otherDrlx.expr, StreamUtils.optionalToList(otherDrlx.implicitCastExpression));
+            this.expr = combinePredicatesWithAnd(this.expr, StreamUtils.optionalToList(this.implicitCastExpression));
+            otherDrlx.expr = combinePredicatesWithAnd(otherDrlx.expr, StreamUtils.optionalToList(otherDrlx.implicitCastExpression));
         } else {
             // NullSafeExpressions will be added by PatternDSL.addNullSafeExpr
             newNullSafeExpressions.addAll(this.nullSafeExpressions);
@@ -429,9 +429,9 @@ public class SingleDrlxParseSuccess extends AbstractDrlxParseSuccess {
                 .setExprBinding(this.exprBinding); // only left exprBinding
     }
 
-    private Expression combineExpressions(Expression mainExpr, List<Expression> prefixExpressions) {
-        Expression combo = mainExpr;
-        for (Expression e : prefixExpressions) {
+    private Expression combinePredicatesWithAnd(Expression mainPredicate, List<Expression> prefixPredicates) {
+        Expression combo = mainPredicate;
+        for (Expression e : prefixPredicates) {
             combo = new BinaryExpr( e, combo, BinaryExpr.Operator.AND );
         }
         return combo;

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/TypedExpressionResult.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/TypedExpressionResult.java
@@ -63,6 +63,10 @@ public class TypedExpressionResult {
         return expressionTyperContext.getNullSafeExpressions();
     }
 
+    public Optional<Expression> getInlineCastExpression() {
+        return expressionTyperContext.getInlineCastExpression();
+    }
+
     @Override
     public String toString() {
         return "{" +

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/StreamUtils.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/util/StreamUtils.java
@@ -14,7 +14,9 @@
 
 package org.drools.modelcompiler.util;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class StreamUtils {
@@ -25,5 +27,9 @@ public class StreamUtils {
 
     public static <T> Stream<T> optionalToStream(Optional<T> opt) {
         return opt.map(Stream::of).orElse(Stream.empty());
+    }
+
+    public static <T> List<T> optionalToList(Optional<T> opt) {
+        return optionalToStream(opt).collect(Collectors.toList());
     }
 }

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/MysteriousMan.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/domain/MysteriousMan.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.domain;
+
+public class MysteriousMan extends Person {
+
+    public MysteriousMan() {
+        super();
+    }
+
+    public MysteriousMan(String name, int age) {
+        super(name, age);
+    }
+
+    @Override
+    public Address getAddress() {
+        throw new UnsupportedOperationException("Address is not supported");
+    }
+
+    @Override
+    public void setAddress(Address address) {
+        throw new UnsupportedOperationException("Address is not supported");
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullSafeDereferencingTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/NullSafeDereferencingTest.java
@@ -44,8 +44,7 @@ public class NullSafeDereferencingTest {
 
     @Parameterized.Parameters(name = "KieBase type={0}")
     public static Collection<Object[]> getParameters() {
-        // TODO: EM failed with testMixedNullSafes, testNullSafeInnerConstraint, testNullSafeNullComparison2, testNullSafeWithMethod. File JIRAs
-        return TestParametersUtil.getKieBaseCloudConfigurations(false);
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
     }
 
     @Test


### PR DESCRIPTION
…tor for index with exec-model

- Make sure to place null-check constraint at the beginning of the constraint if possible. So it will be an AlphaNode so index of the main constraint will not be used when the field is null (same as non-exec-model).
-  If a constraint contains `||`, combine null-check constraint with `&&` in the expected order. In this case (= complex constraint), index is not created.
- `instanceof` check will be placed before null-check because `instanceof` may ensure that the property is accessible.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6547

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
