### PR TITLE
[DROOLS-6486] avoid creating a FactHandle for an object already prese…

### DIFF
--- a/drools-core/src/main/java/org/drools/core/reteoo/FromNode.java
+++ b/drools-core/src/main/java/org/drools/core/reteoo/FromNode.java
@@ -47,6 +47,7 @@ import org.drools.core.util.bitmask.AllSetBitMask;
 import org.drools.core.util.bitmask.BitMask;
 import org.drools.core.util.index.TupleList;
 
+import static org.drools.core.base.DefaultKnowledgeHelper.getFactHandleFromWM;
 import static org.drools.core.reteoo.PropertySpecificUtil.calculateNegativeMask;
 import static org.drools.core.reteoo.PropertySpecificUtil.calculatePositiveMask;
 import static org.drools.core.reteoo.PropertySpecificUtil.getAccessibleProperties;
@@ -227,6 +228,11 @@ public class FromNode<T extends FromNode.FromMemory> extends LeftTupleSource
     }
 
     public InternalFactHandle createFactHandle( InternalWorkingMemory workingMemory, Object object ) {
+        InternalFactHandle handle = getFactHandleFromWM(workingMemory, object);
+        if (handle != null && handle.getObject() == object) {
+            return handle;
+        }
+
         if ( objectTypeConf == null ) {
             // use default entry point and object class. Notice that at this point object is assignable to resultClass
             objectTypeConf = new ClassObjectTypeConf( workingMemory.getEntryPoint(), getResultClass(), workingMemory.getKnowledgeBase() );

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/FromTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/FromTest.java
@@ -39,7 +39,6 @@ import org.drools.modelcompiler.domain.PetPerson;
 import org.drools.modelcompiler.domain.Toy;
 import org.drools.modelcompiler.domain.ToysStore;
 import org.drools.modelcompiler.domain.Woman;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 
@@ -142,7 +141,7 @@ public class FromTest extends BaseModelTest {
         Assertions.assertThat(list).containsExactlyInAnyOrder("Charles");
     }
 
-    @Test @Ignore
+    @Test
     public void testModifyWithFrom() {
         // DROOLS-6486
         final String str =


### PR DESCRIPTION
…nt in the working memory while evaluating a FromNode

**JIRA**: https://issues.redhat.com/browse/DROOLS-6486