### PR TITLE
[DROOLS-6668] avoid trying to use JMX in native mode

### DIFF
--- a/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
+++ b/drools-core/src/main/java/org/drools/core/management/DroolsManagementAgent.java
@@ -21,10 +21,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.StandardMBean;
+
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.kie.api.builder.model.KieSessionModel;
@@ -34,66 +34,52 @@ import org.kie.internal.runtime.StatelessKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.drools.core.util.Drools.isNativeImage;
+
 /**
  * The main management agent for Drools. The purpose of this 
  * agent is to serve as a singleton for knowledge base and session
  * monitoring mbeans registration and management.
  */
-public class DroolsManagementAgent
-    implements
-    KieManagementAgentMBean {
+public interface DroolsManagementAgent extends KieManagementAgentMBean {
 
-	private static final String CONTAINER_NAME_PREFIX = "org.kie";
+	String CONTAINER_NAME_PREFIX = "org.kie";
 	
-    private static DroolsManagementAgent  INSTANCE;
-    private static MBeanServer            mbs;
+    Logger logger = LoggerFactory.getLogger(DroolsManagementAgent.class);
 
-    protected static final transient Logger logger = LoggerFactory.getLogger(DroolsManagementAgent.class);
-
-    private long                          kbases;
-    private long                          ksessions;
-    private Map<Object, List<ObjectName>> mbeans;
-    private Map<Object, Object> mbeansRefs = new HashMap<Object, Object>();
-
-    private DroolsManagementAgent() {
-        kbases = 0;
-        ksessions = 0;
-        mbeans = new HashMap<Object, List<ObjectName>>();
+    class DroolsManagementAgentHolder {
+        private static final DroolsManagementAgent INSTANCE = isNativeImage() ? new Dummy() : new Impl();
     }
 
-    public static synchronized DroolsManagementAgent getInstance() {
-        if ( INSTANCE == null ) {
-            INSTANCE = new DroolsManagementAgent();
-        }
-        return INSTANCE;
+    static DroolsManagementAgent getInstance() {
+        return DroolsManagementAgentHolder.INSTANCE;
     }
-    
 
-	public static ObjectName createObjectNameFor(InternalKnowledgeBase kbase) {
+	static ObjectName createObjectNameFor(InternalKnowledgeBase kbase) {
 		return DroolsManagementAgent.createObjectName(
 					DroolsManagementAgent.createObjectNameBy(kbase.getContainerId())
 					+ ",kbaseId=" + ObjectName.quote(kbase.getId())
 					);
 	}
 	
-	public static ObjectName createObjectNameFor(InternalWorkingMemory ksession) {
+	static ObjectName createObjectNameFor(InternalWorkingMemory ksession) {
 		return DroolsManagementAgent.createObjectName(
 				DroolsManagementAgent.createObjectNameFor(ksession.getKnowledgeBase()) + 
 				",group=Sessions,ksessionId=Session-"+ksession.getIdentifier());
 	}
 	
-	public static ObjectName createObjectNameBy(String containerId) {
+	static ObjectName createObjectNameBy(String containerId) {
 		return DroolsManagementAgent.createObjectName(CONTAINER_NAME_PREFIX + ":kcontainerId="+ObjectName.quote(containerId));
 	}
 	
-    public static ObjectName createObjectNameBy(String containerId, String kbaseId, KieSessionModel.KieSessionType ksessionType, String ksessionName) {
+    static ObjectName createObjectNameBy(String containerId, String kbaseId, KieSessionModel.KieSessionType ksessionType, String ksessionName) {
         return DroolsManagementAgent.createObjectName(CONTAINER_NAME_PREFIX + ":kcontainerId="+ObjectName.quote(containerId) 
                     + ",kbaseId=" + ObjectName.quote(kbaseId) 
                     + ",ksessionType=" + ksessionType(ksessionType)
                     + ",ksessionName=" + ObjectName.quote(ksessionName) );
     }
     
-    private static String ksessionType(KieSessionModel.KieSessionType ksessionType) {
+    static String ksessionType(KieSessionModel.KieSessionType ksessionType) {
         switch(ksessionType) {
             case STATELESS:
                 return "Stateless";
@@ -103,162 +89,33 @@ public class DroolsManagementAgent
         }
     }
 
-    public synchronized long getKieBaseCount() {
-        return kbases;
-    }
+    long getKieBaseCount();
 
-    public synchronized long getSessionCount() {
-        return ksessions;
-    }
+    long getSessionCount();
 
-    public synchronized long getNextKnowledgeBaseId() {
-        return ++kbases;
-    }
+    long getNextKnowledgeBaseId();
 
-    public synchronized long getNextKnowledgeSessionId() {
-        return ++ksessions;
-    }
+    long getNextKnowledgeSessionId();
 
-    public void registerKnowledgeBase(InternalKnowledgeBase kbase) {
-        KnowledgeBaseMonitoring mbean = new KnowledgeBaseMonitoring( kbase );
-        registerMBean( kbase,
-                       mbean,
-                       mbean.getName() );
-    }
+    void registerKnowledgeBase(InternalKnowledgeBase kbase);
     
-    public void unregisterKnowledgeBase(InternalKnowledgeBase kbase) {
-        unregisterMBeansFromOwner(kbase);
-    }
+    void unregisterKnowledgeBase(InternalKnowledgeBase kbase);
     
-    public void registerKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession) {
-        GenericKieSessionMonitoringImpl bean = getKnowledgeSessionBean(cbsKey, ksession);
-        if (bean != null) { bean.attach(ksession); }
-    }
-    public void unregisterKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession) {
-        GenericKieSessionMonitoringImpl bean = getKnowledgeSessionBean(cbsKey, ksession);
-        if (bean != null) { bean.detach(ksession); }
-    }
+    void registerKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession);
+
+    void unregisterKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession);
     
-    public void unregisterKnowledgeSessionBean(CBSKey cbsKey) {
-        unregisterMBeansFromOwner(cbsKey);
-    }
+    void unregisterKnowledgeSessionBean(CBSKey cbsKey);
 
-    /**
-     * Get currently registered session monitor, eventually creating it if necessary.
-     * @return the currently registered or newly created session monitor, or null if unable to create and register it on the JMX server.
-     */
-    private GenericKieSessionMonitoringImpl getKnowledgeSessionBean(CBSKey cbsKey, KieRuntimeEventManager ksession) {
-        if (mbeansRefs.get(cbsKey) != null) {
-            return (GenericKieSessionMonitoringImpl) mbeansRefs.get(cbsKey);
-        } else {
-            if (ksession instanceof StatelessKnowledgeSession) {
-                synchronized (mbeansRefs) {
-                    if (mbeansRefs.get(cbsKey) != null) {
-                        return (GenericKieSessionMonitoringImpl) mbeansRefs.get(cbsKey);
-                    } else {
-                        try {
-                            StatelessKieSessionMonitoringImpl mbean = new StatelessKieSessionMonitoringImpl( cbsKey.kcontainerId, cbsKey.kbaseId, cbsKey.ksessionName );
-                            registerMBean( cbsKey, mbean, mbean.getName() );
-                            mbeansRefs.put(cbsKey, mbean);
-                            return mbean;
-                        } catch ( Exception e ) {
-                            logger.error("Unable to instantiate and register StatelessKieSessionMonitoringMBean");
-                        }
-                        return null;
-                    }
-                }
-            } else {
-                synchronized (mbeansRefs) {
-                    if (mbeansRefs.get(cbsKey) != null) {
-                        return (GenericKieSessionMonitoringImpl) mbeansRefs.get(cbsKey);
-                    } else {
-                        try {
-                            KieSessionMonitoringImpl mbean = new KieSessionMonitoringImpl( cbsKey.kcontainerId, cbsKey.kbaseId, cbsKey.ksessionName );
-                            registerMBean( cbsKey, mbean, mbean.getName() );
-                            mbeansRefs.put(cbsKey, mbean);
-                            return mbean;
-                        } catch ( Exception e ) {
-                            logger.error("Unable to instantiate and register (stateful) KieSessionMonitoringMBean");
-                        }
-                        return null;
-                    }
-                }
-            }
-        }
-    }
+    void registerMBean(Object owner, Object mbean, ObjectName name);
 
-    public void registerMBean(Object owner,
-                              Object mbean,
-                              ObjectName name) {
-        try {
-            MBeanServer mbs = getMBeanServer();
-            if ( !mbs.isRegistered( name ) ) {
-                mbs.registerMBean( mbean,
-                                   name );
-                List<ObjectName> mbl = mbeans.get( owner );
-                if ( mbl == null ) {
-                    mbl = new ArrayList<ObjectName>();
-                    mbeans.put( owner,
-                                mbl );
-                    if (mbean instanceof StandardMBean) {
-                        mbeansRefs.put(owner, ((StandardMBean) mbean).getImplementation());
-                    } else {
-                        mbeansRefs.put(owner, mbean);
-                    }
-                }
-                mbl.add( name );
-                logger.debug( "Registered {} into the platform MBean Server", name );
-            }
-        } catch ( Exception e ) {
-            logger.error( "Unable to register mbean " + name + " into the platform MBean Server", e );
-        }
-    }
+    void unregisterMBeansFromOwner(Object owner);
 
-    public void unregisterMBeansFromOwner(Object owner) {
-        List<ObjectName> mbl = mbeans.remove( owner );
-        mbeansRefs.remove(owner);
-        if ( mbl != null ) {
-            MBeanServer mbs = getMBeanServer();
-            for ( ObjectName name : mbl ) {
-                unregisterMBeanFromServer( mbs,
-                                           name );
-            }
-        }
-    }
+    void unregisterMBean( Object owner, ObjectName mbean );
 
-    private void unregisterMBeanFromServer(MBeanServer mbs,
-                                           ObjectName name) {
-        try {
-            mbs.unregisterMBean( name );
-            logger.debug( "Unregistered from MBean Server: {}", name);
-        } catch ( Exception e ) {
-            logger.error( "Exception unregistering mbean: " + name, e);
-        }
-    }
-    
-    public void unregisterMBean( Object owner, ObjectName mbean ) {
-        List<ObjectName> mbl = mbeans.get( owner );
-        if( mbl != null ) {
-            mbl.remove( mbean );
-        }
-        MBeanServer mbs = getMBeanServer();
-        unregisterMBeanFromServer( mbs,
-                                   mbean );
-    }
+    void unregisterDependentsMBeansFromOwner(Object owner);
 
-    public void unregisterDependentsMBeansFromOwner(Object owner) {
-        List<ObjectName> mbl = mbeans.get( owner );
-        if ( mbl != null ) {
-            MBeanServer mbs = getMBeanServer();
-            for ( ObjectName name : mbl.subList( 1, mbl.size() ) ) {
-                unregisterMBeanFromServer( mbs,
-                                           name );
-            }
-            mbl.subList( 1, mbl.size() ).clear();
-        }
-    }
-
-    public static ObjectName createObjectName(String name) {
+    static ObjectName createObjectName(String name) {
         try {
             return new ObjectName( name );
         } catch ( Exception e ) {
@@ -268,15 +125,7 @@ public class DroolsManagementAgent
         }
     }
 
-    private static MBeanServer getMBeanServer() {
-        if ( mbs == null ) {
-            mbs = ManagementFactory.getPlatformMBeanServer();
-        }
-        return mbs;
-    }
-
-
-    public static class CBSKey {
+    class CBSKey {
         private final String kcontainerId;
         private final String kbaseId;
         private final String ksessionName;
@@ -340,6 +189,264 @@ public class DroolsManagementAgent
         public String toString() {
             return "CBSKey [kcontainerId=" + kcontainerId + ", kbaseId=" + kbaseId + ", ksessionName=" + ksessionName + "]";
         }
-        
+    }
+
+    class Impl implements DroolsManagementAgent {
+
+        private static MBeanServer            mbs;
+
+        private long                          kbases;
+        private long                          ksessions;
+        private Map<Object, List<ObjectName>> mbeans;
+        private Map<Object, Object> mbeansRefs = new HashMap<>();
+
+        private Impl() {
+            kbases = 0;
+            ksessions = 0;
+            mbeans = new HashMap<>();
+        }
+
+        @Override
+        public synchronized long getKieBaseCount() {
+            return kbases;
+        }
+
+        @Override
+        public synchronized long getSessionCount() {
+            return ksessions;
+        }
+
+        @Override
+        public synchronized long getNextKnowledgeBaseId() {
+            return ++kbases;
+        }
+
+        @Override
+        public synchronized long getNextKnowledgeSessionId() {
+            return ++ksessions;
+        }
+
+        @Override
+        public void registerKnowledgeBase(InternalKnowledgeBase kbase) {
+            KnowledgeBaseMonitoring mbean = new KnowledgeBaseMonitoring( kbase );
+            registerMBean( kbase,
+                    mbean,
+                    mbean.getName() );
+        }
+
+        @Override
+        public void unregisterKnowledgeBase(InternalKnowledgeBase kbase) {
+            unregisterMBeansFromOwner(kbase);
+        }
+
+        @Override
+        public void registerKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession) {
+            GenericKieSessionMonitoringImpl bean = getKnowledgeSessionBean(cbsKey, ksession);
+            if (bean != null) { bean.attach(ksession); }
+        }
+
+        @Override
+        public void unregisterKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession) {
+            GenericKieSessionMonitoringImpl bean = getKnowledgeSessionBean(cbsKey, ksession);
+            if (bean != null) { bean.detach(ksession); }
+        }
+
+        @Override
+        public void unregisterKnowledgeSessionBean(CBSKey cbsKey) {
+            unregisterMBeansFromOwner(cbsKey);
+        }
+
+        /**
+         * Get currently registered session monitor, eventually creating it if necessary.
+         * @return the currently registered or newly created session monitor, or null if unable to create and register it on the JMX server.
+         */
+        private GenericKieSessionMonitoringImpl getKnowledgeSessionBean(CBSKey cbsKey, KieRuntimeEventManager ksession) {
+            if (mbeansRefs.get(cbsKey) != null) {
+                return (GenericKieSessionMonitoringImpl) mbeansRefs.get(cbsKey);
+            } else {
+                if (ksession instanceof StatelessKnowledgeSession) {
+                    synchronized (mbeansRefs) {
+                        if (mbeansRefs.get(cbsKey) != null) {
+                            return (GenericKieSessionMonitoringImpl) mbeansRefs.get(cbsKey);
+                        } else {
+                            try {
+                                StatelessKieSessionMonitoringImpl mbean = new StatelessKieSessionMonitoringImpl( cbsKey.kcontainerId, cbsKey.kbaseId, cbsKey.ksessionName );
+                                registerMBean( cbsKey, mbean, mbean.getName() );
+                                mbeansRefs.put(cbsKey, mbean);
+                                return mbean;
+                            } catch ( Exception e ) {
+                                logger.error("Unable to instantiate and register StatelessKieSessionMonitoringMBean");
+                            }
+                            return null;
+                        }
+                    }
+                } else {
+                    synchronized (mbeansRefs) {
+                        if (mbeansRefs.get(cbsKey) != null) {
+                            return (GenericKieSessionMonitoringImpl) mbeansRefs.get(cbsKey);
+                        } else {
+                            try {
+                                KieSessionMonitoringImpl mbean = new KieSessionMonitoringImpl( cbsKey.kcontainerId, cbsKey.kbaseId, cbsKey.ksessionName );
+                                registerMBean( cbsKey, mbean, mbean.getName() );
+                                mbeansRefs.put(cbsKey, mbean);
+                                return mbean;
+                            } catch ( Exception e ) {
+                                logger.error("Unable to instantiate and register (stateful) KieSessionMonitoringMBean");
+                            }
+                            return null;
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void registerMBean(Object owner,
+                                  Object mbean,
+                                  ObjectName name) {
+            try {
+                MBeanServer mbs = getMBeanServer();
+                if ( !mbs.isRegistered( name ) ) {
+                    mbs.registerMBean( mbean,
+                            name );
+                    List<ObjectName> mbl = mbeans.get( owner );
+                    if ( mbl == null ) {
+                        mbl = new ArrayList<ObjectName>();
+                        mbeans.put( owner,
+                                mbl );
+                        if (mbean instanceof StandardMBean) {
+                            mbeansRefs.put(owner, ((StandardMBean) mbean).getImplementation());
+                        } else {
+                            mbeansRefs.put(owner, mbean);
+                        }
+                    }
+                    mbl.add( name );
+                    logger.debug( "Registered {} into the platform MBean Server", name );
+                }
+            } catch ( Exception e ) {
+                logger.error( "Unable to register mbean " + name + " into the platform MBean Server", e );
+            }
+        }
+
+        @Override
+        public void unregisterMBeansFromOwner(Object owner) {
+            List<ObjectName> mbl = mbeans.remove( owner );
+            mbeansRefs.remove(owner);
+            if ( mbl != null ) {
+                MBeanServer mbs = getMBeanServer();
+                for ( ObjectName name : mbl ) {
+                    unregisterMBeanFromServer( mbs,
+                            name );
+                }
+            }
+        }
+
+        private void unregisterMBeanFromServer(MBeanServer mbs,
+                                               ObjectName name) {
+            try {
+                mbs.unregisterMBean( name );
+                logger.debug( "Unregistered from MBean Server: {}", name);
+            } catch ( Exception e ) {
+                logger.error( "Exception unregistering mbean: " + name, e);
+            }
+        }
+
+        @Override
+        public void unregisterMBean( Object owner, ObjectName mbean ) {
+            List<ObjectName> mbl = mbeans.get( owner );
+            if( mbl != null ) {
+                mbl.remove( mbean );
+            }
+            MBeanServer mbs = getMBeanServer();
+            unregisterMBeanFromServer( mbs,
+                    mbean );
+        }
+
+        @Override
+        public void unregisterDependentsMBeansFromOwner(Object owner) {
+            List<ObjectName> mbl = mbeans.get( owner );
+            if ( mbl != null ) {
+                MBeanServer mbs = getMBeanServer();
+                for ( ObjectName name : mbl.subList( 1, mbl.size() ) ) {
+                    unregisterMBeanFromServer( mbs,
+                            name );
+                }
+                mbl.subList( 1, mbl.size() ).clear();
+            }
+        }
+
+        private static MBeanServer getMBeanServer() {
+            if ( mbs == null ) {
+                mbs = ManagementFactory.getPlatformMBeanServer();
+            }
+            return mbs;
+        }
+    }
+
+    class Dummy implements DroolsManagementAgent {
+        @Override
+        public long getKieBaseCount() {
+            return 0;
+        }
+
+        @Override
+        public long getSessionCount() {
+            return 0;
+        }
+
+        @Override
+        public long getNextKnowledgeBaseId() {
+            return 0;
+        }
+
+        @Override
+        public long getNextKnowledgeSessionId() {
+            return 0;
+        }
+
+        @Override
+        public void registerKnowledgeBase(InternalKnowledgeBase kbase) {
+
+        }
+
+        @Override
+        public void unregisterKnowledgeBase(InternalKnowledgeBase kbase) {
+
+        }
+
+        @Override
+        public void registerKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession) {
+
+        }
+
+        @Override
+        public void unregisterKnowledgeSessionUnderName(CBSKey cbsKey, KieRuntimeEventManager ksession) {
+
+        }
+
+        @Override
+        public void unregisterKnowledgeSessionBean(CBSKey cbsKey) {
+
+        }
+
+        @Override
+        public void registerMBean(Object owner, Object mbean, ObjectName name) {
+
+        }
+
+        @Override
+        public void unregisterMBeansFromOwner(Object owner) {
+
+        }
+
+        @Override
+        public void unregisterMBean(Object owner, ObjectName mbean) {
+
+        }
+
+        @Override
+        public void unregisterDependentsMBeansFromOwner(Object owner) {
+
+        }
     }
 }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**NOTE!:** Double check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito / Optaplanner 8.
If this PR is not strictly related to drools and kogito project in `drools.git`, it should probably target `7.x`as a branch

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: https://issues.redhat.com/browse/DROOLS-6668

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>

* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>

* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
