### PR TITLE
Use TerminalNodes instead of more generic BaseNodes when iterating the activations

### DIFF
--- a/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
+++ b/drools-core/src/main/java/org/drools/core/common/NetworkNode.java
@@ -54,5 +54,7 @@ public interface NetworkNode
 
     int getAssociationsSize( Rule rule );
 
+    Rule[] getAssociatedRules();
+
     boolean isAssociatedWith( Rule rule );
 }

--- a/drools-core/src/main/java/org/drools/core/common/PhreakActivationIterator.java
+++ b/drools-core/src/main/java/org/drools/core/common/PhreakActivationIterator.java
@@ -39,6 +39,7 @@ import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.ObjectTypeNode.ObjectTypeNodeMemory;
 import org.drools.core.reteoo.RightTuple;
 import org.drools.core.reteoo.RuleTerminalNode;
+import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.reteoo.TupleMemory;
 import org.drools.core.spi.Tuple;
 import org.drools.core.util.FastIterator;
@@ -86,10 +87,10 @@ public class PhreakActivationIterator
 
 
     public static List<RuleTerminalNode> populateRuleTerminalNodes(InternalKnowledgeBase kbase, Set<RuleTerminalNode>  nodeSet) {
-        Collection<BaseNode[]> nodesWithArray = kbase.getReteooBuilder().getTerminalNodes().values();
+        Collection<TerminalNode[]> nodesWithArray = kbase.getReteooBuilder().getTerminalNodes().values();
 
-        for (BaseNode[] nodeArray : nodesWithArray) {
-            for (BaseNode node : nodeArray) {
+        for (TerminalNode[] nodeArray : nodesWithArray) {
+            for (TerminalNode node : nodeArray) {
                 if (node.getType() == NodeTypeEnums.RuleTerminalNode) {
                     nodeSet.add((RuleTerminalNode) node);
                 }

--- a/drools-core/src/main/java/org/drools/core/common/TerminalNodeIterator.java
+++ b/drools-core/src/main/java/org/drools/core/common/TerminalNodeIterator.java
@@ -18,6 +18,7 @@ package org.drools.core.common;
 import java.util.Map;
 
 import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.reteoo.TerminalNode;
 import org.drools.core.util.Iterator;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.kie.api.KieBase;
@@ -26,7 +27,7 @@ public class TerminalNodeIterator
     implements
     Iterator {
     private InternalKnowledgeBase kBase;
-    private BaseNode[][]          nodes;
+    private TerminalNode[][]      nodes;
 
     private int                   i = 0;
     private int                   j = 0;
@@ -37,8 +38,8 @@ public class TerminalNodeIterator
 
     private TerminalNodeIterator(KieBase kBase) {
         this.kBase = (InternalKnowledgeBase)kBase;
-        Map<String, BaseNode[]> rules = this.kBase.getReteooBuilder().getTerminalNodes();
-        nodes = rules.values().toArray( new BaseNode[rules.size()][] );
+        Map<String, TerminalNode[]> rules = this.kBase.getReteooBuilder().getTerminalNodes();
+        nodes = rules.values().toArray( new TerminalNode[rules.size()][] );
     }
     
     public static Iterator iterator(KieBase kBase) {
@@ -49,7 +50,7 @@ public class TerminalNodeIterator
         if ( i >= nodes.length ) {
             return null;
         }
-        BaseNode node = nodes[i][j];
+        TerminalNode node = nodes[i][j];
         
         // now set to the next node
         j++;                

--- a/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java
@@ -812,11 +812,11 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
                                                                                  null, null, handle, getEntryPoint());
 
 
-            BaseNode[] tnodes = evalQuery(queryName, queryObject, handle, pCtx, calledFromRHS);
+            TerminalNode[] tnodes = evalQuery(queryName, queryObject, handle, pCtx, calledFromRHS);
 
             List<Map<String, Declaration>> decls = new ArrayList<Map<String, Declaration>>();
             if ( tnodes != null ) {
-                for ( BaseNode node : tnodes ) {
+                for ( TerminalNode node : tnodes ) {
                     decls.add( ((QueryTerminalNode) node).getSubRule().getOuterDeclarations() );
                 }
             }
@@ -883,13 +883,13 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
         }
     }
 
-    protected BaseNode[] evalQuery(final String queryName, final DroolsQuery queryObject, final InternalFactHandle handle, final PropagationContext pCtx, final boolean isCalledFromRHS) {
+    protected QueryTerminalNode[] evalQuery(final String queryName, final DroolsQuery queryObject, final InternalFactHandle handle, final PropagationContext pCtx, final boolean isCalledFromRHS) {
         ExecuteQuery executeQuery = new ExecuteQuery( queryName, queryObject, handle, pCtx, isCalledFromRHS);
         addPropagation( executeQuery );
         return executeQuery.getResult();
     }
 
-    private class ExecuteQuery extends PropagationEntry.PropagationEntryWithResult<BaseNode[]> {
+    private class ExecuteQuery extends PropagationEntry.PropagationEntryWithResult<QueryTerminalNode[]> {
 
         private final String queryName;
         private final DroolsQuery queryObject;
@@ -907,7 +907,7 @@ public class StatefulKnowledgeSessionImpl extends AbstractRuntime
 
         @Override
         public void execute( InternalWorkingMemory wm ) {
-            BaseNode[] tnodes = kBase.getReteooBuilder().getTerminalNodesForQuery( queryName );
+            QueryTerminalNode[] tnodes = kBase.getReteooBuilder().getTerminalNodesForQuery( queryName );
             if ( tnodes == null ) {
                 throw new RuntimeException( "Query '" + queryName + "' does not exist" );
             }

--- a/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AbstractTerminalNode.java
@@ -36,7 +36,7 @@ import org.drools.core.util.bitmask.AllSetBitMask;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.bitmask.EmptyBitMask;
 
-public abstract class AbstractTerminalNode extends BaseNode implements TerminalNode, PathEndNode, Externalizable {
+public abstract class AbstractTerminalNode extends BaseNode implements TerminalNode, Externalizable {
 
     private LeftTupleSource tupleSource;
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/AlphaNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/AlphaNode.java
@@ -309,6 +309,10 @@ public class AlphaNode extends ObjectSource
             return sink.getAssociationsSize(rule);
         }
 
+        @Override public Rule[] getAssociatedRules() {
+            return sink.getAssociatedRules();
+        }
+
         public boolean isAssociatedWith(Rule rule) {
             return sink.isAssociatedWith(rule);
         }

--- a/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/LeftInputAdapterNode.java
@@ -661,7 +661,11 @@ public class LeftInputAdapterNode extends LeftTupleSource
             return sink.getAssociationsSize(rule);
         }
 
-        public boolean isAssociatedWith( Rule rule ) {
+        @Override public Rule[] getAssociatedRules() {
+            return sink.getAssociatedRules();
+        }
+
+        public boolean isAssociatedWith(Rule rule) {
             return sink.isAssociatedWith( rule );
         }
     }

--- a/drools-core/src/main/java/org/drools/core/reteoo/PathEndNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/PathEndNode.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 
 import org.drools.core.phreak.SegmentUtilities;
 
-public interface PathEndNode extends LeftTupleNode {
+public interface PathEndNode extends LeftTupleSinkNode {
     LeftTupleNode[] getPathNodes();
     boolean hasPathNode(LeftTupleNode node);
 

--- a/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/ReteooBuilder.java
@@ -63,8 +63,8 @@ public class ReteooBuilder
     /** The RuleBase */
     private transient InternalKnowledgeBase  kBase;
 
-    private Map<String, BaseNode[]>     rules;
-    private Map<String, BaseNode[]>     queries;
+    private Map<String, TerminalNode[]>          rules;
+    private Map<String, QueryTerminalNode[]>     queries;
 
     private Map<String, WindowNode>     namedWindows;
 
@@ -110,10 +110,10 @@ public class ReteooBuilder
         final List<TerminalNode> terminals = this.ruleBuilder.addRule( rule,
                                                                        this.kBase );
 
-        BaseNode[] nodes = terminals.toArray( new BaseNode[terminals.size()] );
+        TerminalNode[] nodes = terminals.toArray( new TerminalNode[terminals.size()] );
         this.rules.put( rule.getFullyQualifiedName(), nodes );
         if (rule.isQuery()) {
-            this.queries.put( rule.getName(), nodes );
+            this.queries.put( rule.getName(), terminals.toArray( new QueryTerminalNode[terminals.size()] ) );
         }
     }
 
@@ -138,20 +138,20 @@ public class ReteooBuilder
         return this.idGenerator;
     }
 
-    public synchronized BaseNode[] getTerminalNodes(final RuleImpl rule) {
+    public synchronized TerminalNode[] getTerminalNodes(final RuleImpl rule) {
         return getTerminalNodes( rule.getFullyQualifiedName() );
     }
 
-    public synchronized BaseNode[] getTerminalNodes(final String ruleName) {
+    public synchronized TerminalNode[] getTerminalNodes(final String ruleName) {
         return this.rules.get( ruleName );
     }
 
-    public synchronized BaseNode[] getTerminalNodesForQuery(final String ruleName) {
-        BaseNode[] nodes = this.queries.get( ruleName );
-        return nodes != null ? nodes : getTerminalNodes(ruleName);
+    public synchronized QueryTerminalNode[] getTerminalNodesForQuery(final String ruleName) {
+        QueryTerminalNode[] nodes = this.queries.get( ruleName );
+        return nodes;
     }
 
-    public synchronized Map<String, BaseNode[]> getTerminalNodes() {
+    public synchronized Map<String, TerminalNode[]> getTerminalNodes() {
         return this.rules;
     }
 
@@ -167,13 +167,13 @@ public class ReteooBuilder
             final RuleRemovalContext context = new RuleRemovalContext( rule );
             context.setKnowledgeBase( kBase );
 
-            BaseNode[] rulesTerminalNodes = rules.remove( rule.getFullyQualifiedName() );
+            TerminalNode[] rulesTerminalNodes = rules.remove( rule.getFullyQualifiedName() );
             if (rulesTerminalNodes == null) {
                 // there couldn't be any rule to be removed if it comes from a broken drl
                 continue;
             }
 
-            for ( BaseNode node : rulesTerminalNodes ) {
+            for ( TerminalNode node : rulesTerminalNodes ) {
                 removeTerminalNode( context, (TerminalNode) node, workingMemories );
             }
 
@@ -484,8 +484,8 @@ public class ReteooBuilder
             droolsStream = new DroolsObjectInputStream( bytes );
         }
         try {
-            this.rules = (Map<String, BaseNode[]>) droolsStream.readObject();
-            this.queries = (Map<String, BaseNode[]>) droolsStream.readObject();
+            this.rules = (Map<String, TerminalNode[]>) droolsStream.readObject();
+            this.queries = (Map<String, QueryTerminalNode[]>) droolsStream.readObject();
             this.namedWindows = (Map<String, WindowNode>) droolsStream.readObject();
             this.idGenerator = (IdGenerator) droolsStream.readObject();
         } finally {

--- a/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/RuleTerminalNode.java
@@ -280,7 +280,11 @@ public class RuleTerminalNode extends AbstractTerminalNode {
     }
 
     private int calculateHashCode() {
-        return 31 * this.rule.hashCode() + (consequenceName == null ? 0 : 37 * consequenceName.hashCode());
+        int result = 31 * rule.hashCode();
+        result = 31 * result + subruleIndex;
+        result = 31 * result + (consequenceName != null ? consequenceName.hashCode() : 0);
+
+        return result;
     }
 
     @Override
@@ -293,7 +297,7 @@ public class RuleTerminalNode extends AbstractTerminalNode {
             return false;
         }
         final RuleTerminalNode other = (RuleTerminalNode) object;
-        return rule.equals(other.rule) && (consequenceName == null ? other.consequenceName == null : consequenceName.equals(other.consequenceName));
+        return subruleIndex == other.subruleIndex && rule.equals(other.rule) && (consequenceName == null ? other.consequenceName == null : consequenceName.equals(other.consequenceName));
     }
 
     public short getType() {

--- a/drools-core/src/main/java/org/drools/core/reteoo/TerminalNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/TerminalNode.java
@@ -28,7 +28,7 @@ import org.drools.core.util.bitmask.BitMask;
  */
 public interface TerminalNode
     extends
-    NetworkNode, LeftTupleSinkNode, MemoryFactory<PathMemory> {
+    NetworkNode, PathEndNode, MemoryFactory<PathMemory> {
     
     LeftTupleSource getLeftTupleSource();
     

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSink.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockObjectSink.java
@@ -167,6 +167,10 @@ public class MockObjectSink
         return false;
     }
 
+    @Override public Rule[] getAssociatedRules() {
+        return new Rule[0];
+    }
+
     public ObjectTypeNode.Id getRightInputOtnId() {
         return null;
     }

--- a/drools-core/src/test/java/org/drools/core/reteoo/MockRightTupleSink.java
+++ b/drools-core/src/test/java/org/drools/core/reteoo/MockRightTupleSink.java
@@ -82,7 +82,11 @@ public class MockRightTupleSink
         return 0;
     }
 
-    public boolean isAssociatedWith( Rule rule ) {
+    @Override public Rule[] getAssociatedRules() {
+        return new Rule[0];
+    }
+
+    public boolean isAssociatedWith(Rule rule) {
         return false;
     }
 

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/MockRightTupleSink.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/reteoo/MockRightTupleSink.java
@@ -86,6 +86,10 @@ public class MockRightTupleSink
         return false;
     }
 
+    @Override public Rule[] getAssociatedRules() {
+        return new Rule[0];
+    }
+
     public ObjectTypeNode.Id getRightInputOtnId() {
         return null;
     }


### PR DESCRIPTION
I improved some generics around TerminalNodes, instead of using BaseNode. I also added subRuleIndex to the equals/hashcode.