### PR TITLE
Fix compilation failure related to exec.skip when skipping tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1820,7 +1820,6 @@
         <skipTests>true</skipTests>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
-        <exec.skip>true</exec.skip>
       </properties>
       <build>
         <defaultGoal>clean install</defaultGoal>
@@ -1865,7 +1864,6 @@
         <skipITs>true</skipITs>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
-        <exec.skip>true</exec.skip>
       </properties>
       <build>
         <defaultGoal>clean install</defaultGoal>
@@ -1917,7 +1915,6 @@
       <properties>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
-        <exec.skip>true</exec.skip>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1902,17 +1902,19 @@
     </profile>
     <profile>
       <!--
-        Translates -DskipTests parameter passed to build into setting corresponding skip properties.
+        Translates -DskipAllTests parameter passed to build into setting corresponding skip properties.
         It does NOT reflect the change made to the property value inside the pom files, just from cmd line.
         Inside pom file it needs to be in sync explicitly in each profile.
       -->
-      <id>skip-tests</id>
+      <id>skip-all-tests</id>
       <activation>
         <property>
-          <name>skipTests</name>
+          <name>skipAllTests</name>
         </property>
       </activation>
       <properties>
+        <skipITs>true</skipITs>
+        <skipTests>true</skipTests>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
       </properties>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
