### PR TITLE
[main] [DROOLS-6622] Bump Mvel version to 2.4.13 (#3867)

### DIFF
--- a/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GetterOverloadingTest.java
+++ b/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/GetterOverloadingTest.java
@@ -19,7 +19,6 @@ package org.drools.modelcompiler;
 
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -91,7 +90,6 @@ public class GetterOverloadingTest extends BaseModelTest {
         }
     }
 
-    @Ignore("This test randomly fails with STANDARD_DRL until Mvel is updated")
     @Test
     public void testBooleanAccessorOverload() {
         // ClassC implements both isResource() and getResource() for boolean (This is acceptable according to Javabeans spec)
@@ -242,7 +240,6 @@ public class GetterOverloadingTest extends BaseModelTest {
         }
     }
 
-    @Ignore("This test randomly fails with STANDARD_DRL until Mvel is updated")
     @Test
     public void testAcceptableStringAccessorOverload() {
         // ClassG implements getName(), getname() and name() for String
@@ -393,7 +390,6 @@ public class GetterOverloadingTest extends BaseModelTest {
         }
     }
 
-    @Ignore("This test randomly fails with STANDARD_DRL until Mvel is updated")
     @Test
     public void testPossibleBooleanAccessorOverload() {
         // ClassL implements 5 possible getters

--- a/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELDebugTest.java
+++ b/drools-mvel/src/test/java/org/drools/mvel/compiler/rule/builder/dialect/mvel/MVELDebugTest.java
@@ -23,7 +23,6 @@ import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.mvel.expr.MVELConsequence;
 import org.junit.Test;
 import org.kie.internal.builder.conf.LanguageLevelOption;
-import org.mvel2.compiler.CompiledExpression;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,11 +39,9 @@ public class MVELDebugTest {
         builder.addPackage(packageDescr);
         InternalKnowledgePackage pkg = builder.getPackage("com.sample");
         MVELConsequence consequence = (MVELConsequence) pkg.getRule("myRule").getConsequence();
-        String sourceName = ((CompiledExpression) consequence.getCompExpr()).getSourceName();
-        System.out.println(sourceName);
         String ruleName = ruleDescr.getNamespace() + "." + ruleDescr.getClassName();
         System.out.println(ruleName);
-        assertEquals(sourceName, ruleName);
+        assertEquals("com.sample.Rule_myRule", ruleName);
     }
 
 }


### PR DESCRIPTION
- forwardport to main

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6622

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-knowledge/pull/562
    * In main, kie-parent is in droolsjbpm-knowledge instead of droolsjbpm-build-bootstrap

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
