### PR TITLE
Fix compilation for [DROOLS-5985] by replacing the  TemplateCompiledFEELExpression

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/JavaParserSourceGenerator.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/execmodelbased/JavaParserSourceGenerator.java
@@ -18,7 +18,6 @@ package org.kie.dmn.core.compiler.execmodelbased;
 
 import java.util.List;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.ArrayCreationLevel;
 import com.github.javaparser.ast.CompilationUnit;
@@ -108,6 +107,10 @@ public class JavaParserSourceGenerator {
         final String finalTestClass = testClass;
         classOrInterfaceDeclaration
                 .setName(finalTestClass);
+
+        classOrInterfaceDeclaration.findAll(ClassOrInterfaceType.class,
+                                            ce -> ce.getNameAsString().equals("TemplateCompiledFEELExpression"))
+                .forEach(n -> n.replace(new ClassOrInterfaceType(null, finalTestClass)));
 
         classOrInterfaceDeclaration.findAll(ConstructorDeclaration.class)
                 .forEach(n -> n.replace(new ConstructorDeclaration(finalTestClass)));


### PR DESCRIPTION


**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
