### PR TITLE
DROOLS-6559 add missing license header in test pojo

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/SupportRequest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/model/SupportRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.dmn.feel.model;
 
 public class SupportRequest implements java.io.Serializable {


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6559

**referenced Pull Requests**: none

follows-up on:

* https://github.com/kiegroup/drools/pull/3794

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
