### PR TITLE
[DROOLS-6625] Validate input data

### DIFF
--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MISSING_VALUE_TREATMENT_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MISSING_VALUE_TREATMENT_METHOD.java
@@ -31,7 +31,8 @@ public enum MISSING_VALUE_TREATMENT_METHOD {
     REGRESSION("regression"),
     CLUSTERING("clustering"),
     TIME_SERIES("timeSeries"),
-    MIXED("mixed");
+    MIXED("mixed"),
+    RETURN_INVALID("returnInvalid");
 
     private String name;
 
@@ -40,7 +41,7 @@ public enum MISSING_VALUE_TREATMENT_METHOD {
     }
 
     public static MISSING_VALUE_TREATMENT_METHOD byName(String name) {
-        return Arrays.stream(MISSING_VALUE_TREATMENT_METHOD.values()).filter(value -> Objects.equals(name, value.name)).findFirst().orElseThrow(() -> new KieEnumException("Failed to find MINING_FUNCTION with name: " + name));
+        return Arrays.stream(MISSING_VALUE_TREATMENT_METHOD.values()).filter(value -> Objects.equals(name, value.name)).findFirst().orElseThrow(() -> new KieEnumException("Failed to find MISSING_VALUE_TREATMENT_METHOD with name: " + name));
     }
 
     public String getName() {

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MISSING_VALUE_TREATMENT_METHOD.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/enums/MISSING_VALUE_TREATMENT_METHOD.java
@@ -21,17 +21,16 @@ import java.util.Objects;
 import org.kie.pmml.api.exceptions.KieEnumException;
 
 /**
- * @see <a href=http://dmg.org/pmml/v4-4/MiningSchema.html#xsdType_MISSING-VALUE-TREATMENT-METHOD>MISSING-VALUE_TREATMENT-METHOD</a>
+ * @see
+ * <a href=http://dmg.org/pmml/v4-4/MiningSchema.html#xsdType_MISSING-VALUE-TREATMENT-METHOD>MISSING-VALUE_TREATMENT-METHOD</a>
  */
 public enum MISSING_VALUE_TREATMENT_METHOD {
 
-    ASSOCIATION_RULES("associationRules"),
-    SEQUENCES("sequences"),
-    CLASSIFICATION("classification"),
-    REGRESSION("regression"),
-    CLUSTERING("clustering"),
-    TIME_SERIES("timeSeries"),
-    MIXED("mixed"),
+    AS_IS("asIs"),
+    AS_MEAN("asMean"),
+    AS_MODE("asMode"),
+    AS_MEDIAN("asMedian"),
+    AS_VALUE("asValue"),
     RETURN_INVALID("returnInvalid");
 
     private String name;
@@ -41,7 +40,8 @@ public enum MISSING_VALUE_TREATMENT_METHOD {
     }
 
     public static MISSING_VALUE_TREATMENT_METHOD byName(String name) {
-        return Arrays.stream(MISSING_VALUE_TREATMENT_METHOD.values()).filter(value -> Objects.equals(name, value.name)).findFirst().orElseThrow(() -> new KieEnumException("Failed to find MISSING_VALUE_TREATMENT_METHOD with name: " + name));
+        return Arrays.stream(MISSING_VALUE_TREATMENT_METHOD.values()).filter(value -> Objects.equals(name,
+                                                                                                     value.name)).findFirst().orElseThrow(() -> new KieEnumException("Failed to find MISSING_VALUE_TREATMENT_METHOD with name: " + name));
     }
 
     public String getName() {

--- a/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLInputDataException.java
+++ b/kie-pmml-trusty/kie-pmml-api/src/main/java/org/kie/pmml/api/exceptions/KiePMMLInputDataException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.pmml.api.exceptions;
+
+/**
+ * <code>RuntimeException</code>s to be wrapping to <b>unchecked</b> ones at <i>customer</i> API boundaries
+ */
+public class KiePMMLInputDataException extends KiePMMLException {
+
+    private static final long serialVersionUID = -6638828457762000141L;
+
+    public KiePMMLInputDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public KiePMMLInputDataException(Throwable cause) {
+        super(cause);
+    }
+
+    public KiePMMLInputDataException(String message) {
+        super(message);
+    }
+}

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
@@ -44,8 +44,6 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
     protected MINING_FUNCTION miningFunction;
     protected String targetField;
     protected Map<String, Object> outputFieldsMap = new HashMap<>();
-    protected Map<String, Object> missingValueReplacementMap = new HashMap<>();
-    protected List<String> requiredFieldsList = new ArrayList<>();
     protected List<MiningField> miningFields = new ArrayList<>();
     protected List<OutputField> outputFields = new ArrayList<>();
     protected List<KiePMMLOutputField> kiePMMLOutputFields = new ArrayList<>();
@@ -74,14 +72,6 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
 
     public Map<String, Object> getOutputFieldsMap() {
         return Collections.unmodifiableMap(outputFieldsMap);
-    }
-
-    public Map<String, Object> getMissingValueReplacementMap() {
-        return Collections.unmodifiableMap(missingValueReplacementMap);
-    }
-
-    public List<String> getRequiredFieldsList() {
-        return Collections.unmodifiableList(requiredFieldsList);
     }
 
     /**
@@ -123,7 +113,8 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
     }
 
     public List<KiePMMLOutputField> getKiePMMLOutputFields() {
-        return kiePMMLOutputFields != null  ? Collections.unmodifiableList(kiePMMLOutputFields) : Collections.emptyList();
+        return kiePMMLOutputFields != null ? Collections.unmodifiableList(kiePMMLOutputFields) :
+                Collections.emptyList();
     }
 
     public KiePMMLTransformationDictionary getTransformationDictionary() {
@@ -136,7 +127,8 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
 
     public Map<String, Double> getProbabilityMap() {
         final LinkedHashMap<String, Double> probabilityResultMap = getProbabilityResultMap();
-        return probabilityResultMap != null ? Collections.unmodifiableMap(getFixedProbabilityMap(probabilityResultMap)) : Collections.emptyMap();
+        return probabilityResultMap != null ?
+                Collections.unmodifiableMap(getFixedProbabilityMap(probabilityResultMap)) : Collections.emptyMap();
     }
 
     public Object getPredictedDisplayValue() {
@@ -215,20 +207,5 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
             }
             return this;
         }
-
-        public Builder<T> withMissingValueReplacementMap(Map<String, Object> missingValueReplacementMap) {
-            if (missingValueReplacementMap != null) {
-                toBuild.missingValueReplacementMap.putAll(missingValueReplacementMap);
-            }
-            return this;
-        }
-
-        public Builder<T> withRequiredFieldsList(List<String> requiredFieldsList) {
-            if (requiredFieldsList != null) {
-                toBuild.requiredFieldsList.addAll(requiredFieldsList);
-            }
-            return this;
-        }
-
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/model/KiePMMLModel.java
@@ -45,6 +45,7 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
     protected String targetField;
     protected Map<String, Object> outputFieldsMap = new HashMap<>();
     protected Map<String, Object> missingValueReplacementMap = new HashMap<>();
+    protected List<String> requiredFieldsList = new ArrayList<>();
     protected List<MiningField> miningFields = new ArrayList<>();
     protected List<OutputField> outputFields = new ArrayList<>();
     protected List<KiePMMLOutputField> kiePMMLOutputFields = new ArrayList<>();
@@ -77,6 +78,10 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
 
     public Map<String, Object> getMissingValueReplacementMap() {
         return Collections.unmodifiableMap(missingValueReplacementMap);
+    }
+
+    public List<String> getRequiredFieldsList() {
+        return Collections.unmodifiableList(requiredFieldsList);
     }
 
     /**
@@ -205,13 +210,25 @@ public abstract class KiePMMLModel extends AbstractKiePMMLComponent implements P
         }
 
         public Builder<T> withOutputFieldsMap(Map<String, Object> outputFieldsMap) {
-            toBuild.outputFieldsMap.putAll(outputFieldsMap);
+            if (outputFieldsMap != null) {
+                toBuild.outputFieldsMap.putAll(outputFieldsMap);
+            }
             return this;
         }
 
         public Builder<T> withMissingValueReplacementMap(Map<String, Object> missingValueReplacementMap) {
-            toBuild.missingValueReplacementMap.putAll(missingValueReplacementMap);
+            if (missingValueReplacementMap != null) {
+                toBuild.missingValueReplacementMap.putAll(missingValueReplacementMap);
+            }
             return this;
         }
+
+        public Builder<T> withRequiredFieldsList(List<String> requiredFieldsList) {
+            if (requiredFieldsList != null) {
+                toBuild.requiredFieldsList.addAll(requiredFieldsList);
+            }
+            return this;
+        }
+
     }
 }

--- a/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModel.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/test/java/org/kie/pmml/commons/testingutility/KiePMMLTestingModel.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.kie.pmml.api.enums.MINING_FUNCTION;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.api.exceptions.KiePMMLException;
+import org.kie.pmml.api.models.MiningField;
 import org.kie.pmml.commons.model.KiePMMLExtension;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.KiePMMLOutputField;
@@ -78,6 +79,13 @@ public class KiePMMLTestingModel extends KiePMMLModel {
 
         public Builder withLocalTransformations(final KiePMMLLocalTransformations localTransformations) {
             toBuild.localTransformations = localTransformations;
+            return this;
+        }
+
+        public Builder withMiningFields(final List<MiningField> miningFields) {
+            if (miningFields != null) {
+                toBuild.miningFields = miningFields;
+            }
             return this;
         }
     }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/builders/KiePMMLModelCodegenUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/builders/KiePMMLModelCodegenUtils.java
@@ -15,10 +15,7 @@
  */
 package org.kie.pmml.compiler.commons.builders;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
@@ -29,12 +26,9 @@ import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.utils.Pair;
 import org.dmg.pmml.Field;
-import org.dmg.pmml.MissingValueTreatmentMethod;
 import org.dmg.pmml.Model;
 import org.dmg.pmml.TransformationDictionary;
-import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.api.enums.MINING_FUNCTION;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.api.exceptions.KiePMMLInternalException;
@@ -61,7 +55,8 @@ public class KiePMMLModelCodegenUtils {
     }
 
     /**
-     * Initialize the given <code>ClassOrInterfaceDeclaration</code> with all the <b>common</b> code needed to generate a <code>KiePMMLModel</code>
+     * Initialize the given <code>ClassOrInterfaceDeclaration</code> with all the <b>common</b> code needed to
+     * generate a <code>KiePMMLModel</code>
      * @param modelTemplate
      * @param fields
      * @param transformationDictionary
@@ -71,10 +66,12 @@ public class KiePMMLModelCodegenUtils {
                             final List<Field<?>> fields,
                             final TransformationDictionary transformationDictionary,
                             final Model pmmlModel) {
-        final ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, modelTemplate.getName())));
+        final ConstructorDeclaration constructorDeclaration =
+                modelTemplate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, modelTemplate.getName())));
         final String name = pmmlModel.getModelName();
         final String generatedClassName = getSanitizedClassName(name);
-        final List<MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(pmmlModel.getMiningSchema(), fields);
+        final List<MiningField> miningFields = ModelUtils.convertToKieMiningFieldList(pmmlModel.getMiningSchema(),
+                                                                                      fields);
         final List<OutputField> outputFields = ModelUtils.convertToKieOutputFieldList(pmmlModel.getOutput(), fields);
         final Expression miningFunctionExpression;
         if (pmmlModel.getMiningFunction() != null) {
@@ -84,7 +81,8 @@ public class KiePMMLModelCodegenUtils {
             miningFunctionExpression = new NullLiteralExpr();
         }
         final PMML_MODEL pmmlModelEnum = PMML_MODEL.byName(pmmlModel.getClass().getSimpleName());
-        final NameExpr pmmlMODELExpression = new NameExpr(pmmlModelEnum.getClass().getName() + "." + pmmlModelEnum.name());
+        final NameExpr pmmlMODELExpression =
+                new NameExpr(pmmlModelEnum.getClass().getName() + "." + pmmlModelEnum.name());
         String targetFieldName = getTargetFieldName(fields, pmmlModel).orElse(null);
         final Expression targetFieldExpression;
         if (targetFieldName != null) {
@@ -92,16 +90,13 @@ public class KiePMMLModelCodegenUtils {
         } else {
             targetFieldExpression = new NullLiteralExpr();
         }
-        Map<String, Pair<DATA_TYPE, String>> missingValueReplacements = getMissingValueReplacementsMap(fields, pmmlModel);
-        List<String> requiredFieldsList = getRequiredFieldsList(pmmlModel);
         setKiePMMLModelConstructor(generatedClassName,
                                    constructorDeclaration,
                                    name,
                                    miningFields,
-                                   outputFields,
-                                   missingValueReplacements,
-                                   requiredFieldsList);
-        addTransformationsInClassOrInterfaceDeclaration(modelTemplate, transformationDictionary, pmmlModel.getLocalTransformations());
+                                   outputFields);
+        addTransformationsInClassOrInterfaceDeclaration(modelTemplate, transformationDictionary,
+                                                        pmmlModel.getLocalTransformations());
         final BlockStmt body = constructorDeclaration.getBody();
         CommonCodegenUtils.setAssignExpressionValue(body, "pmmlMODEL", pmmlMODELExpression);
         CommonCodegenUtils.setAssignExpressionValue(body, "miningFunction", miningFunctionExpression);
@@ -113,29 +108,5 @@ public class KiePMMLModelCodegenUtils {
             getCreatedKiePMMLOutputFieldsExpr.setName(GET_CREATED_KIEPMMLOUTPUTFIELDS);
             CommonCodegenUtils.setAssignExpressionValue(body, "kiePMMLOutputFields", getCreatedKiePMMLOutputFieldsExpr);
         }
-    }
-
-    static Map<String, Pair<DATA_TYPE, String>> getMissingValueReplacementsMap(final List<Field<?>> fields, Model pmmlModel) {
-        Map<String, DATA_TYPE> dataTypeMap = fields.stream()
-                .collect(Collectors.toMap(i -> i.getName().getValue(),
-                                          i -> DATA_TYPE.byName(i.getDataType().value()),
-                                          (prevDataType, newDataType) -> newDataType));
-        return pmmlModel.getMiningSchema() == null || pmmlModel.getMiningSchema().getMiningFields() == null
-                ? Collections.emptyMap()
-                : pmmlModel.getMiningSchema().getMiningFields().stream()
-                        .filter(mf -> mf.getMissingValueReplacement() instanceof String)
-                        .collect(Collectors.toMap(
-                                mf -> mf.getName().getValue(),
-                                mf -> new Pair<>(dataTypeMap.get(mf.getName().getValue()), (String) mf.getMissingValueReplacement())
-                        ));
-    }
-
-    static List<String> getRequiredFieldsList(Model pmmlModel) {
-        return pmmlModel.getMiningSchema() == null || pmmlModel.getMiningSchema().getMiningFields() == null
-                ? Collections.emptyList()
-                : pmmlModel.getMiningSchema().getMiningFields().stream()
-                .filter(mf -> MissingValueTreatmentMethod.RETURN_INVALID.equals(mf.getMissingValueTreatment()))
-                .map(mf -> mf.getName().getValue())
-                .collect(Collectors.toList());
     }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/codegenfactories/KiePMMLModelFactoryUtils.java
@@ -18,7 +18,6 @@ package org.kie.pmml.compiler.commons.codegenfactories;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.Modifier;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -38,7 +36,6 @@ import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.utils.Pair;
 import org.dmg.pmml.LocalTransformations;
 import org.dmg.pmml.TransformationDictionary;
 import org.kie.pmml.api.enums.DATA_TYPE;
@@ -64,12 +61,9 @@ import static org.kie.pmml.compiler.commons.codegenfactories.KiePMMLLocalTransfo
 import static org.kie.pmml.compiler.commons.codegenfactories.KiePMMLOutputFieldFactory.getOutputFieldVariableDeclaration;
 import static org.kie.pmml.compiler.commons.codegenfactories.KiePMMLTransformationDictionaryFactory.TRANSFORMATION_DICTIONARY;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.addListPopulation;
-import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.addMapPopulationExpressions;
-import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.assignExprFrom;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.createArraysAsListFromList;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.getReturnStmt;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.getTypedClassOrInterfaceType;
-import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.literalExprFrom;
 import static org.kie.pmml.compiler.commons.utils.CommonCodegenUtils.setAssignExpressionValue;
 
 /**
@@ -97,48 +91,34 @@ public class KiePMMLModelFactoryUtils {
         final BlockStmt body = constructorDeclaration.getBody();
         final ExplicitConstructorInvocationStmt superStatement =
                 CommonCodegenUtils.getExplicitConstructorInvocationStmt(body)
-                .orElseThrow(() -> new KiePMMLException(String.format(MISSING_CONSTRUCTOR_IN_BODY, body)));
+                        .orElseThrow(() -> new KiePMMLException(String.format(MISSING_CONSTRUCTOR_IN_BODY, body)));
         CommonCodegenUtils.setExplicitConstructorInvocationStmtArgument(superStatement, "name", String.format("\"%s\"",
                                                                                                               name));
     }
 
     /**
      * Set the <b>name</b> parameter on <b>super</b> invocation and populate the <b>miningFields/outputFields</b>
-     *
      * @param generatedClassName
      * @param constructorDeclaration
      * @param name
      * @param miningFields
      * @param outputFields
-     * @param missingValueReplacements
-     * @param requiredFieldsList
      */
     public static void setKiePMMLModelConstructor(final String generatedClassName,
                                                   final ConstructorDeclaration constructorDeclaration,
                                                   final String name,
                                                   final List<MiningField> miningFields,
-                                                  final List<OutputField> outputFields,
-                                                  final Map<String, Pair<DATA_TYPE, String>> missingValueReplacements,
-                                                  final List<String> requiredFieldsList) {
+                                                  final List<OutputField> outputFields) {
         setConstructorSuperNameInvocation(generatedClassName, constructorDeclaration, name);
         final BlockStmt body = constructorDeclaration.getBody();
         final List<ObjectCreationExpr> miningFieldsObjectCreations = getMiningFieldsObjectCreations(miningFields);
         addListPopulation(miningFieldsObjectCreations, body, "miningFields");
         final List<ObjectCreationExpr> outputFieldsObjectCreations = getOutputFieldsObjectCreations(outputFields);
         addListPopulation(outputFieldsObjectCreations, body, "outputFields");
-
-        Map<String, Expression> missingValueReplacementsExpr = missingValueReplacements.entrySet().stream().collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> literalExprFrom(entry.getValue().a, entry.getValue().b)
-        ));
-        addMapPopulationExpressions(missingValueReplacementsExpr, body, "missingValueReplacementMap");
-
-        final ExpressionStmt requiredFieldsListExpression = createArraysAsListFromList(requiredFieldsList);
-        final AssignExpr assignRequiredFieldsListExpression = assignExprFrom("requiredFieldsList", requiredFieldsListExpression.getExpression());
-        body.addStatement(assignRequiredFieldsListExpression);
     }
 
-    public static void addGetCreatedKiePMMLOutputFieldsMethod(final ClassOrInterfaceDeclaration modelTemplate, final List<org.dmg.pmml.OutputField> outputFields) {
+    public static void addGetCreatedKiePMMLOutputFieldsMethod(final ClassOrInterfaceDeclaration modelTemplate,
+                                                              final List<org.dmg.pmml.OutputField> outputFields) {
         final MethodDeclaration methodDeclaration = modelTemplate.addMethod(GET_CREATED_KIEPMMLOUTPUTFIELDS,
                                                                             Modifier.Keyword.PRIVATE);
         final ClassOrInterfaceType returnedType =
@@ -175,25 +155,30 @@ public class KiePMMLModelFactoryUtils {
                                                                        final LocalTransformations localTransformations) {
         String createTransformationDictionary = null;
         if (transformationDictionary != null) {
-            BlockStmt createTransformationDictionaryBody = KiePMMLTransformationDictionaryFactory.getKiePMMLTransformationDictionaryVariableDeclaration(transformationDictionary);
+            BlockStmt createTransformationDictionaryBody =
+                    KiePMMLTransformationDictionaryFactory.getKiePMMLTransformationDictionaryVariableDeclaration(transformationDictionary);
             createTransformationDictionaryBody.addStatement(getReturnStmt(TRANSFORMATION_DICTIONARY));
             createTransformationDictionary = "createTransformationDictionary";
-            MethodDeclaration createTransformationDictionaryMethod = toPopulate.addMethod(createTransformationDictionary, Modifier.Keyword.PRIVATE);
+            MethodDeclaration createTransformationDictionaryMethod =
+                    toPopulate.addMethod(createTransformationDictionary, Modifier.Keyword.PRIVATE);
             createTransformationDictionaryMethod.setType(KiePMMLTransformationDictionary.class.getName());
             createTransformationDictionaryMethod.setBody(createTransformationDictionaryBody);
         }
         String createLocalTransformations = null;
         if (localTransformations != null) {
-            BlockStmt createLocalTransformationsBody = KiePMMLLocalTransformationsFactory.getKiePMMLLocalTransformationsVariableDeclaration(localTransformations);
+            BlockStmt createLocalTransformationsBody =
+                    KiePMMLLocalTransformationsFactory.getKiePMMLLocalTransformationsVariableDeclaration(localTransformations);
             createLocalTransformationsBody.addStatement(getReturnStmt(LOCAL_TRANSFORMATIONS));
             createLocalTransformations = "createLocalTransformations";
-            MethodDeclaration createLocalTransformationsMethod = toPopulate.addMethod(createLocalTransformations, Modifier.Keyword.PRIVATE);
+            MethodDeclaration createLocalTransformationsMethod = toPopulate.addMethod(createLocalTransformations,
+                                                                                      Modifier.Keyword.PRIVATE);
             createLocalTransformationsMethod.setType(KiePMMLLocalTransformations.class.getName());
             createLocalTransformationsMethod.setBody(createLocalTransformationsBody);
         }
         final ConstructorDeclaration constructorDeclaration =
                 toPopulate.getDefaultConstructor().orElseThrow(() -> new KiePMMLInternalException(String.format(MISSING_DEFAULT_CONSTRUCTOR, toPopulate.getName())));
-        populateTransformationsInConstructor(constructorDeclaration, createTransformationDictionary, createLocalTransformations);
+        populateTransformationsInConstructor(constructorDeclaration, createTransformationDictionary,
+                                             createLocalTransformations);
     }
 
     /**
@@ -221,11 +206,11 @@ public class KiePMMLModelFactoryUtils {
                     Expression dataType = dtT != null ?
                             new NameExpr(dtT.getClass().getName() + "." + dtT.name())
                             : new NullLiteralExpr();
-                    MISSING_VALUE_TREATMENT_METHOD mVTM =  miningField.getMissingValueTreatmentMethod();
+                    MISSING_VALUE_TREATMENT_METHOD mVTM = miningField.getMissingValueTreatmentMethod();
                     Expression missingValueTreatmentMethod = mVTM != null ?
                             new NameExpr(mVTM.getClass().getName() + "." + mVTM.name())
                             : new NullLiteralExpr();
-                    INVALID_VALUE_TREATMENT_METHOD iVTM =  miningField.getInvalidValueTreatmentMethod();
+                    INVALID_VALUE_TREATMENT_METHOD iVTM = miningField.getInvalidValueTreatmentMethod();
                     Expression invalidValueTreatmentMethod = iVTM != null ?
                             new NameExpr(iVTM.getClass().getName() + "." + iVTM.name())
                             : new NullLiteralExpr();
@@ -284,8 +269,6 @@ public class KiePMMLModelFactoryUtils {
         return toReturn;
     }
 
-
-
     /**
      * Create a <code>List&lt;ObjectCreationExpr&gt;</code> for the given <code>List&lt;OutputField&gt;</code>
      * @param outputFields
@@ -317,12 +300,12 @@ public class KiePMMLModelFactoryUtils {
                     Expression allowedValues = outputField.getAllowedValues() != null ?
                             createArraysAsListFromList(outputField.getAllowedValues()).getExpression()
                             : new NullLiteralExpr();
-                    toReturn.setArguments(NodeList.nodeList(name, opType, dataType, targetField, resultFeature, allowedValues));
+                    toReturn.setArguments(NodeList.nodeList(name, opType, dataType, targetField, resultFeature,
+                                                            allowedValues));
                     return toReturn;
                 })
                 .collect(Collectors.toList());
     }
-
 
     /**
      * Populating the <b>transformationDictionary</b> and <b>localTransformations</b> variables inside the constructor
@@ -331,13 +314,17 @@ public class KiePMMLModelFactoryUtils {
      * @param createLocalTransformations
      */
     static void populateTransformationsInConstructor(final ConstructorDeclaration constructorDeclaration,
-                                                     final String createTransformationDictionary, final String createLocalTransformations) {
+                                                     final String createTransformationDictionary,
+                                                     final String createLocalTransformations) {
         Expression createTransformationDictionaryInitializer = createTransformationDictionary != null ?
-                new MethodCallExpr(new NameExpr("this"), createTransformationDictionary, NodeList.nodeList()) : new NullLiteralExpr();
-        setAssignExpressionValue(constructorDeclaration.getBody(), TRANSFORMATION_DICTIONARY, createTransformationDictionaryInitializer);
-        Expression createLocalTransformationsInitializer =  createLocalTransformations != null ?
-                new MethodCallExpr(new NameExpr("this"), createLocalTransformations, NodeList.nodeList()) : new NullLiteralExpr();
-        setAssignExpressionValue(constructorDeclaration.getBody(), LOCAL_TRANSFORMATIONS, createLocalTransformationsInitializer);
+                new MethodCallExpr(new NameExpr("this"), createTransformationDictionary, NodeList.nodeList()) :
+                new NullLiteralExpr();
+        setAssignExpressionValue(constructorDeclaration.getBody(), TRANSFORMATION_DICTIONARY,
+                                 createTransformationDictionaryInitializer);
+        Expression createLocalTransformationsInitializer = createLocalTransformations != null ?
+                new MethodCallExpr(new NameExpr("this"), createLocalTransformations, NodeList.nodeList()) :
+                new NullLiteralExpr();
+        setAssignExpressionValue(constructorDeclaration.getBody(), LOCAL_TRANSFORMATIONS,
+                                 createLocalTransformationsInitializer);
     }
-
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/JavaParserUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/JavaParserUtils.java
@@ -22,6 +22,7 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -49,7 +50,8 @@ public class JavaParserUtils {
             final InputStream resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName);
             return StaticJavaParser.parse(resource);
         } catch (ParseProblemException e) {
-            throw new KiePMMLInternalException(String.format("Failed to parse %s due to %s", fileName, e.getMessage()), e);
+            throw new KiePMMLInternalException(String.format("Failed to parse %s due to %s", fileName,
+                                                             e.getMessage()), e);
         } catch (Exception e) {
             throw new ExternalException(String.format("Failed to read %s due to %s", fileName, e.getMessage()), e);
         }
@@ -59,7 +61,8 @@ public class JavaParserUtils {
         try {
             return StaticJavaParser.parse(source);
         } catch (ParseProblemException e) {
-            throw new KiePMMLInternalException(String.format("Failed to parse\r\n%s\r\ndue to %s", source, e.getMessage()), e);
+            throw new KiePMMLInternalException(String.format("Failed to parse\r\n%s\r\ndue to %s", source,
+                                                             e.getMessage()), e);
         } catch (Exception e) {
             throw new ExternalException(String.format("Failed to parse\r\n%s\r\ndue to %s", source, e.getMessage()), e);
         }
@@ -93,11 +96,10 @@ public class JavaParserUtils {
      * It throws <code>KiePMMLException</code> if the package name is missing
      * @param cu
      * @return
-     *
      */
     public static String getFullClassName(final CompilationUnit cu) {
         String packageName = cu.getPackageDeclaration()
-                .orElseThrow(() ->new KiePMMLException("Missing package declaration for " + cu.toString()))
+                .orElseThrow(() -> new KiePMMLException("Missing package declaration for " + cu.toString()))
                 .getName().asString();
         String className = cu.getType(0).getName().asString();
         return packageName + "." + className;
@@ -111,6 +113,15 @@ public class JavaParserUtils {
 
     public static BlockStmt parseBlock(final String block) {
         return StaticJavaParser.parseBlock(block);
+    }
+
+    public static BlockStmt parseConstructorBlock(final String block) {
+        // trick due to https://github.com/javaparser/javaparser/issues/2376
+        ConstructorDeclaration cd = (ConstructorDeclaration)
+                StaticJavaParser.parseBodyDeclaration("C()" + block);
+        BlockStmt bs = cd.getBody();
+        bs.remove();
+        return bs;
     }
 
     public static Statement parseStatement(final String statement) {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
@@ -524,16 +524,24 @@ public class ModelUtils {
         return getKiePMMLPrimitiveBoxed(c).map(primitiveBoxed -> primitiveBoxed.getBoxed().getName()).orElse(c.getName());
     }
 
-    public static List<Field<?>> getFieldsFromDataDictionaryTransformationDictionaryAndModel(final DataDictionary dataDictionary,
-                                                                                             final TransformationDictionary transformationDictionary,
-                                                                                             final Model model) {
+    public static List<Field<?>> getFieldsFromDataDictionaryAndTransformationDictionary(final DataDictionary dataDictionary,
+                                                                                             final TransformationDictionary transformationDictionary) {
         final List<Field<?>> toReturn = new ArrayList<>();
-        dataDictionary.getDataFields().stream().map(Field.class::cast)
-                .forEach(toReturn::add);
+        if (dataDictionary != null && dataDictionary.hasDataFields()) {
+            dataDictionary.getDataFields().stream().map(Field.class::cast)
+                    .forEach(toReturn::add);
+        }
         if (transformationDictionary != null && transformationDictionary.hasDerivedFields()) {
             transformationDictionary.getDerivedFields().stream().map(Field.class::cast)
                     .forEach(toReturn::add);
         }
+        return toReturn;
+    }
+
+    public static List<Field<?>> getFieldsFromDataDictionaryTransformationDictionaryAndModel(final DataDictionary dataDictionary,
+                                                                                             final TransformationDictionary transformationDictionary,
+                                                                                             final Model model) {
+        final List<Field<?>> toReturn = getFieldsFromDataDictionaryAndTransformationDictionary(dataDictionary, transformationDictionary);
         LocalTransformations localTransformations = model.getLocalTransformations();
         if (localTransformations != null && localTransformations.hasDerivedFields()) {
             localTransformations.getDerivedFields().stream().map(Field.class::cast)

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/main/java/org/kie/pmml/compiler/commons/utils/ModelUtils.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.dmg.pmml.Array;
+import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.DataField;
 import org.dmg.pmml.DataType;
 import org.dmg.pmml.DerivedField;
@@ -329,10 +330,10 @@ public class ModelUtils {
                 DATA_TYPE.byName(field.getDataType().value()) : null;
         final MISSING_VALUE_TREATMENT_METHOD missingValueTreatmentMethod =
                 toConvert.getMissingValueTreatment() != null ?
-                MISSING_VALUE_TREATMENT_METHOD.byName(toConvert.getMissingValueTreatment().value()) : null;
+                        MISSING_VALUE_TREATMENT_METHOD.byName(toConvert.getMissingValueTreatment().value()) : null;
         final INVALID_VALUE_TREATMENT_METHOD invalidValueTreatmentMethod =
                 toConvert.getInvalidValueTreatment() != null ?
-                INVALID_VALUE_TREATMENT_METHOD.byName(toConvert.getInvalidValueTreatment().value()) : null;
+                        INVALID_VALUE_TREATMENT_METHOD.byName(toConvert.getInvalidValueTreatment().value()) : null;
         final String missingValueReplacement = toConvert.getMissingValueReplacement() != null ?
                 toConvert.getMissingValueReplacement().toString() : null;
         final String invalidValueReplacement = toConvert.getInvalidValueReplacement() != null ?
@@ -521,6 +522,29 @@ public class ModelUtils {
     public static String getBoxedClassName(DataType dataType) {
         Class<?> c = dataType == null ? Object.class : DATA_TYPE.byName(dataType.value()).getMappedClass();
         return getKiePMMLPrimitiveBoxed(c).map(primitiveBoxed -> primitiveBoxed.getBoxed().getName()).orElse(c.getName());
+    }
+
+    public static List<Field<?>> getFieldsFromDataDictionaryTransformationDictionaryAndModel(final DataDictionary dataDictionary,
+                                                                                             final TransformationDictionary transformationDictionary,
+                                                                                             final Model model) {
+        final List<Field<?>> toReturn = new ArrayList<>();
+        dataDictionary.getDataFields().stream().map(Field.class::cast)
+                .forEach(toReturn::add);
+        if (transformationDictionary != null && transformationDictionary.hasDerivedFields()) {
+            transformationDictionary.getDerivedFields().stream().map(Field.class::cast)
+                    .forEach(toReturn::add);
+        }
+        LocalTransformations localTransformations = model.getLocalTransformations();
+        if (localTransformations != null && localTransformations.hasDerivedFields()) {
+            localTransformations.getDerivedFields().stream().map(Field.class::cast)
+                    .forEach(toReturn::add);
+        }
+        Output output = model.getOutput();
+        if (output != null && output.hasOutputFields()) {
+            output.getOutputFields().stream().map(Field.class::cast)
+                    .forEach(toReturn::add);
+        }
+        return toReturn;
     }
 
     static List<String> convertDataFieldValues(List<Value> toConvert) {

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/builders/KiePMMLModelCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/builders/KiePMMLModelCodegenUtilsTest.java
@@ -16,55 +16,139 @@
 
 package org.kie.pmml.compiler.commons.builders;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
-import javax.xml.bind.JAXBException;
-
-import com.github.javaparser.utils.Pair;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import org.dmg.pmml.Field;
+import org.dmg.pmml.Model;
 import org.dmg.pmml.PMML;
+import org.dmg.pmml.TransformationDictionary;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.pmml.api.enums.DATA_TYPE;
+import org.kie.pmml.api.exceptions.KiePMMLException;
+import org.kie.pmml.compiler.commons.utils.JavaParserUtils;
 import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
-import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.kie.pmml.compiler.commons.CommonTestingUtils.getFieldsFromDataDictionary;
-import static org.kie.pmml.compiler.commons.builders.KiePMMLModelCodegenUtils.getMissingValueReplacementsMap;
-import static org.kie.pmml.compiler.commons.builders.KiePMMLModelCodegenUtils.getRequiredFieldsList;
+import static org.kie.pmml.compiler.commons.mocks.TestingModelImplementationProvider.KIE_PMML_TEST_MODEL_TEMPLATE;
+import static org.kie.pmml.compiler.commons.mocks.TestingModelImplementationProvider.KIE_PMML_TEST_MODEL_TEMPLATE_JAVA;
+import static org.kie.pmml.compiler.commons.utils.JavaParserUtils.MAIN_CLASS_NOT_FOUND;
+import static org.kie.pmml.compiler.commons.utils.ModelUtils.getFieldsFromDataDictionaryTransformationDictionaryAndModel;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
 
 public class KiePMMLModelCodegenUtilsTest {
 
-    private static final String MODEL_FILE = "MissingDataRegression.pmml";
+    private static final String MODEL_FILE = "TreeSample.pmml";
+    private static TransformationDictionary transformationDictionary;
+    private static Model model;
+    private static List<Field<?>> fields;
+    private static ClassOrInterfaceDeclaration modelTemplate;
 
-    @Test
-    public void testGetMissingValueReplacementsMap() throws IOException, JAXBException, SAXException {
-        PMML pmml = KiePMMLUtil.load(getFileInputStream(MODEL_FILE), MODEL_FILE);
-
-        Map<String, Pair<DATA_TYPE, String>> retrieved = getMissingValueReplacementsMap(getFieldsFromDataDictionary(pmml.getDataDictionary()), pmml.getModels().get(0));
-
-        assertTrue(retrieved.containsKey("x"));
-        assertEquals(DATA_TYPE.DOUBLE, retrieved.get("x").a);
-        assertEquals("5", retrieved.get("x").b);
-
-        assertTrue(retrieved.containsKey("y"));
-        assertEquals(DATA_TYPE.STRING, retrieved.get("y").a);
-        assertEquals("classB", retrieved.get("y").b);
+    @BeforeClass
+    public static void setup() throws Exception {
+        PMML pmmlModel = KiePMMLUtil.load(getFileInputStream(MODEL_FILE), MODEL_FILE);
+        transformationDictionary = pmmlModel.getTransformationDictionary();
+        model = pmmlModel.getModels().get(0);
+        fields = getFieldsFromDataDictionaryTransformationDictionaryAndModel(pmmlModel.getDataDictionary(),
+                                                                             transformationDictionary,
+                                                                             model);
+        CompilationUnit cloneCU = JavaParserUtils.getKiePMMLModelCompilationUnit("className", "packageName",
+                                                                                 KIE_PMML_TEST_MODEL_TEMPLATE_JAVA,
+                                                                                 KIE_PMML_TEST_MODEL_TEMPLATE);
+        modelTemplate = cloneCU.getClassByName("className")
+                .orElseThrow(() -> new KiePMMLException(MAIN_CLASS_NOT_FOUND + ": " + "className"));
     }
 
     @Test
-    public void testGetRequiredFieldsList() throws IOException, JAXBException, SAXException {
-        PMML pmml = KiePMMLUtil.load(getFileInputStream(MODEL_FILE), MODEL_FILE);
-
-        List<String> retrieved = getRequiredFieldsList(pmml.getModels().get(0));
-
-        assertFalse(retrieved.contains("x"));
-        assertFalse(retrieved.contains("y"));
-        assertTrue(retrieved.contains("z"));
+    public void init() {
+        ConstructorDeclaration constructorDeclaration = modelTemplate.getDefaultConstructor().get();
+        KiePMMLModelCodegenUtils.init(modelTemplate, fields, transformationDictionary, model);
+        BlockStmt body = constructorDeclaration.getBody();
+        Statement expected = JavaParserUtils.parseConstructorBlock("{\n" +
+                                                                           "super(\"golfing\", Collections.emptyList" +
+                                                                           "());\n" +
+                                                                           "    pmmlMODEL = org.kie.pmml.api.enums" +
+                                                                           ".PMML_MODEL" +
+                                                                           ".TREE_MODEL;\n" +
+                                                                           "    transformationDictionary = this" +
+                                                                           ".createTransformationDictionary();\n" +
+                                                                           "    localTransformations = this" +
+                                                                           ".createLocalTransformations();\n" +
+                                                                           "    miningFunction = org.kie.pmml.api" +
+                                                                           ".enums" +
+                                                                           ".MINING_FUNCTION.CLASSIFICATION;\n" +
+                                                                           "    targetField = \"whatIdo\";\n" +
+                                                                           "    miningFields.add(new org.kie.pmml.api" +
+                                                                           ".models" +
+                                                                           ".MiningField(\"temperature\", org.kie" +
+                                                                           ".pmml.api.enums" +
+                                                                           ".FIELD_USAGE_TYPE.ACTIVE, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.DATA_TYPE.DOUBLE, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.INVALID_VALUE_TREATMENT_METHOD" +
+                                                                           ".RETURN_INVALID, null, null, java.util" +
+                                                                           ".Arrays.asList" +
+                                                                           "(), java.util.Arrays.asList()));\n" +
+                                                                           "    miningFields.add(new org.kie.pmml.api" +
+                                                                           ".models" +
+                                                                           ".MiningField(\"humidity\", org.kie.pmml" +
+                                                                           ".api.enums" +
+                                                                           ".FIELD_USAGE_TYPE.ACTIVE, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.DATA_TYPE.DOUBLE, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.INVALID_VALUE_TREATMENT_METHOD" +
+                                                                           ".RETURN_INVALID, null, null, java.util" +
+                                                                           ".Arrays.asList" +
+                                                                           "(), java.util.Arrays.asList()));\n" +
+                                                                           "    miningFields.add(new org.kie.pmml.api" +
+                                                                           ".models" +
+                                                                           ".MiningField(\"windy\", org.kie.pmml.api" +
+                                                                           ".enums" +
+                                                                           ".FIELD_USAGE_TYPE.ACTIVE, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.DATA_TYPE.STRING, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.INVALID_VALUE_TREATMENT_METHOD" +
+                                                                           ".RETURN_INVALID, null, null, java.util" +
+                                                                           ".Arrays.asList" +
+                                                                           "(\"true\", \"false\"), java.util.Arrays" +
+                                                                           ".asList()));" +
+                                                                           "\n" +
+                                                                           "    miningFields.add(new org.kie.pmml.api" +
+                                                                           ".models" +
+                                                                           ".MiningField(\"outlook\", org.kie.pmml" +
+                                                                           ".api.enums" +
+                                                                           ".FIELD_USAGE_TYPE.ACTIVE, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.DATA_TYPE.STRING, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.INVALID_VALUE_TREATMENT_METHOD" +
+                                                                           ".RETURN_INVALID, null, null, java.util" +
+                                                                           ".Arrays.asList" +
+                                                                           "(\"sunny\", \"overcast\", \"rain\"), java" +
+                                                                           ".util" +
+                                                                           ".Arrays.asList()));\n" +
+                                                                           "    miningFields.add(new org.kie.pmml.api" +
+                                                                           ".models" +
+                                                                           ".MiningField(\"whatIdo\", org.kie.pmml" +
+                                                                           ".api.enums" +
+                                                                           ".FIELD_USAGE_TYPE.TARGET, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.DATA_TYPE.STRING, null, org.kie" +
+                                                                           ".pmml.api" +
+                                                                           ".enums.INVALID_VALUE_TREATMENT_METHOD" +
+                                                                           ".RETURN_INVALID, null, null, java.util.Arrays.asList" +
+                                                                           "(\"will play\", \"may play\", \"no play\"), java" +
+                                                                           ".util.Arrays.asList()));\n" +
+                                                                           "}");
+        assertEquals(expected.toString(), body.toString());
+        assertTrue(JavaParserUtils.equalsNode(expected, body));
     }
-
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/builders/KiePMMLModelCodegenUtilsTest.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/java/org/kie/pmml/compiler/commons/builders/KiePMMLModelCodegenUtilsTest.java
@@ -17,6 +17,7 @@
 package org.kie.pmml.compiler.commons.builders;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.bind.JAXBException;
@@ -29,9 +30,11 @@ import org.kie.pmml.compiler.commons.utils.KiePMMLUtil;
 import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.kie.pmml.compiler.commons.CommonTestingUtils.getFieldsFromDataDictionary;
 import static org.kie.pmml.compiler.commons.builders.KiePMMLModelCodegenUtils.getMissingValueReplacementsMap;
+import static org.kie.pmml.compiler.commons.builders.KiePMMLModelCodegenUtils.getRequiredFieldsList;
 import static org.kie.test.util.filesystem.FileUtils.getFileInputStream;
 
 public class KiePMMLModelCodegenUtilsTest {
@@ -42,15 +45,26 @@ public class KiePMMLModelCodegenUtilsTest {
     public void testGetMissingValueReplacementsMap() throws IOException, JAXBException, SAXException {
         PMML pmml = KiePMMLUtil.load(getFileInputStream(MODEL_FILE), MODEL_FILE);
 
-        Map<String, Pair<DATA_TYPE, String>> output = getMissingValueReplacementsMap(getFieldsFromDataDictionary(pmml.getDataDictionary()), pmml.getModels().get(0));
+        Map<String, Pair<DATA_TYPE, String>> retrieved = getMissingValueReplacementsMap(getFieldsFromDataDictionary(pmml.getDataDictionary()), pmml.getModels().get(0));
 
-        assertTrue(output.containsKey("x"));
-        assertEquals(DATA_TYPE.DOUBLE, output.get("x").a);
-        assertEquals("5", output.get("x").b);
+        assertTrue(retrieved.containsKey("x"));
+        assertEquals(DATA_TYPE.DOUBLE, retrieved.get("x").a);
+        assertEquals("5", retrieved.get("x").b);
 
-        assertTrue(output.containsKey("y"));
-        assertEquals(DATA_TYPE.STRING, output.get("y").a);
-        assertEquals("classB", output.get("y").b);
+        assertTrue(retrieved.containsKey("y"));
+        assertEquals(DATA_TYPE.STRING, retrieved.get("y").a);
+        assertEquals("classB", retrieved.get("y").b);
+    }
+
+    @Test
+    public void testGetRequiredFieldsList() throws IOException, JAXBException, SAXException {
+        PMML pmml = KiePMMLUtil.load(getFileInputStream(MODEL_FILE), MODEL_FILE);
+
+        List<String> retrieved = getRequiredFieldsList(pmml.getModels().get(0));
+
+        assertFalse(retrieved.contains("x"));
+        assertFalse(retrieved.contains("y"));
+        assertTrue(retrieved.contains("z"));
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/KiePMMLTestModelTemplate.tmpl
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/KiePMMLTestModelTemplate.tmpl
@@ -8,6 +8,10 @@ public class KiePMMLTestModelTemplate extends KiePMMLTestingModel {
     public KiePMMLTestModelTemplate() {
         super(name, Collections.emptyList());
         pmmlMODEL = null;
+        transformationDictionary = null;
+        localTransformations = null;
+        miningFunction = null;
+        targetField = null;
     }
 
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MissingDataRegression.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MissingDataRegression.pmml
@@ -1,4 +1,4 @@
-<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4" xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-4-1/pmml-4-4.xsd" xmlns="http://www.dmg.org/PMML-4_4">
   <Header/>
   <DataDictionary numberOfFields="3">
     <DataField name="result" optype="continuous" dataType="double"/>
@@ -11,9 +11,10 @@
   </DataDictionary>
   <RegressionModel modelName="MissingDataRegression" functionName="regression" algorithmName="least squares">
     <MiningSchema>
-      <MiningField name="result" usageType="predicted" invalidValueTreatment="returnInvalid"/>
+      <MiningField name="result" usageType="predicted" />
       <MiningField name="x" usageType="active" missingValueReplacement="5"/>
       <MiningField name="y" usageType="active" missingValueReplacement="classB"/>
+      <MiningField name="z" usageType="active" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
       <OutputField name="Predicted_result" optype="continuous" dataType="double" feature="predictedValue"/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MissingDataRegression.pmml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/src/test/resources/MissingDataRegression.pmml
@@ -12,9 +12,9 @@
   <RegressionModel modelName="MissingDataRegression" functionName="regression" algorithmName="least squares">
     <MiningSchema>
       <MiningField name="result" usageType="predicted" />
-      <MiningField name="x" usageType="active" missingValueReplacement="5"/>
-      <MiningField name="y" usageType="active" missingValueReplacement="classB"/>
-      <MiningField name="z" usageType="active" missingValueTreatment="returnInvalid"/>
+      <MiningField name="x" missingValueReplacement="5"/>
+      <MiningField name="y" missingValueReplacement="classB"/>
+      <MiningField name="z" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
       <OutputField name="Predicted_result" optype="continuous" dataType="double" feature="predictedValue"/>

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
@@ -16,7 +16,6 @@
 package org.kie.pmml.compiler.executor;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +42,7 @@ import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageNa
 import static org.kie.pmml.compiler.commons.factories.KiePMMLFactoryFactory.getFactorySourceCode;
 import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndTransformationDictionaryAndModel;
 import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndTransformationDictionaryAndModelWithSources;
+import static org.kie.pmml.compiler.commons.utils.ModelUtils.getFieldsFromDataDictionaryAndTransformationDictionary;
 import static org.kie.pmml.compiler.commons.utils.ModelUtils.getFieldsFromDataDictionaryTransformationDictionaryAndModel;
 
 /**
@@ -163,4 +163,35 @@ public class PMMLCompilerImpl implements PMMLCompiler {
                 .map(Optional::get)
                 .collect(Collectors.toList());
     }
+//
+//    private List<Field<?>> getFieldsFromDataDictionaryAndTransformationDictionary(final DataDictionary dataDictionary,
+//                                                                                  final TransformationDictionary transformationDictionary) {
+//        final List<Field<?>> toReturn = new ArrayList<>();
+//        if (dataDictionary != null) {
+//            dataDictionary.getDataFields().stream().map(Field.class::cast)
+//                    .forEach(toReturn::add);
+//        }
+//        if (transformationDictionary != null && transformationDictionary.hasDerivedFields()) {
+//            transformationDictionary.getDerivedFields().stream().map(Field.class::cast)
+//                    .forEach(toReturn::add);
+//        }
+//        return toReturn;
+//    }
+//
+//    private List<Field<?>> getFieldsFromDataDictionaryTransformationDictionaryAndModel(final DataDictionary dataDictionary,
+//                                                                                       final TransformationDictionary transformationDictionary,
+//                                                                                       final Model model) {
+//        final List<Field<?>> toReturn = getFieldsFromDataDictionaryAndTransformationDictionary(dataDictionary, transformationDictionary);
+//        LocalTransformations localTransformations = model.getLocalTransformations();
+//        if (localTransformations != null && localTransformations.hasDerivedFields()) {
+//            localTransformations.getDerivedFields().stream().map(Field.class::cast)
+//                    .forEach(toReturn::add);
+//        }
+//        Output output =  model.getOutput();
+//        if (output != null && output.hasOutputFields()) {
+//            output.getOutputFields().stream().map(Field.class::cast)
+//                    .forEach(toReturn::add);
+//        }
+//        return toReturn;
+//    }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
@@ -153,7 +153,8 @@ public class PMMLCompilerImpl implements PMMLCompiler {
                                                     final HasClassLoader hasClassloader) {
         logger.trace("getModels {}", pmml);
         TransformationDictionary transformationDictionary = pmml.getTransformationDictionary();
-        final List<Field<?>> fields = getFieldsFromDataDictionaryAndTransformationDictionary(pmml.getDataDictionary(), transformationDictionary);
+        final List<Field<?>> fields = getFieldsFromDataDictionaryAndTransformationDictionary(pmml.getDataDictionary()
+                , transformationDictionary);
         return pmml
                 .getModels()
                 .stream()
@@ -163,35 +164,4 @@ public class PMMLCompilerImpl implements PMMLCompiler {
                 .map(Optional::get)
                 .collect(Collectors.toList());
     }
-//
-//    private List<Field<?>> getFieldsFromDataDictionaryAndTransformationDictionary(final DataDictionary dataDictionary,
-//                                                                                  final TransformationDictionary transformationDictionary) {
-//        final List<Field<?>> toReturn = new ArrayList<>();
-//        if (dataDictionary != null) {
-//            dataDictionary.getDataFields().stream().map(Field.class::cast)
-//                    .forEach(toReturn::add);
-//        }
-//        if (transformationDictionary != null && transformationDictionary.hasDerivedFields()) {
-//            transformationDictionary.getDerivedFields().stream().map(Field.class::cast)
-//                    .forEach(toReturn::add);
-//        }
-//        return toReturn;
-//    }
-//
-//    private List<Field<?>> getFieldsFromDataDictionaryTransformationDictionaryAndModel(final DataDictionary dataDictionary,
-//                                                                                       final TransformationDictionary transformationDictionary,
-//                                                                                       final Model model) {
-//        final List<Field<?>> toReturn = getFieldsFromDataDictionaryAndTransformationDictionary(dataDictionary, transformationDictionary);
-//        LocalTransformations localTransformations = model.getLocalTransformations();
-//        if (localTransformations != null && localTransformations.hasDerivedFields()) {
-//            localTransformations.getDerivedFields().stream().map(Field.class::cast)
-//                    .forEach(toReturn::add);
-//        }
-//        Output output =  model.getOutput();
-//        if (output != null && output.hasOutputFields()) {
-//            output.getOutputFields().stream().map(Field.class::cast)
-//                    .forEach(toReturn::add);
-//        }
-//        return toReturn;
-//    }
 }

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/src/main/java/org/kie/pmml/compiler/executor/PMMLCompilerImpl.java
@@ -24,11 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.dmg.pmml.DataDictionary;
 import org.dmg.pmml.Field;
-import org.dmg.pmml.LocalTransformations;
-import org.dmg.pmml.Model;
-import org.dmg.pmml.Output;
 import org.dmg.pmml.PMML;
 import org.dmg.pmml.TransformationDictionary;
 import org.kie.pmml.api.exceptions.ExternalException;
@@ -47,6 +43,7 @@ import static org.kie.pmml.commons.utils.KiePMMLModelUtils.getSanitizedPackageNa
 import static org.kie.pmml.compiler.commons.factories.KiePMMLFactoryFactory.getFactorySourceCode;
 import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndTransformationDictionaryAndModel;
 import static org.kie.pmml.compiler.commons.implementations.KiePMMLModelRetriever.getFromCommonDataAndTransformationDictionaryAndModelWithSources;
+import static org.kie.pmml.compiler.commons.utils.ModelUtils.getFieldsFromDataDictionaryTransformationDictionaryAndModel;
 
 /**
  * <code>PMMLCompiler</code> default implementation
@@ -56,7 +53,8 @@ public class PMMLCompilerImpl implements PMMLCompiler {
     private static final Logger logger = LoggerFactory.getLogger(PMMLCompilerImpl.class.getName());
 
     @Override
-    public List<KiePMMLModel> getKiePMMLModels(final String packageName, final InputStream inputStream, final String fileName, final HasClassLoader hasClassloader) {
+    public List<KiePMMLModel> getKiePMMLModels(final String packageName, final InputStream inputStream,
+                                               final String fileName, final HasClassLoader hasClassloader) {
         logger.trace("getModels {} {} {}", packageName, inputStream, hasClassloader);
         try {
             PMML commonPMMLModel = KiePMMLUtil.load(inputStream, fileName);
@@ -82,7 +80,8 @@ public class PMMLCompilerImpl implements PMMLCompiler {
             Set<String> expectedClasses = commonPMMLModel.getModels()
                     .stream()
                     .map(model -> {
-                        String modelPackageName = getSanitizedPackageName(String.format("%s.%s", packageName, model.getModelName()));
+                        String modelPackageName = getSanitizedPackageName(String.format("%s.%s", packageName,
+                                                                                        model.getModelName()));
                         return modelPackageName + "." + getSanitizedClassName(model.getModelName());
                     })
                     .collect(Collectors.toSet());
@@ -92,7 +91,8 @@ public class PMMLCompilerImpl implements PMMLCompiler {
                 if (kiePMMLModel instanceof HasSourcesMap) {
                     generatedClasses.addAll(((HasSourcesMap) kiePMMLModel).getSourcesMap().keySet());
                 } else {
-                    throw new KiePMMLException(String.format("Expecting %s at this phase", HasSourcesMap.class.getCanonicalName()));
+                    throw new KiePMMLException(String.format("Expecting %s at this phase",
+                                                             HasSourcesMap.class.getCanonicalName()));
                 }
             });
             if (!generatedClasses.containsAll(expectedClasses)) {
@@ -101,9 +101,9 @@ public class PMMLCompilerImpl implements PMMLCompiler {
                 throw new KiePMMLException("Expected generated class " + missingClasses + " not found");
             }
 
-
             Map<String, String> factorySourceMap = getFactorySourceCode(factoryClassName, packageName, expectedClasses);
-            KiePMMLFactoryModel kiePMMLFactoryModel = new KiePMMLFactoryModel(factoryClassName, packageName, factorySourceMap);
+            KiePMMLFactoryModel kiePMMLFactoryModel = new KiePMMLFactoryModel(factoryClassName, packageName,
+                                                                              factorySourceMap);
             toReturn.add(kiePMMLFactoryModel);
             return toReturn;
         } catch (KiePMMLInternalException e) {
@@ -123,14 +123,19 @@ public class PMMLCompilerImpl implements PMMLCompiler {
      * @return
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      */
-    private List<KiePMMLModel> getModels(final String packageName, final PMML pmml, final HasClassLoader hasClassloader) {
+    private List<KiePMMLModel> getModels(final String packageName, final PMML pmml,
+                                         final HasClassLoader hasClassloader) {
         logger.trace("getModels {}", pmml);
         return pmml
                 .getModels()
                 .stream()
                 .map(model -> {
-                    final List<Field<?>> fields = getFieldsFromDataDictionaryTransformationDictionaryAndModel(pmml.getDataDictionary(), pmml.getTransformationDictionary(), model);
-                    return getFromCommonDataAndTransformationDictionaryAndModel(packageName, fields, pmml.getTransformationDictionary(), model, hasClassloader);
+                    final List<Field<?>> fields =
+                            getFieldsFromDataDictionaryTransformationDictionaryAndModel(pmml.getDataDictionary(),
+                                                                                        pmml.getTransformationDictionary(), model);
+                    return getFromCommonDataAndTransformationDictionaryAndModel(packageName, fields,
+                                                                                pmml.getTransformationDictionary(),
+                                                                                model, hasClassloader);
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -144,11 +149,12 @@ public class PMMLCompilerImpl implements PMMLCompiler {
      * @return
      * @throws KiePMMLException if any <code>KiePMMLInternalException</code> has been thrown during execution
      */
-    private List<KiePMMLModel> getModelsWithSources(final String packageName, final PMML pmml, final HasClassLoader hasClassloader) {
+    private List<KiePMMLModel> getModelsWithSources(final String packageName, final PMML pmml,
+                                                    final HasClassLoader hasClassloader) {
         logger.trace("getModels {}", pmml);
         final List<Field<?>> fields = new ArrayList<>();
         pmml.getDataDictionary().getDataFields().stream().map(Field.class::cast)
-                        .forEach(fields::add);
+                .forEach(fields::add);
         TransformationDictionary transformationDictionary = pmml.getTransformationDictionary();
         if (transformationDictionary.hasDerivedFields()) {
             transformationDictionary.getDerivedFields().stream().map(Field.class::cast)
@@ -157,32 +163,10 @@ public class PMMLCompilerImpl implements PMMLCompiler {
         return pmml
                 .getModels()
                 .stream()
-                .map(model -> getFromCommonDataAndTransformationDictionaryAndModelWithSources(packageName, fields, transformationDictionary, model, hasClassloader))
+                .map(model -> getFromCommonDataAndTransformationDictionaryAndModelWithSources(packageName, fields,
+                                                                                              transformationDictionary, model, hasClassloader))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
-    }
-
-    private List<Field<?>> getFieldsFromDataDictionaryTransformationDictionaryAndModel(final DataDictionary dataDictionary,
-                                                                                       final TransformationDictionary transformationDictionary,
-                                                                                       final Model model) {
-        final List<Field<?>> toReturn = new ArrayList<>();
-        dataDictionary.getDataFields().stream().map(Field.class::cast)
-                .forEach(toReturn::add);
-        if (transformationDictionary != null && transformationDictionary.hasDerivedFields()) {
-            transformationDictionary.getDerivedFields().stream().map(Field.class::cast)
-                    .forEach(toReturn::add);
-        }
-        LocalTransformations localTransformations = model.getLocalTransformations();
-        if (localTransformations != null && localTransformations.hasDerivedFields()) {
-            localTransformations.getDerivedFields().stream().map(Field.class::cast)
-                    .forEach(toReturn::add);
-        }
-        Output output =  model.getOutput();
-        if (output != null && output.hasOutputFields()) {
-            output.getOutputFields().stream().map(Field.class::cast)
-                    .forEach(toReturn::add);
-        }
-        return toReturn;
     }
 }

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
@@ -33,6 +33,8 @@ import org.kie.pmml.commons.transformations.KiePMMLDerivedField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kie.pmml.api.utils.ConverterTypeUtil.convert;
+
 /**
  * Class meant to provide static methods related to <b>pre-process</b> manipulation
  */
@@ -152,11 +154,13 @@ public class PreProcess {
             if (parameterInfo != null) {
                 boolean match = true;
                 Object originalValue = parameterInfo.getValue();
-                if (miningField.getAllowedValues() != null) {
-                    String originalValueString = originalValue.toString();
+                if (miningField.getAllowedValues() != null && !miningField.getAllowedValues().isEmpty() ) {
                     match = miningField.getAllowedValues().stream()
-                            .anyMatch(originalValueString::equals);
-                } else if (miningField.getIntervals() != null) {
+                            .anyMatch(allowedValue -> {
+                                Object allowedObject = convert(originalValue.getClass(), allowedValue);
+                                return originalValue.equals(allowedObject);
+                            });
+                } else if (miningField.getIntervals() != null && !miningField.getIntervals().isEmpty()) {
                     double originalValueNumber = ((Number) originalValue).doubleValue();
                     match = miningField.getIntervals().stream()
                             .anyMatch(interval -> originalValueNumber >= interval.getLeftMargin().doubleValue() &&

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.evaluator.core.utils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.pmml.ParameterInfo;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLContext;
 import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.commons.model.ProcessingDTO;
@@ -48,6 +50,7 @@ public class PreProcess {
      * @return
      */
     public static ProcessingDTO preProcess(final KiePMMLModel model, final PMMLContext context) {
+        verifyMissingValues(model, context);
         addMissingValuesReplacements(model, context);
         final PMMLRequestData requestData = context.getRequestData();
         final ProcessingDTO toReturn = createProcessingDTO(model, requestData.getMappedRequestParams());
@@ -59,6 +62,34 @@ public class PreProcess {
         final List<KiePMMLNameValue> kiePMMLNameValues =
                 getKiePMMLNameValuesFromParameterInfos(mappedRequestParams.values());
         return new ProcessingDTO(model, kiePMMLNameValues);
+    }
+
+    /**
+     * Verify the missing values if defined in original PMML as <b>missingValueTreatment</b>.
+     * <p>
+     *    missingValueTreatment: In a PMML consumer this field is for information only,
+     *    unless the value is returnInvalid, in which case if a missing value is encountered
+     *    in the given field, the model should return a value indicating an invalid result;
+     * </p>
+     *
+     * @param model
+     * @param context
+     * @see
+     * <a href="http://dmg.org/pmml/v4-4/MiningSchema.html#xsdType_MISSING-VALUE-TREATMENT-METHOD">MISSING-VALUE-TREATMENT-METHOD</a>
+     */
+    static void verifyMissingValues(final KiePMMLModel model, final PMMLContext context) {
+        logger.debug("verifyMissingValues {} {}", model, context);
+        final PMMLRequestData requestData = context.getRequestData();
+        final Map<String, ParameterInfo> mappedRequestParams = requestData.getMappedRequestParams();
+        final List<String> requiredFieldsList = model.getRequiredFieldsList();
+        final List<String> missingFields = requiredFieldsList.stream()
+                        .filter(fieldName -> !mappedRequestParams.containsKey(fieldName))
+                                .collect(Collectors.toList());
+        if (!missingFields.isEmpty()) {
+            String error =  String.format("Missing required field(s): %s", String.join(", ", missingFields));
+            logger.error(error);
+            throw new KiePMMLException(error);
+        }
     }
 
     /**

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
@@ -15,6 +15,7 @@
  */
 package org.kie.pmml.evaluator.core.utils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.pmml.ParameterInfo;
+import org.kie.pmml.api.enums.INVALID_VALUE_TREATMENT_METHOD;
 import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLContext;
 import org.kie.pmml.commons.model.KiePMMLModel;
@@ -51,6 +53,7 @@ public class PreProcess {
     public static ProcessingDTO preProcess(final KiePMMLModel model, final PMMLContext context) {
         verifyMissingValues(model, context);
         convertInputData(model, context);
+        verifyInvalidValues(model, context);
         addMissingValuesReplacements(model, context);
         final PMMLRequestData requestData = context.getRequestData();
         final ProcessingDTO toReturn = createProcessingDTO(model, requestData.getMappedRequestParams());
@@ -58,7 +61,8 @@ public class PreProcess {
         return toReturn;
     }
 
-    static ProcessingDTO createProcessingDTO(final KiePMMLModel model, final Map<String, ParameterInfo> mappedRequestParams) {
+    static ProcessingDTO createProcessingDTO(final KiePMMLModel model,
+                                             final Map<String, ParameterInfo> mappedRequestParams) {
         final List<KiePMMLNameValue> kiePMMLNameValues =
                 getKiePMMLNameValuesFromParameterInfos(mappedRequestParams.values());
         return new ProcessingDTO(model, kiePMMLNameValues);
@@ -67,11 +71,10 @@ public class PreProcess {
     /**
      * Verify the missing values if defined in original PMML as <b>missingValueTreatment</b>.
      * <p>
-     *    missingValueTreatment: In a PMML consumer this field is for information only,
-     *    unless the value is returnInvalid, in which case if a missing value is encountered
-     *    in the given field, the model should return a value indicating an invalid result;
+     * missingValueTreatment: In a PMML consumer this field is for information only,
+     * unless the value is returnInvalid, in which case if a missing value is encountered
+     * in the given field, the model should return a value indicating an invalid result;
      * </p>
-     *
      * @param model
      * @param context
      * @see
@@ -83,10 +86,10 @@ public class PreProcess {
         final Map<String, ParameterInfo> mappedRequestParams = requestData.getMappedRequestParams();
         final List<String> requiredFieldsList = model.getRequiredFieldsList();
         final List<String> missingFields = requiredFieldsList.stream()
-                        .filter(fieldName -> !mappedRequestParams.containsKey(fieldName))
-                                .collect(Collectors.toList());
+                .filter(fieldName -> !mappedRequestParams.containsKey(fieldName))
+                .collect(Collectors.toList());
         if (!missingFields.isEmpty()) {
-            String error =  String.format("Missing required field(s): %s", String.join(", ", missingFields));
+            String error = String.format("Missing required field(s): %s", String.join(", ", missingFields));
             logger.error(error);
             throw new KiePMMLException(error);
         }
@@ -103,7 +106,7 @@ public class PreProcess {
         Collection<ParameterInfo> requestParams = requestData.getRequestParams();
         model.getMiningFields().forEach(miningField -> {
             ParameterInfo parameterInfo = requestParams.stream()
-                    .filter(paramInfo ->  miningField.getName().equals(paramInfo.getName()))
+                    .filter(paramInfo -> miningField.getName().equals(paramInfo.getName()))
                     .findFirst()
                     .orElse(null);
             if (parameterInfo != null) {
@@ -116,21 +119,21 @@ public class PreProcess {
     }
 
     /**
-     * Verify the invalid values if defined in original PMML as <b>invalidValueTreatment</b>.
+     * Verify the invalid values if defined in original PMML as <b>invalidValueTreatment</b>,
+     * eventually <b>removing</b> or <b>replacing</b> them, depending on the <b>invalidValueTreatment</b>.
      * <p>
-     *     invalidValueTreatment: This field specifies how invalid input values are handled.
-     *     returnInvalid is the default and specifies that, when an invalid input is encountered,
-     *     the model should return a value indicating an invalid result has been returned.
-     *     asIs means to use the input without modification. asMissing specifies that an invalid
-     *     input value should be treated as a missing value and follow the behavior specified by
-     *     the missingValueReplacement attribute if present (see above). If asMissing is specified
-     *     but there is no respective missingValueReplacement present, a missing value is passed on
-     *     for eventual handling by successive transformations via DerivedFields or in the actual
-     *     mining model. asValue specifies that an invalid input value should be replaced with the
-     *     value specified by attribute invalidValueReplacement which must be present in this case,
-     *     or the PMML is invalid.
+     * invalidValueTreatment: This field specifies how invalid input values are handled.
+     * returnInvalid is the default and specifies that, when an invalid input is encountered,
+     * the model should return a value indicating an invalid result has been returned.
+     * asIs means to use the input without modification. asMissing specifies that an invalid
+     * input value should be treated as a missing value and follow the behavior specified by
+     * the missingValueReplacement attribute if present (see above). If asMissing is specified
+     * but there is no respective missingValueReplacement present, a missing value is passed on
+     * for eventual handling by successive transformations via DerivedFields or in the actual
+     * mining model. asValue specifies that an invalid input value should be replaced with the
+     * value specified by attribute invalidValueReplacement which must be present in this case,
+     * or the PMML is invalid.
      * </p>
-     *
      * @param model
      * @param context
      * @see
@@ -139,16 +142,54 @@ public class PreProcess {
     static void verifyInvalidValues(final KiePMMLModel model, final PMMLContext context) {
         logger.debug("verifyInvalidValues {} {}", model, context);
         final PMMLRequestData requestData = context.getRequestData();
-        final Map<String, ParameterInfo> mappedRequestParams = requestData.getMappedRequestParams();
-        final List<String> requiredFieldsList = model.getRequiredFieldsList();
-        final List<String> missingFields = requiredFieldsList.stream()
-                .filter(fieldName -> !mappedRequestParams.containsKey(fieldName))
-                .collect(Collectors.toList());
-        if (!missingFields.isEmpty()) {
-            String error =  String.format("Missing required field(s): %s", String.join(", ", missingFields));
-            logger.error(error);
-            throw new KiePMMLException(error);
-        }
+        final Collection<ParameterInfo> requestParams = requestData.getRequestParams();
+        final List<ParameterInfo> toRemove = new ArrayList<>();
+        model.getMiningFields().forEach(miningField -> {
+            ParameterInfo parameterInfo = requestParams.stream()
+                    .filter(paramInfo -> miningField.getName().equals(paramInfo.getName()))
+                    .findFirst()
+                    .orElse(null);
+            if (parameterInfo != null) {
+                boolean match = true;
+                Object originalValue = parameterInfo.getValue();
+                if (miningField.getAllowedValues() != null) {
+                    String originalValueString = originalValue.toString();
+                    match = miningField.getAllowedValues().stream()
+                            .anyMatch(originalValueString::equals);
+                } else if (miningField.getIntervals() != null) {
+                    double originalValueNumber = ((Number) originalValue).doubleValue();
+                    match = miningField.getIntervals().stream()
+                            .anyMatch(interval -> originalValueNumber >= interval.getLeftMargin().doubleValue() &&
+                                    originalValueNumber <= interval.getRightMargin().doubleValue());
+                }
+                if (!match) {
+                    INVALID_VALUE_TREATMENT_METHOD invalidValueTreatmentMethod = miningField.getInvalidValueTreatmentMethod() != null ? miningField.getInvalidValueTreatmentMethod()
+                            : INVALID_VALUE_TREATMENT_METHOD.RETURN_INVALID;
+                    switch (invalidValueTreatmentMethod) {
+                        case RETURN_INVALID:
+                            throw new KiePMMLException("Invalid value " + originalValue + " for " + miningField.getName());
+                        case AS_MISSING:
+                            toRemove.add(parameterInfo);
+                            break;
+                        case AS_VALUE:
+                            String invalidValueReplacement = miningField.getInvalidValueReplacement();
+                            if (invalidValueReplacement == null) {
+                                throw new KiePMMLException("Missing required invalidValueReplacement for " + miningField.getName());
+                            } else {
+                                Object requiredValue = miningField.getDataType().getActualValue(invalidValueReplacement);
+                                parameterInfo.setType(miningField.getDataType().getMappedClass());
+                                parameterInfo.setValue(requiredValue);
+                            }
+                            break;
+                        case AS_IS:
+                            break;
+                        default:
+                            throw new KiePMMLException("Unmanaged INVALID_VALUE_TREATMENT_METHOD " + invalidValueTreatmentMethod);
+                    }
+                }
+                toRemove.forEach(requestData::removeRequestParam);
+            }
+        });
     }
 
     /**

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PreProcess.java
@@ -28,6 +28,7 @@ import org.kie.pmml.api.enums.FIELD_USAGE_TYPE;
 import org.kie.pmml.api.enums.INVALID_VALUE_TREATMENT_METHOD;
 import org.kie.pmml.api.enums.MISSING_VALUE_TREATMENT_METHOD;
 import org.kie.pmml.api.exceptions.KiePMMLException;
+import org.kie.pmml.api.exceptions.KiePMMLInputDataException;
 import org.kie.pmml.api.models.MiningField;
 import org.kie.pmml.api.runtime.PMMLContext;
 import org.kie.pmml.commons.model.KiePMMLModel;
@@ -215,7 +216,7 @@ public class PreProcess {
         Object originalValue = parameterInfo.getValue();
         switch (invalidValueTreatmentMethod) {
             case RETURN_INVALID:
-                throw new KiePMMLException("Invalid value " + originalValue + " for " + miningField.getName());
+                throw new KiePMMLInputDataException("Invalid value " + originalValue + " for " + miningField.getName());
             case AS_MISSING:
                 toRemove.add(parameterInfo);
                 break;
@@ -224,7 +225,7 @@ public class PreProcess {
             case AS_VALUE:
                 String invalidValueReplacement = miningField.getInvalidValueReplacement();
                 if (invalidValueReplacement == null) {
-                    throw new KiePMMLException("Missing required invalidValueReplacement for " + miningField.getName());
+                    throw new KiePMMLInputDataException("Missing required invalidValueReplacement for " + miningField.getName());
                 } else {
                     Object requiredValue =
                             miningField.getDataType().getActualValue(invalidValueReplacement);
@@ -250,7 +251,7 @@ public class PreProcess {
                         : MISSING_VALUE_TREATMENT_METHOD.RETURN_INVALID;
         switch (missingValueTreatmentMethod) {
             case RETURN_INVALID:
-                throw new KiePMMLException("Missing required value for " + miningField.getName());
+                throw new KiePMMLInputDataException("Missing required value for " + miningField.getName());
             case AS_IS:
             case AS_MEAN:
             case AS_MODE:

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PreProcessTest.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/test/java/org/kie/pmml/evaluator/core/utils/PreProcessTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.pmml.evaluator.core.utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import org.kie.api.pmml.ParameterInfo;
 import org.kie.pmml.api.enums.DATA_TYPE;
 import org.kie.pmml.api.enums.MINING_FUNCTION;
 import org.kie.pmml.api.enums.OP_TYPE;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLContext;
 import org.kie.pmml.commons.model.ProcessingDTO;
 import org.kie.pmml.commons.model.expressions.KiePMMLApply;
@@ -56,6 +58,40 @@ public class PreProcessTest {
     private static final String PARAM_2 = "PARAM_2";
     private static final Double value1 = 100.0;
     private static final Double value2 = 5.0;
+
+    @Test
+    public void verifyMissingValuesNotMissing() {
+        List<String> requiredFieldsList = new ArrayList<>();
+        KiePMMLTestingModel model = KiePMMLTestingModel.builder("TESTINGMODEL", Collections.emptyList(), MINING_FUNCTION.REGRESSION)
+                .withRequiredFieldsList(requiredFieldsList)
+                .build();
+        PMMLRequestData pmmlRequestData = new PMMLRequestData("123", "modelName");
+        pmmlRequestData.addRequestParam("age", 123);
+        pmmlRequestData.addRequestParam("work", "work");
+        PMMLContext pmmlContext = new PMMLContextImpl(pmmlRequestData);
+        PreProcess.verifyMissingValues(model, pmmlContext);
+        requiredFieldsList.add("age");
+        requiredFieldsList.add("work");
+        model = KiePMMLTestingModel.builder("TESTINGMODEL", Collections.emptyList(), MINING_FUNCTION.REGRESSION)
+                .withRequiredFieldsList(requiredFieldsList)
+                .build();
+        PreProcess.verifyMissingValues(model, pmmlContext);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void verifyMissingValuesMissing() {
+        List<String> requiredFieldsList = new ArrayList<>();
+        requiredFieldsList.add("place");
+        requiredFieldsList.add("city");
+        KiePMMLTestingModel model = KiePMMLTestingModel.builder("TESTINGMODEL", Collections.emptyList(), MINING_FUNCTION.REGRESSION)
+                .withRequiredFieldsList(requiredFieldsList)
+                .build();
+        PMMLRequestData pmmlRequestData = new PMMLRequestData("123", "modelName");
+        pmmlRequestData.addRequestParam("age", 123);
+        pmmlRequestData.addRequestParam("work", "work");
+        PMMLContext pmmlContext = new PMMLContextImpl(pmmlRequestData);
+        PreProcess.verifyMissingValues(model, pmmlContext);
+    }
 
     @Test
     public void addMissingValuesReplacements() {

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_2
-      http://www.dmg.org/v4-2-1/pmml-4-2.xsd"
-      xmlns="http://www.dmg.org/PMML-4_2">
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4"
+      xsi:schemaLocation="http://www.dmg.org/PMML-4_4
+      http://www.dmg.org/v4-4-1/pmml-4-4.xsd"
+      xmlns="http://www.dmg.org/PMML-4_4">
   <Header copyright="KNIME">
     <Application name="KNIME" version="2.8.0"/>
   </Header>
@@ -21,6 +21,7 @@
     </DataField>
     <DataField name="class" optype="categorical" dataType="string"/>
     <DataField name="text_input" optype="categorical" dataType="string"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -89,6 +90,7 @@
       <MiningField name="petal_length" invalidValueTreatment="asIs"/>
       <MiningField name="petal_width" invalidValueTreatment="asIs"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
       <MiningField name="class" usageType="predicted"/>
     </MiningSchema>
     <Output>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/main/resources/clusterwithtransformations/ClusterWithTransformations.pmml
@@ -21,7 +21,10 @@
     </DataField>
     <DataField name="class" optype="categorical" dataType="string"/>
     <DataField name="text_input" optype="categorical" dataType="string"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6"/>
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6"/>
+    </DataField>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -90,11 +93,11 @@
       <MiningField name="petal_length" invalidValueTreatment="asIs"/>
       <MiningField name="petal_width" invalidValueTreatment="asIs"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
-      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
+      <MiningField name="input3" missingValueTreatment="returnInvalid"/>
       <MiningField name="class" usageType="predicted"/>
     </MiningSchema>
     <Output>
-      <OutputField name="out_class" feature="predictedValue" dataType="string" optype="categorical">
+      <OutputField name="out_class" dataType="string" optype="categorical">
         <FieldRef field="class"/>
       </OutputField>
       <OutputField name="out_normcontinuous_field" feature="transformedValue" dataType="double" optype="continuous">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -88,6 +89,7 @@ public class ClusterWithTransformationsTest extends AbstractPMMLTest {
         inputData.put("petal_length", petalLength);
         inputData.put("petal_width", petalWidth);
         inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 34.1);
 
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
 
@@ -134,5 +136,16 @@ public class ClusterWithTransformationsTest extends AbstractPMMLTest {
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_MAPVALUED_FIELD)).isEqualTo(expected);
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isEqualTo(1.0);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testClusterWithTransformationsWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("sepal_length", sepalLength);
+        inputData.put("sepal_width", sepalWidth);
+        inputData.put("petal_length", petalLength);
+        inputData.put("petal_width", petalWidth);
+        inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
@@ -174,4 +174,16 @@ public class ClusterWithTransformationsTest extends AbstractPMMLTest {
         inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
+
+    @Test(expected = KiePMMLException.class)
+    public void testClusterWithTransformationsInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("sepal_length", sepalLength);
+        inputData.put("sepal_width", sepalWidth);
+        inputData.put("petal_length", petalLength);
+        inputData.put("petal_width", petalWidth);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 4.1);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/src/test/java/org/kie/pmml/clustering/tests/ClusterWithTransformationsTest.java
@@ -31,6 +31,8 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(Parameterized.class)
 public class ClusterWithTransformationsTest extends AbstractPMMLTest {
 
@@ -146,6 +148,30 @@ public class ClusterWithTransformationsTest extends AbstractPMMLTest {
         inputData.put("petal_length", petalLength);
         inputData.put("petal_width", petalWidth);
         inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testClusterWithTransformationsConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("sepal_length", String.valueOf(sepalLength));
+        inputData.put("sepal_width", String.valueOf(sepalWidth));
+        inputData.put("petal_length", String.valueOf(petalLength));
+        inputData.put("petal_width", String.valueOf(petalWidth));
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testClusterWithTransformationsNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("sepal_length", sepalLength);
+        inputData.put("sepal_width", sepalWidth);
+        inputData.put("petal_length", petalLength);
+        inputData.put("petal_width", petalWidth);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModel.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/src/main/java/org/kie/pmml/models/drools/commons/model/KiePMMLDroolsModel.java
@@ -73,7 +73,8 @@ public abstract class KiePMMLDroolsModel extends KiePMMLModel implements IsDrool
         }
         final PMML4Result toReturn = getPMML4Result(targetField);
         String fullClassName = this.getClass().getName();
-        String packageName =  fullClassName.contains(".") ? fullClassName.substring(0, fullClassName.lastIndexOf('.')) : "";
+        String packageName = fullClassName.contains(".") ?
+                fullClassName.substring(0, fullClassName.lastIndexOf('.')) : "";
         KiePMMLSessionUtils.Builder builder = KiePMMLSessionUtils.builder((KieBase) knowledgeBase, name, packageName,
                                                                           toReturn)
                 .withObjectsInSession(requestData, fieldTypeMap)
@@ -100,7 +101,6 @@ public abstract class KiePMMLDroolsModel extends KiePMMLModel implements IsDrool
                 .add("miningFunction=" + miningFunction)
                 .add("targetField='" + targetField + "'")
                 .add("outputFieldsMap=" + outputFieldsMap)
-                .add("missingValueReplacementMap=" + missingValueReplacementMap)
                 .add("name='" + name + "'")
                 .add("extensions=" + extensions)
                 .add("id='" + id + "'")

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
@@ -1,4 +1,6 @@
-<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4" xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-4-1/pmml-4-4.xsd" xmlns="http://www.dmg.org/PMML-4_4">
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4"
+      xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-4-1/pmml-4-4.xsd"
+      xmlns="http://www.dmg.org/PMML-4_4">
   <Header/>
   <DataDictionary>
     <DataField name="input1" optype="continuous" dataType="double"/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
@@ -1,14 +1,16 @@
-<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4" xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-4-1/pmml-4-4.xsd" xmlns="http://www.dmg.org/PMML-4_4">
   <Header/>
   <DataDictionary>
     <DataField name="input1" optype="continuous" dataType="double"/>
     <DataField name="input2" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
     <DataField name="score" optype="continuous" dataType="double"/>
   </DataDictionary>
   <Scorecard modelName="SimpleScorecard" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="5" baselineMethod="other">
     <MiningSchema>
       <MiningField name="input1" usageType="active" invalidValueTreatment="asMissing"/>
       <MiningField name="input2" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
       <MiningField name="score" usageType="target"/>
     </MiningSchema>
     <Output>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
@@ -3,18 +3,21 @@
   <DataDictionary>
     <DataField name="input1" optype="continuous" dataType="double"/>
     <DataField name="input2" optype="continuous" dataType="double"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6"/>
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6"/>
+    </DataField>
     <DataField name="score" optype="continuous" dataType="double"/>
   </DataDictionary>
   <Scorecard modelName="SimpleScorecard" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="5" baselineMethod="other">
     <MiningSchema>
-      <MiningField name="input1" usageType="active" invalidValueTreatment="asMissing"/>
-      <MiningField name="input2" usageType="active" invalidValueTreatment="asMissing"/>
-      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
+      <MiningField name="input1" invalidValueTreatment="asMissing"/>
+      <MiningField name="input2" invalidValueTreatment="asMissing"/>
+      <MiningField name="input3" missingValueTreatment="returnInvalid"/>
       <MiningField name="score" usageType="target"/>
     </MiningSchema>
     <Output>
-      <OutputField name="Score" feature="predictedValue" dataType="double" optype="continuous"/>
+      <OutputField name="Score" dataType="double" optype="continuous"/>
       <OutputField name="Reason Code 1" rank="1" feature="reasonCode" dataType="string" optype="categorical"/>
       <OutputField name="Reason Code 2" rank="2" feature="reasonCode" dataType="string" optype="categorical"/>
     </Output>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
@@ -31,6 +31,8 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(Parameterized.class)
 public class SimpleScorecardTest extends AbstractPMMLTest {
 
@@ -90,6 +92,24 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("input1", input1);
         inputData.put("input2", input2);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testSimpleScorecardConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", String.valueOf(input1));
+        inputData.put("input2", String.valueOf(input2));
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSimpleScorecardNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", input1);
+        inputData.put("input2", input2);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -75,11 +76,20 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("input1", input1);
         inputData.put("input2", input2);
+        inputData.put("input3", 34.1);
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
 
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isEqualTo(score);
         Assertions.assertThat(pmml4Result.getResultVariables().get(REASON_CODE1_FIELD)).isEqualTo(reasonCode1);
         Assertions.assertThat(pmml4Result.getResultVariables().get(REASON_CODE2_FIELD)).isEqualTo(reasonCode2);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSimpleScorecardWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", input1);
+        inputData.put("input2", input2);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/src/test/java/org/kie/pmml/models/drools/scorecard/tests/SimpleScorecardTest.java
@@ -57,7 +57,7 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         this.reasonCode2 = reasonCode2;
     }
 
-  @BeforeClass
+    @BeforeClass
     public static void setupClass() {
         pmmlRuntime = getPMMLRuntime(FILE_NAME);
     }
@@ -110,6 +110,15 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         inputData.put("input1", input1);
         inputData.put("input2", input2);
         inputData.put("input3", true);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSimpleScorecardInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", input1);
+        inputData.put("input2", input2);
+        inputData.put("input3", 4.1);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
@@ -1,5 +1,6 @@
-<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns="http://www.dmg.org/PMML-4_2">
+<PMML version="4.4" xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-2-1/pmml-4-4.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.dmg.org/PMML-4_4">
   <Header>
     <Application name="Drools-PMML" version="7.0.0-SNAPSHOT" />
   </Header>
@@ -13,6 +14,7 @@
       <Value value="nothing" />
     </DataField>
     <DataField name="text_input" optype="categorical" dataType="string"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -101,9 +103,10 @@
       <MiningField name="humidity"  usageType="active" />
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
       <MiningField name="decision" usageType="predicted" />
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
-      <OutputField name="weatherdecision" targetField="decision" />
+      <OutputField name="weatherdecision" targetField="decision" dataType="string" />
       <OutputField name="out_der_temperature" dataType="double" feature="transformedValue">
         <FieldRef field="der_temperature"/>
       </OutputField>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
@@ -2,19 +2,22 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://www.dmg.org/PMML-4_4">
   <Header>
-    <Application name="Drools-PMML" version="7.0.0-SNAPSHOT" />
+    <Application name="Drools-PMML" version="7.0.0-SNAPSHOT"/>
   </Header>
 
   <DataDictionary numberOfFields="3">
-    <DataField name="temperature" dataType="double" optype="continuous" />
-    <DataField name="humidity" dataType="double" optype="continuous" />
+    <DataField name="temperature" dataType="double" optype="continuous"/>
+    <DataField name="humidity" dataType="double" optype="continuous"/>
     <DataField name="decision" dataType="string" optype="categorical">
-      <Value value="sunglasses" />
-      <Value value="umbrella" />
-      <Value value="nothing" />
+      <Value value="sunglasses"/>
+      <Value value="umbrella"/>
+      <Value value="nothing"/>
     </DataField>
     <DataField name="text_input" optype="categorical" dataType="string"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6"/>
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6"/>
+    </DataField>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -30,7 +33,7 @@
     </DefineFunction>
     <DefineFunction name="norm_discrete_function" optype="categorical" dataType="string">
       <ParameterField name="eval_decision"/>
-      <NormDiscrete field="eval_decision" value="umbrella" />
+      <NormDiscrete field="eval_decision" value="umbrella"/>
     </DefineFunction>
     <DefineFunction name="fun_humidity_fieldref" optype="continuous" dataType="double">
       <ParameterField name="humidity_fake"/>
@@ -99,14 +102,14 @@
   </TransformationDictionary>
   <TreeModel modelName="SampleMineTreeModelWithTransformations" functionName="classification">
     <MiningSchema>
-      <MiningField name="temperature"  usageType="active" />
-      <MiningField name="humidity"  usageType="active" />
+      <MiningField name="temperature"/>
+      <MiningField name="humidity"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
-      <MiningField name="decision" usageType="predicted" />
-      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
+      <MiningField name="decision" usageType="predicted"/>
+      <MiningField name="input3" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
-      <OutputField name="weatherdecision" targetField="decision" dataType="string" />
+      <OutputField name="weatherdecision" targetField="decision" dataType="string"/>
       <OutputField name="out_der_temperature" dataType="double" feature="transformedValue">
         <FieldRef field="der_temperature"/>
       </OutputField>
@@ -120,12 +123,12 @@
         <FieldRef field="normcontinuous_field"/>
       </OutputField>
       <OutputField name="out_normdiscrete_field" feature="transformedValue" dataType="string" optype="categorical">
-        <Apply function="norm_discrete_function" >
+        <Apply function="norm_discrete_function">
           <FieldRef field="decision"/>
         </Apply>
       </OutputField>
       <OutputField name="out_discretize_field" feature="transformedValue" dataType="string" optype="categorical">
-        <Apply function="discretize_function" >
+        <Apply function="discretize_function">
           <FieldRef field="temperature"/>
         </Apply>
       </OutputField>
@@ -148,26 +151,26 @@
           </InlineTable>
         </MapValues>
       </OutputField>
-      <OutputField name="out_text_index_normalization_field" feature="transformedValue" dataType="double" optype="continuous" >
-        <Apply function="TEXT_INDEX_NORMALIZATION_FUNCTION" >
+      <OutputField name="out_text_index_normalization_field" feature="transformedValue" dataType="double" optype="continuous">
+        <Apply function="TEXT_INDEX_NORMALIZATION_FUNCTION">
           <FieldRef field="text_input"/>
           <Constant>ui_good</Constant>
         </Apply>
       </OutputField>
     </Output>
     <Node score="nothing" id="1">
-      <True />
+      <True/>
       <Node score="sunglasses" id="2">
         <CompoundPredicate booleanOperator="and">
-          <SimplePredicate field="der_temperature" operator="greaterThan" value="25" />
-          <SimplePredicate field="der_fun_humidity_apply" operator="lessOrEqual" value="20" />
+          <SimplePredicate field="der_temperature" operator="greaterThan" value="25"/>
+          <SimplePredicate field="der_fun_humidity_apply" operator="lessOrEqual" value="20"/>
         </CompoundPredicate>
       </Node>
       <Node score="umbrella" id="3">
-        <SimplePredicate field="der_fun_humidity_apply" operator="greaterThan" value="50" />
+        <SimplePredicate field="der_fun_humidity_apply" operator="greaterThan" value="50"/>
       </Node>
       <Node score="nothing" id="4">
-        <True />
+        <True/>
       </Node>
     </Node>
   </TreeModel>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -31,6 +31,8 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(Parameterized.class)
 public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest {
 
@@ -130,6 +132,26 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         inputData.put("temperature", temperature);
         inputData.put("humidity", humidity);
         inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testSampleMineTreeModelWithTransformationsConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", String.valueOf(temperature));
+        inputData.put("humidity",String.valueOf(humidity));
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSampleMineTreeModelWithTransformationsNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", temperature);
+        inputData.put("humidity", humidity);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -75,11 +76,12 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
     }
 
     @Test
-    public void testSetPredicateTree() throws Exception {
+    public void testSampleMineTreeModelWithTransformations() throws Exception {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("temperature", temperature);
         inputData.put("humidity", humidity);
         inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 34.1);
 
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isNotNull();
@@ -120,5 +122,14 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_MAPVALUED_FIELD)).isEqualTo(expected);
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isEqualTo(1.0);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSampleMineTreeModelWithTransformationsWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", temperature);
+        inputData.put("humidity", humidity);
+        inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/src/test/java/org/kie/pmml/models/drools/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -63,7 +63,7 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         this.expectedResult = expectedResult;
     }
 
-  @BeforeClass
+    @BeforeClass
     public static void setupClass() {
         pmmlRuntime = getPMMLRuntime(FILE_NAME);
     }
@@ -139,7 +139,7 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
     public void testSampleMineTreeModelWithTransformationsConvertible() {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("temperature", String.valueOf(temperature));
-        inputData.put("humidity",String.valueOf(humidity));
+        inputData.put("humidity", String.valueOf(humidity));
         inputData.put("text_input", TEXT_INPUT);
         inputData.put("input3", "34.1");
         assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
@@ -152,6 +152,16 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         inputData.put("humidity", humidity);
         inputData.put("text_input", TEXT_INPUT);
         inputData.put("input3", true);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSampleMineTreeModelWithTransformationsInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", temperature);
+        inputData.put("humidity", humidity);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 4.1);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/minimgmodelchain/MiningModelChain.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/minimgmodelchain/MiningModelChain.pmml
@@ -39,7 +39,6 @@
       <MiningField name="occupation" />
       <MiningField name="residenceState" />
       <MiningField name="validLicense" />
-      <MiningField name="overallScore" />
       <MiningField name="qualificationLevel" usageType="target"/>
     </MiningSchema>
     <Segmentation multipleModelMethod="modelChain">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
@@ -33,6 +33,7 @@
     <DataField name="validLicense" optype="categorical" dataType="boolean"/>
     <DataField name="overallScore" optype="continuous" dataType="double"/>
     <DataField name="text_input" optype="categorical" dataType="string"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -140,6 +141,7 @@
       <MiningField name="validLicense" usageType="active" invalidValueTreatment="asMissing"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
       <MiningField name="categoricalResult" usageType="predicted" invalidValueTreatment="returnInvalid"/>
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
       <OutputField name="Number of Claims" feature="predictedValue" dataType="double" optype="continuous"/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/main/resources/mixedmining/MiningModel_Mixed.pmml
@@ -33,7 +33,10 @@
     <DataField name="validLicense" optype="categorical" dataType="boolean"/>
     <DataField name="overallScore" optype="continuous" dataType="double"/>
     <DataField name="text_input" optype="categorical" dataType="string"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6"/>
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6"/>
+    </DataField>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -49,7 +52,7 @@
     </DefineFunction>
     <DefineFunction name="norm_discrete_function" optype="categorical" dataType="string">
       <ParameterField name="eval_occupation"/>
-      <NormDiscrete field="eval_occupation" value="SKYDIVER" />
+      <NormDiscrete field="eval_occupation" value="SKYDIVER"/>
     </DefineFunction>
     <DefineFunction name="fun_occupation_referred" optype="categorical" dataType="string">
       <ParameterField name="occupation_referred"/>
@@ -133,15 +136,15 @@
   </TransformationDictionary>
   <MiningModel functionName="regression" modelName="MixedMining">
     <MiningSchema>
-      <MiningField name="categoricalX" usageType="active" invalidValueTreatment="returnInvalid"/>
-      <MiningField name="categoricalY" usageType="active" invalidValueTreatment="returnInvalid"/>
-      <MiningField name="age" usageType="active" invalidValueTreatment="asMissing"/>
-      <MiningField name="occupation" usageType="active" invalidValueTreatment="asMissing"/>
-      <MiningField name="residenceState" usageType="active" invalidValueTreatment="asMissing"/>
-      <MiningField name="validLicense" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="categoricalX"/>
+      <MiningField name="categoricalY"/>
+      <MiningField name="age" invalidValueTreatment="asMissing"/>
+      <MiningField name="occupation" invalidValueTreatment="asMissing"/>
+      <MiningField name="residenceState" invalidValueTreatment="asMissing"/>
+      <MiningField name="validLicense" invalidValueTreatment="asMissing"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
-      <MiningField name="categoricalResult" usageType="predicted" invalidValueTreatment="returnInvalid"/>
-      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
+      <MiningField name="categoricalResult" usageType="predicted"/>
+      <MiningField name="input3" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
       <OutputField name="Number of Claims" feature="predictedValue" dataType="double" optype="continuous"/>
@@ -160,20 +163,20 @@
         <FieldRef field="normcontinuous_field"/>
       </OutputField>
       <OutputField name="out_normdiscrete_field" feature="transformedValue" dataType="string" optype="categorical">
-        <Apply function="norm_discrete_function" >
+        <Apply function="norm_discrete_function">
           <FieldRef field="occupation"/>
         </Apply>
       </OutputField>
       <OutputField name="out_discretize_field" feature="transformedValue" dataType="string" optype="categorical">
-        <Apply function="discretize_function" >
+        <Apply function="discretize_function">
           <FieldRef field="age"/>
         </Apply>
       </OutputField>
       <OutputField name="out_mapvalued_field" feature="transformedValue" dataType="string" optype="categorical">
         <FieldRef field="mapvalued_field"/>
       </OutputField>
-      <OutputField name="out_text_index_normalization_field" feature="transformedValue" dataType="double" optype="continuous" >
-        <Apply function="TEXT_INDEX_NORMALIZATION_FUNCTION" >
+      <OutputField name="out_text_index_normalization_field" feature="transformedValue" dataType="double" optype="continuous">
+        <Apply function="TEXT_INDEX_NORMALIZATION_FUNCTION">
           <FieldRef field="text_input"/>
           <Constant>ui_good</Constant>
         </Apply>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -102,6 +103,7 @@ public class MixedMiningTest extends AbstractPMMLTest {
         inputData.put("residenceState", residenceState);
         inputData.put("validLicense", validLicense);
         inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 34.1);
 
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
 
@@ -153,5 +155,18 @@ public class MixedMiningTest extends AbstractPMMLTest {
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_MAPVALUED_FIELD)).isEqualTo(expected);
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isEqualTo(1.0);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testMixedMiningWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("categoricalX", categoricalX);
+        inputData.put("categoricalY", categoricalY);
+        inputData.put("age", age);
+        inputData.put("occupation", occupation);
+        inputData.put("residenceState", residenceState);
+        inputData.put("validLicense", validLicense);
+        inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
@@ -77,7 +77,7 @@ public class MixedMiningTest extends AbstractPMMLTest {
         this.expectedResult = expectedResult;
     }
 
-  @BeforeClass
+    @BeforeClass
     public static void setupClass() {
         pmmlRuntime = getPMMLRuntime(FILE_NAME);
     }
@@ -197,6 +197,20 @@ public class MixedMiningTest extends AbstractPMMLTest {
         inputData.put("validLicense", validLicense);
         inputData.put("text_input", TEXT_INPUT);
         inputData.put("input3", true);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testMixedMiningInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("categoricalX", categoricalX);
+        inputData.put("categoricalY", categoricalY);
+        inputData.put("age", age);
+        inputData.put("occupation", occupation);
+        inputData.put("residenceState", residenceState);
+        inputData.put("validLicense", validLicense);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 4.1);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/src/test/java/org/kie/pmml/mining/tests/MixedMiningTest.java
@@ -31,6 +31,8 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(Parameterized.class)
 public class MixedMiningTest extends AbstractPMMLTest {
 
@@ -167,6 +169,34 @@ public class MixedMiningTest extends AbstractPMMLTest {
         inputData.put("residenceState", residenceState);
         inputData.put("validLicense", validLicense);
         inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testMixedMiningConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("categoricalX", categoricalX);
+        inputData.put("categoricalY", categoricalY);
+        inputData.put("age", String.valueOf(age));
+        inputData.put("occupation", occupation);
+        inputData.put("residenceState", residenceState);
+        inputData.put("validLicense", String.valueOf(validLicense));
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testMixedMiningNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("categoricalX", categoricalX);
+        inputData.put("categoricalY", categoricalY);
+        inputData.put("age", age);
+        inputData.put("occupation", occupation);
+        inputData.put("residenceState", residenceState);
+        inputData.put("validLicense", validLicense);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
@@ -9,6 +9,7 @@
     </DataField>
     <DataField name="number_of_claims" optype="continuous" dataType="double"/>
     <DataField name="text_input" optype="categorical" dataType="string"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -142,6 +143,7 @@
       <MiningField name="car_location"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
       <MiningField name="number_of_claims" usageType="target"/>
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
       <OutputField name="Number of Claims" feature="predictedValue" dataType="double" optype="continuous"/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/linearregressionsamplewithtransformations/LinearRegressionSampleWithTransformations.pmml
@@ -9,7 +9,10 @@
     </DataField>
     <DataField name="number_of_claims" optype="continuous" dataType="double"/>
     <DataField name="text_input" optype="categorical" dataType="string"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6" />
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6" />
+    </DataField>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/missingdataregression/MissingDataRegression.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/main/resources/missingdataregression/MissingDataRegression.pmml
@@ -1,4 +1,6 @@
-<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4"
+      xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-4-1/pmml-4-4.xsd"
+      xmlns="http://www.dmg.org/PMML-4_4">
   <Header/>
   <DataDictionary numberOfFields="3">
     <DataField name="result" optype="continuous" dataType="double"/>
@@ -11,9 +13,9 @@
   </DataDictionary>
   <RegressionModel modelName="MissingDataRegression" functionName="regression" algorithmName="least squares">
     <MiningSchema>
-      <MiningField name="result" usageType="predicted" invalidValueTreatment="returnInvalid"/>
-      <MiningField name="x" usageType="active" missingValueReplacement="5"/>
-      <MiningField name="y" usageType="active" missingValueReplacement="classB"/>
+      <MiningField name="result" usageType="predicted" />
+      <MiningField name="x" missingValueReplacement="5" missingValueTreatment="asMean"/>
+      <MiningField name="y" missingValueReplacement="classB" missingValueTreatment="asMean"/>
     </MiningSchema>
     <Output>
       <OutputField name="Predicted_result" optype="continuous" dataType="double" feature="predictedValue"/>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
@@ -200,4 +200,15 @@ public class LinearRegressionSampleWithTransformationsTest extends AbstractPMMLT
         inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
+
+    @Test(expected = KiePMMLException.class)
+    public void testLinearRegressionSampleInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("age", age);
+        inputData.put("salary", salary);
+        inputData.put("car_location", car_location);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 4.1);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
@@ -32,6 +32,8 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(Parameterized.class)
 public class LinearRegressionSampleWithTransformationsTest extends AbstractPMMLTest {
 
@@ -174,6 +176,28 @@ public class LinearRegressionSampleWithTransformationsTest extends AbstractPMMLT
         inputData.put("salary", salary);
         inputData.put("car_location", car_location);
         inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testLinearRegressionSampleWithTransformationsConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("age", String.valueOf(age));
+        inputData.put("salary",String.valueOf(salary));
+        inputData.put("car_location", car_location);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testLinearRegressionSampleWithTransformationsNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("age", age);
+        inputData.put("salary", salary);
+        inputData.put("car_location", car_location);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/src/test/java/org/kie/pmml/regression/tests/LinearRegressionSampleWithTransformationsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -98,12 +99,13 @@ public class LinearRegressionSampleWithTransformationsTest extends AbstractPMMLT
     }
 
     @Test
-    public void testLogisticRegressionIrisData() throws Exception {
+    public void testLinearRegressionSampleWithTransformations() throws Exception {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("age", age);
         inputData.put("salary", salary);
         inputData.put("car_location", car_location);
         inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 34.1);
 
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
 
@@ -163,5 +165,15 @@ public class LinearRegressionSampleWithTransformationsTest extends AbstractPMMLT
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_MAPVALUED_FIELD)).isEqualTo(expected);
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isEqualTo(1.0);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testLinearRegressionSampleWithTransformationsWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("age", age);
+        inputData.put("salary", salary);
+        inputData.put("car_location", car_location);
+        inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
@@ -3,7 +3,10 @@
   <DataDictionary>
     <DataField name="input1" optype="continuous" dataType="double"/>
     <DataField name="input2" optype="continuous" dataType="double"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6" />
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6" />
+    </DataField>
     <DataField name="score" optype="continuous" dataType="double"/>
   </DataDictionary>
   <Scorecard modelName="SimpleScorecard" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="5" baselineMethod="other">

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/main/resources/simplescorecard/SimpleScorecard.pmml
@@ -1,14 +1,16 @@
-<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4" xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-4-1/pmml-4-4.xsd" xmlns="http://www.dmg.org/PMML-4_4">
   <Header/>
   <DataDictionary>
     <DataField name="input1" optype="continuous" dataType="double"/>
     <DataField name="input2" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
     <DataField name="score" optype="continuous" dataType="double"/>
   </DataDictionary>
   <Scorecard modelName="SimpleScorecard" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="5" baselineMethod="other">
     <MiningSchema>
       <MiningField name="input1" usageType="active" invalidValueTreatment="asMissing"/>
       <MiningField name="input2" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
       <MiningField name="score" usageType="target"/>
     </MiningSchema>
     <Output>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
@@ -112,4 +112,13 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSimpleScorecardInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", input1);
+        inputData.put("input2", input2);
+        inputData.put("input3", 4.1);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
@@ -31,6 +31,8 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(Parameterized.class)
 public class SimpleScorecardTest extends AbstractPMMLTest {
 
@@ -90,6 +92,24 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("input1", input1);
         inputData.put("input2", input2);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testSimpleScorecardConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", String.valueOf(input1));
+        inputData.put("input2", String.valueOf(input2));
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSimpleScorecardNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", input1);
+        inputData.put("input2", input2);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/src/test/java/org/kie/pmml/models/scorecard/tests/SimpleScorecardTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -75,11 +76,20 @@ public class SimpleScorecardTest extends AbstractPMMLTest {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("input1", input1);
         inputData.put("input2", input2);
+        inputData.put("input3", 34.1);
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
 
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isEqualTo(score);
         Assertions.assertThat(pmml4Result.getResultVariables().get(REASON_CODE1_FIELD)).isEqualTo(reasonCode1);
         Assertions.assertThat(pmml4Result.getResultVariables().get(REASON_CODE2_FIELD)).isEqualTo(reasonCode2);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSimpleScorecardWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("input1", input1);
+        inputData.put("input2", input2);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
@@ -1,5 +1,6 @@
-<PMML version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns="http://www.dmg.org/PMML-4_2">
+<PMML version="4.4" xsi:schemaLocation="http://www.dmg.org/PMML-4_4 http://www.dmg.org/v4-2-1/pmml-4-4.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.dmg.org/PMML-4_4">
   <Header>
     <Application name="Drools-PMML" version="7.0.0-SNAPSHOT" />
   </Header>
@@ -13,6 +14,7 @@
       <Value value="nothing" />
     </DataField>
     <DataField name="text_input" optype="categorical" dataType="string"/>
+    <DataField name="input3" optype="continuous" dataType="double"/>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -101,9 +103,10 @@
       <MiningField name="humidity"  usageType="active" />
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
       <MiningField name="decision" usageType="predicted" />
+      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
-      <OutputField name="weatherdecision" targetField="decision" />
+      <OutputField name="weatherdecision" targetField="decision" dataType="string" />
       <OutputField name="out_der_temperature" dataType="double" feature="transformedValue">
         <FieldRef field="der_temperature"/>
       </OutputField>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/main/resources/sampleminetreemodelwithtransformations/SampleMineTreeModelWithTransformations.pmml
@@ -2,19 +2,22 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://www.dmg.org/PMML-4_4">
   <Header>
-    <Application name="Drools-PMML" version="7.0.0-SNAPSHOT" />
+    <Application name="Drools-PMML" version="7.0.0-SNAPSHOT"/>
   </Header>
 
   <DataDictionary numberOfFields="3">
-    <DataField name="temperature" dataType="double" optype="continuous" />
-    <DataField name="humidity" dataType="double" optype="continuous" />
+    <DataField name="temperature" dataType="double" optype="continuous"/>
+    <DataField name="humidity" dataType="double" optype="continuous"/>
     <DataField name="decision" dataType="string" optype="categorical">
-      <Value value="sunglasses" />
-      <Value value="umbrella" />
-      <Value value="nothing" />
+      <Value value="sunglasses"/>
+      <Value value="umbrella"/>
+      <Value value="nothing"/>
     </DataField>
     <DataField name="text_input" optype="categorical" dataType="string"/>
-    <DataField name="input3" optype="continuous" dataType="double"/>
+    <DataField name="input3" optype="continuous" dataType="double">
+      <Interval closure="closedClosed" leftMargin="12.1" rightMargin="14.6"/>
+      <Interval closure="closedClosed" leftMargin="29.1" rightMargin="44.6"/>
+    </DataField>
   </DataDictionary>
   <TransformationDictionary>
     <DefineFunction name="discretize_function" optype="categorical" dataType="string">
@@ -30,7 +33,7 @@
     </DefineFunction>
     <DefineFunction name="norm_discrete_function" optype="categorical" dataType="string">
       <ParameterField name="eval_decision"/>
-      <NormDiscrete field="eval_decision" value="umbrella" />
+      <NormDiscrete field="eval_decision" value="umbrella"/>
     </DefineFunction>
     <DefineFunction name="fun_humidity_fieldref" optype="continuous" dataType="double">
       <ParameterField name="humidity_fake"/>
@@ -99,14 +102,14 @@
   </TransformationDictionary>
   <TreeModel modelName="SampleMineTreeModelWithTransformations" functionName="classification">
     <MiningSchema>
-      <MiningField name="temperature"  usageType="active" />
-      <MiningField name="humidity"  usageType="active" />
+      <MiningField name="temperature"/>
+      <MiningField name="humidity"/>
       <MiningField name="text_input" invalidValueTreatment="asIs"/>
-      <MiningField name="decision" usageType="predicted" />
-      <MiningField name="input3" usageType="active" missingValueTreatment="returnInvalid"/>
+      <MiningField name="decision" usageType="predicted"/>
+      <MiningField name="input3" missingValueTreatment="returnInvalid"/>
     </MiningSchema>
     <Output>
-      <OutputField name="weatherdecision" targetField="decision" dataType="string" />
+      <OutputField name="weatherdecision" targetField="decision" dataType="string"/>
       <OutputField name="out_der_temperature" dataType="double" feature="transformedValue">
         <FieldRef field="der_temperature"/>
       </OutputField>
@@ -120,12 +123,12 @@
         <FieldRef field="normcontinuous_field"/>
       </OutputField>
       <OutputField name="out_normdiscrete_field" feature="transformedValue" dataType="string" optype="categorical">
-        <Apply function="norm_discrete_function" >
+        <Apply function="norm_discrete_function">
           <FieldRef field="decision"/>
         </Apply>
       </OutputField>
       <OutputField name="out_discretize_field" feature="transformedValue" dataType="string" optype="categorical">
-        <Apply function="discretize_function" >
+        <Apply function="discretize_function">
           <FieldRef field="temperature"/>
         </Apply>
       </OutputField>
@@ -148,26 +151,26 @@
           </InlineTable>
         </MapValues>
       </OutputField>
-      <OutputField name="out_text_index_normalization_field" feature="transformedValue" dataType="double" optype="continuous" >
-        <Apply function="TEXT_INDEX_NORMALIZATION_FUNCTION" >
+      <OutputField name="out_text_index_normalization_field" feature="transformedValue" dataType="double" optype="continuous">
+        <Apply function="TEXT_INDEX_NORMALIZATION_FUNCTION">
           <FieldRef field="text_input"/>
           <Constant>ui_good</Constant>
         </Apply>
       </OutputField>
     </Output>
     <Node score="nothing" id="1">
-      <True />
+      <True/>
       <Node score="sunglasses" id="2">
         <CompoundPredicate booleanOperator="and">
-          <SimplePredicate field="der_temperature" operator="greaterThan" value="25" />
-          <SimplePredicate field="der_fun_humidity_apply" operator="lessOrEqual" value="20" />
+          <SimplePredicate field="der_temperature" operator="greaterThan" value="25"/>
+          <SimplePredicate field="der_fun_humidity_apply" operator="lessOrEqual" value="20"/>
         </CompoundPredicate>
       </Node>
       <Node score="umbrella" id="3">
-        <SimplePredicate field="der_fun_humidity_apply" operator="greaterThan" value="50" />
+        <SimplePredicate field="der_fun_humidity_apply" operator="greaterThan" value="50"/>
       </Node>
       <Node score="nothing" id="4">
-        <True />
+        <True/>
       </Node>
     </Node>
   </TreeModel>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -155,4 +155,14 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSampleMineTreeModelWithTransformationsInvalidValue() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", temperature);
+        inputData.put("humidity", humidity);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 4.1);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -32,6 +32,7 @@ import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
 public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest {
@@ -132,6 +133,26 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         inputData.put("temperature", temperature);
         inputData.put("humidity", humidity);
         inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
+    }
+
+    @Test
+    public void testSampleMineTreeModelWithTransformationsConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", String.valueOf(temperature));
+        inputData.put("humidity",String.valueOf(humidity));
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", "34.1");
+        assertNotNull(evaluate(pmmlRuntime, inputData, MODEL_NAME));
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSampleMineTreeModelWithTransformationsNotConvertible() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", temperature);
+        inputData.put("humidity", humidity);
+        inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", true);
         evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/src/test/java/org/kie/pmml/models/tree/tests/SampleMineTreeModelWithTransformationsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.pmml.PMML4Result;
+import org.kie.pmml.api.exceptions.KiePMMLException;
 import org.kie.pmml.api.runtime.PMMLRuntime;
 import org.kie.pmml.models.tests.AbstractPMMLTest;
 
@@ -77,11 +78,12 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
     }
 
     @Test
-    public void testSetPredicateTree() throws Exception {
+    public void testSampleMineTreeModelWithTransformations() throws Exception {
         final Map<String, Object> inputData = new HashMap<>();
         inputData.put("temperature", temperature);
         inputData.put("humidity", humidity);
         inputData.put("text_input", TEXT_INPUT);
+        inputData.put("input3", 34.1);
 
         PMML4Result pmml4Result = evaluate(pmmlRuntime, inputData, MODEL_NAME);
         Assertions.assertThat(pmml4Result.getResultVariables().get(TARGET_FIELD)).isNotNull();
@@ -122,5 +124,14 @@ public class SampleMineTreeModelWithTransformationsTest extends AbstractPMMLTest
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_MAPVALUED_FIELD)).isEqualTo(expected);
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isNotNull();
         Assertions.assertThat(pmml4Result.getResultVariables().get(OUT_TEXT_INDEX_NORMALIZATION_FIELD)).isEqualTo(1.0);
+    }
+
+    @Test(expected = KiePMMLException.class)
+    public void testSampleMineTreeModelWithTransformationsWithoutRequired() {
+        final Map<String, Object> inputData = new HashMap<>();
+        inputData.put("temperature", temperature);
+        inputData.put("humidity", humidity);
+        inputData.put("text_input", TEXT_INPUT);
+        evaluate(pmmlRuntime, inputData, MODEL_NAME);
     }
 }


### PR DESCRIPTION
@danielezonca @kostola  @jiripetrlik

See https://issues.redhat.com/browse/DROOLS-6625

This PR
1) define three "validation" steps inside PreProcess: `convertInputData`, `verifyFixInvalidValues`, `verifyAddMissingValues`
2) modify one integration test for each model to verify correct application
3) modify MiningModel evaluator to propagate results from one segment as input to the next one