### PR TITLE
[DROOLS-6594] Manage OutputField with PROBABILITY in common place

### DIFF
--- a/kie-pmml-trusty/Release.md
+++ b/kie-pmml-trusty/Release.md
@@ -31,6 +31,15 @@ Currently known limitations:
 Transformations
 ===============
 
+rel 7.60.0
+----------
+Implemented overall functionality
+
+Currently known limitations:
+
+1. Only _Aggregation_ and _Lag_ not implemented
+
+
 rel 7.41.0
 ----------
 Implemented basic functionality
@@ -55,6 +64,12 @@ Currently known limitations:
 
 Tree model implementation status
 ================================
+
+rel 7.60.0
+----------
+Currently known limitation:
+
+1. _ScoreDistribution_ and probability evaluation available only in codegen (not-drools) implementation
 
 rel 7.36.0
 ----------

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLValidationException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLValidationException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.api.exceptions;
+
+public class KiePMMLValidationException extends KiePMMLException {
+
+    public KiePMMLValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public KiePMMLValidationException(Throwable cause) {
+        super(cause);
+    }
+
+    public KiePMMLValidationException(String message) {
+        super(message);
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLFactoryModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLFactoryModel.java
@@ -16,6 +16,7 @@
 package org.kie.pmml.commons.model;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.kie.pmml.api.exceptions.KiePMMLException;
@@ -27,6 +28,7 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
  */
 public class KiePMMLFactoryModel extends KiePMMLModel implements HasSourcesMap {
 
+    private static final long serialVersionUID = 1654176510018808424L;
     private final String kmodulePackageName;
     protected Map<String, String> sourcesMap;
 
@@ -43,6 +45,11 @@ public class KiePMMLFactoryModel extends KiePMMLModel implements HasSourcesMap {
 
     @Override
     public Map<String, Object> getOutputFieldsMap() {
+        throw new KiePMMLException("KiePMMLFactoryModel is not meant to be used for actual usage");
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
         throw new KiePMMLException("KiePMMLFactoryModel is not meant to be used for actual usage");
     }
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
@@ -131,7 +131,7 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
 
     public Map<String, Double> getProbabilityMap() {
         final LinkedHashMap<String, Double> probabilityResultMap = getProbabilityResultMap();
-        return probabilityResultMap != null  ? Collections.unmodifiableMap(getFixedProbabilityMap(probabilityResultMap)) : Collections.emptyMap();
+        return probabilityResultMap != null ? Collections.unmodifiableMap(getFixedProbabilityMap(probabilityResultMap)) : Collections.emptyMap();
     }
 
     public Object getPredictedDisplayValue() {
@@ -173,7 +173,7 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
      */
     protected abstract LinkedHashMap<String, Double> getProbabilityResultMap();
 
-    private LinkedHashMap<String, Double> getFixedProbabilityMap(final LinkedHashMap<String, Double> probabilityResultMap) {
+    private static LinkedHashMap<String, Double> getFixedProbabilityMap(final LinkedHashMap<String, Double> probabilityResultMap) {
         LinkedHashMap<String, Double> toReturn = new LinkedHashMap<>();
         String[] resultMapKeys = probabilityResultMap.keySet().toArray(new String[0]);
         AtomicReference<Double> sumCounter = new AtomicReference<>(0.0);

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
@@ -18,8 +18,10 @@ package org.kie.pmml.commons.model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.kie.pmml.api.enums.MINING_FUNCTION;
@@ -127,6 +129,11 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
         return localTransformations;
     }
 
+    public Map<String, Double> getProbabilityMap() {
+        final LinkedHashMap<String, Double> probabilityResultMap = getProbabilityResultMap();
+        return probabilityResultMap != null  ? Collections.unmodifiableMap(getFixedProbabilityMap(probabilityResultMap)) : Collections.emptyMap();
+    }
+
     public Object getPredictedDisplayValue() {
         return predictedDisplayValue;
     }
@@ -159,6 +166,30 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
      * @return
      */
     public abstract Object evaluate(final Object knowledgeBase, final Map<String, Object> requestData);
+
+    /**
+     * Returns the <b>probability map</b> evaluated by the model
+     * @return
+     */
+    protected abstract LinkedHashMap<String, Double> getProbabilityResultMap();
+
+    private LinkedHashMap<String, Double> getFixedProbabilityMap(final LinkedHashMap<String, Double> probabilityResultMap) {
+        LinkedHashMap<String, Double> toReturn = new LinkedHashMap<>();
+        String[] resultMapKeys = probabilityResultMap.keySet().toArray(new String[0]);
+        AtomicReference<Double> sumCounter = new AtomicReference<>(0.0);
+        for (int i = 0; i < probabilityResultMap.size(); i++) {
+            String key = resultMapKeys[i];
+            double value = probabilityResultMap.get(key);
+            if (i < resultMapKeys.length - 1) {
+                sumCounter.accumulateAndGet(value, Double::sum);
+                toReturn.put(key, value);
+            } else {
+                // last element
+                toReturn.put(key, 1 - sumCounter.get());
+            }
+        }
+        return toReturn;
+    }
 
     public abstract static class Builder<T extends KiePMMLModel> extends AbstractKiePMMLComponent.Builder<T> {
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLOutputField.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLOutputField.java
@@ -90,6 +90,8 @@ public class KiePMMLOutputField extends AbstractKiePMMLComponent {
         switch (resultFeature) {
             case PREDICTED_VALUE:
                 return evaluatePredictedValue(processingDTO);
+            case PROBABILITY:
+                return evaluateProbabilityValue(processingDTO);
             case REASON_CODE:
                 return evaluateReasonCodeValue(processingDTO);
             case TRANSFORMED_VALUE:
@@ -112,6 +114,10 @@ public class KiePMMLOutputField extends AbstractKiePMMLComponent {
     public Object evaluatePredictedValue(final ProcessingDTO processingDTO) {
         return commonEvaluate(getValueFromKiePMMLNameValuesByVariableName(targetField, processingDTO.getKiePMMLNameValues())
                                       .orElse(null), dataType);
+    }
+
+    public Object evaluateProbabilityValue(final ProcessingDTO processingDTO) {
+        return processingDTO.getProbabilityMap() != null ? processingDTO.getProbabilityMap().get(value) : null;
     }
 
     public Object evaluateReasonCodeValue(final ProcessingDTO processingDTO) {

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLOutputField.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLOutputField.java
@@ -26,6 +26,8 @@ import org.kie.pmml.api.enums.RESULT_FEATURE;
 import org.kie.pmml.commons.model.abstracts.AbstractKiePMMLComponent;
 import org.kie.pmml.commons.model.expressions.KiePMMLExpression;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.kie.pmml.commons.utils.KiePMMLModelUtils.commonEvaluate;
 
@@ -34,6 +36,7 @@ import static org.kie.pmml.commons.utils.KiePMMLModelUtils.commonEvaluate;
  */
 public class KiePMMLOutputField extends AbstractKiePMMLComponent {
 
+    private static final Logger logger = LoggerFactory.getLogger(KiePMMLOutputField.class);
     private static final long serialVersionUID = 2408750585433339543L;
     private RESULT_FEATURE resultFeature = RESULT_FEATURE.PREDICTED_VALUE;
     private String targetField = null;
@@ -91,7 +94,17 @@ public class KiePMMLOutputField extends AbstractKiePMMLComponent {
                 return evaluateReasonCodeValue(processingDTO);
             case TRANSFORMED_VALUE:
                 return evaluateTransformedValue(processingDTO);
+            case PREDICTED_DISPLAY_VALUE:
+                return processingDTO.getPredictedDisplayValue();
+            case ENTITY_ID:
+            case CLUSTER_ID:
+                return processingDTO.getEntityId();
+            case AFFINITY:
+            case ENTITY_AFFINITY:
+            case CLUSTER_AFFINITY:
+                return processingDTO.getAffinity();
             default:
+                logger.warn("OutputField with feature \"{}\" is currently not implemented and will be ignored.", resultFeature.getName());
                 return null;
         }
     }

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/ProcessingDTO.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/ProcessingDTO.java
@@ -17,7 +17,9 @@ package org.kie.pmml.commons.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.kie.pmml.api.models.MiningField;
 import org.kie.pmml.commons.model.tuples.KiePMMLNameValue;
@@ -40,6 +42,7 @@ public class ProcessingDTO {
     private Object predictedDisplayValue;
     private Object entityId;
     private Object affinity;
+    private Map<String, Double> probabilityMap;
 
     /**
      *
@@ -68,6 +71,7 @@ public class ProcessingDTO {
         this.predictedDisplayValue = model.getPredictedDisplayValue();
         this.entityId = model.getEntityId();
         this.affinity = model.getAffinity();
+        this.probabilityMap = model.getProbabilityMap();
     }
 
     /**
@@ -97,6 +101,7 @@ public class ProcessingDTO {
         this.predictedDisplayValue = null;
         this.entityId = null;
         this.affinity = null;
+        this.probabilityMap = new LinkedHashMap<>();
     }
 
     public List<KiePMMLDefineFunction> getDefineFunctions() {
@@ -164,5 +169,13 @@ public class ProcessingDTO {
 
     public void setAffinity(Object affinity) {
         this.affinity = affinity;
+    }
+
+    public Map<String, Double> getProbabilityMap() {
+        return probabilityMap;
+    }
+
+    public void setProbabilityMap(Map<String, Double> probabilityMap) {
+        this.probabilityMap = probabilityMap;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/ProcessingDTO.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/ProcessingDTO.java
@@ -37,6 +37,9 @@ public class ProcessingDTO {
     private final List<KiePMMLNameValue> kiePMMLNameValues;
     private final List<String> orderedReasonCodes;
     private final List<MiningField> miningFields;
+    private Object predictedDisplayValue;
+    private Object entityId;
+    private Object affinity;
 
     /**
      *
@@ -62,6 +65,9 @@ public class ProcessingDTO {
         this.kiePMMLNameValues = kiePMMLNameValues;
         this.orderedReasonCodes = new ArrayList<>();
         this.miningFields = model.getMiningFields();
+        this.predictedDisplayValue = model.getPredictedDisplayValue();
+        this.entityId = model.getEntityId();
+        this.affinity = model.getAffinity();
     }
 
     /**
@@ -88,6 +94,9 @@ public class ProcessingDTO {
         this.miningFields =  miningFields;
         this.kiePMMLNameValues = kiePMMLNameValues;
         this.orderedReasonCodes = orderedReasonCodes;
+        this.predictedDisplayValue = null;
+        this.entityId = null;
+        this.affinity = null;
     }
 
     public List<KiePMMLDefineFunction> getDefineFunctions() {
@@ -131,5 +140,29 @@ public class ProcessingDTO {
 
     public List<MiningField> getMiningFields() {
         return Collections.unmodifiableList(miningFields);
+    }
+
+    public Object getPredictedDisplayValue() {
+        return predictedDisplayValue;
+    }
+
+    public void setPredictedDisplayValue(Object predictedDisplayValue) {
+        this.predictedDisplayValue = predictedDisplayValue;
+    }
+
+    public Object getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(Object entityId) {
+        this.entityId = entityId;
+    }
+
+    public Object getAffinity() {
+        return affinity;
+    }
+
+    public void setAffinity(Object affinity) {
+        this.affinity = affinity;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameOpType.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameOpType.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import org.kie.pmml.api.enums.OP_TYPE;
 
 /**
- * Class to represent a <b>name/operation type</b> tupla
+ * Class to represent a <b>name/operation type</b> tuple
  */
 public class KiePMMLNameOpType {
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameValue.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLNameValue.java
@@ -18,7 +18,7 @@ package org.kie.pmml.commons.model.tuples;
 import java.util.Objects;
 
 /**
- * Class to represent a <b>name/value (object)</b> tupla
+ * Class to represent a <b>name/value (object)</b> tuple
  */
 public class KiePMMLNameValue {
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLProbabilityConfidence.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLProbabilityConfidence.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.commons.model.tuples;
+
+/**
+ * Class to represent a <b>probability/confidence</b> tuple
+ */
+public class KiePMMLProbabilityConfidence {
+
+    private final double probability;
+    private final double confidence;
+
+    public KiePMMLProbabilityConfidence(double probability, double confidence) {
+        this.probability = probability;
+        this.confidence = confidence;
+    }
+
+    public double getProbability() {
+        return probability;
+    }
+
+    public double getConfidence() {
+        return confidence;
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLValueWeight.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/tuples/KiePMMLValueWeight.java
@@ -18,7 +18,7 @@ package org.kie.pmml.commons.model.tuples;
 import java.util.Objects;
 
 /**
- * Class to represent a <b>Object/Weight (double)</b> tupla
+ * Class to represent a <b>Object/Weight (double)</b> tuple
  */
 public class KiePMMLValueWeight {
 

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModel.java
@@ -15,11 +15,13 @@
  */
 package org.kie.pmml.commons.testingutility;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.kie.pmml.api.enums.MINING_FUNCTION;
 import org.kie.pmml.api.enums.PMML_MODEL;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.KiePMMLExtension;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.KiePMMLOutputField;
@@ -32,46 +34,51 @@ import org.kie.pmml.commons.transformations.KiePMMLTransformationDictionary;
  */
 public class KiePMMLTestingModel extends KiePMMLModel {
 
-        public static PMML_MODEL PMML_MODEL_TYPE = PMML_MODEL.TEST_MODEL;
-        private static final long serialVersionUID = 9009765353822151536L;
+    private static final long serialVersionUID = 9009765353822151536L;
+    public static PMML_MODEL PMML_MODEL_TYPE = PMML_MODEL.TEST_MODEL;
 
-        public KiePMMLTestingModel(String name, List<KiePMMLExtension> extensions) {
-            super(name, extensions);
+    public KiePMMLTestingModel(String name, List<KiePMMLExtension> extensions) {
+        super(name, extensions);
+    }
+
+    public static Builder builder(String name, List<KiePMMLExtension> extensions, MINING_FUNCTION miningFunction) {
+        return new Builder(name, extensions, miningFunction);
+    }
+
+    @Override
+    public Object evaluate(final Object knowledgeBase, Map<String, Object> requestData) {
+        return null;
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return null;
+    }
+
+    public static class Builder extends KiePMMLModel.Builder<KiePMMLTestingModel> {
+
+        private Builder(String name, List<KiePMMLExtension> extensions, MINING_FUNCTION miningFunction) {
+            super("TestingModel-", PMML_MODEL_TYPE, miningFunction, () -> new KiePMMLTestingModel(name, extensions));
         }
 
-        public static Builder builder(String name, List<KiePMMLExtension> extensions, MINING_FUNCTION miningFunction) {
-            return new Builder(name, extensions, miningFunction);
+        public Builder withKiePMMLOutputFields(List<KiePMMLOutputField> kiePMMLOutputFields) {
+            toBuild.kiePMMLOutputFields = kiePMMLOutputFields;
+            return this;
         }
 
-        @Override
-        public Object evaluate(final Object knowledgeBase, Map<String, Object> requestData) {
-            return null;
+        public Builder withKiePMMLTargets(List<KiePMMLTarget> kiePMMLTargets) {
+            toBuild.kiePMMLTargets = kiePMMLTargets;
+            return this;
         }
 
-        public static class Builder extends KiePMMLModel.Builder<KiePMMLTestingModel> {
+        public Builder withTransformationDictionary(final KiePMMLTransformationDictionary transformationDictionary) {
+            toBuild.transformationDictionary = transformationDictionary;
+            return this;
+        }
 
-            private Builder(String name, List<KiePMMLExtension> extensions, MINING_FUNCTION miningFunction) {
-                super("TestingModel-", PMML_MODEL_TYPE, miningFunction, () -> new KiePMMLTestingModel(name, extensions));
-            }
-
-            public Builder withKiePMMLOutputFields(List<KiePMMLOutputField> kiePMMLOutputFields) {
-                toBuild.kiePMMLOutputFields = kiePMMLOutputFields;
-                return this;
-            }
-
-            public Builder withKiePMMLTargets(List<KiePMMLTarget> kiePMMLTargets) {
-                toBuild.kiePMMLTargets = kiePMMLTargets;
-                return this;
-            }
-
-            public Builder withTransformationDictionary(final KiePMMLTransformationDictionary transformationDictionary) {
-                toBuild.transformationDictionary = transformationDictionary;
-                return this;
-            }
-
-            public Builder withLocalTransformations(final KiePMMLLocalTransformations localTransformations) {
-                toBuild.localTransformations = localTransformations;
-                return this;
-            }
+        public Builder withLocalTransformations(final KiePMMLLocalTransformations localTransformations) {
+            toBuild.localTransformations = localTransformations;
+            return this;
         }
     }
+}

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/PMMLModelTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/testutils/PMMLModelTestUtils.java
@@ -39,6 +39,7 @@ import org.dmg.pmml.OutputField;
 import org.dmg.pmml.PMML;
 import org.dmg.pmml.ParameterField;
 import org.dmg.pmml.ResultFeature;
+import org.dmg.pmml.ScoreDistribution;
 import org.dmg.pmml.SimplePredicate;
 import org.dmg.pmml.SimpleSetPredicate;
 import org.dmg.pmml.Target;
@@ -77,8 +78,7 @@ public class PMMLModelTestUtils {
     }
 
     public static TransformationDictionary getTransformationDictionary() {
-        TransformationDictionary toReturn = new TransformationDictionary();
-        return toReturn;
+        return new TransformationDictionary();
     }
 
     public static MiningSchema getMiningSchema(List<MiningField> miningFields) {
@@ -391,6 +391,23 @@ public class PMMLModelTestUtils {
         final SimpleSetPredicate.BooleanOperator[] values = SimpleSetPredicate.BooleanOperator.values();
         int rndIndex = new Random().nextInt(values.length);
         return values[rndIndex];
+    }
+
+    public static List<ScoreDistribution> getRandomPMMLScoreDistributions(boolean withProbability) {
+        List<Double> probabilities = withProbability ? Arrays.asList(0.1, 0.3, 0.6) : Arrays.asList(null, null, null);
+        return IntStream.range(0, 3)
+                .mapToObj(i -> getRandomPMMLScoreDistribution(probabilities.get(i)))
+                .collect(Collectors.toList());
+    }
+
+    public static ScoreDistribution getRandomPMMLScoreDistribution(Double probability) {
+        Random random = new Random();
+        ScoreDistribution toReturn = new ScoreDistribution();
+        toReturn.setValue(RandomStringUtils.random(6, true, false));
+        toReturn.setRecordCount(random.nextInt(100));
+        toReturn.setConfidence((double) random.nextInt(1) / 100);
+        toReturn.setProbability(probability);
+        return toReturn;
     }
 
     public static List<String> getStringObjects(Array.Type arrayType, int size) {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuntimeFactoryInternalTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-assembler/src/test/java/org/kie/pmml/evaluator/assembler/factories/PMMLRuntimeFactoryInternalTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
@@ -189,32 +188,29 @@ public class PMMLRuntimeFactoryInternalTest {
         return new KiePMMLModelWithNested(modelName, kiePmmlModels);
     }
 
-    private class KiePMMLModelA extends KiePMMLModel {
+    private class KiePMMLModelA extends KiePMMLTestingModel {
+
+        private static final long serialVersionUID = -8174670245229417048L;
 
         public KiePMMLModelA(String name) {
             super(name, Collections.emptyList());
         }
 
-        @Override
-        public Object evaluate(Object knowledgeBase, Map<String, Object> requestData) {
-            return null;
-        }
     }
 
-    private class KiePMMLModelB extends KiePMMLModel {
+    private class KiePMMLModelB extends KiePMMLTestingModel {
+
+        private static final long serialVersionUID = 8521110750870376450L;
 
         public KiePMMLModelB(String name) {
             super(name, Collections.emptyList());
         }
 
-        @Override
-        public Object evaluate(Object knowledgeBase, Map<String, Object> requestData) {
-            return null;
-        }
     }
 
-    private class KiePMMLModelWithNested extends KiePMMLModel implements HasNestedModels {
+    private class KiePMMLModelWithNested extends KiePMMLTestingModel implements HasNestedModels {
 
+        private static final long serialVersionUID = -3005462259673834598L;
         private final List<KiePMMLModel> nestedModels;
 
         public KiePMMLModelWithNested(String modelName, List<KiePMMLModel> nestedModels) {
@@ -227,9 +223,5 @@ public class PMMLRuntimeFactoryInternalTest {
             return nestedModels;
         }
 
-        @Override
-        public Object evaluate(Object knowledgeBase, Map<String, Object> requestData) {
-            return null;
-        }
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PostProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PostProcess.java
@@ -76,6 +76,7 @@ public class PostProcess {
         toPopulate.setAffinity(model.getAffinity());
         toPopulate.setEntityId(model.getEntityId());
         toPopulate.setPredictedDisplayValue(model.getPredictedDisplayValue());
+        toPopulate.setProbabilityMap(model.getProbabilityMap());
     }
 
     /**

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PostProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PostProcess.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 import org.kie.api.pmml.PMML4Result;
 import org.kie.pmml.api.enums.DATA_TYPE;
-import org.kie.pmml.api.enums.RESULT_FEATURE;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.models.MiningField;
 import org.kie.pmml.commons.model.KiePMMLModel;
@@ -52,9 +51,16 @@ public class PostProcess {
         executeTargets(toReturn, processingDTO);
         updateTargetValueType(model, toReturn);
         populateProcessingDTO(toReturn, model,  processingDTO);
-        populateOutputFields(toReturn, processingDTO,  model);
+        populateOutputFields(toReturn, processingDTO);
     }
 
+    /**
+     * Method used to populate a <code>ProcessingDTO</code> with values accumulated inside the given <code>KiePMMLModel</code>
+     * during evaluation
+     * @param pmml4Result
+     * @param model
+     * @param toPopulate
+     */
     static void populateProcessingDTO(final PMML4Result pmml4Result, final KiePMMLModel model, final ProcessingDTO toPopulate) {
         pmml4Result.getResultVariables().forEach((key, value) -> toPopulate.addKiePMMLNameValue(new KiePMMLNameValue(key, value)));
         final Map<String, Double> sortedByValue
@@ -67,6 +73,9 @@ public class PostProcess {
                                           LinkedHashMap::new));
         final List<String> orderedReasonCodes = new ArrayList<>(sortedByValue.keySet());
         toPopulate.addOrderedReasonCodes(orderedReasonCodes);
+        toPopulate.setAffinity(model.getAffinity());
+        toPopulate.setEntityId(model.getEntityId());
+        toPopulate.setPredictedDisplayValue(model.getPredictedDisplayValue());
     }
 
     /**
@@ -119,11 +128,10 @@ public class PostProcess {
      * @param processingDTO
      */
     static void populateOutputFields(final PMML4Result toUpdate,
-                                     final ProcessingDTO processingDTO,
-                                     final KiePMMLModel model) {
+                                     final ProcessingDTO processingDTO) {
         logger.debug("populateOutputFields {} {}", toUpdate, processingDTO);
         for (KiePMMLOutputField outputField : processingDTO.getOutputFields()) {
-            Object variableValue = outputFieldToValue(outputField, processingDTO, model);
+            Object variableValue = outputField.evaluate(processingDTO);
             if (variableValue != null) {
                 String variableName = outputField.getName();
                 toUpdate.addResultVariable(variableName, variableValue);
@@ -132,44 +140,4 @@ public class PostProcess {
         }
     }
 
-    /**
-     * This method extract the value of the specified output field either from
-     * the processing DTO or the model, depending from the field type.
-     *
-     * @param outputField
-     * @param processingDTO
-     * @param model
-     *
-     * @return the correct value as Object if the field is implemented or null if
-     * the field is not implemented. It is up to the caller to handle the null case.
-     */
-    private static Object outputFieldToValue(KiePMMLOutputField outputField, ProcessingDTO processingDTO, KiePMMLModel model) {
-        RESULT_FEATURE resultFeature = RESULT_FEATURE.getOrDefault(outputField.getResultFeature());
-        switch (resultFeature) {
-            case PREDICTED_VALUE:
-                return outputField.evaluatePredictedValue(processingDTO);
-
-            case TRANSFORMED_VALUE:
-                return outputField.evaluateTransformedValue(processingDTO);
-
-            case REASON_CODE:
-                return outputField.evaluateReasonCodeValue(processingDTO);
-
-            case PREDICTED_DISPLAY_VALUE:
-                return model.getPredictedDisplayValue();
-
-            case ENTITY_ID:
-            case CLUSTER_ID:
-                return model.getEntityId();
-
-            case AFFINITY:
-            case ENTITY_AFFINITY:
-            case CLUSTER_AFFINITY:
-                return model.getAffinity();
-
-            default:
-                logger.warn("OutputField with feature \"{}\" is currently not implemented and will be ignored.", resultFeature.getName());
-                return null;
-        }
-    }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
@@ -41,6 +41,12 @@ public class PreProcess {
         // Avoid instantiation
     }
 
+    /**
+     * Method to create a <code>ProcessingDTO</code> with <b>fix</b> values from the given <code>KiePMMLModel</code>
+     * @param model
+     * @param context
+     * @return
+     */
     public static ProcessingDTO preProcess(final KiePMMLModel model, final PMMLContext context) {
         addMissingValuesReplacements(model, context);
         final PMMLRequestData requestData = context.getRequestData();

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PostProcessTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PostProcessTest.java
@@ -102,7 +102,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithDefaultNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertTrue(toUpdate.getResultVariables().isEmpty());
     }
@@ -119,7 +119,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithNameValues(kiePMMLModel, kiePMMLNameValue);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
@@ -135,7 +135,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithDefaultNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
         assertTrue(toUpdate.getResultVariables().isEmpty());
     }
 
@@ -151,7 +151,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithDefaultNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
@@ -178,7 +178,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithEmptyNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
@@ -222,7 +222,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO1 = buildProcessingDTOWithEmptyNameValues(kiePMMLModel1);
         PMML4Result toUpdate1 = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate1, processingDTO1, kiePMMLModel1);
+        PostProcess.populateOutputFields(toUpdate1, processingDTO1);
 
         assertFalse(toUpdate1.getResultVariables().isEmpty());
         assertTrue(toUpdate1.getResultVariables().containsKey(OUTPUT_NAME));
@@ -239,7 +239,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO2 = buildProcessingDTOWithEmptyNameValues(kiePMMLModel2);
         PMML4Result toUpdate2 = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate2, processingDTO2, kiePMMLModel2);
+        PostProcess.populateOutputFields(toUpdate2, processingDTO2);
 
         assertFalse(toUpdate2.getResultVariables().isEmpty());
         assertTrue(toUpdate2.getResultVariables().containsKey(OUTPUT_NAME));
@@ -292,7 +292,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO1 = buildProcessingDTOWithEmptyNameValues(kiePMMLModel1);
         PMML4Result toUpdate1 = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate1, processingDTO1, kiePMMLModel1);
+        PostProcess.populateOutputFields(toUpdate1, processingDTO1);
 
         assertFalse(toUpdate1.getResultVariables().isEmpty());
         assertTrue(toUpdate1.getResultVariables().containsKey(OUTPUT_NAME));
@@ -309,7 +309,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO2 = buildProcessingDTOWithEmptyNameValues(kiePMMLModel2);
         PMML4Result toUpdate2 = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate2, processingDTO2, kiePMMLModel2);
+        PostProcess.populateOutputFields(toUpdate2, processingDTO2);
 
         assertFalse(toUpdate2.getResultVariables().isEmpty());
         assertTrue(toUpdate2.getResultVariables().containsKey(OUTPUT_NAME));
@@ -359,7 +359,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO1 = buildProcessingDTOWithEmptyNameValues(kiePMMLModel1);
         PMML4Result toUpdate1 = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate1, processingDTO1, kiePMMLModel1);
+        PostProcess.populateOutputFields(toUpdate1, processingDTO1);
 
         assertFalse(toUpdate1.getResultVariables().isEmpty());
         assertTrue(toUpdate1.getResultVariables().containsKey(OUTPUT_NAME));
@@ -376,7 +376,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO2 = buildProcessingDTOWithEmptyNameValues(kiePMMLModel2);
         PMML4Result toUpdate2 = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate2, processingDTO2, kiePMMLModel2);
+        PostProcess.populateOutputFields(toUpdate2, processingDTO2);
 
         assertFalse(toUpdate2.getResultVariables().isEmpty());
         assertTrue(toUpdate2.getResultVariables().containsKey(OUTPUT_NAME));
@@ -421,7 +421,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithEmptyNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
@@ -474,7 +474,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithEmptyNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
@@ -528,7 +528,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithEmptyNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
         assertEquals(value1/value2, toUpdate.getResultVariables().get(OUTPUT_NAME));
@@ -546,7 +546,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithEmptyNameValues(kiePMMLModel);
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));
@@ -568,7 +568,7 @@ public class PostProcessTest {
         ProcessingDTO processingDTO = buildProcessingDTOWithNameValues(kiePMMLModel, new KiePMMLNameValue(variableName, variableValue));
         PMML4Result toUpdate = new PMML4Result();
 
-        PostProcess.populateOutputFields(toUpdate, processingDTO, kiePMMLModel);
+        PostProcess.populateOutputFields(toUpdate, processingDTO);
 
         assertFalse(toUpdate.getResultVariables().isEmpty());
         assertTrue(toUpdate.getResultVariables().containsKey(OUTPUT_NAME));

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModel.java
@@ -17,6 +17,7 @@ package  org.kie.pmml.models.clustering.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,6 +78,11 @@ public abstract class KiePMMLClusteringModel extends KiePMMLModel {
         setAffinity(aggregates[selectedIndex]);
 
         return clusters.get(selectedIndex).getId().orElseGet(() -> Integer.toString(selectedEntityId));
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
     }
 
     private double computeAdjustmentFactor(Map<String, Object> requestData) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModel.java
@@ -77,7 +77,7 @@ public abstract class KiePMMLClusteringModel extends KiePMMLModel {
         setEntityId(selectedEntityId);
         setAffinity(aggregates[selectedIndex]);
 
-        return clusters.get(selectedIndex).getId().orElseGet(() -> Integer.toString(selectedEntityId));
+        return selectedCluster.getId().orElseGet(() -> Integer.toString(selectedEntityId));
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModelWithSources.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/src/main/java/org/kie/pmml/models/clustering/model/KiePMMLClusteringModelWithSources.java
@@ -16,6 +16,7 @@
 package  org.kie.pmml.models.clustering.model;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.kie.pmml.api.exceptions.KiePMMLException;
@@ -41,6 +42,11 @@ public class KiePMMLClusteringModelWithSources extends KiePMMLClusteringModel im
 
     @Override
     public Map<String, Object> getOutputFieldsMap() {
+        throw new KiePMMLException("KiePMMLClusteringModelWithSources is not meant to be used for actual usage");
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
         throw new KiePMMLException("KiePMMLClusteringModelWithSources is not meant to be used for actual usage");
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelWithSources.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelWithSources.java
@@ -16,6 +16,7 @@
 package org.kie.pmml.models.drools.commons.model;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.kie.pmml.api.exceptions.KiePMMLException;
@@ -26,6 +27,7 @@ import org.kie.pmml.commons.HasRule;
  */
 public class KiePMMLDroolsModelWithSources extends KiePMMLDroolsModel implements HasRule {
 
+    private static final long serialVersionUID = -168095076511604775L;
     protected Map<String, String> sourcesMap;
     protected Map<String, String> rulesSourceMap;
     private final String kmodulePackageName;
@@ -45,12 +47,17 @@ public class KiePMMLDroolsModelWithSources extends KiePMMLDroolsModel implements
 
     @Override
     public Object evaluate(final Object knowledgeBase, Map<String, Object> requestData) {
-        throw new KiePMMLException("KiePMMLRegressionModelWithSources. is not meant to be used for actual evaluation");
+        throw new KiePMMLException("KiePMMLDroolsModelWithSources. is not meant to be used for actual evaluation");
     }
 
     @Override
     public Map<String, Object> getOutputFieldsMap() {
-        throw new KiePMMLException("KiePMMLRegressionModelWithSources. is not meant to be used for actual usage");
+        throw new KiePMMLException("KiePMMLDroolsModelWithSources. is not meant to be used for actual usage");
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        throw new KiePMMLException("KiePMMLDroolsModelWithSources is not meant to be used for actual usage");
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModelTest.java
@@ -18,6 +18,7 @@ package org.kie.pmml.models.drools.commons.model;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,6 +68,11 @@ public class KiePMMLDroolsModelTest {
         @Override
         public Object evaluate(Object knowledgeBase, Map<String, Object> requestData) {
             return super.evaluate(knowledgeBase, requestData);
+        }
+
+        @Override
+        protected LinkedHashMap<String, Double> getProbabilityResultMap() {
+            return new LinkedHashMap<>();
         }
 
         @Override

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
@@ -375,7 +375,7 @@ public class DroolsModelProviderTest {
 
         @Override
         protected LinkedHashMap<String, Double> getProbabilityResultMap() {
-            return null;
+            return new LinkedHashMap<>();
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/test/java/org/kie/pmml/models/drools/provider/DroolsModelProviderTest.java
@@ -19,6 +19,7 @@ package org.kie.pmml.models.drools.provider;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -370,6 +371,11 @@ public class DroolsModelProviderTest {
             this.transformationDictionary = transformationDictionary;
             this.model = model;
             this.fieldTypeMap = fieldTypeMap;
+        }
+
+        @Override
+        protected LinkedHashMap<String, Double> getProbabilityResultMap() {
+            return null;
         }
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/src/main/java/org/kie/pmml/models/drools/scorecard/model/KiePMMLScorecardModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/src/main/java/org/kie/pmml/models/drools/scorecard/model/KiePMMLScorecardModel.java
@@ -15,10 +15,9 @@
  */
 package org.kie.pmml.models.drools.scorecard.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
-import org.kie.api.pmml.PMML4Result;
 import org.kie.pmml.api.enums.MINING_FUNCTION;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.commons.model.KiePMMLExtension;
@@ -27,6 +26,7 @@ import org.kie.pmml.models.drools.commons.model.KiePMMLDroolsModel;
 public class KiePMMLScorecardModel extends KiePMMLDroolsModel {
 
     public static final PMML_MODEL PMML_MODEL_TYPE = PMML_MODEL.SCORECARD_MODEL;
+    private static final long serialVersionUID = 3726828657243287195L;
 
     protected KiePMMLScorecardModel(String modelName, List<KiePMMLExtension> extensions) {
         super(modelName, extensions);
@@ -41,9 +41,8 @@ public class KiePMMLScorecardModel extends KiePMMLDroolsModel {
     }
 
     @Override
-    public Object evaluate(final Object knowledgeBase, Map<String, Object> requestData) {
-        final PMML4Result toReturn = (PMML4Result) super.evaluate(knowledgeBase, requestData);
-        return toReturn;
+    protected LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
     }
 
     public static class Builder extends KiePMMLDroolsModel.Builder<KiePMMLScorecardModel> {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/java/org/kie/pmml/models/drools/tree/model/KiePMMLTreeModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/src/main/java/org/kie/pmml/models/drools/tree/model/KiePMMLTreeModel.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.models.drools.tree.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,6 +33,11 @@ public class KiePMMLTreeModel extends KiePMMLDroolsModel {
     protected KiePMMLTreeModel(String name, List<KiePMMLExtension> extensions, String algorithmName) {
         super(name, extensions);
         this.algorithmName = algorithmName;
+    }
+
+    @Override
+    protected LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
     }
 
     public static Builder builder(String name, List<KiePMMLExtension> extensions, MINING_FUNCTION miningFunction, String algorithmName) {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModel.java
@@ -15,17 +15,18 @@
  */
 package org.kie.pmml.models.mining.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.kie.pmml.api.enums.MINING_FUNCTION;
+import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.HasNestedModels;
 import org.kie.pmml.commons.model.KiePMMLExtension;
 import org.kie.pmml.commons.model.KiePMMLModel;
-import org.kie.pmml.api.enums.MINING_FUNCTION;
-import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.models.mining.model.segmentation.KiePMMLSegment;
 import org.kie.pmml.models.mining.model.segmentation.KiePMMLSegmentation;
 
@@ -35,6 +36,7 @@ import org.kie.pmml.models.mining.model.segmentation.KiePMMLSegmentation;
 public class KiePMMLMiningModel extends KiePMMLModel implements HasNestedModels {
 
     public static final PMML_MODEL PMML_MODEL_TYPE = PMML_MODEL.MINING_MODEL;
+    private static final long serialVersionUID = 1074200573309922605L;
 
     protected String algorithmName;
     protected boolean scorable = true;
@@ -51,6 +53,12 @@ public class KiePMMLMiningModel extends KiePMMLModel implements HasNestedModels 
     @Override
     public Object evaluate(final Object knowledgeBase, final Map<String, Object> requestData) {
         throw new KiePMMLException("KiePMMLMiningModel is not meant to be used for actual evaluation");
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
+//        throw new KiePMMLException("KiePMMLMiningModel is not meant to be used for actual usage");
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/src/main/java/org/kie/pmml/models/mining/model/KiePMMLMiningModel.java
@@ -58,7 +58,6 @@ public class KiePMMLMiningModel extends KiePMMLModel implements HasNestedModels 
     @Override
     public LinkedHashMap<String, Double> getProbabilityResultMap() {
         return new LinkedHashMap<>();
-//        throw new KiePMMLException("KiePMMLMiningModel is not meant to be used for actual usage");
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableClassificationFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableClassificationFactory.java
@@ -38,7 +38,6 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import org.dmg.pmml.OpType;
 import org.dmg.pmml.OutputField;
-import org.dmg.pmml.ResultFeature;
 import org.dmg.pmml.regression.RegressionModel;
 import org.dmg.pmml.regression.RegressionTable;
 import org.kie.pmml.api.enums.OP_TYPE;
@@ -51,7 +50,6 @@ import org.kie.pmml.models.regression.model.tuples.KiePMMLTableSourceCategory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.kie.pmml.commons.Constants.MISSING_BODY_TEMPLATE;
 import static org.kie.pmml.commons.Constants.MISSING_DEFAULT_CONSTRUCTOR;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.addMethod;
 import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.getFromFileName;
@@ -159,48 +157,6 @@ public class KiePMMLRegressionTableClassificationFactory {
             body.addStatement(new MethodCallExpr(new NameExpr("categoryTableMap"), "put", expressions));
         });
     }
-
-//    /**
-//     * Add entries <b>output field/output value</b> inside <b>populateOutputFieldsMap</b> method
-//     * @param tableTemplate
-//     * @param outputFields
-//     */
-//    static void populateOutputFieldsMapWithProbability(final ClassOrInterfaceDeclaration tableTemplate,
-//                                                final List<OutputField> outputFields) {
-//        MethodDeclaration methodDeclaration = tableTemplate.getMethodsByName("populateOutputFieldsMapWithProbability").get(0);
-//        BlockStmt body =
-//                methodDeclaration.getBody().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_BODY_TEMPLATE, "populateOutputFieldsMapWithProbability")));
-//        populateOutputFieldsMapWithProbability(body, outputFields);
-//    }
-
-
-//    /**
-//     * Add entries <b>output field/output value</b> inside <b>populateOutputFieldsMapWithProbability</b> method
-//     * @param body
-//     * @param outputFields
-//     */
-//    static void populateOutputFieldsMapWithProbability(final BlockStmt body,
-//                                                               final List<OutputField> outputFields) {
-//        outputFields.stream()
-//                .filter(outputField -> ResultFeature.PROBABILITY.equals(outputField.getResultFeature()))
-//                .forEach(outputField -> {
-//                    StringLiteralExpr key = new StringLiteralExpr(outputField.getName().getValue());
-//                    Expression value = null;
-//                    if (outputField.getValue() != null) {
-//                        NodeList<Expression> expressions =
-//                                NodeList.nodeList(new StringLiteralExpr(outputField.getValue().toString()));
-//                        value = new MethodCallExpr(new NameExpr("probabilityMap"), "get", expressions);
-//                    } else if (outputField.getTargetField() != null) {
-//                        NodeList<Expression> expressions =
-//                                NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().getValue()));
-//                        value = new MethodCallExpr(new NameExpr("probabilityMap"), "get", expressions);
-//                    }
-//                    if (value != null) {
-//                        NodeList<Expression> expressions = NodeList.nodeList(key, value);
-//                        body.addStatement(new MethodCallExpr(new NameExpr("outputFieldsMap"), "put", expressions));
-//                    }
-//                });
-//    }
 
     /**
      * Add the  <b>getProbabilityMapMethod</b>s <code>MethodDeclaration</code> to the class

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableClassificationFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableClassificationFactory.java
@@ -112,7 +112,7 @@ public class KiePMMLRegressionTableClassificationFactory {
                 REGRESSION_NORMALIZATION_METHOD.byName(normalizationMethod.value());
         final OP_TYPE opTypePmml = opType != null ? OP_TYPE.byName(opType.value()) : null;
         populateGetProbabilityMapMethod(normalizationMethod, tableTemplate);
-        populateOutputFieldsMapWithProbability(tableTemplate, outputFields);
+//        populateOutputFieldsMapWithProbability(tableTemplate, outputFields);
         populateIsBinaryMethod(opType, regressionTablesMap.size(), tableTemplate);
         final ConstructorDeclaration constructorDeclaration =
                 tableTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, tableTemplate.getName())));
@@ -160,47 +160,47 @@ public class KiePMMLRegressionTableClassificationFactory {
         });
     }
 
-    /**
-     * Add entries <b>output field/output value</b> inside <b>populateOutputFieldsMap</b> method
-     * @param tableTemplate
-     * @param outputFields
-     */
-    static void populateOutputFieldsMapWithProbability(final ClassOrInterfaceDeclaration tableTemplate,
-                                                final List<OutputField> outputFields) {
-        MethodDeclaration methodDeclaration = tableTemplate.getMethodsByName("populateOutputFieldsMapWithProbability").get(0);
-        BlockStmt body =
-                methodDeclaration.getBody().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_BODY_TEMPLATE, "populateOutputFieldsMapWithProbability")));
-        populateOutputFieldsMapWithProbability(body, outputFields);
-    }
+//    /**
+//     * Add entries <b>output field/output value</b> inside <b>populateOutputFieldsMap</b> method
+//     * @param tableTemplate
+//     * @param outputFields
+//     */
+//    static void populateOutputFieldsMapWithProbability(final ClassOrInterfaceDeclaration tableTemplate,
+//                                                final List<OutputField> outputFields) {
+//        MethodDeclaration methodDeclaration = tableTemplate.getMethodsByName("populateOutputFieldsMapWithProbability").get(0);
+//        BlockStmt body =
+//                methodDeclaration.getBody().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_BODY_TEMPLATE, "populateOutputFieldsMapWithProbability")));
+//        populateOutputFieldsMapWithProbability(body, outputFields);
+//    }
 
 
-    /**
-     * Add entries <b>output field/output value</b> inside <b>populateOutputFieldsMapWithProbability</b> method
-     * @param body
-     * @param outputFields
-     */
-    static void populateOutputFieldsMapWithProbability(final BlockStmt body,
-                                                               final List<OutputField> outputFields) {
-        outputFields.stream()
-                .filter(outputField -> ResultFeature.PROBABILITY.equals(outputField.getResultFeature()))
-                .forEach(outputField -> {
-                    StringLiteralExpr key = new StringLiteralExpr(outputField.getName().getValue());
-                    Expression value = null;
-                    if (outputField.getValue() != null) {
-                        NodeList<Expression> expressions =
-                                NodeList.nodeList(new StringLiteralExpr(outputField.getValue().toString()));
-                        value = new MethodCallExpr(new NameExpr("probabilityMap"), "get", expressions);
-                    } else if (outputField.getTargetField() != null) {
-                        NodeList<Expression> expressions =
-                                NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().getValue()));
-                        value = new MethodCallExpr(new NameExpr("probabilityMap"), "get", expressions);
-                    }
-                    if (value != null) {
-                        NodeList<Expression> expressions = NodeList.nodeList(key, value);
-                        body.addStatement(new MethodCallExpr(new NameExpr("outputFieldsMap"), "put", expressions));
-                    }
-                });
-    }
+//    /**
+//     * Add entries <b>output field/output value</b> inside <b>populateOutputFieldsMapWithProbability</b> method
+//     * @param body
+//     * @param outputFields
+//     */
+//    static void populateOutputFieldsMapWithProbability(final BlockStmt body,
+//                                                               final List<OutputField> outputFields) {
+//        outputFields.stream()
+//                .filter(outputField -> ResultFeature.PROBABILITY.equals(outputField.getResultFeature()))
+//                .forEach(outputField -> {
+//                    StringLiteralExpr key = new StringLiteralExpr(outputField.getName().getValue());
+//                    Expression value = null;
+//                    if (outputField.getValue() != null) {
+//                        NodeList<Expression> expressions =
+//                                NodeList.nodeList(new StringLiteralExpr(outputField.getValue().toString()));
+//                        value = new MethodCallExpr(new NameExpr("probabilityMap"), "get", expressions);
+//                    } else if (outputField.getTargetField() != null) {
+//                        NodeList<Expression> expressions =
+//                                NodeList.nodeList(new StringLiteralExpr(outputField.getTargetField().getValue()));
+//                        value = new MethodCallExpr(new NameExpr("probabilityMap"), "get", expressions);
+//                    }
+//                    if (value != null) {
+//                        NodeList<Expression> expressions = NodeList.nodeList(key, value);
+//                        body.addStatement(new MethodCallExpr(new NameExpr("outputFieldsMap"), "put", expressions));
+//                    }
+//                });
+//    }
 
     /**
      * Add the  <b>getProbabilityMapMethod</b>s <code>MethodDeclaration</code> to the class

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableClassificationFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/src/main/java/org/kie/pmml/models/regression/compiler/factories/KiePMMLRegressionTableClassificationFactory.java
@@ -110,7 +110,6 @@ public class KiePMMLRegressionTableClassificationFactory {
                 REGRESSION_NORMALIZATION_METHOD.byName(normalizationMethod.value());
         final OP_TYPE opTypePmml = opType != null ? OP_TYPE.byName(opType.value()) : null;
         populateGetProbabilityMapMethod(normalizationMethod, tableTemplate);
-//        populateOutputFieldsMapWithProbability(tableTemplate, outputFields);
         populateIsBinaryMethod(opType, regressionTablesMap.size(), tableTemplate);
         final ConstructorDeclaration constructorDeclaration =
                 tableTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, tableTemplate.getName())));

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/main/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluator.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/src/main/java/org/kie/pmml/models/regression/evaluator/PMMLRegressionModelEvaluator.java
@@ -20,10 +20,10 @@ import java.util.Map;
 import org.drools.core.util.StringUtils;
 import org.kie.api.KieBase;
 import org.kie.api.pmml.PMML4Result;
-import org.kie.pmml.api.exceptions.KiePMMLInternalException;
 import org.kie.pmml.api.enums.PMML_MODEL;
-import org.kie.pmml.evaluator.api.exceptions.KiePMMLModelException;
+import org.kie.pmml.api.exceptions.KiePMMLInternalException;
 import org.kie.pmml.api.runtime.PMMLContext;
+import org.kie.pmml.evaluator.api.exceptions.KiePMMLModelException;
 import org.kie.pmml.evaluator.core.executor.PMMLModelEvaluator;
 import org.kie.pmml.models.regression.model.KiePMMLRegressionClassificationTable;
 import org.kie.pmml.models.regression.model.KiePMMLRegressionModel;
@@ -60,7 +60,6 @@ public class PMMLRegressionModelEvaluator implements PMMLModelEvaluator<KiePMMLR
         toReturn.addResultVariable(targetField, result);
         toReturn.setResultObjectName(targetField);
         toReturn.setResultCode(OK.getName());
-        model.getOutputFieldsMap().forEach(toReturn::addResultVariable);
         return toReturn;
     }
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionClassificationTable.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionClassificationTable.java
@@ -21,17 +21,19 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.DoubleUnaryOperator;
 
-import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.enums.OP_TYPE;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.models.regression.model.enums.REGRESSION_NORMALIZATION_METHOD;
 
 import static org.kie.pmml.commons.Constants.EXPECTED_TWO_ENTRIES_RETRIEVED;
 
 public abstract class KiePMMLRegressionClassificationTable extends KiePMMLRegressionTable {
 
+    private static final long serialVersionUID = 458989873257189359L;
     protected REGRESSION_NORMALIZATION_METHOD regressionNormalizationMethod;
     protected OP_TYPE opType;
     protected Map<String, KiePMMLRegressionTable> categoryTableMap = new LinkedHashMap<>(); // Insertion order matters
+    protected LinkedHashMap<String, Double> probabilityResultMap = new LinkedHashMap<>(); // Insertion order matters
 
     @Override
     public Object evaluateRegression(Map<String, Object> input) {
@@ -39,10 +41,8 @@ public abstract class KiePMMLRegressionClassificationTable extends KiePMMLRegres
         for (Map.Entry<String, KiePMMLRegressionTable> entry : categoryTableMap.entrySet()) {
             resultMap.put(entry.getKey(), (Double) entry.getValue().evaluateRegression(input));
         }
-        final LinkedHashMap<String, Double> probabilityMap = getProbabilityMap(resultMap);
-        final Map.Entry<String, Double> predictedEntry = Collections.max(probabilityMap.entrySet(), Map.Entry.comparingByValue());
-        probabilityMap.put(targetField, predictedEntry.getValue());
-        populateOutputFieldsMapWithProbability(predictedEntry, probabilityMap);
+        probabilityResultMap  = getProbabilityMap(resultMap);
+        final Map.Entry<String, Double> predictedEntry = Collections.max(probabilityResultMap.entrySet(), Map.Entry.comparingByValue());
         return predictedEntry.getKey();
     }
 
@@ -54,7 +54,9 @@ public abstract class KiePMMLRegressionClassificationTable extends KiePMMLRegres
 
     protected abstract LinkedHashMap<String, Double> getProbabilityMap(final LinkedHashMap<String, Double> resultMap);
 
-    protected abstract void populateOutputFieldsMapWithProbability(final Map.Entry<String, Double> predictedEntry, final LinkedHashMap<String, Double> probabilityMap);
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return probabilityResultMap;
+    }
 
     protected void updateResult(final AtomicReference<Double> toUpdate) {
         // NOOP

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionModel.java
@@ -16,6 +16,7 @@
 package org.kie.pmml.models.regression.model;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.kie.pmml.commons.model.KiePMMLModel;
@@ -25,6 +26,7 @@ import org.kie.pmml.commons.model.KiePMMLModel;
  */
 public abstract class KiePMMLRegressionModel extends KiePMMLModel {
 
+    private static final long serialVersionUID = -6870859552385880008L;
     protected KiePMMLRegressionTable regressionTable;
 
     public KiePMMLRegressionModel(String modelName) {
@@ -39,6 +41,11 @@ public abstract class KiePMMLRegressionModel extends KiePMMLModel {
     @Override
     public Map<String, Object> getOutputFieldsMap() {
         return regressionTable.getOutputFieldsMap();
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return regressionTable.getProbabilityResultMap();
     }
 
     public KiePMMLRegressionTable getRegressionTable() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTable.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/java/org/kie/pmml/models/regression/model/KiePMMLRegressionTable.java
@@ -17,6 +17,7 @@ package org.kie.pmml.models.regression.model;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -80,6 +81,10 @@ public abstract class KiePMMLRegressionTable implements Serializable {
 
     public double getIntercept() {
         return intercept;
+    }
+
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
     }
 
     protected abstract void updateResult(final AtomicReference<Double> toUpdate);

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/resources/KiePMMLRegressionTableClassificationTemplate.tmpl
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/main/resources/KiePMMLRegressionTableClassificationTemplate.tmpl
@@ -30,9 +30,4 @@ public class KiePMMLRegressionTableClassificationTemplate extends KiePMMLRegress
 
     }
 
-     @Override
-     protected void populateOutputFieldsMapWithProbability(final Map.Entry<String, Double> predictedEntry, final LinkedHashMap<String, Double> probabilityMap) {
-
-     }
-
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionClassificationTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionClassificationTableTest.java
@@ -38,8 +38,6 @@ public class KiePMMLRegressionClassificationTableTest {
     private static final DoubleUnaryOperator SECOND_ITEM_OPERATOR = aDouble -> 1 - aDouble;
     private static final String CASE_A = "caseA";
     private static final String CASE_B = "caseB";
-    private static final String PROBABILITY_FALSE = String.format("probability(%s)", CASE_A);
-    private static final String PROBABILITY_TRUE = String.format("probability(%s)", CASE_B);
     private final KiePMMLRegressionClassificationTable classificationTable;
     private final double firstTableResult;
     private final double secondTableResult;
@@ -69,11 +67,11 @@ public class KiePMMLRegressionClassificationTableTest {
         input.put("b", 32);
         Object retrieved = classificationTable.evaluateRegression(input);
         assertEquals(expectedResult, retrieved);
-        final Map<String, Object> outputFieldsMap = classificationTable.getOutputFieldsMap();
+        final Map<String, Double> probabilityResultMap = classificationTable.getProbabilityResultMap();
         double expectedDouble = FIRST_ITEM_OPERATOR.applyAsDouble(firstTableResult);
-        assertEquals(expectedDouble, outputFieldsMap.get(PROBABILITY_FALSE));
+        assertEquals(expectedDouble, probabilityResultMap.get(CASE_A), 0);
         expectedDouble = SECOND_ITEM_OPERATOR.applyAsDouble(expectedDouble);
-        assertEquals(expectedDouble, outputFieldsMap.get(PROBABILITY_TRUE));
+        assertEquals(expectedDouble, probabilityResultMap.get(CASE_B), 0);
     }
 
     @Test
@@ -109,6 +107,8 @@ public class KiePMMLRegressionClassificationTableTest {
     private KiePMMLRegressionClassificationTable getKiePMMLRegressionClassificationTable() {
         KiePMMLRegressionClassificationTable toReturn = new KiePMMLRegressionClassificationTable() {
 
+            private static final long serialVersionUID = 8046624834036965711L;
+
             @Override
             public boolean isBinary() {
                 return true;
@@ -124,12 +124,12 @@ public class KiePMMLRegressionClassificationTableTest {
                 return null;
             }
 
-            @Override
-            protected void populateOutputFieldsMapWithProbability(Map.Entry<String, Double> predictedEntry,
-                                                                  LinkedHashMap<String, Double> probabilityMap) {
-                outputFieldsMap.put(PROBABILITY_FALSE, probabilityMap.get(CASE_A));
-                outputFieldsMap.put(PROBABILITY_TRUE, probabilityMap.get(CASE_B));
-            }
+//            @Override
+//            protected void populateOutputFieldsMapWithProbability(Map.Entry<String, Double> predictedEntry,
+//                                                                  LinkedHashMap<String, Double> probabilityMap) {
+//                outputFieldsMap.put(PROBABILITY_FALSE, probabilityMap.get(CASE_A));
+//                outputFieldsMap.put(PROBABILITY_TRUE, probabilityMap.get(CASE_B));
+//            }
 
         };
         toReturn.categoryTableMap.put(CASE_A, getKiePMMLRegressionTable(firstTableResult));

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionClassificationTableTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/src/test/java/org/kie/pmml/models/regression/model/KiePMMLRegressionClassificationTableTest.java
@@ -124,13 +124,6 @@ public class KiePMMLRegressionClassificationTableTest {
                 return null;
             }
 
-//            @Override
-//            protected void populateOutputFieldsMapWithProbability(Map.Entry<String, Double> predictedEntry,
-//                                                                  LinkedHashMap<String, Double> probabilityMap) {
-//                outputFieldsMap.put(PROBABILITY_FALSE, probabilityMap.get(CASE_A));
-//                outputFieldsMap.put(PROBABILITY_TRUE, probabilityMap.get(CASE_B));
-//            }
-
         };
         toReturn.categoryTableMap.put(CASE_A, getKiePMMLRegressionTable(firstTableResult));
         toReturn.categoryTableMap.put(CASE_B, getKiePMMLRegressionTable(secondTableResult));

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/src/main/java/org/kie/pmml/models/scorecard/model/KiePMMLScorecardModel.java
@@ -17,6 +17,7 @@ package org.kie.pmml.models.scorecard.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,5 +72,10 @@ public class KiePMMLScorecardModel extends KiePMMLModel {
                                         reasonCodeAlgorithm,
                                         useReasonCodes,
                                         baselineScore).orElse(null);
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactory.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/main/java/org/kie/pmml/models/tree/compiler/factories/KiePMMLTreeModelFactory.java
@@ -84,8 +84,9 @@ public class KiePMMLTreeModelFactory {
                                                                                  KIE_PMML_TREE_MODEL_TEMPLATE);
         ClassOrInterfaceDeclaration modelTemplate = cloneCU.getClassByName(className)
                 .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + className));
+        final Double missingValuePenalty =  model.getMissingValuePenalty() != null ? model.getMissingValuePenalty().doubleValue() : null;
         final KiePMMLNodeFactory.NodeNamesDTO nodeNamesDTO = new KiePMMLNodeFactory.NodeNamesDTO(model.getNode(),
-                                                                                                 createNodeClassName(), null);
+                                                                                                 createNodeClassName(), null, missingValuePenalty);
         String fullNodeClassName = packageName + "." + nodeNamesDTO.nodeClassName;
         final List<DerivedField> derivedFields = getDerivedFields(transformationDictionary,
                                                                   model.getLocalTransformations());

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSample.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/src/test/resources/TreeSample.pmml
@@ -28,28 +28,42 @@
     </MiningSchema>
     <Node score="will play" id="A">
       <True/>
+      <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+      <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+      <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
       <Node score="32" id="A_A">
         <SimplePredicate field="outlook" operator="equal" value="sunny"/>
+        <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+        <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+        <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
         <Node score="will play" id="A_A_A">
           <CompoundPredicate booleanOperator="and">
             <SimplePredicate field="temperature" operator="lessThan" value="90"/>
             <SimplePredicate field="temperature" operator="greaterThan" value="50"/>
           </CompoundPredicate>
+          <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
           <Node score="will play"  id="A_A_A_A">
             <SimplePredicate field="humidity" operator="lessThan" value="80"/>
+            <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+            <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+            <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
           </Node>
           <Node score="no play" id="A_A_A_B">
             <SimplePredicate field="humidity" operator="greaterOrEqual" value="80"/>
+            <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+            <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+            <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
           </Node>
         </Node>
         <Node score="no play" id="A_A_B">
           <SimpleSetPredicate field="occupation" booleanOperator="isIn">
             <Array n="2" type="string">SKYDIVER ASTRONAUT</Array>
           </SimpleSetPredicate>
-<!--          <CompoundPredicate booleanOperator="or">-->
-<!--            <SimplePredicate field="temperature" operator="greaterOrEqual" value="90"/>-->
-<!--            <SimplePredicate field="temperature" operator="lessOrEqual" value="50"/>-->
-<!--          </CompoundPredicate>-->
+          <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
         </Node>
       </Node>
       <Node score="may play" id="A_B">
@@ -57,6 +71,9 @@
           <SimplePredicate field="outlook" operator="equal" value="overcast"/>
           <SimplePredicate field="outlook" operator="equal" value="rain"/>
         </CompoundPredicate>
+        <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+        <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+        <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
         <Node score="may play" id="A_B_A">
           <CompoundPredicate booleanOperator="and">
             <SimplePredicate field="temperature" operator="greaterThan" value="60"/>
@@ -65,12 +82,18 @@
             <SimplePredicate field="humidity" operator="lessThan" value="70"/>
             <SimplePredicate field="windy" operator="equal" value="false"/>
           </CompoundPredicate>
+          <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
         </Node>
         <Node score="no play" id="A_B_B">
           <CompoundPredicate booleanOperator="and">
             <SimplePredicate field="outlook" operator="equal" value="rain"/>
             <SimplePredicate field="humidity" operator="lessThan" value="70"/>
           </CompoundPredicate>
+          <ScoreDistribution value="will play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="may play" recordCount="50" confidence="0.333333333333333"/>
+          <ScoreDistribution value="no play" recordCount="50" confidence="0.333333333333333"/>
         </Node>
       </Node>
     </Node>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNode.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNode.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.models.tree.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +23,7 @@ import java.util.function.Function;
 
 import org.kie.pmml.commons.model.KiePMMLExtension;
 import org.kie.pmml.commons.model.abstracts.AbstractKiePMMLComponent;
+import org.kie.pmml.commons.model.tuples.KiePMMLProbabilityConfidence;
 
 public class KiePMMLNode extends AbstractKiePMMLComponent {
 
@@ -32,10 +34,15 @@ public class KiePMMLNode extends AbstractKiePMMLComponent {
         super(name, extensions);
     }
 
-    protected static Optional<Object> getNestedScore(final List<Function<Map<String, Object>, Object>> nodeFunctions, final Map<String, Object> requestData) {
-        Optional<Object> toReturn = Optional.empty();
-        for (Function<Map<String, Object>, Object> function : nodeFunctions) {
-            final Object evaluation = function.apply(requestData);
+    protected static LinkedHashMap<String, KiePMMLProbabilityConfidence> getProbabilityConfidenceMap(final List<KiePMMLScoreDistribution> kiePMMLScoreDistributions,
+                                                                                                     final double missingValuePenalty) {
+        return (kiePMMLScoreDistributions != null && !kiePMMLScoreDistributions.isEmpty()) ?  evaluateProbabilityConfidenceMap(kiePMMLScoreDistributions, missingValuePenalty) : new LinkedHashMap<>();
+    }
+
+    protected static Optional<KiePMMLNodeResult> getNestedKiePMMLNodeResult(final List<Function<Map<String, Object>, KiePMMLNodeResult>> nodeFunctions, final Map<String, Object> requestData) {
+        Optional<KiePMMLNodeResult> toReturn = Optional.empty();
+        for (Function<Map<String, Object>, KiePMMLNodeResult> function : nodeFunctions) {
+            final KiePMMLNodeResult evaluation = function.apply(requestData);
             toReturn = Optional.ofNullable(evaluation);
             if (toReturn.isPresent()) {
                 break;
@@ -43,4 +50,26 @@ public class KiePMMLNode extends AbstractKiePMMLComponent {
         }
         return toReturn;
     }
+
+    static LinkedHashMap<String, KiePMMLProbabilityConfidence> evaluateProbabilityConfidenceMap(final List<KiePMMLScoreDistribution> kiePMMLScoreDistributions,
+                                                                                                final double missingValuePenalty) {
+        LinkedHashMap<String, KiePMMLProbabilityConfidence> toReturn = new LinkedHashMap<>();
+        if (kiePMMLScoreDistributions == null || kiePMMLScoreDistributions.isEmpty()) {
+            return toReturn;
+        }
+        if (kiePMMLScoreDistributions.get(0).hasProbability()) {
+            for (KiePMMLScoreDistribution kiePMMLScoreDistribution : kiePMMLScoreDistributions) {
+                toReturn.put(kiePMMLScoreDistribution.getValue(), new KiePMMLProbabilityConfidence(kiePMMLScoreDistribution.getProbability(), kiePMMLScoreDistribution.getEvaluatedConfidence(missingValuePenalty)));
+            }
+        } else {
+            int totalRecordCount = kiePMMLScoreDistributions.stream()
+                    .map(KiePMMLScoreDistribution::getRecordCount)
+                    .reduce(0, Integer::sum);
+            for (KiePMMLScoreDistribution kiePMMLScoreDistribution : kiePMMLScoreDistributions) {
+                toReturn.put(kiePMMLScoreDistribution.getValue(), new KiePMMLProbabilityConfidence(kiePMMLScoreDistribution.getEvaluatedProbability(totalRecordCount), kiePMMLScoreDistribution.getEvaluatedConfidence(missingValuePenalty)));
+            }
+        }
+        return toReturn;
+    }
+    
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNodeResult.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLNodeResult.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.models.tree.model;
+
+import java.util.LinkedHashMap;
+
+import org.kie.pmml.commons.model.tuples.KiePMMLProbabilityConfidence;
+
+/**
+ * Class used as DTO to propagate Tree model results
+ */
+public class KiePMMLNodeResult {
+
+    private final Object score;
+
+    private final LinkedHashMap<String, Double> probabilityMap;
+    private final LinkedHashMap<String, Double> confidenceMap;
+
+    public KiePMMLNodeResult(Object score,
+                             LinkedHashMap<String, KiePMMLProbabilityConfidence> probabilityConfidenceMap) {
+        this.score = score;
+        probabilityMap = new LinkedHashMap<>();
+        confidenceMap = new LinkedHashMap<>();
+        probabilityConfidenceMap.forEach((targetClass, probabilityConfidenceTuple) -> {
+            probabilityMap.put(targetClass, probabilityConfidenceTuple.getProbability());
+            confidenceMap.put(targetClass, probabilityConfidenceTuple.getConfidence());
+        });
+    }
+
+    public Object getScore() {
+        return score;
+    }
+
+    public LinkedHashMap<String, Double> getProbabilityMap() {
+        return probabilityMap;
+    }
+
+    public LinkedHashMap<String, Double> getConfidenceMap() {
+        return confidenceMap;
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLScoreDistribution.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLScoreDistribution.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.models.tree.model;
+
+import java.util.List;
+
+import org.kie.pmml.api.exceptions.KiePMMLValidationException;
+import org.kie.pmml.commons.model.KiePMMLExtension;
+import org.kie.pmml.commons.model.abstracts.AbstractKiePMMLComponent;
+
+public class KiePMMLScoreDistribution extends AbstractKiePMMLComponent {
+
+    private static final long serialVersionUID = -8674575012261916224L;
+    private final String value;
+    private final int recordCount;
+    private final Double confidence; // must be >= 0 and <= 1; using wrapped class because it could be nullable
+    private final Double probability; // must be >= 0 and <= 1; using wrapped class because it could be nullable
+
+    public KiePMMLScoreDistribution(
+            final String name,
+            final List<KiePMMLExtension> extensions,
+            final String value,
+            final int recordCount,
+            final Double confidence,
+            final Double probability) {
+        super(name, extensions);
+        this.value = value;
+        this.recordCount = recordCount;
+        this.confidence = confidence;
+        this.probability = probability;
+    }
+
+    public boolean hasProbability() {
+        return probability != null;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public int getRecordCount() {
+        return recordCount;
+    }
+
+    public double getProbability() {
+        if (probability == null) {
+            throw new KiePMMLValidationException("Missing expected probability");
+        }
+       return probability;
+    }
+
+    public Double getConfidence() {
+        return confidence;
+    }
+
+    public double getEvaluatedProbability(int totalRecordCount) {
+        return (double)recordCount / (double)totalRecordCount;
+    }
+
+    public Double getEvaluatedConfidence(double missingValuePenalty) {
+        return confidence != null ? confidence * missingValuePenalty : null;
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLTreeModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLTreeModel.java
@@ -20,14 +20,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.KiePMMLModel;
 
 public class KiePMMLTreeModel extends KiePMMLModel {
 
     private static final long serialVersionUID = -5158590062736070465L;
 
-    protected Function<Map<String, Object>, Object> nodeFunction;
+    protected Function<Map<String, Object>, KiePMMLNodeResult> nodeFunction;
+    private LinkedHashMap<String, Double> probabilityResultMap;
 
     public KiePMMLTreeModel(String modelName) {
         super(modelName, Collections.emptyList());
@@ -35,12 +35,14 @@ public class KiePMMLTreeModel extends KiePMMLModel {
 
     @Override
     public Object evaluate(final Object knowledgeBase, final Map<String, Object> requestData) {
-        return nodeFunction.apply(requestData);
+        KiePMMLNodeResult kiePMMLNodeResult = nodeFunction.apply(requestData);
+        probabilityResultMap = kiePMMLNodeResult.getProbabilityMap();
+        return kiePMMLNodeResult.getScore();
     }
 
     @Override
     public LinkedHashMap<String, Double> getProbabilityResultMap() {
-        return new LinkedHashMap<>();
+        return probabilityResultMap;
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLTreeModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/java/org/kie/pmml/models/tree/model/KiePMMLTreeModel.java
@@ -16,9 +16,11 @@
 package  org.kie.pmml.models.tree.model;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.commons.model.KiePMMLModel;
 
 public class KiePMMLTreeModel extends KiePMMLModel {
@@ -34,6 +36,11 @@ public class KiePMMLTreeModel extends KiePMMLModel {
     @Override
     public Object evaluate(final Object knowledgeBase, final Map<String, Object> requestData) {
         return nodeFunction.apply(requestData);
+    }
+
+    @Override
+    public LinkedHashMap<String, Double> getProbabilityResultMap() {
+        return new LinkedHashMap<>();
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/resources/KiePMMLNodeTemplate.tmpl
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/main/resources/KiePMMLNodeTemplate.tmpl
@@ -16,6 +16,8 @@ import org.kie.pmml.commons.model.predicates.KiePMMLSimpleSetPredicate;
 import org.kie.pmml.commons.model.predicates.KiePMMLTruePredicate;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.models.tree.model.KiePMMLNode;
+import org.kie.pmml.models.tree.model.KiePMMLNodeResult;
+import org.kie.pmml.models.tree.model.KiePMMLScoreDistribution;
 
 
 
@@ -25,17 +27,20 @@ public class KiePMMLNodeTemplate extends KiePMMLNode {
         super(name, Collections.emptyList());
     }
 
-    public static Object evaluateNode(final Map<String, Object> requestData) {
+    public static KiePMMLNodeResult evaluateNode(final Map<String, Object> requestData) {
             if (!predicate.evaluate(requestData)) {
                 return null;
             }
-            final List<Function<Map<String, Object>, Object>> nodeFunctions = null;
+            final List<Function<Map<String, Object>, KiePMMLNodeResult>> nodeFunctions = null;
             final Object score = null;
+            final List<KiePMMLScoreDistribution> scoreDistributions = null;
+            final double missingValuePenalty = 1.0;
+            KiePMMLNodeResult kiePMMLNodeResult = new KiePMMLNodeResult(score, KiePMMLNode.getProbabilityConfidenceMap(scoreDistributions, missingValuePenalty));
             if (nodeFunctions.isEmpty()) {
-                return score;
+                return kiePMMLNodeResult;
             }
-            Optional<Object> nestedScore = KiePMMLNode.getNestedScore(nodeFunctions, requestData);
-            return nestedScore.orElse(score);
+            Optional<KiePMMLNodeResult> nestedKiePMMLNodeResult = KiePMMLNode.getNestedKiePMMLNodeResult(nodeFunctions, requestData);
+            return nestedKiePMMLNodeResult.orElse(kiePMMLNodeResult);
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLNodeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLNodeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.models.tree.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Test;
+import org.kie.pmml.commons.model.tuples.KiePMMLProbabilityConfidence;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.pmml.models.tree.model.KiePMMLTreeTestUtils.getRandomKiePMMLScoreDistributions;
+
+public class KiePMMLNodeTest {
+
+    @Test
+    public void getProbabilityConfidenceMap() {
+        LinkedHashMap<String, KiePMMLProbabilityConfidence> retrieved = KiePMMLNode.getProbabilityConfidenceMap(null, 1.0);
+        assertNotNull(retrieved);
+        assertTrue(retrieved.isEmpty());
+        retrieved = KiePMMLNode.getProbabilityConfidenceMap(Collections.emptyList(), 1.0);
+        assertNotNull(retrieved);
+        assertTrue(retrieved.isEmpty());
+        List<KiePMMLScoreDistribution> kiePMMLScoreDistributions = getRandomKiePMMLScoreDistributions(false);
+        retrieved = KiePMMLNode.getProbabilityConfidenceMap(kiePMMLScoreDistributions, 1.0);
+        assertNotNull(retrieved);
+        assertEquals(kiePMMLScoreDistributions.size(), retrieved.size());
+    }
+
+    @Test
+    public void evaluateProbabilityConfidenceMap() {
+        List<KiePMMLScoreDistribution> kiePMMLScoreDistributions = getRandomKiePMMLScoreDistributions(false);
+        int totalRecordCount = kiePMMLScoreDistributions.stream()
+                .map(KiePMMLScoreDistribution::getRecordCount)
+                .reduce(0, Integer::sum);
+        final double missingValuePenalty = (double) new Random().nextInt(100)/10;
+        LinkedHashMap<String, KiePMMLProbabilityConfidence> retrievedNoProbability = KiePMMLNode.getProbabilityConfidenceMap(kiePMMLScoreDistributions, missingValuePenalty);
+        assertNotNull(retrievedNoProbability);
+        kiePMMLScoreDistributions.forEach(kiePMMLScoreDistribution -> {
+            assertTrue(retrievedNoProbability.containsKey(kiePMMLScoreDistribution.getValue()));
+            KiePMMLProbabilityConfidence kiePMMLProbabilityConfidence = retrievedNoProbability.get(kiePMMLScoreDistribution.getValue());
+            assertNotNull(kiePMMLProbabilityConfidence);
+            double probabilityExpected = (double) kiePMMLScoreDistribution.getRecordCount() / (double) totalRecordCount;
+            double confidenceExpected = kiePMMLScoreDistribution.getConfidence() * missingValuePenalty;
+            assertEquals(probabilityExpected, kiePMMLProbabilityConfidence.getProbability(), 0.000000001);
+            assertEquals(confidenceExpected, kiePMMLProbabilityConfidence.getConfidence(), 0.000000001);
+        });
+        //
+        kiePMMLScoreDistributions = getRandomKiePMMLScoreDistributions(true);
+        LinkedHashMap<String, KiePMMLProbabilityConfidence> retrievedProbability = KiePMMLNode.getProbabilityConfidenceMap(kiePMMLScoreDistributions, missingValuePenalty);
+        assertNotNull(retrievedNoProbability);
+        kiePMMLScoreDistributions.forEach(kiePMMLScoreDistribution -> {
+            assertTrue(retrievedProbability.containsKey(kiePMMLScoreDistribution.getValue()));
+            KiePMMLProbabilityConfidence kiePMMLProbabilityConfidence = retrievedProbability.get(kiePMMLScoreDistribution.getValue());
+            assertNotNull(kiePMMLProbabilityConfidence);
+            double probabilityExpected = kiePMMLScoreDistribution.getProbability();
+            double confidenceExpected = kiePMMLScoreDistribution.getConfidence() * missingValuePenalty;
+            assertEquals(probabilityExpected, kiePMMLProbabilityConfidence.getProbability(), 0.000000001);
+            assertEquals(confidenceExpected, kiePMMLProbabilityConfidence.getConfidence(), 0.000000001);
+        });
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLTreeTestUtils.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/src/test/java/org/kie/pmml/models/tree/model/KiePMMLTreeTestUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.pmml.models.tree.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class KiePMMLTreeTestUtils {
+
+    public static List<KiePMMLScoreDistribution> getRandomKiePMMLScoreDistributions(boolean withProbability) {
+        List<Double> probabilities = withProbability ? Arrays.asList(0.1, 0.3, 0.6) : Arrays.asList(null, null, null);
+        return IntStream.range(0, 3)
+                .mapToObj(i -> getRandomKiePMMLScoreDistribution(probabilities.get(i)))
+                .collect(Collectors.toList());
+    }
+
+    public static KiePMMLScoreDistribution getRandomKiePMMLScoreDistribution(Double probability) {
+        Random random = new Random();
+        return new KiePMMLScoreDistribution(RandomStringUtils.random(6, true, false),
+                                            null,
+                                            RandomStringUtils.random(6, true, false),
+                                            random.nextInt(100),
+                                            (double) random.nextInt(1) / 100,
+                                            probability);
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/IrisDataTreeTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/IrisDataTreeTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.data.Percentage;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,9 +18,13 @@ import org.kie.pmml.models.tests.AbstractPMMLTest;
 @RunWith(Parameterized.class)
 public class IrisDataTreeTest extends AbstractPMMLTest {
 
+    private static final Percentage TOLERANCE_PERCENTAGE = Percentage.withPercentage(0.000001);
     private static final String FILE_NAME = "irisTree.pmml";
     private static final String MODEL_NAME = "IrisTreeModel";
     private static final String TARGET_FIELD = "Species";
+    private static final String PROBABILITY_SETOSA = "Probability_setosa";
+    private static final String PROBABILITY_VERSICOLOR = "Probability_versicolor";
+    private static final String PROBABILITY_VIRGINICA = "Probability_virginica";
     private static PMMLRuntime pmmlRuntime;
 
     private double sepalLength;
@@ -27,17 +32,27 @@ public class IrisDataTreeTest extends AbstractPMMLTest {
     private double petalLength;
     private double petalWidth;
     private String expectedResult;
+    private double probabilitySetosa;
+    private double probabilityVersicolor;
+    private double probabilityVirginica;
 
     public IrisDataTreeTest(double sepalLength, double sepalWidth, double petalLength,
-                            double petalWidth, String expectedResult) {
+                            double petalWidth,
+                            String expectedResult,
+                            double probabilitySetosa,
+                            double probabilityVersicolor,
+                            double probabilityVirginica) {
         this.sepalLength = sepalLength;
         this.sepalWidth = sepalWidth;
         this.petalLength = petalLength;
         this.petalWidth = petalWidth;
         this.expectedResult = expectedResult;
+        this.probabilitySetosa = probabilitySetosa;
+        this.probabilityVersicolor = probabilityVersicolor;
+        this.probabilityVirginica = probabilityVirginica;
     }
 
-  @BeforeClass
+    @BeforeClass
     public static void setupClass() {
         pmmlRuntime = getPMMLRuntime(FILE_NAME);
     }
@@ -45,11 +60,11 @@ public class IrisDataTreeTest extends AbstractPMMLTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {6.9, 3.1, 5.1, 2.3, "virginica"},
-                {5.8, 2.6, 4.0, 1.2, "versicolor"},
-                {5.7, 3.0, 4.2, 1.2, "versicolor"},
-                {5.0, 3.3, 1.4, 0.2, "setosa"},
-                {5.4, 3.9, 1.3, 0.4, "setosa"}
+                {6.9, 3.1, 5.1, 2.3, "virginica", 0.0, 0.021739130434782608, 0.9782608695652174},
+                {5.8, 2.6, 4.0, 1.2, "versicolor", 0.0, 0.9074074074074074, 0.09259259259259259},
+                {5.7, 3.0, 4.2, 1.2, "versicolor", 0.0, 0.9074074074074074, 0.09259259259259259},
+                {5.0, 3.3, 1.4, 0.2, "setosa", 1.0, 0.0, 0.0},
+                {5.4, 3.9, 1.3, 0.4, "setosa", 1.0, 0.0, 0.0},
         });
     }
 
@@ -64,5 +79,12 @@ public class IrisDataTreeTest extends AbstractPMMLTest {
 
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isEqualTo(expectedResult);
+        Assertions.assertThat(pmml4Result.getResultVariables().get(PROBABILITY_SETOSA)).isNotNull();
+
+        Assertions.assertThat(pmml4Result.getResultVariables().get(PROBABILITY_SETOSA)).isEqualTo(probabilitySetosa);
+        Assertions.assertThat(pmml4Result.getResultVariables().get(PROBABILITY_VERSICOLOR)).isNotNull();
+        Assertions.assertThat((double) pmml4Result.getResultVariables().get(PROBABILITY_VERSICOLOR)).isCloseTo(probabilityVersicolor, TOLERANCE_PERCENTAGE);
+        Assertions.assertThat(pmml4Result.getResultVariables().get(PROBABILITY_VIRGINICA)).isNotNull();
+        Assertions.assertThat((double) pmml4Result.getResultVariables().get(PROBABILITY_VIRGINICA)).isCloseTo(probabilityVirginica, TOLERANCE_PERCENTAGE);
     }
 }


### PR DESCRIPTION
@danielezonca @kostola  @jiripetrlik

See https://issues.redhat.com/browse/DROOLS-6594

Depends on https://github.com/kiegroup/drools/pull/3829
https://github.com/kiegroup/droolsjbpm-integration/pull/2604

Main modifications

1. definition of ` protected abstract LinkedHashMap<String, Double> getProbabilityResultMap();` inside `KiePMMLModel`, to be implemented by all concrete KiePMMLModels
2. definition of ` public Map<String, Double> getProbabilityMap()` inside `KiePMMLModel` that return a "corrected" representation of the above
3. populating `ProcessingDTO` with `KiePMMLModel.getProbabilityMap()`
4. move all the OutputField resultFeature switch logic inside `KiePMMLOutputField. evaluate(ProcessingDTO)`
5. using `ProcessingDTO.getProbabilityMap()` for "PROBABILITY" result feature
6. adapted TreeModel codegen to use the new semantic for probability

