### PR TITLE
[DROOLS-6571] DMN evaluation errors when the same FEEL object-access …

### DIFF
--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -764,5 +764,14 @@ public class EvalHelper {
             result = 31 * result + (propertyName != null ? propertyName.hashCode() : 0);
             return result;
         }
+
+        @Override
+        public String toString() {
+            return "AccessorCacheKey{" +
+                    "classLoader=" + classLoader +
+                    ", className='" + className + '\'' +
+                    ", propertyName='" + propertyName + '\'' +
+                    '}';
+        }
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -437,8 +437,8 @@ public class EvalHelper {
 
     /**
      * {@link #getDefinedValue(Object, String)} method instead.
-     * @deprecated this method cannot distinguish null because: 1. property undefined for current, 2. an error, 3. a properly defined property value valorized to null. 
-     * 
+     * @deprecated this method cannot distinguish null because: 1. property undefined for current, 2. an error, 3. a properly defined property value valorized to null.
+     *
      */
     public static Object getValue(final Object current, final String property) {
         return getDefinedValue(current, property).getValueResult().getOrElse(null);
@@ -454,8 +454,9 @@ public class EvalHelper {
     public static Method getGenericAccessor(Class<?> clazz, String field) {
         LOG.trace( "getGenericAccessor({}, {})", clazz, field );
 
-        String accessorQualifiedName = new StringBuilder(clazz.getCanonicalName())
-			.append(".").append(field).toString();
+        String accessorQualifiedName = getClassLoaderName(clazz.getClassLoader()) +
+                "." + clazz.getCanonicalName() +
+                "." + field;
 
         return accessorCache.computeIfAbsent(accessorQualifiedName, key ->
         	Stream.of( clazz.getMethods() )
@@ -465,6 +466,12 @@ public class EvalHelper {
             )
             .findFirst()
             .orElse( getAccessor( clazz, field ) ));
+    }
+
+    private static String getClassLoaderName(ClassLoader classLoader) {
+        return classLoader == null
+                ? "bootstrap"
+                : classLoader.getClass().getSimpleName() + "@" + classLoader.hashCode();
     }
 
     public static void clearGenericAccessorCache() {

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -455,10 +455,10 @@ public class EvalHelper {
     public static Method getGenericAccessor(Class<?> clazz, String field) {
         LOG.trace( "getGenericAccessor({}, {})", clazz, field );
 
-        AccessorCacheKey accessorQualifiedName =
+        AccessorCacheKey accessorCacheKey =
                 new AccessorCacheKey( clazz.getClassLoader(), clazz.getCanonicalName(), field );
 
-        return accessorCache.computeIfAbsent(accessorQualifiedName, key ->
+        return accessorCache.computeIfAbsent(accessorCacheKey, key ->
         	Stream.of( clazz.getMethods() )
             .filter( m -> Optional.ofNullable( m.getAnnotation( FEELProperty.class ) )
                     .map( ann -> ann.value().equals( field ) )

--- a/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvalHelperTest.java
+++ b/kie-dmn/kie-dmn-feel/src/test/java/org/kie/dmn/feel/util/EvalHelperTest.java
@@ -16,9 +16,11 @@
 
 package org.kie.dmn.feel.util;
 
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 
 import org.junit.Test;
+import org.kie.dmn.feel.lang.FEELProperty;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -52,12 +54,31 @@ public class EvalHelperTest {
         assertEquals("ab c", normalizeVariableName("ab c  "));
         assertEquals("a b", normalizeVariableName("a\u00A0b"));
     }
-    
+
     @Test
     public void testGetBigDecimalOrNull() {
         assertEquals(new BigDecimal("10"), getBigDecimalOrNull(10d));
         assertEquals(new BigDecimal("10"), getBigDecimalOrNull(10.00000000D));
         assertEquals(new BigDecimal("10000000000.5"), getBigDecimalOrNull(10000000000.5D));
     }
-    
+
+    @Test
+    public void testGetGenericAccessor() throws NoSuchMethodException {
+        Method expectedAccessor = TestPojo.class.getMethod("getAProperty");
+
+        assertEquals("getGenericAccessor should work on Java bean accessors.",
+                     expectedAccessor,
+                     EvalHelper.getGenericAccessor(TestPojo.class, "aProperty"));
+
+        assertEquals("getGenericAccessor should work for methods annotated with '@FEELProperty'.",
+                     expectedAccessor,
+                     EvalHelper.getGenericAccessor(TestPojo.class, "feelPropertyIdentifier"));
+    }
+
+    private static class TestPojo {
+        @FEELProperty("feelPropertyIdentifier")
+        public String getAProperty() {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
…invocation is used by two kie containers

initial fix implementation for discussion

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://issues.redhat.com/browse/DROOLS-6571)


TODO: 
- [x] add test for changed `getGenericAccessor` 
- [x] consider affect of this on DMNRuntimeTest.testAccessorCache? 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
