### PR TITLE
DROOLS-6337 today() and now() functions not evaluated correctly in Test Scenarios

### DIFF
--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
@@ -92,6 +92,10 @@ public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
                 new IllegalArgumentException("Error during evaluation: " + l.stream().map(FEELEvent::getMessage).collect(Collectors.joining(", "))));
     }
     
+    /**
+     * Perform compilation and evaluation of FEEL Unary Tests,
+     * implementing the command pattern of {@link DMNFeelExpressionEvaluator#executeAndVerifyErrors(Function)}
+     */
     private static class EvaluateUTCommand implements Function<FEEL, Either<List<FEELEvent>, Boolean>> {
         
         private final String rawExpression;

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
@@ -78,7 +78,7 @@ public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
 
     @Override
     protected Object internalLiteralEvaluation(String raw, String className) {
-        return executeAndVerifyErrors(feel -> feel.evaluate(raw));
+        return executeAndVerifyErrors(FEEL::evaluate);
     }
 
     @Override

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
@@ -78,7 +78,7 @@ public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
 
     @Override
     protected Object internalLiteralEvaluation(String raw, String className) {
-        return executeAndVerifyErrors(FEEL::evaluate);
+        return executeAndVerifyErrors(feel -> feel.evaluate(raw));
     }
 
     @Override

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/main/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluator.java
@@ -18,6 +18,8 @@ package org.drools.scenariosimulation.backend.expression;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,14 +34,13 @@ import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
 import org.kie.dmn.core.compiler.profiles.ExtendedDMNProfile;
 import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.lang.EvaluationContext;
-import org.kie.dmn.feel.lang.Type;
-import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
-import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.lang.impl.FEELImpl;
 import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.runtime.UnaryTest;
 import org.kie.dmn.feel.runtime.events.SyntaxErrorEvent;
 import org.kie.dmn.feel.runtime.functions.FEELFnResult;
 import org.kie.dmn.feel.runtime.functions.extended.CodeFunction;
+import org.kie.dmn.feel.util.Either;
 
 import static java.util.Collections.singletonList;
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.UNARY_PARAMETER_IDENTIFIER;
@@ -61,18 +62,6 @@ public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
                                                                                feelEvent.getSourceException()));
     }
 
-    protected EvaluationContext newEvaluationContext() {
-        return newEvaluationContext(null);
-    }
-
-    protected EvaluationContext newEvaluationContext(FEELEventListener eventListener) {
-        final FEELEventListenersManager eventsManager = new FEELEventListenersManager();
-        if (eventListener != null) {
-            eventsManager.addListener(eventListener);
-        }
-        return new EvaluationContextImpl(classLoader, eventsManager);
-    }
-
     protected FEEL newFeelEvaluator(AtomicReference<FEELEvent> errorHolder) {
         // cleanup existing error
         errorHolder.set(null);
@@ -89,8 +78,7 @@ public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
 
     @Override
     protected Object internalLiteralEvaluation(String raw, String className) {
-        EvaluationContext evaluationContext = newEvaluationContext();
-        return executeAndVerifyErrors(feel -> feel.evaluate(raw, evaluationContext));
+        return executeAndVerifyErrors(feel -> feel.evaluate(raw));
     }
 
     @Override
@@ -99,22 +87,41 @@ public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
             return true;
         }
 
-        Map<String, Type> variables = new HashMap<>();
-        variables.put(UNARY_PARAMETER_IDENTIFIER, BuiltInType.UNKNOWN);
-        List<UnaryTest> unaryTests = executeAndVerifyErrors(feel -> feel.evaluateUnaryTests(rawExpression, variables));
+        Either<List<FEELEvent>, Boolean> utCommandResult = executeAndVerifyErrors(new EvaluateUTCommand(rawExpression, resultValue));
+        return utCommandResult.getOrElseThrow(l ->
+                new IllegalArgumentException("Error during evaluation: " + l.stream().map(FEELEvent::getMessage).collect(Collectors.joining(", "))));
+    }
+    
+    private static class EvaluateUTCommand implements Function<FEEL, Either<List<FEELEvent>, Boolean>> {
+        
+        private final String rawExpression;
+        private final Object resultValue;
 
-        List<FEELEvent> utEvalErrors = new ArrayList<>();
-        EvaluationContext evaluationContext = newEvaluationContext(errorEvent -> {
-            utEvalErrors.add(errorEvent);
-        });
-        evaluationContext.setValue(UNARY_PARAMETER_IDENTIFIER, resultValue);
-        boolean allMatch = unaryTests.stream().allMatch(unaryTest -> Optional
-                        .ofNullable(unaryTest.apply(evaluationContext, resultValue))
-                        .orElse(false));
-        if (!utEvalErrors.isEmpty()) {
-            throw new IllegalArgumentException("Error during evaluation: " + utEvalErrors.stream().map(FEELEvent::getMessage).collect(Collectors.joining(", ")));
+        public EvaluateUTCommand(String rawExpression, Object resultValue) {
+            this.rawExpression = rawExpression;
+            this.resultValue = resultValue;
         }
-        return allMatch;
+        
+        @Override
+        public Either<List<FEELEvent>, Boolean> apply(FEEL feel) {
+            List<UnaryTest> unaryTests = feel.evaluateUnaryTests(rawExpression,
+                                                                 Collections.singletonMap(UNARY_PARAMETER_IDENTIFIER,
+                                                                                          BuiltInType.UNKNOWN));
+            final List<FEELEvent> utEvalErrors = new ArrayList<>();
+            final FEELEventListener utErrorListener = errorEvent -> utEvalErrors.add(errorEvent);
+            EvaluationContext evaluationContext = ((FEELImpl) feel).newEvaluationContext(Arrays.asList(utErrorListener),
+                                                                                         Collections.singletonMap(UNARY_PARAMETER_IDENTIFIER,
+                                                                                                                  resultValue));
+            boolean allMatch = unaryTests.stream().allMatch(unaryTest -> Optional
+                            .ofNullable(unaryTest.apply(evaluationContext, resultValue))
+                            .orElse(false));
+            if (utEvalErrors.isEmpty()) {
+                return Either.ofRight(allMatch);
+            } else {
+                return Either.ofLeft(utEvalErrors);
+            }
+        }
+        
     }
 
     /**

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -18,7 +18,7 @@ package org.drools.scenariosimulation.backend.expression;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -293,11 +294,11 @@ public class DMNFeelExpressionEvaluatorTest {
     
     @Test
     public void drools6337() {
-        LocalDateTime now = expressionEvaluator.evaluateLiteralExpression("now()", LocalDateTime.class.getCanonicalName());
-        LocalDate today = expressionEvaluator.evaluateLiteralExpression("today()", LocalDate.class.getCanonicalName());
+        ZonedDateTime now = (ZonedDateTime) expressionEvaluator.evaluateLiteralExpression("now()", ZonedDateTime.class.getCanonicalName(), Collections.emptyList()); 
+        LocalDate today = (LocalDate) expressionEvaluator.evaluateLiteralExpression("today()", LocalDate.class.getCanonicalName(), Collections.emptyList());
         assertNotNull(now);
         assertNotNull(today);
-        assertTrue(expressionEvaluator.evaluateUnaryExpression("now() > ?", now.minusDays(1), LocalDateTime.class).isSuccessful());
-        assertTrue(expressionEvaluator.evaluateUnaryExpression("today() > ?", today.minusDays(1), LocalDateTime.class).isSuccessful());
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("now() > ?", now.minusDays(1), ZonedDateTime.class).isSuccessful());
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("today() > ?", today.minusDays(1), LocalDate.class).isSuccessful());
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -293,7 +293,8 @@ public class DMNFeelExpressionEvaluatorTest {
     }
     
     @Test
-    public void drools6337() {
+    public void testUnaryTestUsingKieExtendedProfile() {
+    // DROOLS-6337 today() and now() functions not evaluated correctly in Test Scenarios
         ZonedDateTime now = (ZonedDateTime) expressionEvaluator.evaluateLiteralExpression("now()", ZonedDateTime.class.getCanonicalName(), Collections.emptyList()); 
         LocalDate today = (LocalDate) expressionEvaluator.evaluateLiteralExpression("today()", LocalDate.class.getCanonicalName(), Collections.emptyList());
         assertNotNull(now);

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -18,6 +18,7 @@ package org.drools.scenariosimulation.backend.expression;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -288,5 +289,11 @@ public class DMNFeelExpressionEvaluatorTest {
         assertFalse(expressionEvaluator.isStructuredInput(Set.class.getCanonicalName()));
         assertFalse(expressionEvaluator.isStructuredInput(Integer.class.getCanonicalName()));
         assertFalse(expressionEvaluator.isStructuredInput(String.class.getCanonicalName()));
+    }
+    
+    @Test
+    public void drools6589() {
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("now() > ?", LocalDateTime.of(2020, 9,6,11,34), LocalDateTime.class).isSuccessful());
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("today() > ?", LocalDate.of(2020, 9, 6), LocalDateTime.class).isSuccessful());
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -293,7 +293,11 @@ public class DMNFeelExpressionEvaluatorTest {
     
     @Test
     public void drools6337() {
-        assertTrue(expressionEvaluator.evaluateUnaryExpression("now() > ?", LocalDateTime.of(2020, 9,6,11,34), LocalDateTime.class).isSuccessful());
-        assertTrue(expressionEvaluator.evaluateUnaryExpression("today() > ?", LocalDate.of(2020, 9, 6), LocalDateTime.class).isSuccessful());
+        LocalDateTime now = expressionEvaluator.evaluateLiteralExpression("now()", LocalDateTime.class.getCanonicalName());
+        LocalDate today = expressionEvaluator.evaluateLiteralExpression("today()", LocalDate.class.getCanonicalName());
+        assertNotNull(now);
+        assertNotNull(today);
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("now() > ?", now.minusDays(1), LocalDateTime.class).isSuccessful());
+        assertTrue(expressionEvaluator.evaluateUnaryExpression("today() > ?", today.minusDays(1), LocalDateTime.class).isSuccessful());
     }
 }

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/src/test/java/org/drools/scenariosimulation/backend/expression/DMNFeelExpressionEvaluatorTest.java
@@ -292,7 +292,7 @@ public class DMNFeelExpressionEvaluatorTest {
     }
     
     @Test
-    public void drools6589() {
+    public void drools6337() {
         assertTrue(expressionEvaluator.evaluateUnaryExpression("now() > ?", LocalDateTime.of(2020, 9,6,11,34), LocalDateTime.class).isSuccessful());
         assertTrue(expressionEvaluator.evaluateUnaryExpression("today() > ?", LocalDate.of(2020, 9, 6), LocalDateTime.class).isSuccessful());
     }


### PR DESCRIPTION
@yesamer could you kindly verify all acceptance criteria of DROOLS-6337 with this fix, please?

**JIRA**: https://issues.redhat.com/browse/DROOLS-6337

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
