### PR TITLE
[DROOLS-6530] always use unix separator for internal paths representation

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFileSystem.java
@@ -55,6 +55,8 @@ import org.kie.api.io.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
 public class MemoryFileSystem
     implements
     FileSystem,
@@ -76,7 +78,7 @@ public class MemoryFileSystem
 
     public MemoryFileSystem() {
         folder = new MemoryFolder( this, "" );
-        folders.put( "", new HashSet<FileSystemItem>() );
+        folders.put( "", new HashSet<>() );
     }
 
     public Folder getRootFolder() {
@@ -170,7 +172,7 @@ public class MemoryFileSystem
     }
 
     public void mark() {
-        modifiedFilesSinceLastMark = new HashSet<String>();
+        modifiedFilesSinceLastMark = new HashSet<>();
     }
 
     public Collection<String> getModifiedResourcesSinceLastMark() {
@@ -203,8 +205,7 @@ public class MemoryFileSystem
                 createFolder( (MemoryFolder) folder.getParent() );
             }
 
-            folders.put( folder.getPath().toPortableString(),
-                         new HashSet<FileSystemItem>() );
+            folders.put( folder.getPath().toPortableString(), new HashSet<>() );
 
             Folder parent = folder.getParent();
             folders.get( parent.getPath().toPortableString() ).add( folder );
@@ -384,7 +385,7 @@ public class MemoryFileSystem
     }
 
     public void write(String pResourceName, Resource resource, boolean createFolder) {
-        pResourceName = pResourceName.replace( java.io.File.separatorChar, '/' );
+        pResourceName = normalizePath(pResourceName);
 
         if (pResourceName.endsWith( "/" )) {
             // avoid to create files for empty folders

--- a/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFolder.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/compiler/io/memory/MemoryFolder.java
@@ -18,6 +18,7 @@ package org.drools.compiler.compiler.io.memory;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 import org.drools.compiler.compiler.io.File;
 import org.drools.compiler.compiler.io.Folder;
@@ -25,11 +26,11 @@ import org.drools.compiler.compiler.io.Path;
 import org.drools.compiler.compiler.io.FileSystemItem;
 import org.drools.core.util.StringUtils;
 
-public class MemoryFolder
-        implements
-        Folder,
-        Serializable {
-    private MemoryFileSystem mfs;
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
+public class MemoryFolder implements Folder, Serializable {
+
+    private final MemoryFileSystem mfs;
 
     private String           path;
     
@@ -80,8 +81,7 @@ public class MemoryFolder
             String p = trimLeadingAndTrailing( path );
             
             if ( p.indexOf( '/' ) == -1 ) {
-                pFolder = new MemoryFolder( mfs,
-                                         "" );            
+                pFolder = new MemoryFolder( mfs, "" );
             } else {           
                 String[] elements = p.split( "/" );
         
@@ -96,8 +96,7 @@ public class MemoryFolder
                         first = false;
                     }
                 }
-                pFolder = new MemoryFolder( mfs,
-                                            newPath );
+                pFolder = new MemoryFolder( mfs, newPath );
             }
         }
         
@@ -109,6 +108,8 @@ public class MemoryFolder
         if (p.isEmpty()) {
             return p;
         }
+        p = normalizePath(p);
+
         while ( p.charAt( 0 ) == '/') {
             p = p.substring( 1 );
         }
@@ -149,10 +150,7 @@ public class MemoryFolder
         if ( obj == null ) return false;
         if ( getClass() != obj.getClass() ) return false;
         MemoryFolder other = (MemoryFolder) obj;
-        if ( path == null ) {
-            if ( other.path != null ) return false;
-        } else if ( !path.equals( other.path ) ) return false;
-        return true;
+        return Objects.equals(path, other.path);
     }
 
     @Override

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ClasspathKieProject.java
@@ -30,7 +30,6 @@ import java.net.URLDecoder;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -54,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
 import static org.drools.compiler.kproject.models.KieModuleModelImpl.KMODULE_JAR_PATH;
 import static org.drools.reflective.classloader.ProjectClassLoader.createProjectClassLoader;
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 /**
  * Discovers all KieModules on the classpath, via the kmodule.xml file.
@@ -67,9 +67,9 @@ public class ClasspathKieProject extends AbstractKieProject {
 
     public static final String OSGI_KIE_MODULE_CLASS_NAME     = "org.kie.osgi.compiler.OsgiKieModule";
 
-    private Map<ReleaseId, InternalKieModule>     kieModules  = new HashMap<>();
+    private final Map<ReleaseId, InternalKieModule>     kieModules  = new HashMap<>();
 
-    private Map<String, InternalKieModule>  kJarFromKBaseName = new HashMap<>();
+    private final Map<String, InternalKieModule>  kJarFromKBaseName = new HashMap<>();
 
     private final KieRepository kieRepository;
     
@@ -125,9 +125,7 @@ public class ClasspathKieProject extends AbstractKieProject {
             }
 
             // Map of kmodule urls
-            Iterator<URL> e = resources.iterator();
-            while (e.hasNext()) {
-                URL url = e.next();
+            for (URL url : resources) {
                 notifyKieModuleFound(url);
                 try {
                     InternalKieModule kModule = fetchKModule(url);
@@ -136,13 +134,13 @@ public class ClasspathKieProject extends AbstractKieProject {
                         ReleaseId releaseId = kModule.getReleaseId();
                         kieModules.put(releaseId, kModule);
 
-                        log.debug( "Discovered classpath module " + releaseId.toExternalForm() );
+                        log.debug("Discovered classpath module " + releaseId.toExternalForm());
 
                         kieRepository.addKieModule(kModule);
                     }
 
-                } catch ( Exception exc ) {
-                    log.error( "Unable to build index of kmodule.xml url=" + url.toExternalForm() + "\n" + exc.getMessage() );
+                } catch (Exception exc) {
+                    log.error("Unable to build index of kmodule.xml url=" + url.toExternalForm() + "\n" + exc.getMessage());
                 }
             }
         }
@@ -307,17 +305,13 @@ public class ClasspathKieProject extends AbstractKieProject {
         rootPath = rootPath.substring( rootPath.lastIndexOf( '!' ) + 1 );
         // read jar file from uber-jar
         InputStream in = ClasspathKieProject.class.getResourceAsStream(rootPath);
-        ZipInputStream zipIn = new ZipInputStream(in);
-        try {
+        try (ZipInputStream zipIn = new ZipInputStream(in)) {
             ZipEntry entry = zipIn.getNextEntry();
             while (entry != null) {
                 // process each entry
                 String fileName = entry.getName();
                 if ( fileName.endsWith( "pom.properties" ) && fileName.startsWith( "META-INF/maven/" ) ) {
-                    String pomProps = StringUtils.readFileAsString( new InputStreamReader( zipIn, IoUtils.UTF8_CHARSET ) );
-                    //zipIn.closeEntry();
-                    
-                    return pomProps;
+                    return StringUtils.readFileAsString( new InputStreamReader( zipIn, IoUtils.UTF8_CHARSET ) );
                 }
                 
                 // get next entry if needed
@@ -325,15 +319,7 @@ public class ClasspathKieProject extends AbstractKieProject {
             }
         } catch ( Exception e ) {
             log.error( "Unable to load pom.properties from zip input stream " + rootPath + "\n" + e.getMessage() );
-        } finally {
-            try {
-                if (zipIn != null) {
-                    zipIn.close();
-                }
-            } catch ( IOException e ) {
-                log.error( "Error when closing zip InputStream to " + rootPath + "\n" + e.getMessage() );
-            }
-        }   
+        }
         
         return null;
     }
@@ -472,7 +458,7 @@ public class ClasspathKieProject extends AbstractKieProject {
         String path = null;
         try {
             File f = (File)m.invoke( m2.invoke(null, url.toURI()) );
-            path = f.getPath();
+            path = normalizePath(f.getPath());
         } catch (Exception e) {
             log.error( "Error when reading virtual file from " + url.toString(), e );
         }
@@ -487,23 +473,23 @@ public class ClasspathKieProject extends AbstractKieProject {
         }
 
         int kModulePos = urlString.length() - ("/" + KieModuleModelImpl.KMODULE_JAR_PATH).length();
-        boolean isInJar = urlString.substring(kModulePos - 4, kModulePos).equals(".jar");
+        boolean isInJar = urlString.startsWith(".jar", kModulePos - 4);
 
         try {
-            if (isInJar && path.contains("contents" + File.separator)) {
+            if (isInJar && path.contains("contents/")) {
                 String jarName = urlString.substring(0, kModulePos);
                 jarName = jarName.substring(jarName.lastIndexOf('/')+1);
                 String jarFolderPath = path.substring( 0, path.length() - ("contents/" + KieModuleModelImpl.KMODULE_JAR_PATH).length() );
                 String jarPath = jarFolderPath + jarName;
                 path = new File(jarPath).exists() ? jarPath : jarFolderPath + "content";
-            } else if (path.endsWith(File.separator + KieModuleModelImpl.KMODULE_FILE_NAME)) {
+            } else if (path.endsWith("/" + KieModuleModelImpl.KMODULE_FILE_NAME)) {
                 path = path.substring( 0, path.length() - ("/" + KieModuleModelImpl.KMODULE_JAR_PATH).length() );
             }
 
             log.info( "Virtual file physical path = " + path );
             return path;
         } catch (Exception e) {
-            log.error( "Error when reading virtual file from " + url.toString(), e );
+            log.error( "Error when reading virtual file from " + url, e );
         }
         return url.getPath();
     }

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DiskResourceReader.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/DiskResourceReader.java
@@ -28,23 +28,26 @@ import java.util.Set;
 import org.kie.memorycompiler.resources.ResourceReader;
 
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 public class DiskResourceReader implements ResourceReader {
     private final File root;
+    private final String rootPath;
 
     private Map<String, Integer> filesHashing;
 
-    public DiskResourceReader( final File pRoot ) {
-        root = pRoot;        
+    public DiskResourceReader( final File root ) {
+        this.root = root;
+        this.rootPath = normalizePath(root.getAbsolutePath());
     }
     
     public boolean isAvailable( final String pResourceName ) {
-        return new File(root, pResourceName).exists();
+        return new File(rootPath, normalizePath(pResourceName)).exists();
     }
 
     public byte[] getBytes( final String pResourceName ) {
         try {
-            return readBytesFromInputStream(new FileInputStream(new File(root, pResourceName)));
+            return readBytesFromInputStream(new FileInputStream(new File(rootPath, normalizePath(pResourceName))));
         } catch(Exception e) {
             return null;
         }
@@ -107,7 +110,7 @@ public class DiskResourceReader implements ResourceReader {
                 list(directoryFiles[i], pFiles);
             }
         } else {
-            pFiles.add(pFile.getAbsolutePath().substring(root.getAbsolutePath().length()+1));
+            pFiles.add( normalizePath( pFile.getAbsolutePath().substring(rootPath.length()+1) ) );
         }
     }   
     

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieBuilderImpl.java
@@ -294,9 +294,8 @@ public class KieBuilderImpl
 
     private void addKBasesFilesToTrg() {
         for ( String fileName : srcMfs.getFileNames() ) {
-            String normalizedName = fileName.replace( File.separatorChar, '/' );
-            if ( normalizedName.startsWith( RESOURCES_ROOT ) ) {
-                copySourceToTarget( normalizedName );
+            if ( fileName.startsWith( RESOURCES_ROOT ) ) {
+                copySourceToTarget( fileName );
             }
         }
     }
@@ -701,7 +700,6 @@ public class KieBuilderImpl
             if ( isJavaSourceFile( fileName )
                     && noClassFileForGivenSourceFile( classFiles, fileName )
                     && notVetoedByFilter( classFilter, fileName ) ) {
-                fileName = fileName.replace( File.separatorChar, '/' );
 
                 if ( !fileName.startsWith( JAVA_ROOT ) && !fileName.startsWith( JAVA_TEST_ROOT ) ) {
                     results.addMessage( Level.WARNING, fileName, "Found Java file out of the Java source folder: \"" + fileName + "\"" );

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/ZipKieModule.java
@@ -37,6 +37,7 @@ import org.kie.api.builder.model.KieModuleModel;
 import org.kie.internal.io.ResourceFactory;
 
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 public class ZipKieModule extends AbstractKieModule implements InternalKieModule, Serializable {
     private File file;
@@ -140,7 +141,7 @@ public class ZipKieModule extends AbstractKieModule implements InternalKieModule
     }
 
     private Map<String, List<String>> processZipUrl( String urlPath, int urlSeparatorPos ) throws IOException {
-        String folderInUrl = urlPath.substring( urlSeparatorPos + 1 ).replace("\\", "/");
+        String folderInUrl = normalizePath( urlPath.substring( urlSeparatorPos + 1 ) );
         // read jar file from uber-jar
         InputStream in = this.getClass().getResourceAsStream(folderInUrl);
         if (in == null) {
@@ -155,7 +156,7 @@ public class ZipKieModule extends AbstractKieModule implements InternalKieModule
 
     private Map<String, List<String>> processFolderInZipFile( String urlPath, int urlSeparatorPos ) throws IOException {
         String jarFile = urlPath.substring( 0, urlSeparatorPos );
-        String folderInUrl = urlPath.substring( urlSeparatorPos + 1 ).replace("\\", "/");
+        String folderInUrl = normalizePath( urlPath.substring( urlSeparatorPos + 1 ) );
         String rootFolder = folderInUrl.startsWith( "/" ) ? folderInUrl.substring( 1 ) : folderInUrl;
 
         try (FileInputStream fis = new FileInputStream(jarFile);

--- a/drools-core-reflective/src/main/java/org/drools/reflective/util/ClassUtils.java
+++ b/drools-core-reflective/src/main/java/org/drools/reflective/util/ClassUtils.java
@@ -139,21 +139,6 @@ public abstract class ClassUtils {
         return pResourceName.substring( 0, i );
     }
 
-    public static String toJavaCasing(final String pName) {
-        final char[] name = pName.toLowerCase().toCharArray();
-        name[0] = Character.toUpperCase( name[0] );
-        return new String( name );
-    }
-
-    public static String clazzName(final File base,
-                                   final File file) {
-        final int rootLength = base.getAbsolutePath().length();
-        final String absFileName = file.getAbsolutePath();
-        final int p = absFileName.lastIndexOf('.');
-        final String relFileName = absFileName.substring(rootLength + 1, p);
-        return relFileName.replace(File.separatorChar, '.');
-    }
-
     public static String relative(final File base,
                                   final File file) {
         final int rootLength = base.getAbsolutePath().length();

--- a/drools-core/src/main/java/org/drools/core/command/runtime/rule/EnableAuditLogCommand.java
+++ b/drools-core/src/main/java/org/drools/core/command/runtime/rule/EnableAuditLogCommand.java
@@ -1,7 +1,5 @@
 package org.drools.core.command.runtime.rule;
 
-import java.io.File;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -12,6 +10,8 @@ import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.command.RegistryContext;
+
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 @XmlRootElement
 @XmlAccessorType( XmlAccessType.NONE )
@@ -30,7 +30,7 @@ public class EnableAuditLogCommand implements ExecutableCommand<Void> {
         this.filename = filename;
 
         if ( directory != null ) {
-            auditLogFile = directory + File.separator + filename;
+            auditLogFile = normalizePath(directory + '/' + filename);
         }
 
     }

--- a/drools-core/src/main/java/org/drools/core/io/impl/BaseResource.java
+++ b/drools-core/src/main/java/org/drools/core/io/impl/BaseResource.java
@@ -31,6 +31,7 @@ import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
 
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 public abstract class BaseResource
         implements
@@ -111,18 +112,18 @@ public abstract class BaseResource
     }
 
     public InternalResource setSourcePath(String path) {
-        this.sourcePath = path;
+        this.sourcePath = normalizePath( path );
         return this;
     }
 
     public InternalResource setTargetPath(String path) {
-        this.targetPath = path;
+        this.targetPath = normalizePath( path );
         return this;
     }
 
     public List<String> getCategories() {
         if ( categories == null ) {
-            categories = new ArrayList<String>();
+            categories = new ArrayList<>();
         }
         return categories;
     }

--- a/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ClassUtils.java
@@ -138,8 +138,7 @@ public final class ClassUtils {
     }
 
     public static String convertClassToResourcePath(final String pName) {
-        return pName.replace( '.',
-                              '/' ) + ".class";
+        return pName.replace( '.', '/' ) + ".class";
     }
 
     /**
@@ -149,21 +148,6 @@ public final class ClassUtils {
     public static String stripExtension(final String pResourceName) {
         final int i = pResourceName.lastIndexOf('.');
         return pResourceName.substring( 0, i );
-    }
-
-    public static String toJavaCasing(final String pName) {
-        final char[] name = pName.toLowerCase().toCharArray();
-        name[0] = Character.toUpperCase( name[0] );
-        return new String( name );
-    }
-
-    public static String clazzName(final File base,
-                                   final File file) {
-        final int rootLength = base.getAbsolutePath().length();
-        final String absFileName = file.getAbsolutePath();
-        final int p = absFileName.lastIndexOf('.');
-        final String relFileName = absFileName.substring(rootLength + 1, p);
-        return relFileName.replace(File.separatorChar, '.');
     }
 
     public static String relative(final File base,

--- a/drools-core/src/main/java/org/drools/core/util/ConfFileUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/ConfFileUtils.java
@@ -24,6 +24,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
 public class ConfFileUtils {
    
     /**
@@ -36,8 +38,8 @@ public class ConfFileUtils {
         URL url = null;
         
         // User home 
-        String userHome = System.getProperty( "user.home" );
-        if ( userHome.endsWith( "\\" ) || userHome.endsWith( "/" ) ) {
+        String userHome = normalizePath( System.getProperty( "user.home" ) );
+        if ( userHome.endsWith( "/" ) ) {
             url = getURLForFile( userHome + confName );
         } else {
             url = getURLForFile( userHome + "/" + confName );

--- a/drools-ecj/src/main/java/org/drools/ecj/EclipseJavaCompiler.java
+++ b/drools-ecj/src/main/java/org/drools/ecj/EclipseJavaCompiler.java
@@ -48,6 +48,8 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
 /**
  * Eclipse compiler implementation
  */
@@ -167,7 +169,7 @@ public final class EclipseJavaCompiler extends AbstractJavaCompiler {
 
         final ICompilationUnit[] compilationUnits = new ICompilationUnit[pSourceFiles.length];
         for (int i = 0; i < compilationUnits.length; i++) {
-            final String sourceFile = pSourceFiles[i];
+            final String sourceFile = normalizePath(pSourceFiles[i]);
 
             if (pReader.isAvailable(sourceFile)) {
                 compilationUnits[i] = new CompilationUnit(pReader, sourceFile);

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/main/java/org/drools/impact/analysis/graph/graphviz/GraphImageGenerator.java
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/src/main/java/org/drools/impact/analysis/graph/graphviz/GraphImageGenerator.java
@@ -42,12 +42,13 @@ import org.slf4j.LoggerFactory;
 import static guru.nidi.graphviz.model.Factory.graph;
 import static guru.nidi.graphviz.model.Factory.node;
 import static guru.nidi.graphviz.model.Factory.to;
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 public class GraphImageGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(GraphImageGenerator.class);
 
-    private static final String DEFAULT_OUTPUT_DIR = "target" + File.separator + "graph-output";
+    private static final String DEFAULT_OUTPUT_DIR = "target/graph-output";
 
     private String graphName;
     private int width = 0; // when 0, auto-sized
@@ -87,7 +88,7 @@ public class GraphImageGenerator {
     }
 
     public void setOutputDir(String outputDir) {
-        this.outputDir = outputDir;
+        this.outputDir = normalizePath(outputDir);
     }
 
     public int getWidth() {
@@ -163,7 +164,7 @@ public class GraphImageGenerator {
         guru.nidi.graphviz.model.Graph graph = convertGraph(g);
 
         try {
-            String filePath = outputDir + File.separator + graphName + ".dot";
+            String filePath = outputDir + "/" + graphName + ".dot";
             Graphviz.fromGraph(graph).totalMemory(totalMemory).width(width).height(height).render(Format.DOT).toFile(new File(filePath));
             logger.info("--- Graph dot format is generated to " + filePath);
         } catch (IOException e) {
@@ -175,7 +176,7 @@ public class GraphImageGenerator {
         guru.nidi.graphviz.model.Graph graph = convertGraph(g);
 
         try {
-            String filePath = outputDir + File.separator + graphName + ".png";
+            String filePath = outputDir + "/" + graphName + ".png";
             Graphviz.fromGraph(graph).totalMemory(totalMemory).width(width).height(height).render(Format.PNG).toFile(new File(filePath));
             logger.info("--- Graph png image is generated to " + filePath);
         } catch (IOException e) {
@@ -187,7 +188,7 @@ public class GraphImageGenerator {
         guru.nidi.graphviz.model.Graph graph = convertGraph(g);
 
         try {
-            String filePath = outputDir + File.separator + graphName + ".svg";
+            String filePath = outputDir + "/" + graphName + ".svg";
             Graphviz.fromGraph(graph).totalMemory(totalMemory).width(width).height(height).render(Format.SVG).toFile(new File(filePath));
             logger.info("--- Graph svg image is generated to " + filePath);
         } catch (IOException e) {

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/GeneratedFile.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/GeneratedFile.java
@@ -19,6 +19,8 @@ package org.drools.modelcompiler.builder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
 public class GeneratedFile {
 
     public enum Type {
@@ -54,7 +56,7 @@ public class GeneratedFile {
 
     private GeneratedFile(Type type, String path, byte[] data) {
         this.type = type;
-        this.path = path;
+        this.path = normalizePath(path);
         this.data = data;
     }
 

--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/benchmark/BenchmarkUtil.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/benchmark/BenchmarkUtil.java
@@ -43,7 +43,7 @@ public final class BenchmarkUtil {
     }
 
     private static void writeDomainModelToKJar(final KieServices kieServices, final KieFileSystem kieFileSystem) {
-        final String javaSrc = Person.class.getCanonicalName().replace( '.', File.separatorChar ) + ".java";
+        final String javaSrc = Person.class.getCanonicalName().replace( '.', '/' ) + ".java";
         final Resource javaResource = kieServices.getResources().newFileSystemResource("src/test/java/" + javaSrc);
         kieFileSystem.write("src/main/java/" + javaSrc, javaResource);
     }

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Field.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/components/Field.java
@@ -20,6 +20,8 @@ import org.drools.compiler.lang.descr.BaseDescr;
 import org.drools.verifier.data.VerifierComponent;
 import org.drools.verifier.report.components.Cause;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
 public class Field extends VerifierComponent<BaseDescr>
     implements
     Cause {
@@ -45,9 +47,7 @@ public class Field extends VerifierComponent<BaseDescr>
     
     @Override
     public String getPath() {
-        return String.format( "%s/field[@name='%s']",
-                              getObjectTypePath(),
-                              getName() );
+        return normalizePath( String.format( "%s/field[@name='%s']", getObjectTypePath(), getName() ) );
     }
 
     public VerifierComponentType getVerifierComponentType() {

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/HTMLReportWriter.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/HTMLReportWriter.java
@@ -16,7 +16,6 @@
 
 package org.drools.verifier.report.html;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.zip.ZipOutputStream;
@@ -44,21 +43,21 @@ public class HTMLReportWriter extends ReportModeller
 
         // Base files
         // index.htm
-        writeToFile( UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.HTML_FILE_INDEX,
+        writeToFile( UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.HTML_FILE_INDEX,
                      formPage( UrlFactory.THIS_FOLDER,
                                ComponentsReportVisitor.visitObjectTypeCollection( UrlFactory.THIS_FOLDER,
                                                                                   data.<ObjectType> getAll( VerifierComponentType.OBJECT_TYPE ) ) ) );
 
         // packages.htm
-        writeToFile( UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.HTML_FILE_PACKAGES,
+        writeToFile( UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.HTML_FILE_PACKAGES,
                      formPage( UrlFactory.THIS_FOLDER,
                                ComponentsReportVisitor.visitRulePackageCollection( UrlFactory.THIS_FOLDER,
                                                                                    data.<RulePackage> getAll( VerifierComponentType.RULE_PACKAGE ) ) ) );
 
         // Rules
-        String ruleFolder = UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.RULE_FOLDER;
+        String ruleFolder = UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.RULE_FOLDER;
         for ( VerifierRule rule : data.<VerifierRule> getAll( VerifierComponentType.RULE ) ) {
-            writeToFile( ruleFolder + File.separator + rule.getPath() + ".htm",
+            writeToFile( ruleFolder + "/" + rule.getPath() + ".htm",
                          formPage( UrlFactory.PREVIOUS_FOLDER,
                                    ComponentsReportVisitor.visitRule( UrlFactory.PREVIOUS_FOLDER,
                                                                       rule,
@@ -66,9 +65,9 @@ public class HTMLReportWriter extends ReportModeller
         }
 
         // ObjectTypes
-        String objectTypeFolder = UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.OBJECT_TYPE_FOLDER;
+        String objectTypeFolder = UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.OBJECT_TYPE_FOLDER;
         for ( ObjectType objectType : data.<ObjectType> getAll( VerifierComponentType.OBJECT_TYPE ) ) {
-            writeToFile( objectTypeFolder + File.separator + objectType.getPath() + ".htm",
+            writeToFile( objectTypeFolder + "/" + objectType.getPath() + ".htm",
                          formPage( UrlFactory.PREVIOUS_FOLDER,
                                    ComponentsReportVisitor.visitObjectType( UrlFactory.PREVIOUS_FOLDER,
                                                                             objectType,
@@ -76,9 +75,9 @@ public class HTMLReportWriter extends ReportModeller
         }
 
         // Fields
-        String fieldFolder = UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.FIELD_FOLDER;
+        String fieldFolder = UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.FIELD_FOLDER;
         for ( Field field : data.<Field> getAll( VerifierComponentType.FIELD ) ) {
-            writeToFile( fieldFolder + File.separator + field.getPath() + ".htm",
+            writeToFile( fieldFolder + "/" + field.getPath() + ".htm",
                          formPage( UrlFactory.PREVIOUS_FOLDER,
                                    ComponentsReportVisitor.visitField( UrlFactory.PREVIOUS_FOLDER,
                                                                        field,
@@ -89,12 +88,12 @@ public class HTMLReportWriter extends ReportModeller
         writeMessages( result );
 
         // css files
-        String cssFolder = UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.CSS_FOLDER;
-        writeToFile( cssFolder + File.separator + UrlFactory.CSS_BASIC,
+        String cssFolder = UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.CSS_FOLDER;
+        writeToFile( cssFolder + "/" + UrlFactory.CSS_BASIC,
                      ComponentsReportVisitor.getCss( UrlFactory.CSS_BASIC ) );
 
         // Image files
-        String imagesFolder = UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.IMAGES_FOLDER;
+        String imagesFolder = UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.IMAGES_FOLDER;
 
         copyFile( imagesFolder,
                   "hdrlogo_drools50px.gif" );
@@ -117,7 +116,7 @@ public class HTMLReportWriter extends ReportModeller
                                                                                 result.getBySeverity( Severity.NOTE ),
                                                                                 data );
 
-        writeToFile( UrlFactory.SOURCE_FOLDER + File.separator + UrlFactory.HTML_FILE_VERIFIER_MESSAGES,
+        writeToFile( UrlFactory.SOURCE_FOLDER + "/" + UrlFactory.HTML_FILE_VERIFIER_MESSAGES,
                      formPage( UrlFactory.THIS_FOLDER,
                                errors + warnings + notes ) );
     }

--- a/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ReportModeller.java
+++ b/drools-verifier/drools-verifier-drl/src/main/java/org/drools/verifier/report/html/ReportModeller.java
@@ -17,7 +17,6 @@
 package org.drools.verifier.report.html;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -52,7 +51,7 @@ abstract class ReportModeller {
 
     public void copyFile(String destination,
                          String filename) throws IOException {
-        zout.putNextEntry( new JarEntry( destination + File.separator + filename ) );
+        zout.putNextEntry( new JarEntry( destination + "/" + filename ) );
 
         InputStream in = HTMLReportWriter.class.getResourceAsStream( filename );
 

--- a/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelperImpl.java
+++ b/kie-ci/src/main/java/org/kie/api/builder/helper/KieModuleDeploymentHelperImpl.java
@@ -494,7 +494,7 @@ final class KieModuleDeploymentHelperImpl extends FluentKieModuleDeploymentHelpe
                 try {
                     kjarResources.addAll(internalLoadResources(filePath, false));
                 } catch (FileNotFoundException fnfe) {
-                    throw new RuntimeException("No file found at '" + filePath + "' -- if it's a directory, please add a " + File.separator + " to the end of the path.");
+                    throw new RuntimeException("No file found at '" + filePath + "' -- if it's a directory, please add a / to the end of the path.");
                 } catch (Exception e) {
                     throw new RuntimeException("Unable to load resource from '" + filePath + "'", e);
                 }

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompiler.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/jdknative/NativeJavaCompiler.java
@@ -57,6 +57,8 @@ import org.kie.memorycompiler.StoreClassLoader;
 import org.kie.memorycompiler.resources.ResourceReader;
 import org.kie.memorycompiler.resources.ResourceStore;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
+
 public class NativeJavaCompiler extends AbstractJavaCompiler {
 
     public JavaCompilerSettings createDefaultSettings() {
@@ -78,7 +80,7 @@ public class NativeJavaCompiler extends AbstractJavaCompiler {
         try (StandardJavaFileManager jFileManager = compiler.getStandardFileManager(diagnostics, null, null)) {
             try {
                 jFileManager.setLocation( StandardLocation.CLASS_PATH, pSettings.getClasspathLocations() );
-                jFileManager.setLocation( StandardLocation.CLASS_OUTPUT, Collections.singletonList(new File("target" + File.separator + "classes")) );
+                jFileManager.setLocation( StandardLocation.CLASS_OUTPUT, Collections.singletonList(new File("target/classes")) );
             } catch (IOException e) {
                 // ignore if cannot set the classpath
             }
@@ -86,7 +88,7 @@ public class NativeJavaCompiler extends AbstractJavaCompiler {
             try (MemoryFileManager fileManager = new MemoryFileManager( jFileManager, pClassLoader )) {
                 final List<JavaFileObject> units = new ArrayList<JavaFileObject>();
                 for (final String sourcePath : pResourcePaths) {
-                    units.add( new CompilationUnit( sourcePath, pReader ) );
+                    units.add( new CompilationUnit( normalizePath(sourcePath), pReader ) );
                 }
 
                 Iterable<String> options = new NativeJavaCompilerSettings( pSettings ).toOptionsList();

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/MemoryResourceReader.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/MemoryResourceReader.java
@@ -15,68 +15,57 @@
 package org.kie.memorycompiler.resources;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 
 /**
  * A memory based reader to compile from memory
  */
 public class MemoryResourceReader implements ResourceReader {
     
-    private Map<String, byte[]> resources = new ConcurrentHashMap<>();
+    private final Map<String, byte[]> resources = new ConcurrentHashMap<>();
 
     private Set<String> modifiedResourcesSinceLastMark;
 
-    public boolean isAvailable( final String pResourceName ) {
-        if (resources == null) {
-            return false;
-        }
-
-        return resources.containsKey(pResourceName);
+    public boolean isAvailable( final String resourceName ) {
+        return resources.containsKey(normalizePath(resourceName));
     }
     
-    public void add( final String pResourceName, final byte[] pContent ) {
-        resources.put(pResourceName, pContent);
+    public void add( final String resourceName, final byte[] pContent ) {
+        String normalizedName = normalizePath(resourceName);
+        resources.put(normalizedName, pContent);
         if (modifiedResourcesSinceLastMark != null) {
-            modifiedResourcesSinceLastMark.add(pResourceName);
+            modifiedResourcesSinceLastMark.add(normalizedName);
         }
     }
     
-    public void remove( final String pResourceName ) {
-        if (resources != null) {
-            resources.remove(pResourceName);
-        }
+    public void remove( final String resourceName ) {
+        resources.remove(normalizePath(resourceName));
     }
 
     public void mark() {
-        modifiedResourcesSinceLastMark = new HashSet<String>();
+        modifiedResourcesSinceLastMark = new HashSet<>();
     }
 
     public Collection<String> getModifiedResourcesSinceLastMark() {
         return modifiedResourcesSinceLastMark;
     }
 
-    public byte[] getBytes( final String pResourceName ) {
-        return (byte[]) resources.get(pResourceName);
+    public byte[] getBytes( final String resourceName ) {
+        return resources.get(normalizePath(resourceName));
     }
 
     public Collection<String> getFileNames() {
-        if ( resources == null ) {
-            return Collections.emptySet();
-        }
-        
-        return resources.keySet();       
+        return resources.keySet();
     }
     /**
      * @deprecated
      */
     public String[] list() {
-        if (resources == null) {
-            return new String[0];
-        }
-        return (String[]) resources.keySet().toArray(new String[resources.size()]);
+        return resources.keySet().toArray(new String[resources.size()]);
     }
 }

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/PathUtils.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/PathUtils.java
@@ -21,7 +21,7 @@ public class PathUtils {
     private static final boolean IS_WINDOWS_SEPARATOR = File.separatorChar == '\\';
 
     public static String normalizePath(String s) {
-        return IS_WINDOWS_SEPARATOR ? s.replace('\\', '/') : s;
+        return IS_WINDOWS_SEPARATOR && s != null ? s.replace('\\', '/') : s;
     }
 
 }

--- a/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/PathUtils.java
+++ b/kie-memory-compiler/src/main/java/org/kie/memorycompiler/resources/PathUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021. Red Hat, Inc. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.memorycompiler.resources;
+
+import java.io.File;
+
+public class PathUtils {
+
+    private static final boolean IS_WINDOWS_SEPARATOR = File.separatorChar == '\\';
+
+    public static String normalizePath(String s) {
+        return IS_WINDOWS_SEPARATOR ? s.replace('\\', '/') : s;
+    }
+
+}

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLCompilerService.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLCompilerService.java
@@ -15,7 +15,6 @@
  */
 package org.kie.pmml.evaluator.assembler.service;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,6 +36,7 @@ import org.kie.pmml.evaluator.assembler.factories.PMMLRuleMapperFactory;
 import org.kie.pmml.evaluator.assembler.factories.PMMLRuleMappersFactory;
 import org.kie.pmml.evaluator.assembler.implementations.HasKnowledgeBuilderImpl;
 
+import static org.kie.memorycompiler.resources.PathUtils.normalizePath;
 import static org.kie.pmml.evaluator.assembler.factories.PMMLRuleMapperFactory.KIE_PMML_RULE_MAPPER_CLASS_NAME;
 import static org.kie.pmml.evaluator.assembler.factories.PMMLRuleMappersFactory.KIE_PMML_RULE_MAPPERS_CLASS_NAME;
 import static org.kie.pmml.evaluator.assembler.service.PMMLAssemblerService.PMML_COMPILER_CACHE_KEY;
@@ -181,10 +181,8 @@ public class PMMLCompilerService {
     }
 
     static String getFileName(final String fullPath) {
-        String toReturn = fullPath;
-        if (fullPath.contains(File.separator)) {
-            toReturn = fullPath.substring(fullPath.lastIndexOf(File.separator) + 1);
-        } else if (fullPath.contains("/")) {
+        String toReturn = normalizePath(fullPath);
+        if (fullPath.contains("/")) {
             toReturn = fullPath.substring(fullPath.lastIndexOf('/') + 1);
         }
         return toReturn;

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLCompilerService.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/main/java/org/kie/pmml/evaluator/assembler/service/PMMLCompilerService.java
@@ -182,8 +182,8 @@ public class PMMLCompilerService {
 
     static String getFileName(final String fullPath) {
         String toReturn = normalizePath(fullPath);
-        if (fullPath.contains("/")) {
-            toReturn = fullPath.substring(fullPath.lastIndexOf('/') + 1);
+        if (toReturn.contains("/")) {
+            toReturn = toReturn.substring(toReturn.lastIndexOf('/') + 1);
         }
         return toReturn;
     }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/provider/DroolsModelProvider.java
@@ -15,7 +15,6 @@
  */
 package org.kie.pmml.models.drools.provider;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,7 +55,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.toList;
-
 import static org.drools.core.util.StringUtils.getPkgUUID;
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedClassName;
 import static org.kie.pmml.models.drools.commons.factories.KiePMMLDescrFactory.getBaseDescr;
@@ -212,8 +210,7 @@ public abstract class DroolsModelProvider<T extends Model, E extends KiePMMLDroo
         List<GeneratedFile> generatedRuleFiles = generateRulesFiles(packageDescr);
         return generatedRuleFiles.stream()
                 .collect(Collectors.toMap(generatedFile -> generatedFile.getPath()
-                                                  .replace(File.separatorChar, '.')
-                                                  .replace('/', '.') // some drools path are hardcoded to "/"
+                                                  .replace('/', '.')
                                                   .replace(".java", ""),
                                           generatedFile -> new String(generatedFile.getData())));
     }

--- a/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
+++ b/kie-pmml/src/main/java/org/kie/pmml/pmml_4_2/PMML4Compiler.java
@@ -16,7 +16,6 @@
 
 package org.kie.pmml.pmml_4_2;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -484,7 +482,7 @@ public class PMML4Compiler {
 
         if (resource.getSourcePath() != null) {
             String originalPath = resource.getSourcePath();
-            int start = originalPath.lastIndexOf(File.separator);
+            int start = originalPath.lastIndexOf('/');
             byteArrayResource.setSourcePath("generated-sources/" + originalPath.substring(start) + ".pmml");
         } else {
             byteArrayResource.setSourcePath("generated-sources/" + helper.getContext() + ".pmml");

--- a/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/global/HeaderTest.java
+++ b/kie-pmml/src/test/java/org/kie/pmml/pmml_4_2/global/HeaderTest.java
@@ -18,7 +18,6 @@ package org.kie.pmml.pmml_4_2.global;
 
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 
@@ -43,7 +42,7 @@ public class HeaderTest extends DroolsAbstractPMMLTest {
 
     @Test
     public void testPMMLHeader() {
-        String source = PMML4Helper.pmmlDefaultPackageName().replace( ".", File.separator ) + File.separator + "test_header.xml";
+        String source = PMML4Helper.pmmlDefaultPackageName().replace( '.', '/' ) + "/" + "test_header.xml";
 
         boolean header = false;
         boolean timestamp = false;


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6530

Follows: https://github.com/kiegroup/drools/pull/3822#issuecomment-915839015