### PR TITLE
[DROOLS-5985] DMN Alpha Network - Support different Hit Policies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.8
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Check Surefire Report

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.8
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Check Surefire Report

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNFEELHelper.java
@@ -251,10 +251,8 @@ public class DMNFEELHelper {
                                                                      || (msg.getSourceId() != null && element.getId() != null && msg.getSourceId().equals(element.getId()))) );
     }
 
-    public ClassOrInterfaceDeclaration generateUnaryTestsSource(String unaryTests, DMNCompilerContext ctx, Type inputColumnType, boolean isStatic) {
-        CompilerContext compilerContext =
-                ctx.toCompilerContext()
-                        .addInputVariableType("?", inputColumnType);
+    public ClassOrInterfaceDeclaration generateUnaryTestsSource(CompilerContext compilerContext, String unaryTests, Type inputColumnType, boolean isStatic) {
+        compilerContext.addInputVariableType("?", inputColumnType);
 
         ProcessedUnaryTest compiledUnaryTest = ((FEELImpl) feel).compileUnaryTests(unaryTests, compilerContext);
         CompilationUnit compilationUnit = compiledUnaryTest.getSourceCode().clone();
@@ -263,8 +261,8 @@ public class DMNFEELHelper {
                 .setStatic(isStatic);
     }
 
-    public ClassOrInterfaceDeclaration generateStaticUnaryTestsSource(String unaryTests, DMNCompilerContext ctx, Type inputColumnType) {
-        return generateUnaryTestsSource(unaryTests, ctx, inputColumnType, true);
+    public ClassOrInterfaceDeclaration generateStaticUnaryTestsSource(CompilerContext compilerContext, String unaryTests, Type inputColumnType) {
+        return generateUnaryTestsSource(compilerContext, unaryTests, inputColumnType, true);
     }
 
     public static class FEELEventsListenerImpl implements FEELEventListener {
@@ -300,10 +298,12 @@ public class DMNFEELHelper {
     }
 
     public ClassOrInterfaceDeclaration generateFeelExpressionSource(String input, CompilerContext compilerContext1) {
+        return generateFeelExpressionCompilationUnit(input, compilerContext1)
+                .getType(0)
+                .asClassOrInterfaceDeclaration().setStatic(true);
+    }
 
-        CompilationUnit compilationUnit = ((FEELImpl) feel).compileExpression(input, compilerContext1).getSourceCode();
-        return compilationUnit.getType(0)
-                .asClassOrInterfaceDeclaration()
-                .setStatic(true);
+    public CompilationUnit generateFeelExpressionCompilationUnit(String input, CompilerContext compilerContext1) {
+        return ((FEELImpl) feel).compileExpression(input, compilerContext1).getSourceCode();
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkBuilderContext.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkBuilderContext.java
@@ -28,22 +28,22 @@ import org.drools.model.Variable;
 
 import static org.drools.model.DSL.declarationOf;
 
-public class NetworkBuilderContext {
+public class AlphaNetworkBuilderContext {
 
     public InternalKnowledgeBase kBase;
     public BuildContext buildContext;
-    public Variable<TableContext> variable;
+    public Variable<PropertyEvaluator> variable;
     public Declaration declaration;
     public ObjectTypeNode otn;
 
     public ResultCollector resultCollector;
 
-    public NetworkBuilderContext(ResultCollector resultCollector) {
-        kBase = (InternalKnowledgeBase) KnowledgeBaseFactory.newKnowledgeBase();
+    public AlphaNetworkBuilderContext(ResultCollector resultCollector) {
+        kBase = KnowledgeBaseFactory.newKnowledgeBase();
         buildContext = new BuildContext(kBase);
         EntryPointNode entryPoint = buildContext.getKnowledgeBase().getRete().getEntryPointNodes().values().iterator().next();
-        ClassObjectType objectType = new ClassObjectType(TableContext.class);
-        variable = declarationOf(TableContext.class, "$ctx");
+        ClassObjectType objectType = new ClassObjectType(PropertyEvaluator.class);
+        variable = declarationOf(PropertyEvaluator.class, "$ctx");
 
         Pattern pattern = new Pattern(1, objectType, "$ctx");
         declaration = pattern.getDeclaration();

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkCreation.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/AlphaNetworkCreation.java
@@ -22,6 +22,7 @@ import org.drools.core.reteoo.AlphaNode;
 import org.drools.core.reteoo.ObjectSource;
 import org.drools.core.reteoo.builder.BuildUtils;
 import org.drools.core.rule.Declaration;
+import org.drools.core.rule.Function;
 import org.drools.core.spi.Constraint;
 import org.drools.model.Index;
 import org.drools.model.constraints.SingleConstraint1;
@@ -30,31 +31,40 @@ import org.drools.model.functions.Predicate1;
 import org.drools.model.index.AlphaIndexImpl;
 import org.drools.modelcompiler.constraints.ConstraintEvaluator;
 import org.drools.modelcompiler.constraints.LambdaConstraint;
+import org.kie.dmn.feel.lang.EvaluationContext;
 
 public class AlphaNetworkCreation {
 
     private static final BuildUtils buildUtils = new BuildUtils();
 
-    private final NetworkBuilderContext ctx;
+    private final AlphaNetworkBuilderContext ctx;
 
-    public AlphaNetworkCreation(NetworkBuilderContext ctx) {
+    public AlphaNetworkCreation(AlphaNetworkBuilderContext ctx) {
         this.ctx = ctx;
     }
 
-    public void addResultSink(ObjectSource source, Object result) {
-        source.addObjectSink(new ResultCollectorAlphaSink(getNextId(), source, ctx.buildContext, result, ctx.resultCollector));
+    public void addResultSink(ObjectSource source, int row, String columnName, Function1<EvaluationContext, Object> outputEvaluationFunction) {
+        ResultCollectorAlphaSink objectSink = new ResultCollectorAlphaSink(getNextId(),
+                                                                           source,
+                                                                           ctx.buildContext,
+                                                                           row,
+                                                                           columnName,
+                                                                           ctx.resultCollector,
+                                                                           outputEvaluationFunction
+        );
+        source.addObjectSink(objectSink);
     }
 
     private int getNextId() {
         return ctx.buildContext.getNextId();
     }
 
-    public AlphaNode createAlphaNode(ObjectSource source, String id, Predicate1<TableContext> predicate) {
+    public AlphaNode createAlphaNode(ObjectSource source, String id, Predicate1<PropertyEvaluator> predicate) {
         return createAlphaNode(source, id, predicate, null);
     }
 
     @Deprecated
-    public AlphaNode createAlphaNode(ObjectSource source, Predicate1<TableContext> predicate, Index index) {
+    public AlphaNode createAlphaNode(ObjectSource source, Predicate1<PropertyEvaluator> predicate, Index index) {
         return createAlphaNode(source, UUID.randomUUID().toString(), predicate, null);
     }
 
@@ -63,15 +73,17 @@ public class AlphaNetworkCreation {
      * <p>
      * Prefix: column name + value
      */
-    public AlphaNode createAlphaNode(ObjectSource source, String id, Predicate1<TableContext> predicate, Index index) {
-        SingleConstraint1<TableContext> constraint = new SingleConstraint1<>(id, ctx.variable, predicate);
+    // TODO DT-ANC this should return the LambdaConstraint/AlphaNode tuple.
+    // The Alpha Node will be used to generate the ANC and the LambdaConstraint will be inlined using the Alpha Node Id as a reference
+    public AlphaNode createAlphaNode(ObjectSource source, String id, Predicate1<PropertyEvaluator> predicate, Index index) {
+        SingleConstraint1<PropertyEvaluator> constraint = new SingleConstraint1<>(id, ctx.variable, predicate);
         constraint.setIndex(index);
         LambdaConstraint lambda = new LambdaConstraint(new ConstraintEvaluator(new Declaration[]{ctx.declaration}, constraint));
         lambda.setType(Constraint.ConstraintType.ALPHA);
         return buildUtils.attachNode(ctx.buildContext, new AlphaNode(getNextId(), lambda, source, ctx.buildContext));
     }
 
-    public static <I> AlphaIndexImpl<TableContext, I> createIndex(Class<I> indexedClass, Function1<TableContext, I> leftExtractor, I rightValue) {
+    public static <I> AlphaIndexImpl<PropertyEvaluator, I> createIndex(Class<I> indexedClass, Function1<PropertyEvaluator, I> leftExtractor, I rightValue) {
         return new AlphaIndexImpl<>(indexedClass, Index.ConstraintType.EQUAL, 1, leftExtractor, rightValue);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ColumnDefinition.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ColumnDefinition.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.core.compiler.alphanetbased;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import org.kie.dmn.core.compiler.DMNFEELHelper;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.model.api.UnaryTests;
+
+import static org.kie.dmn.core.compiler.alphanetbased.TableCell.ALPHANETWORK_STATIC_PACKAGE;
+import static org.kie.dmn.feel.codegen.feel11.CodegenStringUtil.replaceIntegerLiteralExprWith;
+import static org.kie.dmn.feel.codegen.feel11.CodegenStringUtil.replaceSimpleNameWith;
+import static org.kie.dmn.feel.codegen.feel11.CodegenStringUtil.replaceStringLiteralExprWith;
+
+/**
+ * Used to generate Column Validators from ColumnValidatorTemplate.java
+ */
+public class ColumnDefinition {
+
+    private final String feelClassName;
+    private final String feelClassNameWithPackage;
+
+    private final String className;
+    private final String classNameWithPackage;
+
+    private final DMNFEELHelper feel;
+    private final CompilerContext compilerContext;
+
+    protected int columnIndex;
+
+    protected final Optional<UnaryTests> optionalInputValues;
+    protected final Type type;
+    protected final String validValues;
+    protected final String columnName;
+    protected final String decisionTableName;
+
+    public ColumnDefinition(int columnIndex,
+                            String decisionTableName,
+                            String columnName,
+                            UnaryTests inputValues,
+                            Type type,
+                            DMNFEELHelper feel,
+                            CompilerContext compilerContext) {
+        this.columnIndex = columnIndex;
+        this.columnName = columnName;
+        this.type = type;
+        this.optionalInputValues = Optional.ofNullable(inputValues);
+        this.feel = feel;
+        this.compilerContext = compilerContext;
+        this.validValues = optionalInputValues.map(UnaryTests::getText).orElse(null);
+        this.decisionTableName = decisionTableName;
+
+        feelClassName = String.format("UnaryTestColumnValidator%s", columnIndex);
+        feelClassNameWithPackage = ALPHANETWORK_STATIC_PACKAGE + "." + feelClassName;
+
+        className = String.format("ColumnValidator%s", columnIndex);
+        classNameWithPackage = ALPHANETWORK_STATIC_PACKAGE + "." + className;
+    }
+
+    public void compileUnaryTestAndAddTo(Map<String, String> allGeneratedSources) {
+        optionalInputValues.ifPresent(inputValues -> {
+            UnaryTestClass unaryTestClass = new UnaryTestClass(inputValues.getText(), feel, compilerContext, type);
+            unaryTestClass.compileUnaryTestAndAddTo(allGeneratedSources, feelClassName, feelClassNameWithPackage, ALPHANETWORK_STATIC_PACKAGE);
+        });
+
+    }
+
+    public void initColumnValidatorTemplateAddToClasses(CompilationUnit columnValidatorTemplate, Map<String, String> validatorGeneratedClasses) {
+
+        replaceSimpleNameWith(columnValidatorTemplate, "ColumnValidatorTemplate", className);
+
+        replaceSimpleNameWith(columnValidatorTemplate, "ColumnValidatorX", feelClassNameWithPackage);
+
+        // TODO DT-ANC check quoting
+        replaceStringLiteralExprWith(columnValidatorTemplate, "VALID_VALUES", validValues.replace("\"", "\\\""));
+        replaceStringLiteralExprWith(columnValidatorTemplate, "COLUMN_NAME", columnName);
+        replaceStringLiteralExprWith(columnValidatorTemplate, "DECISION_TABLE_NAME", decisionTableName);
+
+        validatorGeneratedClasses.put(classNameWithPackage, columnValidatorTemplate.toString());
+    }
+
+    public void initValidationStatement(BlockStmt newValidationStatement) {
+        newValidationStatement.removeComment();
+
+        replaceSimpleNameWith(newValidationStatement, "resultValidation0", "resultValidation" + columnIndex);
+        replaceSimpleNameWith(newValidationStatement, "ValidatorC0", classNameWithPackage);
+        replaceIntegerLiteralExprWith(newValidationStatement, 777, columnIndex);
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNCompiledAlphaNetwork.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/DMNCompiledAlphaNetwork.java
@@ -16,18 +16,26 @@
 
 package org.kie.dmn.core.compiler.alphanetbased;
 
+import java.util.Optional;
+
 import org.drools.ancompiler.CompiledNetwork;
+import org.drools.core.reteoo.ObjectTypeNode;
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.decisiontables.DecisionTable;
+import org.kie.dmn.feel.runtime.events.InvalidInputEvent;
 
 public interface DMNCompiledAlphaNetwork {
 
     void initRete();
 
-    CompiledNetwork createCompiledAlphaNetwork(AlphaNetDMNEvaluatorCompiler compiler);
-
     void setCompiledAlphaNetwork(CompiledNetwork compiledAlphaNetwork);
 
-    Object evaluate(EvaluationContext evalCtx);
+    ObjectTypeNode getObjectTypeNode();
+
+    Optional<InvalidInputEvent> validate(EvaluationContext evaluationContext);
+
+    Object evaluate(EvaluationContext evaluationContext, DecisionTable decisionTable);
 
     ResultCollector getResultCollector();
+
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/FeelDecisionTable.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/FeelDecisionTable.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.core.compiler.alphanetbased;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.core.compiler.DMNFEELHelper;
+import org.kie.dmn.core.compiler.alphanetbased.evaluator.OutputClausesWithType;
+import org.kie.dmn.core.impl.BaseDMNTypeImpl;
+import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.runtime.UnaryTest;
+import org.kie.dmn.model.api.UnaryTests;
+
+// This is a trimmed down version of the original Decision Table used to evaluate Hit Policies
+public class FeelDecisionTable implements org.kie.dmn.feel.runtime.decisiontables.DecisionTable {
+
+    private final String name;
+    private final List<OutputClause> outputs;
+
+    public FeelDecisionTable(String decisionTableName,
+                             List<OutputClausesWithType.OutputClauseWithType> outputs,
+                             DMNFEELHelper feelHelper,
+                             Map<String, Type> allVariableTypes,
+                             DMNType unknownType) {
+        this.name = decisionTableName;
+        List<OutputClause> list = new ArrayList<>();
+        for (OutputClausesWithType.OutputClauseWithType output : outputs) {
+            FEELOutputClause feelOutputClause = new FEELOutputClause(output.getOutputClause(),
+                                                                     output.getDmnBaseType(),
+                                                                     feelHelper,
+                                                                     allVariableTypes,
+                                                                     unknownType);
+            list.add(feelOutputClause);
+        }
+        this.outputs = list;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public List<? extends OutputClause> getOutputs() {
+        return outputs;
+    }
+
+    public static class FEELOutputClause implements org.kie.dmn.feel.runtime.decisiontables.DecisionTable.OutputClause {
+
+        protected String name;
+        protected List<UnaryTest> outputValues;
+        protected CompiledFEELExpression compiledDefault;
+        private BaseDMNTypeImpl outputClauseType;
+
+        FEELOutputClause(org.kie.dmn.model.api.OutputClause outputClause,
+                         BaseDMNTypeImpl outputClauseType,
+                         DMNFEELHelper feelHelper,
+                         Map<String, Type> allVariableTypes,
+                         DMNType unknownType) {
+            this.name = outputClause.getName();
+            this.outputClauseType = outputClauseType;
+            this.outputValues = getOutputValuesTests(feelHelper, allVariableTypes, unknownType, outputClause.getOutputValues());
+        }
+
+        protected List<UnaryTest> getOutputValuesTests(DMNFEELHelper feel,
+                                                       Map<String, Type> variableTypes,
+                                                       DMNType unknownType,
+                                                       UnaryTests outputValues) {
+
+            String outputValuesText = Optional.ofNullable(outputValues)
+                    .map(UnaryTests::getText).orElse(null);
+
+            if (outputValuesText != null && !outputValuesText.isEmpty()) {
+                return feel.evaluateUnaryTests(outputValuesText, variableTypes);
+            }
+
+            if (outputClauseType != unknownType && outputClauseType.getAllowedValuesFEEL() != null) {
+                return outputClauseType.getAllowedValuesFEEL();
+            }
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public List<UnaryTest> getOutputValues() {
+            return outputValues;
+        }
+
+        @Override
+        public Type getType() {
+            return outputClauseType.getFeelType();
+        }
+
+        @Override
+        public boolean isCollection() {
+            return outputClauseType.isCollection();
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/GeneratedSources.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/GeneratedSources.java
@@ -16,32 +16,50 @@
 
 package org.kie.dmn.core.compiler.alphanetbased;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import org.drools.ancompiler.CompiledNetworkSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.Optional.of;
+import static org.kie.dmn.core.compiler.alphanetbased.TableCell.ALPHANETWORK_STATIC_PACKAGE;
+
 public class GeneratedSources {
+
+    // TODO DT-ANC support specific packages for both DMN and Alpha Network classes
+    private static final String ANC_PACKAGE = "org.drools.ancompiler";
 
     private static final Logger logger = LoggerFactory.getLogger(GeneratedSources.class);
 
-    private final Map<String, String> allClasses = new HashMap<>();
+    // This is only for debugging purposes and should NEVER be enabled in production
+    private static final boolean DUMP_GENERATED_CLASSES = false;
 
-    private String alphaNetworkClass = null;
+    private final Map<String, String> allGeneratedSources = new HashMap<>();
+
+    private String alphaNetworkClassName = null;
+    private Optional<Path> optionalDumpFolder = Optional.empty();
 
     public void addNewSourceClass(String classNameWithPackage, String classSourceCode) {
-        allClasses.put(classNameWithPackage, classSourceCode);
+        allGeneratedSources.put(classNameWithPackage, classSourceCode);
     }
 
     public void addNewAlphaNetworkClass(String alphaNetworkClassWithPackage, String toString) {
         addNewSourceClass(alphaNetworkClassWithPackage, toString);
-        this.alphaNetworkClass = alphaNetworkClassWithPackage;
+        this.alphaNetworkClassName = alphaNetworkClassWithPackage;
     }
 
     public DMNCompiledAlphaNetwork newInstanceOfAlphaNetwork(Map<String, Class<?>> compiledClasses) {
-        Class<?> inputSetClass = compiledClasses.get(alphaNetworkClass);
+        Class<?> inputSetClass = compiledClasses.get(alphaNetworkClassName);
         Object inputSetInstance;
         try {
             inputSetInstance = inputSetClass.getDeclaredConstructor().newInstance();
@@ -51,20 +69,73 @@ public class GeneratedSources {
         return (DMNCompiledAlphaNetwork) inputSetInstance;
     }
 
-    public Map<String, String> getAllClasses() {
-        return Collections.unmodifiableMap(allClasses);
+    public Map<String, String> getAllGeneratedSources() {
+        return Collections.unmodifiableMap(allGeneratedSources);
     }
 
     public void logGeneratedClasses() {
         if (logger.isDebugEnabled()) {
-            for (Map.Entry<String, String> kv : allClasses.entrySet()) {
+            for (Map.Entry<String, String> kv : allGeneratedSources.entrySet()) {
                 logger.debug("Generated class {}", kv.getKey());
                 logger.debug(kv.getValue());
             }
         }
     }
 
-    public void addUnaryTestClasses(Map<String, String> unaryTestClasses) {
-        allClasses.putAll(unaryTestClasses);
+    public void dumpGeneratedClasses() {
+        if (DUMP_GENERATED_CLASSES) {
+            try {
+
+                Path generatedSources = Paths.get("target", "generated-sources");
+                Path currentDirectory = Paths.get("").toAbsolutePath().resolve(generatedSources);
+                Path tempDirWithPrefix = Files.createTempDirectory(currentDirectory, alphaNetworkClassName);
+
+                for (Map.Entry<String, String> kv : allGeneratedSources.entrySet()) {
+
+                    Path path = tempDirWithPrefix.resolve(kv.getKey().replace(".", "/") + ".java");
+                    Files.createDirectories(path.getParent());
+
+                    final String tempDirPackage = tempDirWithPrefix.getName(8).toString();
+                    String javaSource = kv.getValue();
+
+                    // each run will have its own package
+                    String withUniquePackageDMN = javaSource.replace(ALPHANETWORK_STATIC_PACKAGE, tempDirPackage + "." + ALPHANETWORK_STATIC_PACKAGE);
+
+                    Files.write(path, withUniquePackageDMN.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Dumped files to: \n\n{}\n", tempDirWithPrefix);
+                }
+
+                optionalDumpFolder = of(tempDirWithPrefix);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void dumpGeneratedAlphaNetwork(CompiledNetworkSource compiledNetworkSource) {
+        if (DUMP_GENERATED_CLASSES) {
+            try {
+                Path tempDirWithPrefix = this.optionalDumpFolder.orElseThrow(RuntimeException::new);
+
+                Path path = tempDirWithPrefix.resolve(compiledNetworkSource.getName().replace(".", "/") + ".java");
+
+                Files.createDirectories(path.getParent());
+
+                final String tempDirPackage = tempDirWithPrefix.getName(8).toString();
+
+                String javaSource = compiledNetworkSource.getSource();
+                String withUniquePackageANC = javaSource.replace("package " + ANC_PACKAGE, "package " + tempDirPackage + "." + ANC_PACKAGE);
+
+                Files.write(path, withUniquePackageANC.getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void putAllGeneratedFEELTestClasses(Map<String, String> unaryTestClasses) {
+        allGeneratedSources.putAll(unaryTestClasses);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/PropertyEvaluator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/PropertyEvaluator.java
@@ -16,18 +16,21 @@
 
 package org.kie.dmn.core.compiler.alphanetbased;
 
+import java.util.Arrays;
+
 import org.kie.dmn.feel.lang.EvaluationContext;
 
-public class TableContext {
+// A class used to evaluate a property name against a FEEL evaluation context
+public class PropertyEvaluator {
 
-    private final EvaluationContext evalCtx;
+    private final EvaluationContext evaluationContext;
     private final Object[] values;
 
-    public TableContext(EvaluationContext evalCtx, String... propertyNames) {
-        this.evalCtx = evalCtx;
+    public PropertyEvaluator(EvaluationContext evaluationContext, String... propertyNames) {
+        this.evaluationContext = evaluationContext;
         this.values = new Object[propertyNames.length];
         for (int i = 0; i < propertyNames.length; i++) {
-            values[i] = evalCtx.getValue(propertyNames[i]);
+            values[i] = evaluationContext.getValue(propertyNames[i]);
         }
     }
 
@@ -35,7 +38,14 @@ public class TableContext {
         return values[i];
     }
 
-    public EvaluationContext getEvalCtx() {
-        return evalCtx;
+    public EvaluationContext getEvaluationContext() {
+        return evaluationContext;
+    }
+
+    @Override
+    public String toString() {
+        return "PropertyEvaluator{" +
+                "values=" + Arrays.toString(values) +
+                '}';
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ResultCollector.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ResultCollector.java
@@ -17,21 +17,165 @@
 package org.kie.dmn.core.compiler.alphanetbased;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.drools.model.functions.Function1;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.decisiontables.DecisionTable;
+import org.kie.dmn.feel.runtime.decisiontables.HitPolicy;
+import org.kie.dmn.feel.runtime.decisiontables.Indexed;
+import org.kie.dmn.feel.runtime.events.DecisionTableRulesMatchedEvent;
+import org.kie.dmn.feel.runtime.events.HitPolicyViolationEvent;
+
+import static java.util.stream.Collectors.toList;
+import static org.kie.dmn.feel.runtime.decisiontables.DecisionTableImpl.checkResults;
 
 public class ResultCollector {
 
-    private final List<Object> results = new ArrayList<>();
+    private final Results results = new Results();
+    private final List<FEELEvent> events = new ArrayList<>();
 
-    public void addResult(Object o) {
-        results.add(o);
+    static class Results {
+
+        private final TreeMap<Integer, List<ResultObject>> resultGroupedByRow = new TreeMap<>();
+
+        public void addResult(ResultObject resultObject) {
+            resultGroupedByRow
+                    .computeIfAbsent(resultObject.row, i -> new ArrayList<>(1)) // 10 (the default for Java) columns output are not that usual
+                    .add(resultObject);
+        }
+
+        public void clearResults() {
+            resultGroupedByRow.clear();
+        }
+
+        List<Indexed> matches() {
+            return indexes().map(i -> (Indexed) () -> i).collect(toList());
+        }
+
+        private Stream<Integer> indexes() {
+            return resultGroupedByRow.keySet().stream();
+        }
+
+        public boolean hasNoIndexes() {
+            return !indexes().findAny().isPresent();
+        }
+
+        public List<Object> evaluateResults(EvaluationContext evaluationContext) {
+            if (!resultGroupedByRow.isEmpty() && resultGroupedByRow.firstEntry().getValue().size() > 1) {
+                return multipleResultWithColumnNameAsKey(evaluationContext);
+            } else {
+                return singleColumnResult(evaluationContext);
+            }
+        }
+
+        private List<Object> singleColumnResult(EvaluationContext evaluationContext) {
+            return resultGroupedByRow.values()
+                    .stream()
+                    .map(r -> r.get(0)) // we know there's only one result see evaluateResults
+                    .map(r -> r.eval(evaluationContext))
+                    .collect(toList());
+        }
+
+        // Actually List<Map<String, Object>>
+        private List<Object> multipleResultWithColumnNameAsKey(EvaluationContext evaluationContext) {
+            return resultGroupedByRow
+                    .values()
+                    .stream()
+                    .map(resultsGroupedByRow -> resultsGroupedByRow.stream().collect(
+                            Collectors.toMap(ResultObject::getColumnName,
+                                             (ResultObject resultObject) -> resultObject.eval(evaluationContext))))
+                    .collect(toList());
+        }
+    }
+
+    public void addResult(int row, String columnName, Function1<EvaluationContext, Object> outputEvaluationFunction) {
+        results.addResult(new ResultObject(row, columnName, outputEvaluationFunction));
+    }
+
+    static class ResultObject {
+
+        private final int row;
+        private final String columnName;
+        private final Function1<EvaluationContext, Object> outputEvaluationFunction;
+
+        public ResultObject(int row, String columnName, Function1<EvaluationContext, Object> outputEvaluationFunction) {
+            this.row = row;
+            this.columnName = columnName;
+            this.outputEvaluationFunction = outputEvaluationFunction;
+        }
+
+        public int getRow() {
+            return row;
+        }
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public Object eval(EvaluationContext evaluationContext) {
+            return outputEvaluationFunction.apply(evaluationContext);
+        }
     }
 
     public void clearResults() {
-        results.clear();
+        results.clearResults();
     }
 
-    public Object getWithHitPolicy() {
-        return results.isEmpty() ? null : results.get(0);
+    public List<FEELEvent> getEvents() {
+        return events;
+    }
+
+    public Object applyHitPolicy(EvaluationContext evaluationContext,
+                                 HitPolicy hitPolicy,
+                                 DecisionTable decisionTable) {
+
+        if (results.hasNoIndexes()) {
+//            if (evaluator.hasDefaultValues()) { TODO DT-ANC default values
+//                return evaluator.defaultToOutput(evalCtx);
+//            }
+            if (hitPolicy.getDefaultValue() != null) {
+                return hitPolicy.getDefaultValue();
+            }
+            events.add(new HitPolicyViolationEvent(
+                    FEELEvent.Severity.WARN,
+                    String.format("No rule matched for decision table '%s' and no default values were defined. Setting result to null.", decisionTable.getName()),
+                    decisionTable.getName(),
+                    Collections.emptyList()));
+        }
+
+        List<? extends Indexed> matchIndexes = results.matches();
+        evaluationContext.notifyEvt( () -> {
+                               List<Integer> matchedIndexes = matchIndexes.stream().map( dr -> dr.getIndex() + 1 ).collect(Collectors.toList() );
+                               return new DecisionTableRulesMatchedEvent(FEELEvent.Severity.INFO,
+                                                                         String.format("Rules matched for decision table '%s': %s", decisionTable.getName(), matchIndexes),
+                                                                         decisionTable.getName(),
+                                                                         decisionTable.getName(),
+                                                                         matchedIndexes );
+                           }
+        );
+
+        List<Object> resultObjects = results.evaluateResults(evaluationContext);
+
+        Map<Integer, String> errorMessages = checkResults(decisionTable.getOutputs(), evaluationContext, matchIndexes, resultObjects );
+        if (!errorMessages.isEmpty()) {
+            List<Integer> offending = new ArrayList<>(errorMessages.keySet());
+            events.add(new HitPolicyViolationEvent(
+                    FEELEvent.Severity.ERROR,
+                    String.format("Errors found evaluating decision table '%s': \n%s",
+                                  decisionTable.getName(),
+                                  String.join("\n", errorMessages.values())),
+                    decisionTable.getName(),
+                    offending));
+            return null;
+        }
+
+        return hitPolicy.getDti().dti(evaluationContext, decisionTable, matchIndexes, resultObjects);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ResultCollectorAlphaSink.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/ResultCollectorAlphaSink.java
@@ -23,25 +23,33 @@ import org.drools.core.reteoo.ModifyPreviousTuples;
 import org.drools.core.reteoo.ObjectSource;
 import org.drools.core.reteoo.builder.BuildContext;
 import org.drools.core.spi.PropagationContext;
+import org.drools.model.functions.Function1;
+import org.drools.model.functions.Predicate1;
+import org.kie.dmn.feel.lang.EvaluationContext;
 
 public class ResultCollectorAlphaSink extends LeftInputAdapterNode {
 
-    private Object result;
-    private ResultCollector resultCollector;
+    private final int row;
+    private final String columnName;
+    private final ResultCollector resultCollector;
+    private final Function1<EvaluationContext, Object> outputEvaluationFunction;
 
-    public ResultCollectorAlphaSink(int id, ObjectSource source, BuildContext context, Object result, ResultCollector resultCollector) {
+    public ResultCollectorAlphaSink(int id, ObjectSource source,
+                                    BuildContext context,
+                                    int row,
+                                    String columnName,
+                                    ResultCollector resultCollector,
+                                    Function1<EvaluationContext, Object> outputEvaluationFunction) {
         super(id, source, context);
-        this.result = result;
+        this.row = row;
+        this.columnName = columnName;
         this.resultCollector = resultCollector;
-    }
-
-    public ResultCollectorAlphaSink() {
-        super(); // java:S2060
+        this.outputEvaluationFunction = outputEvaluationFunction;
     }
 
     @Override
     public void assertObject(InternalFactHandle factHandle, PropagationContext propagationContext, InternalWorkingMemory workingMemory) {
-        resultCollector.addResult(result);
+        resultCollector.addResult(row, columnName, outputEvaluationFunction);
     }
 
     @Override

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableCellParser.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableCellParser.java
@@ -17,11 +17,17 @@
 package org.kie.dmn.core.compiler.alphanetbased;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.core.impl.DMNModelImpl;
 import org.kie.dmn.feel.lang.Type;
 import org.kie.dmn.model.api.DecisionRule;
 import org.kie.dmn.model.api.DecisionTable;
 import org.kie.dmn.model.api.InputClause;
+import org.kie.dmn.model.api.LiteralExpression;
+
+import static org.kie.dmn.feel.lang.types.BuiltInType.determineTypeFromName;
 
 public class TableCellParser {
     TableCell.TableCellFactory tableCellFactory;
@@ -30,10 +36,12 @@ public class TableCellParser {
         this.tableCellFactory = tableCellFactory;
     }
 
-    public TableCells parseCells(DecisionTable decisionTable, DTQNameToTypeResolver resolver) {
+    public TableCells parseCells(DecisionTable decisionTable, DTQNameToTypeResolver resolver, String decisionTableName) {
         List<DecisionRule> rows = decisionTable.getRule();
         List<InputClause> columns = decisionTable.getInput();
         TableCells tableCells = new TableCells(rows.size(), columns.size());
+
+        parseColumnDefinition(decisionTableName, columns, tableCells);
 
         for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
             DecisionRule row = rows.get(rowIndex);
@@ -48,15 +56,54 @@ public class TableCellParser {
                                                                   input,
                                                                   columnName,
                                                                   columnType);
-                if (inputColumnIndex == row.getInputEntry().size() - 1) { // last column
-                    cell.setOutput(row.getOutputEntry().get(0).getText()); // assume only one output
-                }
+
 
                 tableCells.add(cell);
+
+                if (inputColumnIndex == row.getInputEntry().size() - 1) { // last column
+                    tableCells.initialiseOutputColumnsCollection(row.getOutputEntry().size());
+                    List<LiteralExpression> outputEntry = row.getOutputEntry();
+                    for (int outputColumnIndex = 0; outputColumnIndex < outputEntry.size(); outputColumnIndex++) {
+
+                        TableIndex outputColumnTableIndex = tableIndex.outputTableIndex(outputColumnIndex);
+
+                        LiteralExpression outputExpression = outputEntry.get(outputColumnIndex);
+                        String outputRawText = outputExpression.getText();
+
+                        String outputColumnName = Optional.ofNullable(decisionTable.getOutput().get(outputColumnIndex).getName()).orElse("");
+
+                        TableCell outputCell = tableCellFactory.createOutputCell(outputColumnTableIndex, outputRawText, outputColumnName, columnType);
+                        tableCells.addOutputCell(outputCell);
+                    }
+                }
             }
-
-
         }
         return tableCells;
+    }
+
+    private void parseColumnDefinition(String decisionTableName, List<InputClause> columns, TableCells tableCells) {
+        for (int columnIndex = 0, columnsSize = columns.size(); columnIndex < columnsSize; columnIndex++) {
+            InputClause column = columns.get(columnIndex);
+
+            Type type = determineTypeFromName(column.getInputExpression().getTypeRef() != null ? column.getInputExpression().getTypeRef().getLocalPart() : null);
+
+            tableCells.addColumnCell(columnIndex, tableCellFactory.createColumnDefinition(columnIndex,
+                                                                       decisionTableName,
+                                                                       column.getInputExpression().getText(),
+                                                                       column.getInputValues(),
+                                                                                          type));
+        }
+    }
+
+    public DMNType parseDMNType(DMNModelImpl model, LiteralExpression inputExpression) {
+        if (inputExpression.getTypeRef() != null) {
+            String exprTypeRefNS = inputExpression.getTypeRef().getNamespaceURI();
+            if (exprTypeRefNS == null || exprTypeRefNS.isEmpty()) {
+                exprTypeRefNS = model.getNamespace();
+            }
+            return model.getTypeRegistry().resolveType(exprTypeRefNS, inputExpression.getTypeRef().getLocalPart());
+        } else {
+            return null;
+        }
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableIndex.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/TableIndex.java
@@ -39,6 +39,11 @@ public class TableIndex {
         return String.format("%sR%sC%s", sourceString, row + 1, column + 1);
     }
 
+    public String appendOutputSuffix(String prefix) {
+        // DMN DTable are 1Based
+        return String.format("%sR%sC%sFeelExpression", prefix, row + 1, column + 1);
+    }
+
     public InputClause getColumn(List<InputClause> columns) {
         return columns.get(column);
     }
@@ -51,8 +56,11 @@ public class TableIndex {
         return column;
     }
 
-    public void addToCells(TableCell[][] cells, TableCell tableCell) {
-        cells[row][column] = tableCell;
+    public int rowIndex() {
+        return row;
     }
 
+    public TableIndex outputTableIndex(int outputColumnIndex) {
+        return new TableIndex(row, outputColumnIndex);
+    }
 }

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/UnaryTestClass.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/UnaryTestClass.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.core.compiler.alphanetbased;
+
+import java.util.Map;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import org.kie.dmn.core.compiler.DMNFEELHelper;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.Type;
+
+import static org.kie.dmn.feel.codegen.feel11.CodegenStringUtil.replaceSimpleNameWith;
+
+public class UnaryTestClass {
+    private final String input;
+    private final DMNFEELHelper feel;
+    private final CompilerContext compilerContext;
+    private final Type type;
+
+    public UnaryTestClass(String input,
+                          DMNFEELHelper feel,
+                          CompilerContext compilerContext,
+                          Type type) {
+        this.input = input;
+        this.feel = feel;
+        this.compilerContext = compilerContext;
+        this.type = type;
+    }
+
+    public void compileUnaryTestAndAddTo(Map<String, String> allGeneratedSources,
+                                         String className,
+                                         String classNameWithPackage,
+                                         String packageName) {
+        ClassOrInterfaceDeclaration sourceCode = feel.generateUnaryTestsSource(
+                compilerContext,
+                input,
+                type,
+                false);
+
+        replaceSimpleNameWith(sourceCode, "TemplateCompiledFEELUnaryTests", className);
+
+        sourceCode.setName(className);
+
+        CompilationUnit cu = new CompilationUnit(packageName);
+        ClassOrInterfaceDeclaration classOrInterfaceDeclaration = cu.addClass(className);
+        classOrInterfaceDeclaration.replace(sourceCode);
+
+        allGeneratedSources.put(classNameWithPackage, cu.toString());
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/ColumnValidator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/ColumnValidator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.core.compiler.alphanetbased.evaluator;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.UnaryTest;
+import org.kie.dmn.feel.runtime.events.InvalidInputEvent;
+
+public abstract class ColumnValidator {
+
+    protected abstract List<UnaryTest> validationInputTests();
+
+    protected abstract DMNType dmnType();
+
+    protected abstract String validValues();
+
+    protected abstract String columnName();
+
+    protected abstract String decisionTableName();
+
+    public Optional<InvalidInputEvent> validate(EvaluationContext evaluationContext, Object actualValue) {
+        if (validationInputTests() != null) {
+            boolean satisfies = true;
+            if (dmnType() != null && dmnType().isCollection() && actualValue instanceof Collection) {
+                for (Object parameterItem : (Collection<?>) actualValue) {
+                    satisfies &= applyAllValidationUnitTests(evaluationContext, parameterItem);
+                }
+            } else {
+                satisfies = applyAllValidationUnitTests(evaluationContext, actualValue);
+            }
+            if (!satisfies) {
+                return Optional.of(new InvalidInputEvent(FEELEvent.Severity.ERROR,
+                                                         String.format("%s='%s' does not match any of the valid values %s for decision table '%s'.", columnName(), actualValue, validValues(), decisionTableName()),
+                                                         decisionTableName(),
+                                                         null,
+                                                         validValues()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Boolean applyAllValidationUnitTests(EvaluationContext ctx, Object parameterItem) {
+        return validationInputTests()
+                .stream()
+                .map(ut -> ut.apply(ctx, parameterItem))
+                .filter(x -> x != null && x)
+                .findAny()
+                .orElse(false);
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/OutputClausesWithType.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/alphanetbased/evaluator/OutputClausesWithType.java
@@ -1,0 +1,50 @@
+package org.kie.dmn.core.compiler.alphanetbased.evaluator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.dmn.core.impl.BaseDMNTypeImpl;
+import org.kie.dmn.core.impl.DMNModelImpl;
+import org.kie.dmn.model.api.DecisionTable;
+import org.kie.dmn.model.api.OutputClause;
+
+import static org.kie.dmn.core.compiler.DMNEvaluatorCompiler.inferTypeRef;
+
+public class OutputClausesWithType {
+
+    private final DMNModelImpl dmnModel;
+    private final DecisionTable decisionTable;
+
+    public OutputClausesWithType(DMNModelImpl dmnModel, DecisionTable decisionTable) {
+        this.dmnModel = dmnModel;
+        this.decisionTable = decisionTable;
+    }
+
+    public List<OutputClauseWithType> inferTypeForOutputClauses(List<OutputClause> outputClauses) {
+        List<OutputClauseWithType> outputClausesWithTypes = new ArrayList<>();
+        for (OutputClause outputClause : outputClauses) {
+            BaseDMNTypeImpl typeRef = inferTypeRef(dmnModel, decisionTable, outputClause);
+            outputClausesWithTypes.add(new OutputClauseWithType(outputClause, typeRef));
+        }
+        return outputClausesWithTypes;
+    }
+
+    public static class OutputClauseWithType {
+
+        private final OutputClause outputClause;
+        private final BaseDMNTypeImpl dmnBaseType;
+
+        public OutputClauseWithType(OutputClause outputClause, BaseDMNTypeImpl dmnBaseType) {
+            this.outputClause = outputClause;
+            this.dmnBaseType = dmnBaseType;
+        }
+
+        public OutputClause getOutputClause() {
+            return outputClause;
+        }
+
+        public BaseDMNTypeImpl getDmnBaseType() {
+            return dmnBaseType;
+        }
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/ExecModelDMNEvaluatorCompiler.java
@@ -386,8 +386,7 @@ public class ExecModelDMNEvaluatorCompiler extends DMNEvaluatorCompiler {
                         instancesBuilder.append( "    private static final CompiledDTTest " + testClass + "_INSTANCE = new CompiledDTTest( new " + testClass + "() );\n" );
 
                         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = feel.generateStaticUnaryTestsSource(
-                                input,
-                                ctx,
+                                ctx.toCompilerContext(), input,
                                 dTableModel.getColumns().get(j).getType());
 
                         replaceSimpleNameWith(classOrInterfaceDeclaration, "TemplateCompiledFEELUnaryTests", testClass);

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/AlphaNodeCreationTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/AlphaNodeCreationTemplate.java
@@ -1,23 +1,53 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.dmn.core.alphasupport;
 
+import org.kie.dmn.core.compiler.alphanetbased.AlphaNetworkBuilderContext;
 import org.kie.dmn.core.compiler.alphanetbased.AlphaNetworkCreation;
-import org.kie.dmn.core.compiler.alphanetbased.TableContext;
+import org.kie.dmn.core.compiler.alphanetbased.PropertyEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // All implementations are used only for templating purposes and should never be called
 public class AlphaNodeCreationTemplate {
 
+    Logger logger = LoggerFactory.getLogger(AlphaNodeCreationTemplate.class);
+
     private AlphaNetworkCreation alphaNetworkCreation;
 
-    public AlphaNodeCreationTemplate(org.kie.dmn.core.compiler.alphanetbased.NetworkBuilderContext ctx) {
+    public AlphaNodeCreationTemplate(AlphaNetworkBuilderContext ctx) {
         alphaNetworkCreation = new AlphaNetworkCreation(ctx);
     }
-// ref: https://github.com/kiegroup/drools/blame/cde68c4b3aee560259387373bea27b607a811c72/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java#L710-L713
-    boolean testRxCx(TableContext x) {
+
+    // There will be one of this for each column
+    // ref: https://github.com/kiegroup/drools/blame/cde68c4b3aee560259387373bea27b607a811c72/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/DMNEvaluatorCompiler.java#L710-L713
+    boolean testRxCx(PropertyEvaluator x) {
         return UnaryTestRXCX.getInstance().getUnaryTests()
                 .stream()
                 .anyMatch(t -> {
-                    Boolean result = t.apply(x.getEvalCtx(), x.getValue(99999));
+                    Object value = x.getValue(99999);
+                    Boolean result = t.apply(x.getEvaluationContext(), value);
+                    if(logger.isTraceEnabled()) {
+                        logger.trace("Result for " + "UnaryTestRXCX" + " on values " + x + ": " + result);
+                    }
                     return result != null && result;
                 });
+    }
+
+    Object outputRxCx(org.kie.dmn.feel.lang.EvaluationContext x) {
+        return OutputRXCX.getInstance().apply(x);
     }
 }

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/ColumnValidatorTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/ColumnValidatorTemplate.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.core.alphasupport;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.kie.dmn.api.core.DMNType;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.core.alphasupport.UnaryTestR1C1;
+import org.kie.dmn.core.compiler.alphanetbased.evaluator.ColumnValidator;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.UnaryTest;
+import org.kie.dmn.feel.runtime.events.InvalidInputEvent;
+
+public class ColumnValidatorTemplate extends ColumnValidator {
+
+    @Override
+    protected List<UnaryTest> validationInputTests() {
+        return ColumnValidatorX.getInstance().getUnaryTests();
+    }
+
+    // TODO DT-ANC this should be a string
+    @Override
+    protected DMNType dmnType() {
+        return null;
+    }
+
+    @Override
+    protected String validValues() {
+        return "VALID_VALUES";
+    }
+
+    @Override
+    protected String columnName() {
+        return "COLUMN_NAME";
+    }
+
+    @Override
+    protected String decisionTableName() {
+        return "DECISION_TABLE_NAME";
+    }
+
+    private static ColumnValidatorTemplate INSTANCE;
+
+    public static ColumnValidatorTemplate getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ColumnValidatorTemplate();
+        }
+        return INSTANCE;
+    }
+}

--- a/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/DMNAlphaNetworkTemplate.java
+++ b/kie-dmn/kie-dmn-core/src/main/resources/org/kie/dmn/core/alphasupport/DMNAlphaNetworkTemplate.java
@@ -1,29 +1,40 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.dmn.core.alphasupport;
 
 import java.lang.Override;
-import java.util.Map;
+import java.util.Optional;
 
-import org.drools.ancompiler.CompiledNetworkSource;
-import org.drools.ancompiler.ObjectTypeNodeCompiler;
-import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.core.common.DefaultFactHandle;
 import org.drools.core.reteoo.AlphaNode;
 import org.drools.ancompiler.CompiledNetwork;
 import org.drools.core.reteoo.ObjectTypeNode;
-import org.drools.core.reteoo.Rete;
-import org.drools.core.reteoo.ReteDumper;
 import org.drools.model.Index;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.dmn.core.compiler.alphanetbased.AlphaNetworkCreation;
 import org.kie.dmn.core.compiler.alphanetbased.DMNCompiledAlphaNetwork;
-import org.kie.dmn.core.compiler.alphanetbased.NetworkBuilderContext;
+import org.kie.dmn.core.compiler.alphanetbased.AlphaNetworkBuilderContext;
 import org.kie.dmn.core.compiler.alphanetbased.ResultCollector;
 import org.kie.dmn.feel.lang.EvaluationContext;
-import org.kie.dmn.core.compiler.alphanetbased.TableContext;
-import org.kie.memorycompiler.KieMemoryCompiler;
-import org.kie.dmn.core.compiler.alphanetbased.AlphaNetDMNEvaluatorCompiler;
-import static org.kie.dmn.core.compiler.alphanetbased.AlphaNetworkCreation.createIndex;
+import org.kie.dmn.core.compiler.alphanetbased.PropertyEvaluator;
+import org.kie.dmn.feel.runtime.decisiontables.DecisionTable;
+import org.kie.dmn.feel.runtime.decisiontables.HitPolicy;
+import org.kie.dmn.feel.runtime.events.InvalidInputEvent;
 
-import static org.drools.core.util.MapUtils.mapValues;
+import static org.kie.dmn.core.compiler.alphanetbased.AlphaNetworkCreation.createIndex;
 
 // All implementations are used only for templating purposes and should never be called
 public class DMNAlphaNetworkTemplate implements DMNCompiledAlphaNetwork {
@@ -31,8 +42,12 @@ public class DMNAlphaNetworkTemplate implements DMNCompiledAlphaNetwork {
     protected final ResultCollector resultCollector = new ResultCollector();
     protected CompiledNetwork compiledNetwork;
 
-    protected final NetworkBuilderContext ctx = new NetworkBuilderContext(resultCollector);
-    protected final AlphaNetworkCreation alphaNetworkCreation = new AlphaNetworkCreation(ctx);
+    protected final AlphaNetworkBuilderContext builderContext = new AlphaNetworkBuilderContext(resultCollector);
+    protected final AlphaNetworkCreation alphaNetworkCreation = new AlphaNetworkCreation(builderContext);
+
+    private final HitPolicy hitPolicy = HitPolicy.fromString("HIT_POLICY_NAME");
+
+    protected PropertyEvaluator propertyEvaluator;
 
     @Override
     public void initRete() {
@@ -42,8 +57,8 @@ public class DMNAlphaNetworkTemplate implements DMNCompiledAlphaNetwork {
         }
 
         Index index3 = createIndex(String.class, x -> (String) x.getValue(0), "dummy");
-        AlphaNode alphaDummy = alphaNetworkCreation.createAlphaNode(ctx.otn, x -> false, index3);
-        alphaNetworkCreation.addResultSink(alphaDummy, "DUMMY");
+        AlphaNode alphaDummy = alphaNetworkCreation.createAlphaNode(builderContext.otn, x -> false, index3);
+        alphaNetworkCreation.addResultSink(alphaDummy, 0, "dummy", p -> true);
     }
 
     @Override
@@ -52,16 +67,47 @@ public class DMNAlphaNetworkTemplate implements DMNCompiledAlphaNetwork {
     }
 
     @Override
-    public CompiledNetwork createCompiledAlphaNetwork(AlphaNetDMNEvaluatorCompiler compiler) {
-        return compiler.createCompiledAlphaNetwork(ctx.otn);
+    public ObjectTypeNode getObjectTypeNode() {
+        return builderContext.otn;
+    }
+
+    public PropertyEvaluator getOrCreatePropertyEvaluator(EvaluationContext evaluationContext) {
+        if(propertyEvaluator == null) {
+            propertyEvaluator = new PropertyEvaluator(evaluationContext, "PROPERTY_NAMES");
+        }
+        return propertyEvaluator;
     }
 
     @Override
-    public Object evaluate(EvaluationContext evalCtx) {
+    public Optional<InvalidInputEvent> validate(EvaluationContext evaluationContext) {
+        PropertyEvaluator propertyEvaluator = getOrCreatePropertyEvaluator(evaluationContext);
+
+        // Validation Column
+        {
+            Optional<InvalidInputEvent> resultValidation0 =
+                    ValidatorC0.getInstance().validate(evaluationContext,
+                                                       propertyEvaluator.getValue(777));
+            if (resultValidation0.isPresent()) {
+                return resultValidation0;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+
+    @Override
+    public Object evaluate(EvaluationContext evaluationContext, DecisionTable decisionTable) {
+        // Clean previous results
         resultCollector.clearResults();
-        TableContext ctx = new TableContext(evalCtx, "PROPERTY_NAMES");
-        compiledNetwork.propagateAssertObject(new DefaultFactHandle(ctx), null, null);
-        return resultCollector.getWithHitPolicy();
+
+        // Fire rete network
+        compiledNetwork.propagateAssertObject(new DefaultFactHandle(getOrCreatePropertyEvaluator(evaluationContext)), null, null);
+
+        // Find result with Hit Policy applied
+        Object result = resultCollector.applyHitPolicy(evaluationContext, hitPolicy, decisionTable);
+
+        return result;
     }
 
     @Override

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNDecisionTableHitPolicyTest.java
@@ -19,8 +19,10 @@ package org.kie.dmn.core;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
+import org.kie.api.builder.Message;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNModel;
@@ -33,14 +35,18 @@ import org.kie.dmn.feel.runtime.events.HitPolicyViolationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest {
@@ -68,12 +74,15 @@ public class DMNDecisionTableHitPolicyTest extends BaseInterpretedVsCompiledTest
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "0004-simpletable-U");
         assertThat(dmnModel, notNullValue());
 
+        // Risk Category is constrained to "High", "Low", "Medium" and "ASD" is not allowed
         final DMNContext context = getSimpleTableContext(BigDecimal.valueOf(18), "ASD", false);
         final DMNResult dmnResult = runtime.evaluateAll(dmnModel, context);
         final DMNContext result = dmnResult.getContext();
 
         assertThat(result.get("Approval Status"), nullValue());
         assertTrue(dmnResult.getMessages().size() > 0);
+        DMNMessage message = dmnResult.getMessages().iterator().next();
+        assertEquals(message.getText(), "DMN: RiskCategory='ASD' does not match any of the valid values \"High\", \"Low\", \"Medium\" for decision table '_0004-simpletable-U'. (DMN id: _0004-simpletable-U, FEEL expression evaluation error) ");
     }
 
     @Test

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/DMNDecisionTableAlphaSupportingTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/alphanetwork/DMNDecisionTableAlphaSupportingTest.java
@@ -57,7 +57,7 @@ public class DMNDecisionTableAlphaSupportingTest extends BaseInterpretedVsAlphaN
     }
 
     @Test
-    public void testSimpleDecisionTableHitPolicyCollectMax() {
+    public void testSimpleTableMultipleTests() {
         final DMNRuntime runtime = DMNRuntimeUtil.createRuntime("an-simpletable-multipletests.dmn", this.getClass());
         final DMNModel dmnModel = runtime.getModel("https://github.com/kiegroup/kie-dmn", "an-simpletable-multipletests");
         MatcherAssert.assertThat(dmnModel, notNullValue());

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/ASTCompilerVisitor.java
@@ -428,7 +428,7 @@ public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
                 Expressions.filter(expr.getExpression(), lambda.name()),
                 // here we could still try to infer the result type, but presently use ANY
                 BuiltInType.UNKNOWN).withFD(expr).withFD(filter);
-        r.addFieldDesclaration(lambda.field());
+        r.addFieldDeclaration(lambda.field());
         return r;
     }
 
@@ -557,8 +557,8 @@ public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
 
         DirectCompilerResult r =
                 DirectCompilerResult.of(with, BuiltInType.UNKNOWN);
-        r.addFieldDesclaration(nameLambda.field());
-        r.addFieldDesclaration(exprLambda.field());
+        r.addFieldDeclaration(nameLambda.field());
+        r.addFieldDeclaration(exprLambda.field());
         r.withFD(iterName);
         r.withFD(iterExpr);
 
@@ -570,7 +570,7 @@ public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
                             rangeEnd.getExpression(),
                             rangeEndExpr.getText());
             with.addArgument(rangeLambda.name());
-            r.addFieldDesclaration(rangeLambda.field());
+            r.addFieldDeclaration(rangeLambda.field());
             r.withFD(rangeEnd);
         }
 
@@ -676,7 +676,7 @@ public class ASTCompilerVisitor implements Visitor<DirectCompilerResult> {
         DirectCompilerResult r =
                 DirectCompilerResult.of(namedLambda.name(), BuiltInType.UNARY_TEST)
                         .withFD(value);
-        r.addFieldDesclaration(namedLambda.field());
+        r.addFieldDeclaration(namedLambda.field());
         return r;
     }
 }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSupport.java
@@ -499,7 +499,7 @@ public class CompiledFEELSupport {
         MethodCallExpr list = new MethodCallExpr(compiledFeelSemanticMappingsFQN(), "list", new NodeList<>(new NameExpr(constantName)));
 
         DirectCompilerResult directCompilerResult = DirectCompilerResult.of(list, BuiltInType.LIST);
-        directCompilerResult.addFieldDesclaration(fd);
+        directCompilerResult.addFieldDeclaration(fd);
         return directCompilerResult;
 
     }

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerResult.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/DirectCompilerResult.java
@@ -69,7 +69,7 @@ public class DirectCompilerResult {
         return Collections.unmodifiableSet(fieldDeclarations);
     }
     
-    public boolean addFieldDesclaration(FieldDeclaration d) {
+    public boolean addFieldDeclaration(FieldDeclaration d) {
         return fieldDeclarations.add(d);
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Expressions.java
@@ -96,7 +96,7 @@ public class Expressions {
     public static final String LEFT = "left";
     public static final NameExpr LEFT_EXPR = new NameExpr(LEFT);
     public static final UnknownType UNKNOWN_TYPE = new UnknownType();
-    public static final NameExpr STDLIB = new NameExpr(CompiledFEELSupport.class.getSimpleName());
+    public static final NameExpr STDLIB = new NameExpr(CompiledFEELSupport.class.getCanonicalName());
 
     public static Expression dash() {
         return DASH_UNARY_TEST;
@@ -145,22 +145,22 @@ public class Expressions {
     }
 
     private static MethodCallExpr arithmetic(String op, Expression left, Expression right) {
-        return new MethodCallExpr(null, op, new NodeList<>(left, right));
+        return new MethodCallExpr(compiledFeelSemanticMappingsFQN(), op, new NodeList<>(left, right));
     }
 
     private static MethodCallExpr equality(String op, Expression left, Expression right) {
-        return new MethodCallExpr(null, op, new NodeList<>(left, right));
+        return new MethodCallExpr(compiledFeelSemanticMappingsFQN(), op, new NodeList<>(left, right));
     }
 
     private static MethodCallExpr comparison(String op, Expression left, Expression right) {
-        return new MethodCallExpr(null, op, new NodeList<>(left, right));
+        return new MethodCallExpr(compiledFeelSemanticMappingsFQN(), op, new NodeList<>(left, right));
     }
 
     private static MethodCallExpr booleans(String op, Expression left, Expression right) {
         Expression l = coerceToBoolean(left);
         Expression r = supplierLambda(coerceToBoolean(right));
 
-        return new MethodCallExpr(null, op, new NodeList<>(l, r));
+        return new MethodCallExpr(compiledFeelSemanticMappingsFQN(), op, new NodeList<>(l, r));
     }
 
     public static Expression unary(

--- a/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
+++ b/kie-dmn/kie-dmn-feel/src/main/java/org/kie/dmn/feel/codegen/feel11/Functions.java
@@ -83,7 +83,7 @@ public class Functions {
         DirectCompilerResult r = DirectCompilerResult.of(
                 Functions.internal(list, new NameExpr(fnName)),
                 BuiltInType.FUNCTION);
-        r.addFieldDesclaration(Constants.function(fnName, lambda));
+        r.addFieldDeclaration(Constants.function(fnName, lambda));
         return r;
     }
 

--- a/kie-dmn/kie-dmn-feel/src/main/resources/TemplateCompiledFEELExpression.java
+++ b/kie-dmn/kie-dmn-feel/src/main/resources/TemplateCompiledFEELExpression.java
@@ -7,11 +7,20 @@ import org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression;
 import org.kie.dmn.feel.codegen.feel11.CompiledFEELSupport;
 import org.kie.dmn.feel.lang.EvaluationContext;
 
-public class TemplateCompiledFEELExpression implements CompiledFEELExpression {
+public class TemplateCompiledFEELExpression implements org.kie.dmn.feel.codegen.feel11.CompiledFEELExpression {
 
     @Override
     public Object apply(EvaluationContext feelExprCtx) {
         return null;
+    }
+
+    private static TemplateCompiledFEELExpression INSTANCE;
+
+    public static TemplateCompiledFEELExpression getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TemplateCompiledFEELExpression();
+        }
+        return INSTANCE;
     }
 
 }


### PR DESCRIPTION
* Outputs are now compiled feel expression as well
* Multiple output columns
* Hit Policies while compiling with Alpha Network Compiler
* Compiled Validation of Decision Table
* with DUMP_GENERATED_CLASSES it's possible to find the generated files in the `target/generated-sources` directory

**Thank you for submitting this pull request**

https://issues.redhat.com/browse/DROOLS-5985

Backport PR on 7.x branch here https://github.com/kiegroup/drools/pull/3861

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
