### PR TITLE
Fix xxe injection vulnerability

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieModuleMarshaller.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kproject/models/KieModuleMarshaller.java
@@ -31,6 +31,8 @@ import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import javax.xml.XMLConstants;
 import org.drools.core.util.AbstractXStreamConverter;
 import org.drools.core.util.IoUtils;
 import org.kie.api.builder.model.KieBaseModel;
@@ -185,12 +187,18 @@ public class KieModuleMarshaller {
 
         private static void validate(Source source, Source duplicateSource) {
             try {
-                schema.newValidator().validate(source);
+                Validator validator = schema.newValidator();
+                validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                validator.validate(source);
             } catch (Exception schemaException) {
                 try {
                     // For backwards compatibility, validate against the old namespace (which has 6.0.0 hardcoded)
                     if (oldSchema != null) {
-                        oldSchema.newValidator().validate( duplicateSource );
+                        Validator oldValidator = oldSchema.newValidator();
+                        oldValidator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                        oldValidator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                        oldValidator.validate(duplicateSource);
                     }
                 } catch (Exception oldSchemaException) {
                     // Throw the original exception, as we want them to use that


### PR DESCRIPTION
The Validator class is not used correctly, resulting in an xxe injection vulnerability.