### PR TITLE
Performance Fix by caching DMN Profile

### DIFF
--- a/drools-core/src/main/java/org/drools/core/impl/InternalKnowledgeBase.java
+++ b/drools-core/src/main/java/org/drools/core/impl/InternalKnowledgeBase.java
@@ -16,6 +16,7 @@
 package org.drools.core.impl;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +154,7 @@ public interface InternalKnowledgeBase extends KieBase {
 
     List<AsyncReceiveNode> getReceiveNodes();
     void addReceiveNode(AsyncReceiveNode node);
+    Instant getPkgsLastUpdatedAt();
 
     boolean hasMultipleAgendaGroups();
 }

--- a/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
+++ b/drools-core/src/main/java/org/drools/core/impl/KnowledgeBaseImpl.java
@@ -22,6 +22,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -135,6 +136,12 @@ public class KnowledgeBaseImpl
     private RuleBaseConfiguration config;
 
     protected Map<String, InternalKnowledgePackage> pkgs;
+
+    /**
+     * Allows external stakeholders to track if the pkgs collection has been modified
+     * since the last access.
+     */
+    private Instant pkgsLastUpdatedAt;
 
     private Map<String, Process> processes;
 
@@ -868,6 +875,7 @@ public class KnowledgeBaseImpl
             pkg.getDialectRuntimeRegistry().merge( newPkg.getDialectRuntimeRegistry(),
                                                    this.rootClassLoader,
                                                    true );
+            pkgsLastUpdatedAt = Instant.now();                                                   
 
         }
 
@@ -1794,5 +1802,9 @@ public class KnowledgeBaseImpl
             receiveNodes = new ArrayList<>();
         }
         receiveNodes.add(node);
+    }
+
+    public Instant getPkgsLastUpdatedAt() {
+        return pkgsLastUpdatedAt;
     }
 }


### PR DESCRIPTION
Hi Team,

As you might have noticed from my earlier posts that I am part of evaluation of Drools for DMN execution in our project.

While doing the performance benchmarking of Drools we saw a huge bottleneck and we were able to find the root cause of this bottleneck in the Drools codebase for which we did an internal fix.
I am sharing the use case which we tried , bottleneck which we faced and the code fix which we did to resolve it.
Now, we want guidance on how can we push this patch to Drools codebase.

Use Case :
Execute 5000 rules(1 rule = 1 DMN Decision Table) spread across 3800 DMN files(nested DMN files using Decision Service) in Drools.

Observation :
While executing these 5000 rules in a single call to dmnRuntime.evaluateByName(rootModel,dmnContext,"<RootDecisionName>") it took around 6 seconds.

Fix:
We did a lot of analysis for this performance issue by giving better computation power to run the SpringBoot app where Drools engine was running, sharding the DMNs and executing DMNs using multiple DMNRuntime. Ultimately, we looked into the codebase and found the following issue :

Currently while evaluation of every decision, the DMNRuntimeKBWrappingIKB** checks for update to profiles by iterating over each profile. Time taken to execute increases with the no. of profiles(dmns) in memory.

Our fix is to avoid this check for every decision evaluation, So, the time of update to Kbase is maintained in pkgsLastUpdatedAt and checked before iterating over all the models, this significantly reduces the time taken to complete each decision(DT).

// DMNRuntimeKBWrappingIKB.java
public List<DMNProfile> getProfiles() {
...
for (DMNProfile p : dmnPkg.getProfiles()) {
if (!profiles.contains(p)) {
profiles.add(p);
}
....
}
...
}

Observation after this fix: With the above fix, we are able to execute 5000 rules spread across 3800 DMN files in 508ms.